### PR TITLE
[core] [lua] Add "level -1" support

### DIFF
--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -37,6 +37,8 @@ xi.mod =
     FOOD_HP                         = 1130, -- Food HP (this is added after curse)
     FOOD_MP                         = 1131, -- Food MP (this is added after curse)
 
+    EXP_LVL_MOD                     = 1196, -- Modifies level during /check, exp calculation and certain packets only
+
     TWOHAND_STR                     = 218, -- Same as STR, but only active when using a two handed weapon (e.g. Hasso)
 
     -- Magic Evasion versus elements

--- a/scripts/zones/East_Ronfaure/mobs/Tunnel_Worm.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Tunnel_Worm.lua
@@ -1,16 +1,12 @@
 -----------------------------------
--- Area: South Gustaberg
---  Mob: Huge Hornet
+-- Area: East Ronfaure
+--  Mob: Tunnel Worm
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 76, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/East_Ronfaure/mobs/Wild_Rabbit.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Wild_Rabbit.lua
@@ -1,16 +1,12 @@
 -----------------------------------
--- Area: South Gustaberg
---  Mob: Huge Hornet
+-- Area: East Ronfaure
+--  Mob: Wild Rabbit
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 76, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/East_Sarutabaruta/mobs/Bumblebee.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Bumblebee.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 90, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 89, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/North_Gustaberg/mobs/Huge_Hornet.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Huge_Hornet.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: South Gustaberg
+-- Area: North Gustaberg
 --  Mob: Huge Hornet
 -----------------------------------
 ---@type TMobEntity
@@ -7,10 +7,6 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 76, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/North_Gustaberg/mobs/Tunnel_Worm.lua
+++ b/scripts/zones/North_Gustaberg/mobs/Tunnel_Worm.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 16, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/South_Gustaberg/mobs/Tunnel_Worm.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Tunnel_Worm.lua
@@ -1,16 +1,12 @@
 -----------------------------------
 -- Area: South Gustaberg
---  Mob: Huge Hornet
+--  Mob: Tunnel Worm
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 76, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/West_Ronfaure/mobs/Tunnel_Worm.lua
+++ b/scripts/zones/West_Ronfaure/mobs/Tunnel_Worm.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 1, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/West_Ronfaure/mobs/Wild_Rabbit.lua
+++ b/scripts/zones/West_Ronfaure/mobs/Wild_Rabbit.lua
@@ -1,16 +1,12 @@
 -----------------------------------
--- Area: South Gustaberg
---  Mob: Huge Hornet
+-- Area: West Ronfaure
+--  Mob: Wild Rabbit
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 76, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Bumblebee.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Bumblebee.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 61, 2, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 26, 1, xi.regime.type.FIELDS)
 end

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1650,7 +1650,7 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
                     // The following exceptions apply:
                     // - PC targeted weaponskills always give WSP
                     // - A handful of content: Besieged, DI
-                    if (charutils::CheckMob(this->GetMLevel(), PTarget->GetMLevel()) > EMobDifficulty::TooWeak)
+                    if (charutils::CheckMob(this->GetMLevel(), PTarget) > EMobDifficulty::TooWeak)
                     {
                         charutils::AddWeaponSkillPoints(this, damslot, wspoints);
                     }

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1015,7 +1015,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     bool      validZone = !(this->m_Type & MOBTYPE_BATTLEFIELD) && !(zoneType & ZONE_TYPE::DYNAMIS);
 
     // Check if mob can drop seals -- mobmod to disable drops, zone type isnt battlefield/dynamis, mob is stronger than Too Weak, or mobmod for EXP bonus is -100 or lower (-100% exp)
