### PR TITLE
[core, lua] Automaton head/frame enums cleanup

### DIFF
--- a/scripts/enum/automaton.lua
+++ b/scripts/enum/automaton.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Automaton heads and frames
+-----------------------------------
+
+xi = xi or {}
+xi.automaton = xi.automaton or {}
+
+---@enum xi.automaton.frame
+xi.automaton.frame =
+{
+    HARLEQUIN  = 0x20,
+    VALOREDGE  = 0x21,
+    SHARPSHOT  = 0x22,
+    STORMWAKER = 0x23,
+}
+
+---@enum xi.automaton.head
+xi.automaton.head =
+{
+    HARLEQUIN    = 0x01,
+    VALOREDGE    = 0x02,
+    SHARPSHOT    = 0x03,
+    STORMWAKER   = 0x04,
+    SOULSOOTHER  = 0x05,
+    SPIRITREAVER = 0x06,
+}

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -2,7 +2,7 @@
 --  Automaton Global
 -----------------------------------
 xi = xi or {}
-xi.automaton = {}
+xi.automaton = xi.automaton or {}
 
 xi.automaton.abilities =
 {
@@ -31,6 +31,47 @@ xi.automaton.abilities =
     HEAT_CAPACITOR  = 2745,
     BARRAGE_TURBINE = 2746,
     DISRUPTOR       = 2747,
+}
+
+-- [FRAME][HEAD] = Model ID
+local automatonModels =
+{
+    [xi.automaton.frame.HARLEQUIN] =
+    {
+        [xi.automaton.head.HARLEQUIN]    = 0x07B9,
+        [xi.automaton.head.VALOREDGE]    = 0x07BA,
+        [xi.automaton.head.SHARPSHOT]    = 0x07BC,
+        [xi.automaton.head.STORMWAKER]   = 0x07BB,
+        [xi.automaton.head.SOULSOOTHER]  = 0x07D3,
+        [xi.automaton.head.SPIRITREAVER] = 0x07D7,
+    },
+    [xi.automaton.frame.VALOREDGE] =
+    {
+        [xi.automaton.head.HARLEQUIN]    = 0x07BE,
+        [xi.automaton.head.VALOREDGE]    = 0x07BF,
+        [xi.automaton.head.SHARPSHOT]    = 0x07C1,
+        [xi.automaton.head.STORMWAKER]   = 0x07C0,
+        [xi.automaton.head.SOULSOOTHER]  = 0x07D4,
+        [xi.automaton.head.SPIRITREAVER] = 0x07D8,
+    },
+    [xi.automaton.frame.SHARPSHOT] =
+    {
+        [xi.automaton.head.HARLEQUIN]    = 0x07C3,
+        [xi.automaton.head.VALOREDGE]    = 0x07C4,
+        [xi.automaton.head.SHARPSHOT]    = 0x07C6,
+        [xi.automaton.head.STORMWAKER]   = 0x07C5,
+        [xi.automaton.head.SOULSOOTHER]  = 0x07D5,
+        [xi.automaton.head.SPIRITREAVER] = 0x07D9,
+    },
+    [xi.automaton.frame.STORMWAKER] =
+    {
+        [xi.automaton.head.HARLEQUIN]    = 0x07C8,
+        [xi.automaton.head.VALOREDGE]    = 0x07C9,
+        [xi.automaton.head.SHARPSHOT]    = 0x07CB,
+        [xi.automaton.head.STORMWAKER]   = 0x07CA,
+        [xi.automaton.head.SOULSOOTHER]  = 0x07D6,
+        [xi.automaton.head.SPIRITREAVER] = 0x07DA,
+    },
 }
 
 local maneuverList =
@@ -377,4 +418,24 @@ xi.automaton.onUseManeuver = function(player, target, ability, action)
     end
 
     return target:getOverloadChance(maneuverInfo[2] - 1)
+end
+
+---Retrieve model ID of the automaton for cutscene purposes
+---@param player CBaseEntity
+---@return integer
+xi.automaton.getModelId = function(player)
+    local frame          = player:getAutomatonFrame()
+    local head           = player:getAutomatonHead()
+    local defaultModelId = automatonModels[xi.automaton.frame.HARLEQUIN][xi.automaton.head.HARLEQUIN]
+
+    if not frame or not head then
+        return defaultModelId
+    end
+
+    local frameTable = automatonModels[frame]
+    if not frameTable then
+        return defaultModelId
+    end
+
+    return frameTable[head] or defaultModelId
 end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3526,25 +3526,25 @@ function CBaseEntity:getAutomatonName()
 end
 
 ---@nodiscard
----@return integer
+---@return xi.automaton.frame?
 function CBaseEntity:getAutomatonFrame()
 end
 
 ---@nodiscard
----@param itemId integer
+---@param frame xi.automaton.frame
 ---@return nil
-function CBaseEntity:setAutomatonFrame(itemId)
+function CBaseEntity:setAutomatonFrame(frame)
 end
 
 ---@nodiscard
----@return integer
+---@return xi.automaton.head?
 function CBaseEntity:getAutomatonHead()
 end
 
 ---@nodiscard
----@param itemId integer
+---@param head xi.automaton.head
 ---@return nil
-function CBaseEntity:setAutomatonHead(itemId)
+function CBaseEntity:setAutomatonHead(head)
 end
 
 ---@param itemID integer

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -29,6 +29,7 @@
 #include "common/utils.h"
 #include "enmity_container.h"
 #include "entities/trustentity.h"
+#include "enums/automaton.h"
 #include "lua/luautils.h"
 #include "mob_spell_container.h"
 #include "mobskill.h"
