### PR TITLE
Core: Clean up CAIEventHandler

### DIFF
--- a/src/map/ai/helpers/event_handler.cpp
+++ b/src/map/ai/helpers/event_handler.cpp
@@ -19,19 +19,19 @@
 ===========================================================================
 */
 
-#include "event_handler.h"
+#include <map/ai/helpers/event_handler.h>
 
-void CAIEventHandler::addListener(const std::string& eventname, const sol::function& lua_func, const std::string& identifier)
+void CAIEventHandler::addListener(const std::string& eventName, const sol::function& luaFunc, const std::string& identifier)
 {
     TracyZoneScoped;
-    TracyZoneString(eventname);
+    TracyZoneString(eventName);
     TracyZoneString(identifier);
 
-    // Remove entries with same identifier (if they exist).
+    // Remove entries with same identifier (if they exist)
     removeFromAllListeners(identifier);
 
-    // Add the new listener.
-    eventListeners[eventname].emplace_back(identifier, lua_func);
+    // Add the new listener
+    eventListeners_[eventName].emplace_back(identifier, luaFunc);
 }
 
 void CAIEventHandler::removeListener(const std::string& identifier)
@@ -40,21 +40,21 @@ void CAIEventHandler::removeListener(const std::string& identifier)
     TracyZoneString(identifier);
 
     // If we're currently triggering listeners, it isn't safe to remove
-    // the listener from the list, so we'll mark it for lazy removal later.
-    if (isTriggeringListeners)
+    // the listener from the list, so we'll mark it for lazy removal later
+    if (triggerDepth_ > 0)
     {
-        eventsToRemove.push_back(identifier);
+        eventsToRemove_.push_back(identifier);
         return;
     }
 
-    // Otherwise, we can remove the listener immediately.
+    // Otherwise, we can remove the listener immediately
     removeFromAllListeners(identifier);
 }
 
-bool CAIEventHandler::hasListener(const std::string& eventName)
+bool CAIEventHandler::hasListener(const std::string& eventName) const
 {
-    const auto& listeners = eventListeners.find(eventName);
-    return listeners != eventListeners.end() && !listeners->second.empty();
+    const auto& listeners = eventListeners_.find(eventName);
+    return listeners != eventListeners_.end() && !listeners->second.empty();
 }
 
 void CAIEventHandler::removeFromAllListeners(const std::string& identifier)
@@ -62,17 +62,17 @@ void CAIEventHandler::removeFromAllListeners(const std::string& identifier)
     TracyZoneScoped;
     TracyZoneString(identifier);
 
-    const auto isSameIdentifier = [&identifier](const ai_event_t& event)
+    const auto isSameIdentifier = [&identifier](const AIEvent& event)
     {
-        return identifier == event.identifier;
+        return identifier == event.identifier_;
     };
 
-    for (auto& [_, listeners] : eventListeners)
+    for (auto& [_, listeners] : eventListeners_)
     {
-        // Partition the vector so that all elements that match the identifier are at the end.
+        // Partition the vector so that all elements that match the identifier are at the end
         auto it = std::remove_if(listeners.begin(), listeners.end(), isSameIdentifier);
 
-        // Erase the partitioned elements.
+        // Erase the partitioned elements
         listeners.erase(it, listeners.end());
     }
 }

--- a/src/map/ai/helpers/event_handler.h
+++ b/src/map/ai/helpers/event_handler.h
@@ -19,81 +19,82 @@
 ===========================================================================
 */
 
-#ifndef _EVENT_HANDLER
-#define _EVENT_HANDLER
+#pragma once
 
 #include <functional>
 #include <unordered_map>
 #include <vector>
 
-#include "common/cbasetypes.h"
-#include "lua/luautils.h"
+#include <common/cbasetypes.h>
 
