### PR TITLE
[pets, trusts] Fix pets and trusts respecting mob claim rules

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -440,13 +440,13 @@ CBattleEntity* CTargetFind::findMaster(CBattleEntity* PTarget)
 
 bool CTargetFind::isMobOwner(CBattleEntity* PTarget)
 {
-    if (m_PBattleEntity->objtype != TYPE_PC || PTarget->objtype == TYPE_PC)
+    if (findMaster(m_PBattleEntity)->objtype != TYPE_PC || PTarget->objtype == TYPE_PC)
     {
         // always true for mobs, npcs, pets
         return true;
     }
 
-    if (PTarget->m_OwnerID.id == 0 || PTarget->m_OwnerID.id == m_PBattleEntity->id)
+    if (PTarget->m_OwnerID.id == 0 || PTarget->m_OwnerID.id == findMaster(m_PBattleEntity)->id)
     {
         return true;
     }
@@ -462,7 +462,7 @@ bool CTargetFind::isMobOwner(CBattleEntity* PTarget)
     bool found = false;
 
     // clang-format off
-    m_PBattleEntity->ForAlliance([&found, &PTarget](CBattleEntity* PMember)
+    findMaster(m_PBattleEntity)->ForAlliance([&found, &PTarget](CBattleEntity* PMember)
     {
         if (PMember->id == PTarget->m_OwnerID.id)
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Fixes an issue where pets and trust AoE skills did not respect other player character's mob claims.


## Steps to test these changes

Player 1 : Set Job to 75 BST and Call Diremite jug pet.
Player 2: Claim group of mobs separately from Player 1.
Player 1: Have pet fight one of the mobs in the group and have the pet use "Spinning Top".

Before Fix: 
Observe Spinning Top hit the purple claimed mob despite Player 1 not being in the same party as Player 2.

After Fix:
Observe Spinning Top fail to hit the purple claimed mob.

<!-- Clear and detailed steps to test your changes here -->