@@ -54,14 +55,14 @@ void CAutomatonController::setCooldowns()
 {
     switch (PAutomaton->getFrame())
     {
-        case FRAME_SHARPSHOT:
+        case AutomatonFrame::Sharpshot:
         {
             switch (PAutomaton->getHead())
             {
-                case HEAD_SHARPSHOT:
+                case AutomatonHead::Sharpshot:
                     m_rangedCooldown = 20s;
                     break;
-                case HEAD_HARLEQUIN:
+                case AutomatonHead::Harlequin:
                     m_rangedCooldown = 25s;
                     break;
                 default:
@@ -69,17 +70,17 @@ void CAutomatonController::setCooldowns()
             }
         }
         break;
-        case FRAME_HARLEQUIN:
+        case AutomatonFrame::Harlequin:
         {
             setMagicCooldowns();
         }
         break;
-        case FRAME_STORMWAKER:
+        case AutomatonFrame::Stormwaker:
         {
             setMagicCooldowns();
         }
         break;
-        case FRAME_VALOREDGE:
+        case AutomatonFrame::Valoredge:
         {
             m_shieldbashCooldown = 3min;
         }
@@ -91,27 +92,27 @@ void CAutomatonController::setMagicCooldowns()
 {
     switch (PAutomaton->getHead())
     {
-        case HEAD_HARLEQUIN:
+        case AutomatonHead::Harlequin:
         {
             m_magicCooldown    = 10s;
             m_enfeebleCooldown = 10s;
             m_healCooldown     = 15s;
         }
         break;
-        case HEAD_VALOREDGE:
+        case AutomatonHead::Valoredge:
         {
             m_magicCooldown = 20s;
             m_healCooldown  = 20s;
         }
         break;
-        case HEAD_SHARPSHOT:
+        case AutomatonHead::Sharpshot:
         {
             m_magicCooldown    = 12s;
             m_enfeebleCooldown = 12s;
             m_healCooldown     = 18s; // Guess
         }
         break;
-        case HEAD_STORMWAKER:
+        case AutomatonHead::Stormwaker:
         {
             m_magicCooldown     = 10s;
             m_enfeebleCooldown  = 12s;
@@ -120,7 +121,7 @@ void CAutomatonController::setMagicCooldowns()
             m_enhanceCooldown   = 10s; // Guess
         }
         break;
-        case HEAD_SOULSOOTHER:
+        case AutomatonHead::Soulsoother:
         {
             m_magicCooldown    = 4s;
             m_enfeebleCooldown = 4s;
@@ -129,7 +130,7 @@ void CAutomatonController::setMagicCooldowns()
             m_statusCooldown   = 15s;
         }
         break;
-        case HEAD_SPIRITREAVER:
+        case AutomatonHead::Spiritreaver:
         {
             m_magicCooldown     = 10s;
             m_enfeebleCooldown  = 10s;
@@ -142,9 +143,9 @@ void CAutomatonController::setMagicCooldowns()
 // Determines standback behavior for the Automaton.
 // Type 2 animators override all behavior, Valor Edge frame will always enter melee, followed
 // by ranged head types defaulting to ranged behavior.
-bool CAutomatonController::shouldStandBack()
+auto CAutomatonController::shouldStandBack() const -> bool
 {
-    CBattleEntity* PMaster = PAutomaton->PMaster;
+    const CBattleEntity* PMaster = PAutomaton->PMaster;
 
     if (PMaster)
     {
@@ -155,11 +156,11 @@ bool CAutomatonController::shouldStandBack()
             return true;
         }
     }
-    else if (PAutomaton->getFrame() == AUTOFRAMETYPE::FRAME_VALOREDGE)
+    else if (PAutomaton->getFrame() == AutomatonFrame::Valoredge)
     {
         return false;
     }
-    else if (PAutomaton->getHead() >= AUTOHEADTYPE::HEAD_SHARPSHOT)
+    else if (PAutomaton->getHead() >= AutomatonHead::Sharpshot)
     {
         return true;
     }
@@ -167,9 +168,9 @@ bool CAutomatonController::shouldStandBack()
     return false;
 }
 
-CurrentManeuvers CAutomatonController::GetCurrentManeuvers() const
+auto CAutomatonController::GetCurrentManeuvers() const -> CurrentManeuvers
 {
-    auto& statuses = PAutomaton->PMaster->StatusEffectContainer;
+    const auto& statuses = PAutomaton->PMaster->StatusEffectContainer;
     return {
         statuses->GetEffectsCount(EFFECT_FIRE_MANEUVER),
         statuses->GetEffectsCount(EFFECT_ICE_MANEUVER),
@@ -241,7 +242,7 @@ void CAutomatonController::Move()
     CPetController::Move();
 }
 
-bool CAutomatonController::TryAction()
+auto CAutomatonController::TryAction() -> bool
 {
     if (m_Tick > m_LastActionTime + (m_actionCooldown - std::chrono::milliseconds(PAutomaton->getMod(Mod::AUTO_DECISION_DELAY) * 10)))
     {
@@ -254,7 +255,7 @@ bool CAutomatonController::TryAction()
     return false;
 }
 
-bool CAutomatonController::TryShieldBash()
+auto CAutomatonController::TryShieldBash() -> bool
 {
     CState* PState = PTarget->PAI->GetCurrentState();
 
@@ -267,7 +268,7 @@ bool CAutomatonController::TryShieldBash()
     return false;
 }
 
-bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
+auto CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers) -> bool
 {
     // Apparently the automaton has nothing in its spell list, so CanCastSpells must ignore spell lists and recasts?
     if (!PAutomaton->PMaster || m_magicCooldown == 0s ||
@@ -278,7 +279,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
 
     switch (PAutomaton->getHead())
     {
-        case HEAD_VALOREDGE:
+        case AutomatonHead::Valoredge:
         {
             if (TryHeal(maneuvers))
             {
@@ -287,7 +288,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
             }
         }
         break;
-        case HEAD_SHARPSHOT:
+        case AutomatonHead::Sharpshot:
         {
             if (maneuvers.light && TryHeal(maneuvers)) // Light -> Heal
             {
@@ -307,7 +308,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
             }
         }
         break;
-        case HEAD_HARLEQUIN:
+        case AutomatonHead::Harlequin:
         {
             if (maneuvers.light && TryHeal(maneuvers)) // Light -> Heal
             {
@@ -327,7 +328,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
             }
         }
         break;
-        case HEAD_STORMWAKER:
+        case AutomatonHead::Stormwaker:
         {
             bool lowHP = PTarget->GetHPP() <= 30 && PTarget->health.hp <= 300;
             if (lowHP && TryElemental(maneuvers)) // Mob low HP -> Nuke
@@ -369,7 +370,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
             }
         }
         break;
-        case HEAD_SOULSOOTHER:
+        case AutomatonHead::Soulsoother:
         {
             if (maneuvers.light && TryHeal(maneuvers)) // Light -> Heal
             {
@@ -399,7 +400,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
             }
         }
         break;
-        case HEAD_SPIRITREAVER:
+        case AutomatonHead::Spiritreaver:
         {
             if (maneuvers.ice && TryElemental(maneuvers)) // Ice -> Nuke
             {
@@ -428,7 +429,7 @@ bool CAutomatonController::TrySpellcast(const CurrentManeuvers& maneuvers)
     return false;
 }
 
-bool CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers)
+auto CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers) -> bool
 {
     if (!PAutomaton->PMaster || m_healCooldown == 0s ||
         m_Tick <= m_LastHealTime + (m_healCooldown - std::chrono::seconds(PAutomaton->getMod(Mod::AUTO_HEALING_DELAY))))
@@ -506,7 +507,7 @@ bool CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers)
         }
     }
 
-    if (maneuvers.light && !PCastTarget && PAutomaton->getHead() == HEAD_SOULSOOTHER && PAutomaton->PMaster->PParty) // Light + Soulsoother head -> Heal party
+    if (maneuvers.light && !PCastTarget && PAutomaton->getHead() == AutomatonHead::Soulsoother && PAutomaton->PMaster->PParty) // Light + Soulsoother head -> Heal party
     {
         // clang-format off
         if (PMob)
@@ -575,12 +576,12 @@ bool CAutomatonController::TryHeal(const CurrentManeuvers& maneuvers)
     return false;
 }
 
-inline bool resistanceComparator(const std::pair<SpellID, int16>& firstElem, const std::pair<SpellID, int16>& secondElem)
+inline auto resistanceComparator(const std::pair<SpellID, int16>& firstElem, const std::pair<SpellID, int16>& secondElem) -> bool
 {
     return firstElem.second < secondElem.second;
 }
 
-bool CAutomatonController::TryElemental(const CurrentManeuvers& maneuvers)
+auto CAutomatonController::TryElemental(const CurrentManeuvers& maneuvers) -> bool
 {
     if (!PAutomaton->PMaster || m_elementalCooldown == 0s || m_Tick <= m_LastElementalTime + m_elementalCooldown)
     {
@@ -590,9 +591,9 @@ bool CAutomatonController::TryElemental(const CurrentManeuvers& maneuvers)
     std::vector<SpellID> castPriority;
     std::vector<SpellID> defaultPriority;
 
-    int8  tier   = 4;
-    int32 hp     = PTarget->health.hp;
-    int32 selfmp = PAutomaton->health.mp; // Shortcut for wasting less time
+    int8        tier   = 4;
+    const int32 hp     = PTarget->health.hp;
+    const int32 selfmp = PAutomaton->health.mp; // Shortcut for wasting less time
     if (selfmp < 4)
     {
         return false;
@@ -630,7 +631,7 @@ bool CAutomatonController::TryElemental(const CurrentManeuvers& maneuvers)
             castPriority.emplace_back(res.first);
         }
     }
-    else if (PAutomaton->getHead() == HEAD_SPIRITREAVER)
+    else if (PAutomaton->getHead() == AutomatonHead::Spiritreaver)
     {
         if (maneuvers.thunder)
         { // Thunder -> Thunder spells
@@ -713,7 +714,7 @@ bool CAutomatonController::TryElemental(const CurrentManeuvers& maneuvers)
     return false;
 }
 
-bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
+auto CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers) -> bool
 {
     if (!PAutomaton->PMaster || m_enfeebleCooldown == 0s || m_Tick <= m_LastEnfeebleTime + m_enfeebleCooldown)
     {
@@ -725,7 +726,7 @@ bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
 
     switch (PAutomaton->getHead())
     {
-        case HEAD_STORMWAKER:
+        case AutomatonHead::Stormwaker:
         {
             bool dispel = false;
             // clang-format off
@@ -854,7 +855,7 @@ bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
             }
             break;
         }
-        case HEAD_SPIRITREAVER:
+        case AutomatonHead::Spiritreaver:
         {
             if (PAutomaton->GetMPP() < 75 && PTarget->health.mp > 0) // MPP < 75 -> Aspir
             {
@@ -958,7 +959,7 @@ bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
             }
             break;
         }
-        case HEAD_SOULSOOTHER:
+        case AutomatonHead::Soulsoother:
         {
             if (maneuvers.earth)
             { // Earth -> Slow
@@ -1082,7 +1083,7 @@ bool CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers)
     return false;
 }
 
-bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
+auto CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers) -> bool
 {
     if (!PAutomaton->PMaster || m_statusCooldown == 0s || m_Tick <= m_LastStatusTime + m_statusCooldown)
     {
@@ -1091,19 +1092,18 @@ bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
 
     std::vector<SpellID> castPriority;
 
-    // clang-format off
-    PAutomaton->PMaster->StatusEffectContainer->ForEachEffect([&castPriority](CStatusEffect* PStatus)
-    {
-        if (PStatus->GetDuration() > 0s)
+    PAutomaton->PMaster->StatusEffectContainer->ForEachEffect(
+        [&castPriority](CStatusEffect* PStatus)
         {
-            auto id = automaton::FindNaSpell(PStatus);
-            if (id.has_value())
+            if (PStatus->GetDuration() > 0s)
             {
-                castPriority.emplace_back(id.value());
+                auto id = automaton::FindNaSpell(PStatus);
+                if (id.has_value())
+                {
+                    castPriority.emplace_back(id.value());
+                }
             }
-        }
-    });
-    // clang-format on
+        });
 
     for (SpellID& id : castPriority)
     {
@@ -1115,19 +1115,18 @@ bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
 
     castPriority.clear();
 
-    // clang-format off
-    PAutomaton->StatusEffectContainer->ForEachEffect([&castPriority](CStatusEffect* PStatus)
-    {
-        if (PStatus->GetDuration() > 0s)
+    PAutomaton->StatusEffectContainer->ForEachEffect(
+        [&castPriority](CStatusEffect* PStatus)
         {
-            auto id = automaton::FindNaSpell(PStatus);
-            if (id.has_value())
+            if (PStatus->GetDuration() > 0s)
             {
-                castPriority.emplace_back(id.value());
+                auto id = automaton::FindNaSpell(PStatus);
+                if (id.has_value())
+                {
+                    castPriority.emplace_back(id.value());
+                }
             }
-        }
-    });
-    // clang-format on
+        });
 
     for (SpellID& id : castPriority)
     {
@@ -1137,7 +1136,7 @@ bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
         }
     }
 
-    if (maneuvers.water && PAutomaton->getHead() == HEAD_SOULSOOTHER && PAutomaton->PMaster->PParty) // Water + Soulsoother head -> Remove party's statuses
+    if (maneuvers.water && PAutomaton->getHead() == AutomatonHead::Soulsoother && PAutomaton->PMaster->PParty) // Water + Soulsoother head -> Remove party's statuses
     {
         for (auto member : PAutomaton->PMaster->PParty->members)
         {
@@ -1145,19 +1144,18 @@ bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
             {
                 castPriority.clear();
 
-                // clang-format off
-                member->StatusEffectContainer->ForEachEffect([&castPriority](CStatusEffect* PStatus)
-                {
-                    if (PStatus->GetDuration() > 0s)
+                member->StatusEffectContainer->ForEachEffect(
+                    [&castPriority](CStatusEffect* PStatus)
                     {
-                        auto id = automaton::FindNaSpell(PStatus);
-                        if (id.has_value())
+                        if (PStatus->GetDuration() > 0s)
                         {
-                            castPriority.emplace_back(id.value());
+                            auto id = automaton::FindNaSpell(PStatus);
+                            if (id.has_value())
+                            {
+                                castPriority.emplace_back(id.value());
+                            }
                         }
-                    }
-                });
-                // clang-format on
+                    });
 
                 for (auto id : castPriority)
                 {
@@ -1173,14 +1171,14 @@ bool CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers)
     return false;
 }
 
-bool CAutomatonController::TryEnhance()
+auto CAutomatonController::TryEnhance() -> bool
 {
     if (!PAutomaton->PMaster || m_enhanceCooldown == 0s || m_Tick <= m_LastEnhanceTime + m_enhanceCooldown)
     {
         return false;
     }
 
-    if (PAutomaton->getHead() == HEAD_SPIRITREAVER)
+    if (PAutomaton->getHead() == AutomatonHead::Spiritreaver)
     {
         return Cast(PAutomaton->targid, SpellID::Dread_Spikes);
     }
@@ -1305,28 +1303,27 @@ bool CAutomatonController::TryEnhance()
         }
     }
 
-    // clang-format off
-    PAutomaton->StatusEffectContainer->ForEachEffect([&protect, &shell, &haste](CStatusEffect* PStatus)
-    {
-        if (PStatus->GetDuration() > 0s)
+    PAutomaton->StatusEffectContainer->ForEachEffect(
+        [&protect, &shell, &haste](CStatusEffect* PStatus)
         {
-            if (PStatus->GetStatusID() == EFFECT_PROTECT)
+            if (PStatus->GetDuration() > 0s)
             {
-                protect = true;
-            }
+                if (PStatus->GetStatusID() == EFFECT_PROTECT)
+                {
+                    protect = true;
+                }
 
-            if (PStatus->GetStatusID() == EFFECT_SHELL)
-            {
-                shell = true;
-            }
+                if (PStatus->GetStatusID() == EFFECT_SHELL)
+                {
+                    shell = true;
+                }
 
-            if (PStatus->GetStatusID() == EFFECT_HASTE || PStatus->GetStatusID() == EFFECT_GEO_HASTE)
-            {
-                haste = true;
+                if (PStatus->GetStatusID() == EFFECT_HASTE || PStatus->GetStatusID() == EFFECT_GEO_HASTE)
+                {
+                    haste = true;
+                }
             }
-        }
-    });
-    // clang-format on
+        });
 
     if (!PProtectTarget && !protect)
     {
@@ -1491,7 +1488,7 @@ bool CAutomatonController::TryEnhance()
     return false;
 }
 
-bool CAutomatonController::TryTPMove()
+auto CAutomatonController::TryTPMove() -> bool
 {
     if (PAutomaton->health.tp >= 1000)
     {
@@ -1502,7 +1499,7 @@ bool CAutomatonController::TryTPMove()
         // load the skills that the automaton has access to with it's skill
         SKILLTYPE skilltype = SKILL_AUTOMATON_MELEE;
 
-        if (PAutomaton->getFrame() == FRAME_SHARPSHOT)
+        if (PAutomaton->getFrame() == AutomatonFrame::Sharpshot)
         {
             skilltype = SKILL_AUTOMATON_RANGED;
         }
@@ -1584,11 +1581,11 @@ bool CAutomatonController::TryTPMove()
     return false;
 }
 
-bool CAutomatonController::TryRangedAttack() // TODO: Find the animation for its ranged attack
+auto CAutomatonController::TryRangedAttack() -> bool // TODO: Find the animation for its ranged attack
 {
-    if (PAutomaton->getFrame() == FRAME_SHARPSHOT)
+    if (PAutomaton->getFrame() == AutomatonFrame::Sharpshot)
     {
-        timer::duration minDelay   = PAutomaton->getHead() == AUTOHEADTYPE::HEAD_SHARPSHOT ? 5s : 10s;
+        timer::duration minDelay   = PAutomaton->getHead() == AutomatonHead::Sharpshot ? 5s : 10s;
         timer::duration attackTime = m_rangedCooldown - std::chrono::seconds(PAutomaton->getMod(Mod::AUTO_RANGED_DELAY));
 
         if (m_rangedCooldown > 0s && m_Tick > m_LastRangedTime + std::max(attackTime, minDelay))
@@ -1600,7 +1597,7 @@ bool CAutomatonController::TryRangedAttack() // TODO: Find the animation for its
     return false;
 }
 
-bool CAutomatonController::TryAttachment()
+auto CAutomatonController::TryAttachment() -> bool
 {
     if (!PAutomaton->PAI->CanChangeState())
     {
@@ -1612,7 +1609,7 @@ bool CAutomatonController::TryAttachment()
     return false;
 }
 
-bool CAutomatonController::CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts)
+auto CAutomatonController::CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) -> bool
 {
     // Check for spell blockers e.g. silence
     if (PAutomaton->StatusEffectContainer->HasStatusEffect({ EFFECT_SILENCE, EFFECT_MUTE }))
@@ -1629,7 +1626,7 @@ bool CAutomatonController::CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndC
     return PAutomaton->PAI->CanChangeState();
 }
 
-bool CAutomatonController::Cast(uint16 targid, SpellID spellid)
+auto CAutomatonController::Cast(uint16 targid, SpellID spellid) -> bool
 {
     if (!automaton::CanUseSpell(PAutomaton, spellid) || PAutomaton->PRecastContainer->HasRecast(RECAST_MAGIC, static_cast<Recast>(spellid), 0s))
     {
@@ -1639,7 +1636,7 @@ bool CAutomatonController::Cast(uint16 targid, SpellID spellid)
     return CPetController::Cast(targid, spellid);
 }
 
-bool CAutomatonController::MobSkill(uint16 targid, uint16 wsid, std::optional<timer::duration> castTimeOverride)
+auto CAutomatonController::MobSkill(uint16 targid, uint16 wsid, std::optional<timer::duration> castTimeOverride) -> bool
 {
     if (PAutomaton->PRecastContainer->HasRecast(RECAST_ABILITY, static_cast<Recast>(wsid), 0s))
     {
@@ -1648,7 +1645,7 @@ bool CAutomatonController::MobSkill(uint16 targid, uint16 wsid, std::optional<ti
     return CPetController::MobSkill(targid, wsid, castTimeOverride);
 }
 
-bool CAutomatonController::Disengage()
+auto CAutomatonController::Disengage() -> bool
 {
     PTarget = nullptr;
     if (shouldStandBack())

--- a/src/map/ai/controllers/automaton_controller.h
+++ b/src/map/ai/controllers/automaton_controller.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _AUTOMATONCONTROLLER_H
-#define _AUTOMATONCONTROLLER_H
+#pragma once
 
 #include "entities/automatonentity.h"
 #include "pet_controller.h"
@@ -62,7 +61,7 @@ class CAutomatonController : public CPetController
 public:
     CAutomatonController(CAutomatonEntity* PPet);
 
-    virtual bool Disengage() override;
+    virtual auto Disengage() -> bool override;
 
 protected:
     virtual void DoCombatTick(timer::time_point tick) override;
@@ -70,25 +69,25 @@ protected:
 
     void         setCooldowns();
     void         setMagicCooldowns();
-    virtual bool CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) override;
-    virtual bool Cast(uint16 targid, SpellID spellid) override;
-    virtual bool MobSkill(uint16 targid, uint16 wsid, std::optional<timer::duration> castTimeOverride) override;
+    virtual auto CanCastSpells(IgnoreRecastsAndCosts ignoreRecastsAndCosts) -> bool override;
+    virtual auto Cast(uint16 targid, SpellID spellid) -> bool override;
+    virtual auto MobSkill(uint16 targid, uint16 wsid, std::optional<timer::duration> castTimeOverride) -> bool override;
 
 private:
-    bool TryAction();
-    bool TryShieldBash();
-    bool TrySpellcast(const CurrentManeuvers& maneuvers);
-    bool TryHeal(const CurrentManeuvers& maneuvers);
-    bool TryElemental(const CurrentManeuvers& maneuvers);
-    bool TryEnfeeble(const CurrentManeuvers& maneuvers);
-    bool TryStatusRemoval(const CurrentManeuvers& maneuvers);
-    bool TryEnhance();
-    bool TryTPMove();
-    bool TryRangedAttack();
-    bool TryAttachment();
-    bool shouldStandBack();
+    auto TryAction() -> bool;
+    auto TryShieldBash() -> bool;
+    auto TrySpellcast(const CurrentManeuvers& maneuvers) -> bool;
+    auto TryHeal(const CurrentManeuvers& maneuvers) -> bool;
+    auto TryElemental(const CurrentManeuvers& maneuvers) -> bool;
+    auto TryEnfeeble(const CurrentManeuvers& maneuvers) -> bool;
+    auto TryStatusRemoval(const CurrentManeuvers& maneuvers) -> bool;
+    auto TryEnhance() -> bool;
+    auto TryTPMove() -> bool;
+    auto TryRangedAttack() -> bool;
+    auto TryAttachment() -> bool;
+    auto shouldStandBack() const -> bool;
 
-    CurrentManeuvers GetCurrentManeuvers() const;
+    auto GetCurrentManeuvers() const -> CurrentManeuvers;
 
     CAutomatonEntity* PAutomaton;
 
@@ -118,12 +117,10 @@ private:
 namespace automaton
 {
 
-void                   LoadAutomatonSpellList();
-bool                   CanUseSpell(CAutomatonEntity* PCaster, SpellID spellid);
-bool                   CanUseEnfeeble(CBattleEntity* PTarget, SpellID spell);
-std::optional<SpellID> FindNaSpell(CStatusEffect* PStatus);
-void                   LoadAutomatonAbilities();
+void LoadAutomatonSpellList();
+auto CanUseSpell(CAutomatonEntity* PCaster, SpellID spellid) -> bool;
+auto CanUseEnfeeble(CBattleEntity* PTarget, SpellID spell) -> bool;
+auto FindNaSpell(CStatusEffect* PStatus) -> std::optional<SpellID>;
+void LoadAutomatonAbilities();
 
 }; // namespace automaton
-
-#endif

--- a/src/map/entities/automatonentity.cpp
+++ b/src/map/entities/automatonentity.cpp
@@ -29,6 +29,7 @@
 #include "common/tracy.h"
 #include "common/utils.h"
 #include "enmity_container.h"
+#include "enums/automaton.h"
 #include "recast_container.h"
 #include "status_effect_container.h"
 #include "utils/mobutils.h"
@@ -46,22 +47,22 @@ CAutomatonEntity::~CAutomatonEntity()
     TracyZoneScoped;
 }
 
-AUTOFRAMETYPE CAutomatonEntity::getFrame() const
+auto CAutomatonEntity::getFrame() const -> AutomatonFrame
 {
-    return (AUTOFRAMETYPE)m_Equip.Frame;
+    return m_Equip.Frame;
 }
 
-AUTOHEADTYPE CAutomatonEntity::getHead() const
+auto CAutomatonEntity::getHead() const -> AutomatonHead
 {
-    return (AUTOHEADTYPE)m_Equip.Head;
+    return m_Equip.Head;
 }
 
-uint8 CAutomatonEntity::getAttachment(uint8 slotid)
+uint8 CAutomatonEntity::getAttachment(const uint8 slotid) const
 {
     return m_Equip.Attachments[slotid];
 }
 
-bool CAutomatonEntity::hasAttachment(uint8 attachment)
+auto CAutomatonEntity::hasAttachment(const uint8 attachment) const -> bool
 {
     for (auto&& attachmentid : m_Equip.Attachments)
     {
@@ -73,12 +74,12 @@ bool CAutomatonEntity::hasAttachment(uint8 attachment)
     return false;
 }
 
-uint8 CAutomatonEntity::getElementMax(uint8 element)
+auto CAutomatonEntity::getElementMax(const uint8 element) const -> uint8
 {
     return m_ElementMax[element];
 }
 
-uint8 CAutomatonEntity::getElementCapacity(uint8 element)
+auto CAutomatonEntity::getElementCapacity(const uint8 element) const -> uint8
 {
     return m_ElementEquip[element];
 }
@@ -94,22 +95,22 @@ void CAutomatonEntity::burdenTick()
     }
 }
 
-auto CAutomatonEntity::getBurden() -> std::array<uint8, 8>
+auto CAutomatonEntity::getBurden() const -> std::array<uint8, 8>
 {
     return m_Burden;
 }
 
-void CAutomatonEntity::setAllBurden(uint8 burden)
+void CAutomatonEntity::setAllBurden(const uint8 burden)
 {
     m_Burden.fill(burden);
 }
 
-void CAutomatonEntity::setBurdenArray(std::array<uint8, 8> burdenArray)
+void CAutomatonEntity::setBurdenArray(const std::array<uint8, 8> burdenArray)
 {
     m_Burden = burdenArray;
 }
 
-uint8 CAutomatonEntity::addBurden(uint8 element, int8 burden)
+auto CAutomatonEntity::addBurden(const uint8 element, int8 burden) -> uint8
 {
     // Handle Kenkonken Suppress Overload
     if (PMaster->getMod(Mod::SUPPRESS_OVERLOAD) > 0)
@@ -123,7 +124,7 @@ uint8 CAutomatonEntity::addBurden(uint8 element, int8 burden)
     if (burden > 0)
     {
         // check for overload
-        int16 thresh = 30 + PMaster->getMod(Mod::OVERLOAD_THRESH);
+        const int16 thresh = 30 + PMaster->getMod(Mod::OVERLOAD_THRESH);
         if (m_Burden[element] > thresh)
         {
             if (xirand::GetRandomNumber(100) < (m_Burden[element] - thresh + 5))
@@ -136,9 +137,9 @@ uint8 CAutomatonEntity::addBurden(uint8 element, int8 burden)
     return 0;
 }
 
-uint8 CAutomatonEntity::getOverloadChance(uint8 element)
+auto CAutomatonEntity::getOverloadChance(const uint8 element) const -> uint8
 {
-    int16 thresh = 30 + PMaster->getMod(Mod::OVERLOAD_THRESH);
+    const int16 thresh = 30 + PMaster->getMod(Mod::OVERLOAD_THRESH);
 
     return std::clamp(m_Burden[element] - thresh + 5, 0, 255);
 }

--- a/src/map/entities/automatonentity.h
+++ b/src/map/entities/automatonentity.h
@@ -19,34 +19,17 @@
 ===========================================================================
 */
 
-#ifndef _CAUTOMATONENTITY_H
-#define _CAUTOMATONENTITY_H
+#pragma once
 
+#include "enums/automaton.h"
 #include "petentity.h"
+
 #include <array>
-
-enum AUTOFRAMETYPE
-{
-    FRAME_HARLEQUIN  = 0x20,
-    FRAME_VALOREDGE  = 0x21,
-    FRAME_SHARPSHOT  = 0x22,
-    FRAME_STORMWAKER = 0x23
-};
-
-enum AUTOHEADTYPE
-{
-    HEAD_HARLEQUIN    = 0x01,
-    HEAD_VALOREDGE    = 0x02,
-    HEAD_SHARPSHOT    = 0x03,
-    HEAD_STORMWAKER   = 0x04,
-    HEAD_SOULSOOTHER  = 0x05,
-    HEAD_SPIRITREAVER = 0x06
-};
 
 struct automaton_equip_t
 {
-    uint8                 Frame;
-    uint8                 Head;
+    AutomatonFrame        Frame;
+    AutomatonHead         Head;
     std::array<uint8, 12> Attachments;
 };
 
@@ -62,27 +45,27 @@ public:
     std::array<uint8, 8> m_ElementMax{};
     std::array<uint8, 8> m_ElementEquip{};
 
-    AUTOFRAMETYPE getFrame() const;
-    AUTOHEADTYPE  getHead() const;
-    uint8         getAttachment(uint8 slot);
-    bool          hasAttachment(uint8 attachment);
+    auto getFrame() const -> AutomatonFrame;
+    auto getHead() const -> AutomatonHead;
+    auto getAttachment(uint8 slotid) const -> uint8;
+    auto hasAttachment(uint8 attachment) const -> bool;
 
-    uint8 getElementMax(uint8 element);
-    uint8 getElementCapacity(uint8 element);
+    auto getElementMax(uint8 element) const -> uint8;
+    auto getElementCapacity(uint8 element) const -> uint8;
 
-    void  burdenTick();
-    auto  getBurden() -> std::array<uint8, 8>;
-    void  setAllBurden(uint8 burden);
-    void  setBurdenArray(std::array<uint8, 8> burdenArray);
-    uint8 addBurden(uint8 element, int8 burden);
-    uint8 getOverloadChance(uint8 element);
+    void burdenTick();
+    auto getBurden() const -> std::array<uint8, 8>;
+    void setAllBurden(uint8 burden);
+    void setBurdenArray(std::array<uint8, 8> burdenArray);
+    auto addBurden(uint8 element, int8 burden) -> uint8;
+    auto getOverloadChance(uint8 element) const -> uint8;
 
     void PostTick() override;
 
     virtual void Spawn() override;
     virtual void Die() override;
 
-    virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
+    virtual auto ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) -> bool override;
 
     virtual void OnMobSkillFinished(CMobSkillState&, action_t&) override;
     virtual void OnCastFinished(CMagicState&, action_t&) override;
@@ -90,5 +73,3 @@ public:
 private:
     std::array<uint8, 8> m_Burden{};
 };
-
-#endif

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -652,31 +652,31 @@ auto CCharEntity::shouldPetPersistThroughZoning() const -> bool
            (petType == PET_TYPE::JUG_PET && settings::get<bool>("map.KEEP_JUGPET_THROUGH_ZONING"));
 }
 
-void CCharEntity::setAutomatonFrame(AUTOFRAMETYPE frame)
+void CCharEntity::setAutomatonFrame(const AutomatonFrame frame)
 {
     automatonInfo.m_Equip.Frame = frame;
 }
 
-void CCharEntity::setAutomatonHead(AUTOHEADTYPE head)
+void CCharEntity::setAutomatonHead(const AutomatonHead head)
 {
     automatonInfo.m_Equip.Head = head;
 }
 
-void CCharEntity::setAutomatonAttachment(uint8 slotid, uint8 id)
+void CCharEntity::setAutomatonAttachment(const uint8 slotid, const uint8 id)
 {
     automatonInfo.m_Equip.Attachments[slotid] = id;
 }
 
-void CCharEntity::setAutomatonElementMax(uint8 element, uint8 max)
+void CCharEntity::setAutomatonElementMax(const uint8 element, const uint8 max)
 {
     automatonInfo.m_ElementMax[element] = max;
 }
-void CCharEntity::addAutomatonElementCapacity(uint8 element, int8 value)
+void CCharEntity::addAutomatonElementCapacity(const uint8 element, const int8 value)
 {
     automatonInfo.m_ElementEquip[element] += value;
 }
 
-void CCharEntity::setAutomatonElementalCapacityBonus(uint8 bonus)
+void CCharEntity::setAutomatonElementalCapacityBonus(const uint8 bonus)
 {
     if (bonus == automatonInfo.m_elementalCapacityBonus)
     {
@@ -692,22 +692,22 @@ void CCharEntity::setAutomatonElementalCapacityBonus(uint8 bonus)
     automatonInfo.m_elementalCapacityBonus = bonus;
 }
 
-AUTOFRAMETYPE CCharEntity::getAutomatonFrame() const
+auto CCharEntity::getAutomatonFrame() const -> AutomatonFrame
 {
-    return static_cast<AUTOFRAMETYPE>(automatonInfo.m_Equip.Frame);
+    return automatonInfo.m_Equip.Frame;
 }
 
-AUTOHEADTYPE CCharEntity::getAutomatonHead() const
+auto CCharEntity::getAutomatonHead() const -> AutomatonHead
 {
-    return static_cast<AUTOHEADTYPE>(automatonInfo.m_Equip.Head);
+    return automatonInfo.m_Equip.Head;
 }
 
-uint8 CCharEntity::getAutomatonAttachment(uint8 slotid)
+auto CCharEntity::getAutomatonAttachment(const uint8 slotid) const -> uint8
 {
     return automatonInfo.m_Equip.Attachments[slotid];
 }
 
-bool CCharEntity::hasAutomatonAttachment(uint8 attachment)
+auto CCharEntity::hasAutomatonAttachment(const uint8 attachment) const -> bool
 {
     for (auto&& attachmentid : automatonInfo.m_Equip.Attachments)
     {
@@ -719,12 +719,12 @@ bool CCharEntity::hasAutomatonAttachment(uint8 attachment)
     return false;
 }
 
-uint8 CCharEntity::getAutomatonElementMax(uint8 element)
+auto CCharEntity::getAutomatonElementMax(const uint8 element) const -> uint8
 {
     return automatonInfo.m_ElementMax[element];
 }
 
-uint8 CCharEntity::getAutomatonElementCapacity(uint8 element)
+auto CCharEntity::getAutomatonElementCapacity(const uint8 element) const -> uint8
 {
     return automatonInfo.m_ElementEquip[element];
 }

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -370,19 +370,19 @@ public:
     };
     automatonInfo_t automatonInfo{};
 
-    uint8 getAutomatonAttachment(uint8 slot);
-    bool  hasAutomatonAttachment(uint8 attachment);
+    auto getAutomatonAttachment(uint8 slotid) const -> uint8;
+    auto hasAutomatonAttachment(uint8 attachment) const -> bool;
 
-    uint8 getAutomatonElementMax(uint8 element);
-    uint8 getAutomatonElementCapacity(uint8 element);
+    auto getAutomatonElementMax(uint8 element) const -> uint8;
+    auto getAutomatonElementCapacity(uint8 element) const -> uint8;
 
-    AUTOFRAMETYPE getAutomatonFrame() const;
-    AUTOHEADTYPE  getAutomatonHead() const;
+    auto getAutomatonFrame() const -> AutomatonFrame;
+    auto getAutomatonHead() const -> AutomatonHead;
 
-    void setAutomatonFrame(AUTOFRAMETYPE frame);
-    void setAutomatonHead(AUTOHEADTYPE head);
+    void setAutomatonFrame(AutomatonFrame frame);
+    void setAutomatonHead(AutomatonHead head);
 
-    void setAutomatonAttachment(uint8 slot, uint8 id);
+    void setAutomatonAttachment(uint8 slotid, uint8 id);
 
     void setAutomatonElementMax(uint8 element, uint8 max);
     void addAutomatonElementCapacity(uint8 element, int8 value);

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -7,6 +7,7 @@ set(ENUMS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/action/proc_kind.h
     ${CMAKE_CURRENT_SOURCE_DIR}/action/react_kind.h
     ${CMAKE_CURRENT_SOURCE_DIR}/action/resolution.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/automaton.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_area.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_type.h
     ${CMAKE_CURRENT_SOURCE_DIR}/emote.h

--- a/src/map/enums/automaton.h
+++ b/src/map/enums/automaton.h
@@ -1,0 +1,48 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+enum class AutomatonFrame : uint8
+{
+    Harlequin  = 0x20,
+    Valoredge  = 0x21,
+    Sharpshot  = 0x22,
+    Stormwaker = 0x23,
+};
+
+enum class AutomatonHead : uint8
+{
+    Harlequin    = 0x01,
+    Valoredge    = 0x02,
+    Sharpshot    = 0x03,
+    Stormwaker   = 0x04,
+    Soulsoother  = 0x05,
+    Spiritreaver = 0x06,
+};
+
+enum class AutomatonAttachment : uint8
+{
+    OpticFiber   = 198,
+    OpticFiberII = 206,
+};

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -95,6 +95,7 @@
 #include "entities/npcentity.h"
 #include "entities/petentity.h"
 #include "entities/trustentity.h"
+#include "enums/automaton.h"
 #include "enums/chat_message_area.h"
 #include "enums/item_lockflg.h"
 #include "items/item_furnishing.h"
@@ -16544,7 +16545,7 @@ void CLuaBaseEntity::delPetMod(uint16 modID, int16 amount)
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::hasAttachment(uint16 itemID)
+auto CLuaBaseEntity::hasAttachment(const uint16 itemID) const -> bool
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -16563,7 +16564,7 @@ bool CLuaBaseEntity::hasAttachment(uint16 itemID)
  *  Notes   :
  ************************************************************************/
 
-auto CLuaBaseEntity::getAutomatonName() -> std::string
+auto CLuaBaseEntity::getAutomatonName() const -> std::string
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -16587,35 +16588,40 @@ auto CLuaBaseEntity::getAutomatonName() -> std::string
 /************************************************************************
  *  Function: getAutomatonFrame()
  *  Purpose : Returns the integer value of frame being used for automation
- *  Example : local frame = pet:getAutomatonFrame()
+ *  Example : local frame = player:getAutomatonFrame()
  *  Notes   :
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getAutomatonFrame()
+auto CLuaBaseEntity::getAutomatonFrame() const -> std::optional<AutomatonFrame>
 {
     if (m_PBaseEntity->objtype == TYPE_PC)
     {
-        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-        return static_cast<uint8>(PChar->getAutomatonFrame());
-    }
-    else if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() == PET_TYPE::AUTOMATON)
-    {
-        auto* PAutomaton = static_cast<CAutomatonEntity*>(m_PBaseEntity);
-        return static_cast<uint8>(PAutomaton->getFrame());
+        auto frame = static_cast<CCharEntity*>(m_PBaseEntity)->getAutomatonFrame();
+        if (frame >= AutomatonFrame::Harlequin && frame <= AutomatonFrame::Stormwaker)
+        {
+            return frame;
+        }
+
+        return std::nullopt;
     }
 
-    ShowWarning("CLuaBaseEntity::getAutomatonFrame() - Entity is not a PC or an Automaton");
-    return 0;
+    if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() == PET_TYPE::AUTOMATON)
+    {
+        return static_cast<CAutomatonEntity*>(m_PBaseEntity)->getFrame();
+    }
+
+    ShowWarning("CLuaBaseEntity::getAutomatonFrame() - Entity is not a PC or an Automaton.");
+    return std::nullopt;
 }
 
 /************************************************************************
  *  Function: setAutomatonFrame(frameItemID)
  *  Purpose : Sets the provided frame on the automaton
- *  Example : player:setAutomatonFrame(xi.item.VALOREDGE_FRAME)
+ *  Example : player:setAutomatonFrame(xi.automaton.frame.VALOREDGE)
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::setAutomatonFrame(uint8 frameItemID)
+void CLuaBaseEntity::setAutomatonFrame(const AutomatonFrame frame) const
 {
     auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -16625,7 +16631,7 @@ void CLuaBaseEntity::setAutomatonFrame(uint8 frameItemID)
         return;
     }
 
-    puppetutils::setFrame(PChar, frameItemID - 0x2000);
+    puppetutils::setFrame(PChar, frame);
     charutils::SendExtendedJobPackets(PChar);
     puppetutils::SaveAutomaton(PChar);
 }
@@ -16633,35 +16639,40 @@ void CLuaBaseEntity::setAutomatonFrame(uint8 frameItemID)
 /************************************************************************
  *  Function: getAutomatonHead()
  *  Purpose : Returns the integer value of the (active?) automation head
- *  Example : local head = pet:getAutomatonHead()
- *  Notes   : Currently unscripted
- ************************************************************************/
-
-uint8 CLuaBaseEntity::getAutomatonHead()
-{
-    if (m_PBaseEntity->objtype == TYPE_PC)
-    {
-        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
-        return static_cast<uint8>(PChar->getAutomatonHead());
-    }
-    else if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() == PET_TYPE::AUTOMATON)
-    {
-        auto* PAutomaton = static_cast<CAutomatonEntity*>(m_PBaseEntity);
-        return static_cast<uint8>(PAutomaton->getHead());
-    }
-
-    ShowWarning("CLuaBaseEntity::getAutomatonFrame() - Entity is not a PC or an Automaton");
-    return 0;
-}
-
-/************************************************************************
- *  Function: setAutomatonHead(headItemID)
- *  Purpose : Sets the automaton head to the specified item
- *  Example : player:setAutomatonHead(xi.item.VALOREDGE_HEAD)
+ *  Example : local head = player:getAutomatonHead()
  *  Notes   :
  ************************************************************************/
 
-void CLuaBaseEntity::setAutomatonHead(uint8 headItemID)
+auto CLuaBaseEntity::getAutomatonHead() const -> std::optional<AutomatonHead>
+{
+    if (m_PBaseEntity->objtype == TYPE_PC)
+    {
+        auto head = static_cast<CCharEntity*>(m_PBaseEntity)->getAutomatonHead();
+        if (head >= AutomatonHead::Harlequin && head <= AutomatonHead::Spiritreaver)
+        {
+            return head;
+        }
+
+        return std::nullopt;
+    }
+
+    if (m_PBaseEntity->objtype == TYPE_PET && static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() == PET_TYPE::AUTOMATON)
+    {
+        return static_cast<CAutomatonEntity*>(m_PBaseEntity)->getHead();
+    }
+
+    ShowWarning("CLuaBaseEntity::getAutomatonHead() - Entity is not a PC or an Automaton.");
+    return std::nullopt;
+}
+
+/************************************************************************
+ *  Function: setAutomatonHead(head)
+ *  Purpose : Sets the automaton head to the specified item
+ *  Example : player:setAutomatonHead(xi.automaton.head.VALOREDGE)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::setAutomatonHead(const AutomatonHead head) const
 {
     auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
 
@@ -16671,7 +16682,7 @@ void CLuaBaseEntity::setAutomatonHead(uint8 headItemID)
         return;
     }
 
-    puppetutils::setHead(PChar, headItemID - 0x2000);
+    puppetutils::setHead(PChar, head);
     charutils::SendExtendedJobPackets(PChar);
     puppetutils::SaveAutomaton(PChar);
 }
@@ -16683,7 +16694,7 @@ void CLuaBaseEntity::setAutomatonHead(uint8 headItemID)
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::unlockAttachment(uint16 itemID)
+auto CLuaBaseEntity::unlockAttachment(const uint16 itemID) const -> bool
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -16702,7 +16713,7 @@ bool CLuaBaseEntity::unlockAttachment(uint16 itemID)
  *  Notes   :
  ************************************************************************/
 
-uint8 CLuaBaseEntity::getActiveManeuverCount()
+uint8 CLuaBaseEntity::getActiveManeuverCount() const
 {
     auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PEntity)
@@ -16721,7 +16732,7 @@ uint8 CLuaBaseEntity::getActiveManeuverCount()
  *  Notes   : Often used if (target:getActiveManeuverCount() == 3)
  ************************************************************************/
 
-void CLuaBaseEntity::removeOldestManeuver()
+void CLuaBaseEntity::removeOldestManeuver() const
 {
     auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PEntity)
@@ -16740,7 +16751,7 @@ void CLuaBaseEntity::removeOldestManeuver()
  *  Notes   : Often used if (overload ~= 0)
  ************************************************************************/
 
-void CLuaBaseEntity::removeAllManeuvers()
+void CLuaBaseEntity::removeAllManeuvers() const
 {
     auto* PEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (!PEntity)
@@ -16804,7 +16815,7 @@ void CLuaBaseEntity::setAttachment(const uint8 attachmentItemID, const uint8 slo
  *  Example : pet:getAttachments()
  ************************************************************************/
 
-sol::table CLuaBaseEntity::getAttachments()
+auto CLuaBaseEntity::getAttachments() const -> sol::table
 {
     auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(m_PBaseEntity);
 
@@ -16835,7 +16846,7 @@ sol::table CLuaBaseEntity::getAttachments()
  *  Notes   : Called when Optic Fiber has changed.
  ************************************************************************/
 
-void CLuaBaseEntity::updateAttachments()
+void CLuaBaseEntity::updateAttachments() const
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {
@@ -16855,7 +16866,7 @@ void CLuaBaseEntity::updateAttachments()
  *            after percentage is applied.
  ************************************************************************/
 
-void CLuaBaseEntity::reduceBurden(float percentReduction, const sol::object& intReductionObj)
+void CLuaBaseEntity::reduceBurden(const float percentReduction, const sol::object& intReductionObj) const
 {
     if (m_PBaseEntity->objtype == TYPE_NPC)
     {
@@ -16889,7 +16900,7 @@ void CLuaBaseEntity::reduceBurden(float percentReduction, const sol::object& int
  *  Notes   :
  ************************************************************************/
 
-bool CLuaBaseEntity::isExceedingElementalCapacity()
+auto CLuaBaseEntity::isExceedingElementalCapacity() const -> bool
 {
     if (m_PBaseEntity->objtype != TYPE_PC)
     {

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -809,22 +809,22 @@ public:
     void setPetMod(uint16 modID, int16 amount);
     void delPetMod(uint16 modID, int16 amount);
 
-    bool  hasAttachment(uint16 itemID);
-    auto  getAutomatonName() -> std::string;
-    uint8 getAutomatonFrame();
-    void  setAutomatonFrame(uint8 frameItemID);
-    uint8 getAutomatonHead();
-    void  setAutomatonHead(uint8 headItemID);
-    bool  unlockAttachment(uint16 itemID);
-    uint8 getActiveManeuverCount();
-    void  removeOldestManeuver();
-    void  removeAllManeuvers();
-    auto  getAttachment(uint8 slotId) const -> CItem*;
-    auto  getAttachments() -> sol::table;
-    void  setAttachment(uint8 attachmentItemID, uint8 slotID) const;
-    void  updateAttachments();
-    void  reduceBurden(float percentReduction, const sol::object& intReductionObj);
-    bool  isExceedingElementalCapacity();
+    auto hasAttachment(uint16 itemID) const -> bool;
+    auto getAutomatonName() const -> std::string;
+    auto getAutomatonFrame() const -> std::optional<AutomatonFrame>;
+    void setAutomatonFrame(AutomatonFrame frame) const;
+    auto getAutomatonHead() const -> std::optional<AutomatonHead>;
+    void setAutomatonHead(AutomatonHead head) const;
+    auto unlockAttachment(uint16 itemID) const -> bool;
+    auto getActiveManeuverCount() const -> uint8;
+    void removeOldestManeuver() const;
+    void removeAllManeuvers() const;
+    auto getAttachment(uint8 slotId) const -> CItem*;
+    auto getAttachments() const -> sol::table;
+    void setAttachment(uint8 attachmentItemID, uint8 slotID) const;
+    void updateAttachments() const;
+    void reduceBurden(float percentReduction, const sol::object& intReductionObj) const;
+    auto isExceedingElementalCapacity() const -> bool;
 
     auto   getAllRuneEffects() -> sol::table;
     uint8  getActiveRuneCount();

--- a/src/map/packets/c2s/0x102_extended_job.cpp
+++ b/src/map/packets/c2s/0x102_extended_job.cpp
@@ -221,12 +221,12 @@ void GP_CLI_COMMAND_EXTENDED_JOB::process(MapSession* PSession, CCharEntity* PCh
         {
             if (pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Head)] != 0)
             {
-                puppetutils::setHead(PChar, pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Head)]);
+                puppetutils::setHead(PChar, static_cast<AutomatonHead>(pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Head)]));
                 petutils::CalculateAutomatonStats(PChar, PChar->PPet);
             }
             else if (pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Frame)] != 0)
             {
-                puppetutils::setFrame(PChar, pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Frame)]);
+                puppetutils::setFrame(PChar, static_cast<AutomatonFrame>(pupData.Slots[static_cast<uint8_t>(AutomatonSlot::Frame)]));
                 petutils::CalculateAutomatonStats(PChar, PChar->PPet);
             }
             else

--- a/src/map/packets/s2c/0x044_extended_job_pup.h
+++ b/src/map/packets/s2c/0x044_extended_job_pup.h
@@ -24,6 +24,7 @@
 #include "common/cbasetypes.h"
 
 #include "base.h"
+#include "enums/automaton.h"
 
 class CCharEntity;
 
@@ -37,45 +38,45 @@ class PUP final : public GP_SERV_PACKET<PacketS2C::GP_SERV_COMMAND_EXTENDED_JOB,
 public:
     struct PacketData
     {
-        uint8_t  Job;      // PS2: Job
-        uint8_t  IsSubJob; // PS2: IsSubJob
-        uint8_t  padding00[2];
-        uint8_t  Head;
-        uint8_t  Frame;
-        uint8_t  Attachments[12];
-        uint8_t  unknown00[2];
-        uint32_t UnlockedHeads;
-        uint32_t UnlockedFrames;
-        uint8_t  padding01[24];
-        uint32_t UnlockedAttachments[8];
-        char     Name[16]; // assumed to be 16, longest name is 14 chars.
-        uint16_t HP;
-        uint16_t MaxHP;
-        uint16_t MP;
-        uint16_t MaxMP;
-        uint16_t MeleeSkill;
-        uint16_t MeleeSkillCap;
-        uint16_t RangedSkill;
-        uint16_t RangedSkillCap;
-        uint16_t MagicSkill;
-        uint16_t MagicSkillCap;
-        uint8_t  padding03[4];
-        uint16_t STR;
-        uint16_t BonusSTR;
-        uint16_t DEX;
-        uint16_t BonusDEX;
-        uint16_t VIT;
-        uint16_t BonusVIT;
-        uint16_t AGI;
-        uint16_t BonusAGI;
-        uint16_t INT;
-        uint16_t BonusINT;
-        uint16_t MND;
-        uint16_t BonusMND;
-        uint16_t CHR;
-        uint16_t BonusCHR;
-        uint8_t  BonusElementalCapacity;
-        uint8_t  padding04[3];
+        uint8_t        Job;      // PS2: Job
+        uint8_t        IsSubJob; // PS2: IsSubJob
+        uint8_t        padding00[2];
+        AutomatonHead  Head;
+        AutomatonFrame Frame;
+        uint8_t        Attachments[12];
+        uint8_t        unknown00[2];
+        uint32_t       UnlockedHeads;
+        uint32_t       UnlockedFrames;
+        uint8_t        padding01[24];
+        uint32_t       UnlockedAttachments[8];
+        char           Name[16]; // assumed to be 16, longest name is 14 chars.
+        uint16_t       HP;
+        uint16_t       MaxHP;
+        uint16_t       MP;
+        uint16_t       MaxMP;
+        uint16_t       MeleeSkill;
+        uint16_t       MeleeSkillCap;
+        uint16_t       RangedSkill;
+        uint16_t       RangedSkillCap;
+        uint16_t       MagicSkill;
+        uint16_t       MagicSkillCap;
+        uint8_t        padding03[4];
+        uint16_t       STR;
+        uint16_t       BonusSTR;
+        uint16_t       DEX;
+        uint16_t       BonusDEX;
+        uint16_t       VIT;
+        uint16_t       BonusVIT;
+        uint16_t       AGI;
+        uint16_t       BonusAGI;
+        uint16_t       INT;
+        uint16_t       BonusINT;
+        uint16_t       MND;
+        uint16_t       BonusMND;
+        uint16_t       CHR;
+        uint16_t       BonusCHR;
+        uint8_t        BonusElementalCapacity;
+        uint8_t        padding04[3];
     };
 
     PUP(CCharEntity* PChar, bool mjob);

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -49,6 +49,7 @@
 #include "ai/controllers/pet_controller.h"
 #include "ai/states/ability_state.h"
 
+#include "enums/automaton.h"
 #include "mob_modifier.h"
 #include "packets/char_status.h"
 #include "packets/entity_update.h"
@@ -592,21 +593,21 @@ void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats,
 
         switch (PAutomaton->getFrame())
         {
-            default: // case FRAME_HARLEQUIN:
+            default: // case AutomatonFrame::Harlequin:
                 tempSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl));
                 break;
-            case FRAME_VALOREDGE:
+            case AutomatonFrame::Valoredge:
                 PPet->setModifier(Mod::SHIELDBLOCKRATE, 45);
                 PPet->setMobMod(MOBMOD_CAN_SHIELD_BLOCK, 1);
                 tempSkills.evasion = battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl));
                 break;
-            case FRAME_SHARPSHOT:
+            case AutomatonFrame::Sharpshot:
                 tempSkills.evasion = battleutils::GetMaxSkill(1, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
                 break;
-            case FRAME_STORMWAKER:
+            case AutomatonFrame::Stormwaker:
                 tempSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
                 break;
@@ -1021,19 +1022,19 @@ void CalculateAutomatonStats(CBattleEntity* PMaster, CBattleEntity* PPet)
 
         switch (PChar->getAutomatonFrame())
         {
-            default: // case FRAME_HARLEQUIN:
+            default: // case AutomatonFrame::Harlequin:
                 mjob = JOB_WAR;
                 sjob = JOB_RDM;
                 break;
-            case FRAME_VALOREDGE:
+            case AutomatonFrame::Valoredge:
                 mjob = JOB_PLD;
                 sjob = JOB_WAR;
                 break;
-            case FRAME_SHARPSHOT:
+            case AutomatonFrame::Sharpshot:
                 mjob = JOB_RNG;
                 sjob = JOB_PUP;
                 break;
-            case FRAME_STORMWAKER:
+            case AutomatonFrame::Stormwaker:
                 mjob = JOB_RDM;
                 sjob = JOB_WHM;
                 break;
@@ -1053,16 +1054,16 @@ void CalculateAutomatonStats(CBattleEntity* PMaster, CBattleEntity* PPet)
         {
             switch (PChar->getAutomatonFrame())
             {
-                case FRAME_VALOREDGE:
+                case AutomatonFrame::Valoredge:
                     petID = PETID_VALOREDGEFRAME;
                     break;
-                case FRAME_SHARPSHOT:
+                case AutomatonFrame::Sharpshot:
                     petID = PETID_SHARPSHOTFRAME;
                     break;
-                case FRAME_STORMWAKER:
+                case AutomatonFrame::Stormwaker:
                     petID = PETID_STORMWAKERFRAME;
                     break;
-                case FRAME_HARLEQUIN:
+                case AutomatonFrame::Harlequin:
                 default:
                     petID = PETID_HARLEQUINFRAME;
                     break;

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -23,7 +23,8 @@
 #include "battleutils.h"
 #include "charutils.h"
 #include "entities/automatonentity.h"
-#include "instance.h"
+#include "enums/automaton.h"
+#include "items/item_puppet.h"
 #include "itemutils.h"
 #include "job_points.h"
 #include "lua/luautils.h"
@@ -34,6 +35,87 @@
 
 namespace puppetutils
 {
+
+namespace
+{
+// Returns automaton model ID for given frame and head
+auto calculateAutomatonModel(const AutomatonFrame frame, const AutomatonHead head) -> uint16
+{
+    switch (frame)
+    {
+        case AutomatonFrame::Harlequin:
+            switch (head)
+            {
+                case AutomatonHead::Harlequin:
+                    return 0x07B9;
+                case AutomatonHead::Valoredge:
+                    return 0x07BA;
+                case AutomatonHead::Sharpshot:
+                    return 0x07BC;
+                case AutomatonHead::Stormwaker:
+                    return 0x07BB;
+                case AutomatonHead::Soulsoother:
+                    return 0x07D3;
+                case AutomatonHead::Spiritreaver:
+                    return 0x07D7;
+            }
+            break;
+        case AutomatonFrame::Valoredge:
+            switch (head)
+            {
+                case AutomatonHead::Harlequin:
+                    return 0x07BE;
+                case AutomatonHead::Valoredge:
+                    return 0x07BF;
+                case AutomatonHead::Sharpshot:
+                    return 0x07C1;
+                case AutomatonHead::Stormwaker:
+                    return 0x07C0;
+                case AutomatonHead::Soulsoother:
+                    return 0x07D4;
+                case AutomatonHead::Spiritreaver:
+                    return 0x07D8;
+            }
+            break;
+        case AutomatonFrame::Sharpshot:
+            switch (head)
+            {
+                case AutomatonHead::Harlequin:
+                    return 0x07C3;
+                case AutomatonHead::Valoredge:
+                    return 0x07C4;
+                case AutomatonHead::Sharpshot:
+                    return 0x07C6;
+                case AutomatonHead::Stormwaker:
+                    return 0x07C5;
+                case AutomatonHead::Soulsoother:
+                    return 0x07D5;
+                case AutomatonHead::Spiritreaver:
+                    return 0x07D9;
+            }
+            break;
+        case AutomatonFrame::Stormwaker:
+            switch (head)
+            {
+                case AutomatonHead::Harlequin:
+                    return 0x07C8;
+                case AutomatonHead::Valoredge:
+                    return 0x07C9;
+                case AutomatonHead::Sharpshot:
+                    return 0x07CB;
+                case AutomatonHead::Stormwaker:
+                    return 0x07CA;
+                case AutomatonHead::Soulsoother:
+                    return 0x07D6;
+                case AutomatonHead::Spiritreaver:
+                    return 0x07DA;
+            }
+            break;
+    }
+
+    return 0x07B9; // Fallback: Harlequin frame + Harlequin head
+}
+} // namespace
 
 void LoadAutomaton(CCharEntity* PChar)
 {
@@ -62,15 +144,15 @@ void LoadAutomaton(CCharEntity* PChar)
 
             // If any of this happens then the Automaton failed to load properly and should just reset (Should only occur with older characters or if DB is
             // missing)
-            if (tempEquip.Head < HEAD_HARLEQUIN ||
-                tempEquip.Head > HEAD_SPIRITREAVER ||
-                tempEquip.Frame < FRAME_HARLEQUIN ||
-                tempEquip.Frame > FRAME_STORMWAKER)
+            if (tempEquip.Head < AutomatonHead::Harlequin ||
+                tempEquip.Head > AutomatonHead::Spiritreaver ||
+                tempEquip.Frame < AutomatonFrame::Harlequin ||
+                tempEquip.Frame > AutomatonFrame::Stormwaker)
             {
-                PChar->setAutomatonHead(HEAD_HARLEQUIN);
-                tempEquip.Head = HEAD_HARLEQUIN;
-                PChar->setAutomatonFrame(FRAME_HARLEQUIN);
-                tempEquip.Frame = FRAME_HARLEQUIN;
+                PChar->setAutomatonHead(AutomatonHead::Harlequin);
+                tempEquip.Head = AutomatonHead::Harlequin;
+                PChar->setAutomatonFrame(AutomatonFrame::Harlequin);
+                tempEquip.Frame = AutomatonFrame::Harlequin;
 
                 for (int i = 0; i < 12; i++)
                 {
@@ -102,7 +184,8 @@ void LoadAutomaton(CCharEntity* PChar)
             // Always load Optic Fiber and Optic Fiber II first
             for (int i = 0; i < 12; i++)
             {
-                if (tempEquip.Attachments[i] == 198 || tempEquip.Attachments[i] == 206)
+                if (static_cast<AutomatonAttachment>(tempEquip.Attachments[i]) == AutomatonAttachment::OpticFiber ||
+                    static_cast<AutomatonAttachment>(tempEquip.Attachments[i]) == AutomatonAttachment::OpticFiberII)
                 {
                     setAttachment(PChar, i, tempEquip.Attachments[i]);
                 }
@@ -110,7 +193,8 @@ void LoadAutomaton(CCharEntity* PChar)
 
             for (int i = 0; i < 12; i++)
             {
-                if (tempEquip.Attachments[i] != 198 && tempEquip.Attachments[i] != 206)
+                if (static_cast<AutomatonAttachment>(tempEquip.Attachments[i]) != AutomatonAttachment::OpticFiber &&
+                    static_cast<AutomatonAttachment>(tempEquip.Attachments[i]) != AutomatonAttachment::OpticFiberII)
                 {
                     setAttachment(PChar, i, tempEquip.Attachments[i]);
                 }
@@ -140,20 +224,19 @@ void SaveAutomaton(CCharEntity* PChar)
     }
 }
 
-bool UnlockAttachment(CCharEntity* PChar, CItem* PItem)
+auto UnlockAttachment(CCharEntity* PChar, CItem* PItem) -> bool
 {
-    uint16 id = PItem->getID();
+    const uint16 id = PItem->getID();
 
     if (!PItem->isType(ITEM_PUPPET))
     {
         return false;
     }
 
-    uint8 slot = ((CItemPuppet*)PItem)->getEquipSlot();
-
-    if (slot == 3) // automaton attachment
+    const uint8 slot = static_cast<CItemPuppet*>(PItem)->getEquipSlot();
+    if (slot == ITEM_PUPPET_ATTACHMENT)
     {
-        if (addBit(id & 0xFF, (uint8*)PChar->m_unlockedAttachments.attachments, sizeof(PChar->m_unlockedAttachments.attachments)))
+        if (addBit(id & 0xFF, reinterpret_cast<uint8*>(PChar->m_unlockedAttachments.attachments), sizeof(PChar->m_unlockedAttachments.attachments)))
         {
             SaveAttachments(PChar);
             charutils::SendExtendedJobPackets(PChar);
@@ -161,7 +244,7 @@ bool UnlockAttachment(CCharEntity* PChar, CItem* PItem)
         }
         return false;
     }
-    else if (slot == 2) // automaton frame
+    else if (slot == ITEM_PUPPET_FRAME)
     {
         if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.frames, sizeof(PChar->m_unlockedAttachments.frames)))
         {
@@ -171,7 +254,7 @@ bool UnlockAttachment(CCharEntity* PChar, CItem* PItem)
         }
         return false;
     }
-    else if (slot == 1) // automaton head
+    else if (slot == ITEM_PUPPET_HEAD)
     {
         if (addBit(id & 0x0F, &PChar->m_unlockedAttachments.heads, sizeof(PChar->m_unlockedAttachments.heads)))
         {
@@ -184,36 +267,34 @@ bool UnlockAttachment(CCharEntity* PChar, CItem* PItem)
     return false;
 }
 
-bool HasAttachment(CCharEntity* PChar, CItem* PItem)
+auto HasAttachment(const CCharEntity* PChar, CItem* PItem) -> bool
 {
-    uint16 id = PItem->getID();
-
+    const uint16 id = PItem->getID();
     if (!PItem->isType(ITEM_PUPPET))
     {
         return false;
     }
 
-    uint8 slot = ((CItemPuppet*)PItem)->getEquipSlot();
+    const uint8 slot = static_cast<CItemPuppet*>(PItem)->getEquipSlot();
 
-    if (slot == 3) // automaton attachment
+    // Note: getEquipSlot() returns ITEM_PUPPET_EQUIPSLOT values (1-based from DB),
+    // not AutomatonSlot packet indices (0-based).
+    switch (slot)
     {
-        return hasBit(id & 0xFF, (uint8*)PChar->m_unlockedAttachments.attachments, sizeof(PChar->m_unlockedAttachments.attachments));
+        case ITEM_PUPPET_ATTACHMENT:
+            return hasBit(id & 0xFF, reinterpret_cast<const uint8*>(PChar->m_unlockedAttachments.attachments), sizeof(PChar->m_unlockedAttachments.attachments));
+        case ITEM_PUPPET_FRAME:
+            return hasBit(id & 0x0F, &PChar->m_unlockedAttachments.frames, sizeof(PChar->m_unlockedAttachments.frames));
+        case ITEM_PUPPET_HEAD:
+            return hasBit(id & 0x0F, &PChar->m_unlockedAttachments.heads, sizeof(PChar->m_unlockedAttachments.heads));
+        default:
+            return false;
     }
-    else if (slot == 2) // automaton frame
-    {
-        return hasBit(id & 0x0F, &PChar->m_unlockedAttachments.frames, sizeof(PChar->m_unlockedAttachments.frames));
-    }
-    else if (slot == 1) // automaton head
-    {
-        return hasBit(id & 0x0F, &PChar->m_unlockedAttachments.heads, sizeof(PChar->m_unlockedAttachments.heads));
-    }
-    return false;
 }
 
 void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
 {
-    CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + attachment);
-
+    auto* PAttachment = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
     if (attachment != 0)
     {
         if (PAttachment && !HasAttachment(PChar, PAttachment))
@@ -230,7 +311,7 @@ void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
         }
     }
 
-    uint8 oldAttachment = PChar->getAutomatonAttachment(slotId);
+    const uint8 oldAttachment = PChar->getAutomatonAttachment(slotId);
     if (attachment != 0 && oldAttachment != 0)
     {
         setAttachment(PChar, slotId, 0);
@@ -238,18 +319,16 @@ void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
 
     if (attachment != 0)
     {
-        bool valid = false;
-
         if (PAttachment && PAttachment->getEquipSlot() == ITEM_PUPPET_ATTACHMENT)
         {
-            valid = true;
+            bool valid = true;
 
-            // Iterate through the 8 elements and validate if the attachment actually fits the current automaton head/frame
+            // Validate if the attachment fits the current automaton head/frame element capacity
             for (int element = 0; element < 8; element++)
             {
-                auto currentElementCapacity = PChar->getAutomatonElementCapacity(element);
-                auto elementMax             = PChar->getAutomatonElementMax(element);
-                auto attachmentElementPower = ((PAttachment->getElementSlots() >> (element * 4)) & 0xF);
+                const auto currentElementCapacity = PChar->getAutomatonElementCapacity(element);
+                const auto elementMax             = PChar->getAutomatonElementMax(element);
+                const auto attachmentElementPower = ((PAttachment->getElementSlots() >> (element * 4)) & 0xF);
 
                 if (currentElementCapacity + attachmentElementPower > elementMax)
                 {
@@ -257,21 +336,20 @@ void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
                     break;
                 }
             }
-        }
 
-        if (valid)
-        {
-            for (int element = 0; element < 8; element++)
+            if (valid)
             {
-                PChar->addAutomatonElementCapacity(element, (PAttachment->getElementSlots() >> (element * 4)) & 0xF);
+                for (int element = 0; element < 8; element++)
+                {
+                    PChar->addAutomatonElementCapacity(element, (PAttachment->getElementSlots() >> (element * 4)) & 0xF);
+                }
+                PChar->setAutomatonAttachment(slotId, attachment);
+                return;
             }
+        }
 
-            PChar->setAutomatonAttachment(slotId, attachment);
-        }
-        else
-        {
-            setAttachment(PChar, slotId, oldAttachment);
-        }
+        // Invalid attachment or doesn't fit - restore old
+        setAttachment(PChar, slotId, oldAttachment);
     }
     else
     {
@@ -279,13 +357,13 @@ void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
 
         if (attachment != 0)
         {
-            PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + attachment);
+            PAttachment = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
 
             if (PAttachment && PAttachment->getEquipSlot() == ITEM_PUPPET_ATTACHMENT)
             {
                 for (int element = 0; element < 8; element++)
                 {
-                    PChar->addAutomatonElementCapacity(element, -(int8)((PAttachment->getElementSlots() >> (element * 4)) & 0xF));
+                    PChar->addAutomatonElementCapacity(element, -static_cast<int8>((PAttachment->getElementSlots() >> (element * 4)) & 0xF));
                 }
 
                 PChar->setAutomatonAttachment(slotId, 0);
@@ -294,7 +372,7 @@ void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment)
     }
 }
 
-void setFrame(CCharEntity* PChar, uint8 frame)
+void setFrame(CCharEntity* PChar, AutomatonFrame frame)
 {
     uint8 tempElementMax[8];
 
@@ -303,9 +381,9 @@ void setFrame(CCharEntity* PChar, uint8 frame)
         tempElementMax[element] = PChar->getAutomatonElementMax(element);
     }
 
-    if (PChar->getAutomatonFrame() != 0)
+    if (static_cast<uint8>(PChar->getAutomatonFrame()) != 0)
     {
-        CItemPuppet* POldFrame = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->getAutomatonFrame());
+        const auto* POldFrame = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2000 + static_cast<uint8>(PChar->getAutomatonFrame())));
         if (POldFrame == nullptr || POldFrame->getEquipSlot() != ITEM_PUPPET_FRAME)
         {
             return;
@@ -317,8 +395,8 @@ void setFrame(CCharEntity* PChar, uint8 frame)
     }
 
     // Check if they actually have the frame
-    CItemPuppet* PFrame = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + frame);
-    if (PFrame == nullptr || PFrame->getEquipSlot() != ITEM_PUPPET_FRAME || (frame != FRAME_HARLEQUIN && !HasAttachment(PChar, PFrame)))
+    auto* PFrame = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2000 + static_cast<uint8>(frame)));
+    if (PFrame == nullptr || PFrame->getEquipSlot() != ITEM_PUPPET_FRAME || (frame != AutomatonFrame::Harlequin && !HasAttachment(PChar, PFrame)))
     {
         return;
     }
@@ -328,30 +406,8 @@ void setFrame(CCharEntity* PChar, uint8 frame)
         tempElementMax[element] += (PFrame->getElementSlots() >> (element * 4)) & 0xF;
     }
 
-    PChar->setAutomatonFrame((AUTOFRAMETYPE)frame);
-    uint8 head                              = PChar->getAutomatonHead();
-    PChar->automatonInfo.automatonLook.race = 0x07;
-
-    if (head == 3)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xBC + ((frame - 32) * 5);
-    }
-    else if (head == 4)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xBB + ((frame - 32) * 5);
-    }
-    else if (head == 5)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xD3 + ((frame - 32));
-    }
-    else if (head == 6)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xD7 + ((frame - 32));
-    }
-    else
-    {
-        PChar->automatonInfo.automatonLook.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
-    }
+    PChar->setAutomatonFrame(frame);
+    PChar->automatonInfo.automatonLook.modelid = calculateAutomatonModel(frame, PChar->getAutomatonHead());
 
     for (int element = 0; element < 8; element++)
     {
@@ -359,7 +415,7 @@ void setFrame(CCharEntity* PChar, uint8 frame)
     }
 }
 