-    if (!getMobMod(MOBMOD_NO_DROPS) && validZone && charutils::CheckMob(m_HiPCLvl, GetMLevel()) > EMobDifficulty::TooWeak && getMobMod(MOBMOD_EXP_BONUS) > -100)
+    if (!getMobMod(MOBMOD_NO_DROPS) && validZone && charutils::CheckMob(m_HiPCLvl, this) > EMobDifficulty::TooWeak && getMobMod(MOBMOD_EXP_BONUS) > -100)
     {
         // Check for seal drops
         // Only one type of seal can drop per mob

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -11845,7 +11845,7 @@ bool CLuaBaseEntity::checkKillCredit(CLuaBaseEntity* PLuaBaseEntity, const sol::
     float        range  = minRange.is<float>() ? minRange.as<float>() : 100;
     bool         credit = false;
 
-    if (charutils::CheckMob(PMob->m_HiPCLvl, PMob->GetMLevel()) > EMobDifficulty::TooWeak && distance(PMob->loc.p, PChar->loc.p) < range && !PMob->GetCallForHelpFlag())
+    if (charutils::CheckMob(PMob->m_HiPCLvl, PMob) > EMobDifficulty::TooWeak && distance(PMob->loc.p, PChar->loc.p) < range && !PMob->GetCallForHelpFlag())
     {
         if (PChar->PParty && PChar->PParty->GetSyncTarget())
         {
@@ -11882,7 +11882,7 @@ uint8 CLuaBaseEntity::checkDifficulty(CLuaBaseEntity* PLuaBaseEntity)
 
     if (PChar && PMob)
     {
-        return (uint8)charutils::CheckMob((PChar->GetMLevel()), (PMob->GetMLevel()));
+        return static_cast<uint8>(charutils::CheckMob(PChar->GetMLevel(), PMob));
     }
 
     ShowError("Value is not valid");

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -38,6 +38,8 @@ enum class Mod
     FOOD_HP      = 1130, // Food HP (this is added after curse)
     FOOD_MP      = 1131, // Food MP (this is added after curse)
 
+    EXP_LVL_MOD = 1196, // Modifies level during /check, exp calculation and certain packets only
+
     STR = 8,  // Strength
     DEX = 9,  // Dexterity
     VIT = 10, // Vitality
@@ -1150,7 +1152,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1196 and onward
+    // SPARE IDs: 1197 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/packets/c2s/0x0dd_equip_inspect.cpp
+++ b/src/map/packets/c2s/0x0dd_equip_inspect.cpp
@@ -83,8 +83,8 @@ void GP_CLI_COMMAND_EQUIP_INSPECT::process(MapSession* PSession, CCharEntity* PC
                 }
                 else
                 {
-                    uint8          mobLvl   = PMobTarget->GetMLevel();
-                    EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), mobLvl);
+                    int32          mobLvl   = PMobTarget->GetMLevel() + PMobTarget->getMod(Mod::EXP_LVL_MOD);
+                    EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PMobTarget);
 
                     // Calculate main /check message (64 is Too Weak)
                     int32 MessageValue = 64 + static_cast<uint8>(mobCheck);

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4486,8 +4486,10 @@ void LoadExpTable()
  *                                                                       *
  ************************************************************************/
 
-EMobDifficulty CheckMob(uint8 charlvl, uint8 moblvl)
+EMobDifficulty CheckMob(uint8 charlvl, CBattleEntity* PMob)
 {
+    auto moblvl = PMob ? PMob->GetMLevel() + PMob->getMod(Mod::EXP_LVL_MOD) : -1;
+
     uint32 baseExp = GetBaseExp(charlvl, moblvl);
 
     if (baseExp >= 400)
@@ -4528,7 +4530,7 @@ EMobDifficulty CheckMob(uint8 charlvl, uint8 moblvl)
  *                                                                       *
  ************************************************************************/
 
-uint32 GetBaseExp(uint8 charlvl, uint8 moblvl)
+uint32 GetBaseExp(uint8 charlvl, int16 moblvl)
 {
     const int32 levelDif = moblvl - charlvl + 44;
 
@@ -4787,11 +4789,11 @@ void DistributeExperiencePoints(CCharEntity* PChar, CMobEntity* PMob)
 
             bool chainactive = false;
 
-            const uint8 moblevel    = PMob->GetMLevel();
+            const uint8 moblevel    = PMob->GetMLevel() + PMob->getMod(Mod::EXP_LVL_MOD);
             const uint8 memberlevel = PMember->GetMLevel();
 
-            EMobDifficulty mobCheck = CheckMob(maxlevel, moblevel);
-            float          exp      = (float)GetBaseExp(maxlevel, moblevel);
+            EMobDifficulty mobCheck = CheckMob(maxlevel, PMob);
+            float          exp      = static_cast<float>(GetBaseExp(maxlevel, moblevel));
 
             if (mobCheck > EMobDifficulty::TooWeak)
             {

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -92,9 +92,9 @@ void UpdateSubJob(CCharEntity* PChar);
 
 void SetLevelRestriction(CCharEntity* PChar, uint8 lvl);
 
-EMobDifficulty CheckMob(uint8 charlvl, uint8 moblvl);
+EMobDifficulty CheckMob(uint8 charlvl, CBattleEntity* PMob);
 
-uint32 GetBaseExp(uint8 charlvl, uint8 moblvl);
+uint32 GetBaseExp(uint8 charlvl, int16 moblvl);
 uint32 GetExpNEXTLevel(uint8 charlvl);
 
 void DelExperiencePoints(CCharEntity* PChar, float retainpct, uint16 forcedXpLoss);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -768,7 +768,7 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
             }
 
             // checking monsters night/daytime sleep is already taken into account in the CurrentAction check, because monsters don't move in their sleep
-            const EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PCurrentMob->GetMLevel());
+            const EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PCurrentMob);
 
             CMobController* PController = static_cast<CMobController*>(PCurrentMob->PAI->GetController());
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: Mobs that range from level 1 to level 1 in starter zones specifically are treated as level -1 for the purposes of EXP gain. Their stats are the same as a level 1 according to Jimmayus.

On retail...

Level -1 mobs are TW when you are level 8.
Level 1 mobs are TW when you are level 10.
The widescan packet reports level 1 for a "level -1" mob.

## Steps to test these changes

/check a starter mob and see it DC at level 1, TW at level 8. Gain EXP as if it were level -1.

<img width="744" height="95" alt="image" src="https://github.com/user-attachments/assets/d86b5e1c-bfc4-4958-ba05-19651831216f" />
