### PR TITLE
[ci] Skip merge commits for length checks

### DIFF
--- a/tools/ci/sanity_checks/git.py
+++ b/tools/ci/sanity_checks/git.py
@@ -25,7 +25,7 @@ def get_commit_messages():
 
     for hash in get_commit_hashes():
         result = subprocess.run(
-            ["git", "log", "--format=%B", hash, "-n", "1"],
+            ["git", "log", "--format=%B", "--no-merges", hash, "-n", "1"],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Downstreams have an issue where merge commits by _us_ when we merge a PR can be too long, so we need to ignore merge commits during CI. This can trip false negatives where a PR contains a long merge commit, but we usually squash those out.

## Steps to test these changes

I'm adding a positive test (too long commit) to this PR, and letting it spin and tell me I have a long commit. When it fails properly I'll attach proof that it failed, then remove that commit.