-void setHead(CCharEntity* PChar, uint8 head)
+void setHead(CCharEntity* PChar, AutomatonHead head)
 {
     uint8 tempElementMax[8];
 
@@ -368,9 +424,9 @@ void setHead(CCharEntity* PChar, uint8 head)
         tempElementMax[element] = PChar->getAutomatonElementMax(element);
     }
 
-    if (PChar->getAutomatonHead() != 0)
+    if (static_cast<uint8>(PChar->getAutomatonHead()) != 0)
     {
-        CItemPuppet* POldHead = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + PChar->getAutomatonHead());
+        const auto* POldHead = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2000 + static_cast<uint8>(PChar->getAutomatonHead())));
         if (POldHead == nullptr || POldHead->getEquipSlot() != ITEM_PUPPET_HEAD)
         {
             return;
@@ -382,8 +438,8 @@ void setHead(CCharEntity* PChar, uint8 head)
     }
 
     // Check if they actually have the head
-    CItemPuppet* PHead = (CItemPuppet*)itemutils::GetItemPointer(0x2000 + head);
-    if (PHead == nullptr || PHead->getEquipSlot() != ITEM_PUPPET_HEAD || (head != HEAD_HARLEQUIN && !HasAttachment(PChar, PHead)))
+    auto* PHead = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2000 + static_cast<uint8>(head)));
+    if (PHead == nullptr || PHead->getEquipSlot() != ITEM_PUPPET_HEAD || (head != AutomatonHead::Harlequin && !HasAttachment(PChar, PHead)))
     {
         return;
     }