-struct ai_event_t
-{
-    std::string   identifier;
-    sol::function lua_func;
-
-    ai_event_t(const std::string& _ident, sol::function _lua_func)
-    : identifier(_ident)
-    , lua_func(_lua_func)
-    {
-    }
-};
+#include <map/lua/luautils.h>
 
 class CAIEventHandler
 {
-public:
-    void addListener(const std::string& eventname, const sol::function& lua_func, const std::string& identifier);
-    void removeListener(const std::string& identifier);
-    bool hasListener(const std::string& eventName);
-
-    // calls event from core
-    template <class... Args>
-    void triggerListener(const std::string& eventname, Args&&... args)
+    struct AIEvent
     {
-        TracyZoneScoped;
-        TracyZoneString(eventname);
+        std::string   identifier_;
+        sol::function luaFunc_;
 
-        // Mark this Event Handler as currently triggering listeners,
-        // this is to prevent removal of listeners during this loop.
-        isTriggeringListeners = true;
-
-        // If we have registered listeners for this event, trigger them.
-        if (eventListeners.count(eventname))
+        AIEvent(const std::string& identifier, sol::function luaFunc)
+        : identifier_(identifier)
+        , luaFunc_(luaFunc)
         {
-            for (const auto& event : eventListeners.at(eventname))
+        }
+    };
+
+public:
+    void addListener(const std::string& eventName, const sol::function& luaFunc, const std::string& identifier);
+    void removeListener(const std::string& identifier);
+    bool hasListener(const std::string& eventName) const;
+
+    template <class... Args>
+    void triggerListener(const std::string& eventName, Args&&... args) noexcept
+    {
+        // No events or events with this name? Bail out
+        auto it = eventListeners_.find(eventName);
+        if (it == eventListeners_.end())
+        {
+            return;
+        }
+
+        // Only report triggers we're actually going to fire
+        TracyZoneScoped;
+        TracyZoneString(eventName);
+
+        // Prevent modification while iterating
+        ++triggerDepth_;
+        {
+            auto& listeners = it->second;
+            for (auto& event : listeners)
             {
-                auto result = event.lua_func(std::forward<Args&&>(args)...);
+                auto result = event.luaFunc_(std::forward<Args>(args)...);
                 if (!result.valid())
                 {
                     sol::error err = result;
-                    ShowError("Error in listener event %s: %s", eventname, err.what());
-                    isTriggeringListeners = false;
+                    ShowErrorFmt("Error in listener event {}: {}", eventName, err.what());
                 }
             }
         }
+        --triggerDepth_;
 
-        // removeListener may have been called during the lua_func inside the loop.
-        // We've accumulated any possible removals in eventsToRemove, so we can now
-        // safely remove them from the eventListeners map without invalidating the
-        // inner iterator.
-        for (const auto& identifier : eventsToRemove)
+        // Process deferred removals
+        if (!eventsToRemove_.empty())
         {
-            removeFromAllListeners(identifier);
+            for (const auto& identifier : eventsToRemove_)
+            {
+                removeFromAllListeners(identifier);
+            }
+            eventsToRemove_.clear();
         }
-        eventsToRemove.clear();
-
-        isTriggeringListeners = false;
     }
 
 private:
     void removeFromAllListeners(const std::string& identifier);
 
-    bool isTriggeringListeners = false;
+    uint32 triggerDepth_ = 0;
 
-    std::unordered_map<std::string, std::vector<ai_event_t>> eventListeners;
-    std::vector<std::string>                                 eventsToRemove;
+    // TODO: Use string_view and is_transparent unordered_map + string_hash, etc.
+    std::unordered_map<std::string, std::vector<AIEvent>> eventListeners_;
+    std::vector<std::string>                              eventsToRemove_;
 };
-
-#endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There were a few things in here that weren't ideal, and this is an _incredibly_ high traffic area.

- Cleaned up naming
- Early bailout
- Cleaner reporting for Tracy
- Proper protection from reentrance
- Proper arg forwarding
- Renaming and hiding AIEvent
- Flattening trigger logic

This of course pales in comparison to the runtime cost of the actual `event.luaFunc_(std::forward<Args>(args)...);` trigger, but cleanup and better Tracy reporting can't hurt.