### PR TITLE
Adjusted guard rate formula to be more consistent

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -1078,7 +1078,7 @@ xi.combat.physical.calculateGuardRate = function(defender, attacker)
     -- Two data points showed that Guard was approximately 1% better, so skillDelta is at _least_ 6 lower on the same target
     -- The target was a lvl 43 chigoe, using the same parry skill vs guard skill with the known parrying rate data
     -- This is a placeholder and is likely more accurate than the previous code.
-    if skillDelta <= 5 then
+    if skillDelta <= 6 then
         guardRate = math.floor(10 + skillDelta / (36 / 9))
     else
         guardRate = math.floor(10 + skillDelta / (60 / 9))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [x] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Edge Case found: skillDelta of 6 had a lower guardRate than skillDelta of 5 despite being a greater value. Bumping it to use lower divisor at 6 generates a more correct expected value as guardRate is expected to increase or stay the same when skillDelta increases. Not lower like in the case of current formula.

## Steps to test these changes
Evaluate both formulas (current and proposed) and observe results.

<!-- Clear and detailed steps to test your changes here -->
https://docs.google.com/spreadsheets/d/1CsXiz68AwqFeqSFH77oxSqUh7fqwrvSLvKdzUhHLxQs/edit?usp=sharing

Original
if skillDelta <=5 then
delta5=11
delta6=10 (guardRate reduces as skillDelta increases, going against the curve)
delta7=11

Proposed
if skillDelta <=6 then
delta5=11
delta6=11 (guardrate does not reduce as skillDelta increases)
delta7=11