@@ -393,37 +449,16 @@ void setHead(CCharEntity* PChar, uint8 head)
         tempElementMax[element] += (PHead->getElementSlots() >> (element * 4)) & 0xF;
     }
 
-    PChar->setAutomatonHead((AUTOHEADTYPE)head);
-    uint8 frame                             = PChar->getAutomatonFrame();
-    PChar->automatonInfo.automatonLook.race = 0x07;
+    PChar->setAutomatonHead(head);
+    PChar->automatonInfo.automatonLook.modelid = calculateAutomatonModel(PChar->getAutomatonFrame(), head);
 
-    if (head == 3)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xBC + ((frame - 32) * 5);
-    }
-    else if (head == 4)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xBB + ((frame - 32) * 5);
-    }
-    else if (head == 5)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xD3 + ((frame - 32));
-    }
-    else if (head == 6)
-    {
-        PChar->automatonInfo.automatonLook.face = 0xD7 + ((frame - 32));
-    }
-    else
-    {
-        PChar->automatonInfo.automatonLook.face = 0xB9 + ((frame - 32) * 5) + (head - 1);
-    }
     for (int element = 0; element < 8; element++)
     {
         PChar->setAutomatonElementMax(element, tempElementMax[element]);
     }
 }
 
-uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level)
+auto getSkillCap(const CCharEntity* PChar, const SKILLTYPE skill, const uint8 level) -> uint16
 {
     if (PChar == nullptr)
     {
@@ -438,16 +473,16 @@ uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level)
     }
     switch (PChar->getAutomatonFrame())
     {
-        default: // case FRAME_HARLEQUIN:
+        default: // case Harlequin:
             rank = 5;
             break;
-        case FRAME_VALOREDGE:
+        case AutomatonFrame::Valoredge:
             if (skill == SKILL_AUTOMATON_MELEE)
             {
                 rank = 2;
             }
             break;
-        case FRAME_SHARPSHOT:
+        case AutomatonFrame::Sharpshot:
             if (skill == SKILL_AUTOMATON_MELEE)
             {
                 rank = 6;
@@ -457,7 +492,7 @@ uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level)
                 rank = 3;
             }
             break;
-        case FRAME_STORMWAKER:
+        case AutomatonFrame::Stormwaker:
             if (skill == SKILL_AUTOMATON_MELEE)
             {
                 rank = 7;
@@ -471,26 +506,26 @@ uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level)
 
     switch (PChar->getAutomatonHead())
     {
-        case HEAD_VALOREDGE:
+        case AutomatonHead::Valoredge:
             if (skill == SKILL_AUTOMATON_MELEE)
             {
                 rank -= 1;
             }
             break;
-        case HEAD_SHARPSHOT:
+        case AutomatonHead::Sharpshot:
             if (skill == SKILL_AUTOMATON_RANGED)
             {
                 rank -= 1;
             }
             break;
-        case HEAD_STORMWAKER:
+        case AutomatonHead::Stormwaker:
             if (skill == SKILL_AUTOMATON_MELEE || skill == SKILL_AUTOMATON_MAGIC)
             {
                 rank -= 1;
             }
             break;
-        case HEAD_SOULSOOTHER:
-        case HEAD_SPIRITREAVER:
+        case AutomatonHead::Soulsoother:
+        case AutomatonHead::Spiritreaver:
             if (skill == SKILL_AUTOMATON_MAGIC)
             {
                 rank -= 2;
@@ -517,14 +552,14 @@ void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
         return;
     }
 
-    CCharEntity* PChar = (CCharEntity*)PAutomaton->PMaster;
+    auto* PChar = static_cast<CCharEntity*>(PAutomaton->PMaster);
     if (getSkillCap(PChar, SkillID, PAutomaton->GetMLevel()) != 0 && !(PAutomaton->WorkingSkills.skill[SkillID] & 0x8000))
     {
-        uint16 CurSkill = PChar->RealSkills.skill[SkillID];
-        uint16 MaxSkill = getSkillCap(PChar, SkillID, std::min(PAutomaton->GetMLevel(), lvl));
+        const uint16 CurSkill = PChar->RealSkills.skill[SkillID];
+        uint16       MaxSkill = getSkillCap(PChar, SkillID, std::min(PAutomaton->GetMLevel(), lvl));
 
-        int16  Diff          = MaxSkill - CurSkill / 10;
-        double SkillUpChance = Diff / 5.0 + settings::get<double>("map.SKILLUP_CHANCE_MULTIPLIER") * (2.0 - log10(1.0 + CurSkill / 100));
+        const int16 Diff          = MaxSkill - CurSkill / 10;
+        double      SkillUpChance = Diff / 5.0 + settings::get<double>("map.SKILLUP_CHANCE_MULTIPLIER") * (2.0 - log10(1.0 + CurSkill / 100));
 
         double random = xirand::GetRandomNumber(1.);
 
@@ -580,7 +615,7 @@ void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
             // Do skill amount multiplier (Will only be applied if default setting is changed)
             if (settings::get<uint8>("map.SKILLUP_AMOUNT_MULTIPLIER") > 1)
             {
-                SkillAmount += (uint8)(SkillAmount * settings::get<uint8>("map.SKILLUP_AMOUNT_MULTIPLIER"));
+                SkillAmount += static_cast<uint8>(SkillAmount * settings::get<uint8>("map.SKILLUP_AMOUNT_MULTIPLIER"));
                 if (SkillAmount > 9)
                 {
                     SkillAmount = 9;
@@ -602,7 +637,7 @@ void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
                 PAutomaton->WorkingSkills.skill[SkillID] += 1;
                 if (SkillID == SKILL_AUTOMATON_MAGIC)
                 {
-                    uint16 amaSkill                           = PAutomaton->WorkingSkills.skill[SKILL_AUTOMATON_MAGIC];
+                    const uint16 amaSkill                     = PAutomaton->WorkingSkills.skill[SKILL_AUTOMATON_MAGIC];
                     PAutomaton->WorkingSkills.automaton_magic = amaSkill;
                     PAutomaton->WorkingSkills.healing         = amaSkill;
                     PAutomaton->WorkingSkills.enhancing       = amaSkill;
@@ -619,10 +654,9 @@ void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl)
     }
 }
 
-void CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain)
+void CheckAttachmentsForManeuver(const CCharEntity* PChar, const EFFECT maneuver, const bool gain)
 {
-    CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
-
+    auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
     if (PAutomaton)
     {
         uint8 element = maneuver - EFFECT_FIRE_MANEUVER;
@@ -630,7 +664,7 @@ void CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain)
         {
             if (PAutomaton->getAttachment(i) != 0)
             {
-                CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i));
+                auto* PAttachment = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i)));
 
                 if (PAttachment && (PAttachment->getElementSlots() >> (element * 4)) & 0xF)
                 {
@@ -656,8 +690,7 @@ void EquipAttachments(CAutomatonEntity* PAutomaton)
         {
             if (PAutomaton->getAttachment(i) != 0)
             {
-                CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i));
-
+                auto* PAttachment = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i)));
                 if (PAttachment)
                 {
                     luautils::OnAttachmentEquip(PAutomaton, PAttachment);
@@ -667,40 +700,38 @@ void EquipAttachments(CAutomatonEntity* PAutomaton)
     }
 }
 
-void UpdateAttachments(CCharEntity* PChar)
+void UpdateAttachments(const CCharEntity* PChar)
 {
-    CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
-
+    auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
     if (PAutomaton)
     {
         for (uint8 i = 0; i < 12; i++)
         {
             if (PAutomaton->getAttachment(i) != 0)
             {
-                CItemPuppet* PAttachment = (CItemPuppet*)itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i));
+                auto* PAttachment = static_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + PAutomaton->getAttachment(i)));
 
                 if (PAttachment)
                 {
                     int32 maneuver = EFFECT_FIRE_MANEUVER;
-                    for (int i = 0; i < 8; i++)
+                    for (int j = 0; j < 8; j++)
                     {
-                        if (PAttachment->getElementSlots() >> (i * 4) & 0xF)
+                        if (PAttachment->getElementSlots() >> (j * 4) & 0xF)
                         {
-                            maneuver += i;
+                            maneuver += j;
                             break;
                         }
                     }
-                    luautils::OnUpdateAttachment(PAutomaton, PAttachment, PChar->StatusEffectContainer->GetEffectsCount((EFFECT)maneuver));
+                    luautils::OnUpdateAttachment(PAutomaton, PAttachment, PChar->StatusEffectContainer->GetEffectsCount(static_cast<EFFECT>(maneuver)));
                 }
             }
         }
     }
 }
 
-void PreLevelRestriction(CCharEntity* PChar)
+void PreLevelRestriction(const CCharEntity* PChar)
 {
-    CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
-
+    auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
     if (PAutomaton)
     {
         for (int i = 0; i < 12; i++)
@@ -723,19 +754,17 @@ void PreLevelRestriction(CCharEntity* PChar)
     }
 }
 
-void PostLevelRestriction(CCharEntity* PChar)
+void PostLevelRestriction(const CCharEntity* PChar)
 {
-    CAutomatonEntity* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
-
+    auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(PChar->PPet);
     if (PAutomaton)
     {
         for (int i = 0; i < 12; i++)
         {
-            uint8 attachment = PAutomaton->getAttachment(i);
-
+            const uint8 attachment = PAutomaton->getAttachment(i);
             if (attachment != 0)
             {
-                CItemPuppet* PAttachment = dynamic_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
+                auto* PAttachment = dynamic_cast<CItemPuppet*>(itemutils::GetItemPointer(0x2100 + attachment));
                 if (PAttachment)
                 {
                     // Attachment scripts may have custom equip logic that needs to be computed against the LvRestricted puppet stats

--- a/src/map/utils/puppetutils.h
+++ b/src/map/utils/puppetutils.h
@@ -19,32 +19,28 @@
 ===========================================================================
 */
 
-#ifndef _PUPUTILS_H
-#define _PUPUTILS_H
+#pragma once
 
 #include "entities/charentity.h"
-#include "items/item_puppet.h"
 #include "status_effect.h"
 
 namespace puppetutils
 {
 
-void   LoadAutomaton(CCharEntity* PChar);
-void   SaveAttachments(CCharEntity* PChar);
-void   SaveAutomaton(CCharEntity* PChar);
-bool   UnlockAttachment(CCharEntity* PChar, CItem* PItem);
-bool   HasAttachment(CCharEntity* PChar, CItem* PItem);
-void   setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment);
-void   setFrame(CCharEntity* PChar, uint8 frame);
-void   setHead(CCharEntity* PChar, uint8 head);
-uint16 getSkillCap(CCharEntity* PChar, SKILLTYPE skill, uint8 level);
-void   TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl);
-void   CheckAttachmentsForManeuver(CCharEntity* PChar, EFFECT maneuver, bool gain);
-void   EquipAttachments(CAutomatonEntity* PAutomaton);
-void   UpdateAttachments(CCharEntity* PChar);
-void   PreLevelRestriction(CCharEntity* PChar);
-void   PostLevelRestriction(CCharEntity* PChar);
+void LoadAutomaton(CCharEntity* PChar);
+void SaveAttachments(CCharEntity* PChar);
+void SaveAutomaton(CCharEntity* PChar);
+auto UnlockAttachment(CCharEntity* PChar, CItem* PItem) -> bool;
+auto HasAttachment(const CCharEntity* PChar, CItem* PItem) -> bool;
+void setAttachment(CCharEntity* PChar, uint8 slotId, uint8 attachment);
+void setFrame(CCharEntity* PChar, AutomatonFrame frame);
+void setHead(CCharEntity* PChar, AutomatonHead head);
+auto getSkillCap(const CCharEntity* PChar, SKILLTYPE skill, uint8 level) -> uint16;
+void TrySkillUP(CAutomatonEntity* PAutomaton, SKILLTYPE SkillID, uint8 lvl);
+void CheckAttachmentsForManeuver(const CCharEntity* PChar, EFFECT maneuver, bool gain);
+void EquipAttachments(CAutomatonEntity* PAutomaton);
+void UpdateAttachments(const CCharEntity* PChar);
+void PreLevelRestriction(const CCharEntity* PChar);
+void PostLevelRestriction(const CCharEntity* PChar);
 
 }; // namespace puppetutils
-
-#endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Enum classes for Head/Frame/Attachments
- Trailing returns/const wherever possible
- Refactored how automaton model is calculated
- Helper to get model lua side

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Lots of line changes but most of it is just swapping raw integers for the appropriate enums. 
Re-tested models in game.
