### PR TITLE
[lua, sql] Waking Dreams battlefield audit

### DIFF
--- a/scripts/actions/mobskills/cacodemonia.lua
+++ b/scripts/actions/mobskills/cacodemonia.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Cacodemonia
+--
+-- Description: Inflicts a curse on all targets in an area of effect.
+-- Type: Enfeebling
+-- Utsusemi/Blink absorb: Wipes shadows
+-- Range: 15' radial
+-- Notes: Curse has a very long duration.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 35, 0, 60))
+
+    return xi.effect.CURSE_I
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/camisado.lua
+++ b/scripts/actions/mobskills/camisado.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local numhits = 1
     local accmod  = 1
-    local ftp     = 3
+    local ftp     = 2.75
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
     local dmg = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.BLUNT, info.hitslanded)
     target:takeDamage(dmg, mob, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/actions/mobskills/dream_shroud.lua
+++ b/scripts/actions/mobskills/dream_shroud.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Dream Shroud
+--
+-- Description: Enhances Magic Attack and Magic Defense.
+-- Type: Enhancing
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local hour = VanadielHour()
+    local buffvalue = math.abs(12 - hour) + 1
+
+    mob:delStatusEffect(xi.effect.MAGIC_ATK_BOOST)
+    mob:delStatusEffect(xi.effect.MAGIC_DEF_BOOST)
+
+    xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_ATK_BOOST, buffvalue, 0, 180)
+    xi.mobskills.mobBuffMove(mob, xi.effect.MAGIC_DEF_BOOST, 14 - buffvalue, 0, 180)
+
+    skill:setMsg(xi.msg.basic.SKILL_RECEIVES_MAB_MDB)
+
+    return xi.effect.MAGIC_ATK_BOOST
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/nightmare.lua
+++ b/scripts/actions/mobskills/nightmare.lua
@@ -33,8 +33,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local bioPower   = 15
-    local duration   = math.random(20, 30)
+    local bioPower   = math.floor(mob:getMainLvl() / 2)
+    local duration   = 90
     local effectTier = 11
 
     -- Handle unbreakable sleep

--- a/scripts/actions/mobskills/ruinous_omen.lua
+++ b/scripts/actions/mobskills/ruinous_omen.lua
@@ -18,9 +18,8 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    -- TODO: Capture mechanics of this skill. Currently using default astral flow values.
     params.baseDamage     = mob:getMainLvl() + 2
-    params.fTP            = { 9, 9, 9 }
+    params.fTP            = { 10, 10, 10 }
     params.element        = xi.element.DARK
     params.attackType     = xi.attackType.MAGICAL
     params.damageType     = xi.damageType.DARK

--- a/scripts/actions/mobskills/somnolence.lua
+++ b/scripts/actions/mobskills/somnolence.lua
@@ -13,13 +13,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getMainLvl() + 2
-    params.fTP            = { 1.50, 1.50, 1.50 } -- TODO: Capture fTPs
-    params.element        = xi.element.DARK
-    params.attackType     = xi.attackType.MAGICAL
-    params.damageType     = xi.damageType.DARK
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
-    -- TODO: Need animation ID capture
+    params.baseDamage      = mob:getMainLvl() + 2
+    params.fTP             = { 2.00, 2.00, 2.00 }
+    params.element         = xi.element.DARK
+    params.attackType      = xi.attackType.MAGICAL
+    params.damageType      = xi.damageType.DARK
+    params.shadowBehavior  = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.dStatMultiplier = 1.5
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 
@@ -27,7 +27,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         -- TODO: Capture power/duration
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 25, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.WEIGHT, 25, 0, 90)
     end
 
     return info.damage

--- a/scripts/battlefields/The_Shrouded_Maw/darkness_named.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/darkness_named.lua
@@ -42,7 +42,7 @@ local arenaBoxes =
     [3] = {  270,  290,  35,  52, -286, -266 }, -- Area 3
 }
 
-local isPlayerInArenaBox = function(player, area)
+local function isPlayerInArenaBox(player, area)
     local playerX = player:getXPos()
     local playerY = player:getYPos()
     local playerZ = player:getZPos()
@@ -53,7 +53,7 @@ local isPlayerInArenaBox = function(player, area)
     return xCheck and yCheck and zCheck
 end
 
-local handleDiremiteEnmityReset = function(diremite, battlefield)
+local function handleDiremiteEnmityReset(diremite, battlefield)
     if not diremite:isAlive() or not diremite:isEngaged() then
         return
     end
@@ -88,7 +88,7 @@ local handleDiremiteEnmityReset = function(diremite, battlefield)
 end
 
 -- Diremites respawn 10 seconds after death
-local handleDiremiteRespawn = function(diremite)
+local function handleDiremiteRespawn(diremite)
     if not diremite:isAlive() then
         local deathTime = diremite:getLocalVar('deathTime')
 

--- a/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
+++ b/scripts/battlefields/The_Shrouded_Maw/waking_dreams.lua
@@ -36,14 +36,96 @@ function content:onEventFinishWin(player, csid, option, npc)
     player:addTitle(xi.title.HEIR_TO_THE_REALM_OF_DREAMS)
 end
 
+-- Arena boundaries: Defined like regular rectangular regions.
+local arenaBoxes =
+{
+-- [area] = { x(min), x(max), y(min), y(max), z(min), z(max) }
+    [1] = { -250, -230, -46, -25,  275,  294 }, -- Area 1
+    [2] = {  -10,   10,   0,  13,   -6,   14 }, -- Area 2
+    [3] = {  270,  290,  35,  52, -286, -266 }, -- Area 3
+}
+
+local function isPlayerInArenaBox(player, area)
+    local playerX = player:getXPos()
+    local playerY = player:getYPos()
+    local playerZ = player:getZPos()
+    local xCheck  = playerX >= area[1] and playerX <= area[2]
+    local yCheck  = playerY >= area[3] and playerY <= area[4]
+    local zCheck  = playerZ >= area[5] and playerZ <= area[6]
+
+    return xCheck and yCheck and zCheck
+end
+
+local function handleDiremiteEnmityReset(diremite, battlefield)
+    if not diremite:isAlive() or not diremite:isEngaged() then
+        return
+    end
+
+    -- Did a player fall out of the arena?
+    local box = arenaBoxes[battlefield:getArea()]
+    local players = battlefield:getPlayers()
+    local allPlayersInArena = true
+
+    for _, player in ipairs(players) do
+        local inArena = isPlayerInArenaBox(player, box)
+        local wasInPit = player:getLocalVar('inDiremitePit') == 1
+
+        if not inArena then
+            allPlayersInArena = false
+            -- Mark player as in pit
+            if not wasInPit then
+                player:setLocalVar('inDiremitePit', 1)
+            end
+        -- Player is in arena - reset enmity if they just came from pit
+        elseif wasInPit then
+            diremite:resetEnmity(player)
+            player:setLocalVar('inDiremitePit', 0)
+        end
+    end
+
+    -- If all players are in the arena, disengage the Diremite completely
+    -- Diremites despawn if too far from spawn, controlled in Diremite_Dominator.lua
+    if allPlayersInArena then
+        diremite:disengage()
+    end
+end
+
+-- Diremites respawn 10 seconds after death
+local function handleDiremiteRespawn(diremite)
+    if not diremite:isAlive() then
+        local deathTime = diremite:getLocalVar('deathTime')
+
+        if deathTime > 0 and (GetSystemTime() - deathTime) >= 10 then
+            diremite:setLocalVar('deathTime', 0)
+            SpawnMob(diremite:getID())
+        end
+    end
+end
+
+function content:onBattlefieldTick(battlefield, tick)
+    Battlefield.onBattlefieldTick(self, battlefield, tick)
+
+    local areaOffset = (battlefield:getArea() - 1) * 7
+    local baseID = shroudedMawID.mob.DIABOLOS_WD + areaOffset
+
+    -- Check Diremites (offsets 1-6 from base)
+    for i = 1, 6 do
+        local diremite = GetMobByID(baseID + i)
+        if diremite then
+            handleDiremiteRespawn(diremite)
+            handleDiremiteEnmityReset(diremite, battlefield)
+        end
+    end
+end
+
 content.groups =
 {
     {
         mobIds =
         {
-            { shroudedMawID.mob.DIABOLOS + 27 },
-            { shroudedMawID.mob.DIABOLOS + 34 },
-            { shroudedMawID.mob.DIABOLOS + 41 },
+            { shroudedMawID.mob.DIABOLOS_WD      },
+            { shroudedMawID.mob.DIABOLOS_WD + 7  },
+            { shroudedMawID.mob.DIABOLOS_WD + 14 },
         },
 
         allDeath = function(battlefield, mob)
@@ -55,30 +137,30 @@ content.groups =
         mobIds =
         {
             {
-                shroudedMawID.mob.DIABOLOS + 28,
-                shroudedMawID.mob.DIABOLOS + 29,
-                shroudedMawID.mob.DIABOLOS + 30,
-                shroudedMawID.mob.DIABOLOS + 31,
-                shroudedMawID.mob.DIABOLOS + 32,
-                shroudedMawID.mob.DIABOLOS + 33,
+                shroudedMawID.mob.DIABOLOS_WD + 1,
+                shroudedMawID.mob.DIABOLOS_WD + 2,
+                shroudedMawID.mob.DIABOLOS_WD + 3,
+                shroudedMawID.mob.DIABOLOS_WD + 4,
+                shroudedMawID.mob.DIABOLOS_WD + 5,
+                shroudedMawID.mob.DIABOLOS_WD + 6,
             },
 
             {
-                shroudedMawID.mob.DIABOLOS + 35,
-                shroudedMawID.mob.DIABOLOS + 36,
-                shroudedMawID.mob.DIABOLOS + 37,
-                shroudedMawID.mob.DIABOLOS + 38,
-                shroudedMawID.mob.DIABOLOS + 39,
-                shroudedMawID.mob.DIABOLOS + 40,
+                shroudedMawID.mob.DIABOLOS_WD + 8,
+                shroudedMawID.mob.DIABOLOS_WD + 9,
+                shroudedMawID.mob.DIABOLOS_WD + 10,
+                shroudedMawID.mob.DIABOLOS_WD + 11,
+                shroudedMawID.mob.DIABOLOS_WD + 12,
+                shroudedMawID.mob.DIABOLOS_WD + 13,
             },
 
             {
-                shroudedMawID.mob.DIABOLOS + 42,
-                shroudedMawID.mob.DIABOLOS + 43,
-                shroudedMawID.mob.DIABOLOS + 44,
-                shroudedMawID.mob.DIABOLOS + 45,
-                shroudedMawID.mob.DIABOLOS + 46,
-                shroudedMawID.mob.DIABOLOS + 47,
+                shroudedMawID.mob.DIABOLOS_WD + 15,
+                shroudedMawID.mob.DIABOLOS_WD + 16,
+                shroudedMawID.mob.DIABOLOS_WD + 17,
+                shroudedMawID.mob.DIABOLOS_WD + 18,
+                shroudedMawID.mob.DIABOLOS_WD + 19,
+                shroudedMawID.mob.DIABOLOS_WD + 20,
             },
         },
 

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -207,9 +207,11 @@ xi.mobSkill =
     GRAVITY_FIELD                 =  541,
 
     CAMISADO_1                    =  544,
-
+    SOMNOLENCE_1                  =  545,
     NOCTOSHIELD_1                 =  546,
     ULTIMATE_TERROR_1             =  547,
+
+    DREAM_SHROUD_1                =  556,
 
     NIGHTMARE_1                   =  558,
 
@@ -228,6 +230,7 @@ xi.mobSkill =
     CHOKE_BREATH_1                =  579,
     FANTOD_1                      =  580,
     BLOW                          =  581,
+    CACODEMONIA_1                 =  582,
 
     BLANK_GAZE                    =  586,
 
@@ -243,6 +246,10 @@ xi.mobSkill =
     COLD_WAVE_2                   =  600, -- Snoll Tzar
     HIEMAL_STORM                  =  601, -- Snoll Tzar
     HYPOTHERMAL_COMBUSTION_2      =  602, -- Snoll Tzar
+
+    NETHER_BLAST_1                =  610,
+
+    RUINOUS_OMEN_1                =  616,
 
     SWEEP                         =  620,
 
@@ -631,6 +638,8 @@ xi.mobSkill =
     DISSIPATION                   = 1524,
 
     CITADEL_BUSTER                = 1540,
+
+    CAMISADO_2                    = 1554,
 
     FOOT_KICK_2                   = 1567,
     DUST_CLOUD_2                  = 1568,

--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -286,6 +286,7 @@ xi.msg.basic =
     ITEM_NO_TARGET                  = 410, -- No target available. Unable to use item.
     JA_RECEIVES_MAB_MDB_2           = 414, -- <target> receives the effect of Magic Attack Boost and Magic Defense Boost.
     JA_RECEIVES_MAB_MDB             = 415, -- <user> uses <ability>. <target> receives the effect of Magic Attack Boost and Magic Defense Boost.
+    SKILL_RECEIVES_MAB_MDB          = 416, -- <user> uses <skill>. <target> receives the effect of Magic Attack Boost and Magic Defense Boost.
     PROVOKE_SWITCH                  = 418, -- The <actor> uses <action> on <target>. The <target> switches to <actor>!
     LEARNS_SPELL                    = 419, -- <target> learns (NULL)!
     ROLL_MAIN                       = 420, -- The <player> uses .. The total comes to ..! <target> receives the effect of ..

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_DN.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_DN.lua
@@ -73,6 +73,7 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('nightmarePercent', math.random(25, 75))
     mob:setMagicCastingEnabled(false)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
 
     mob:addListener('WEAPONSKILL_STATE_EXIT', 'DIABOLOS_NIGHTMARE_WS', function(mobArg, skillID)
         if
@@ -194,17 +195,19 @@ entity.onMobWeaponSkill = function(mob, target, skill, action)
     end
 end
 
-entity.onMobSpellChoose = function(mob, target)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
-        xi.magic.spell.DRAIN,
-        xi.magic.spell.ASPIR,
-        xi.magic.spell.SLEEP_II,
-        xi.magic.spell.SLEEPGA,
-        xi.magic.spell.BLIND,
+        [1] = { xi.magic.spell.DISPEL,   target, false, xi.action.type.DAMAGE_TARGET,     nil,                 0, 100 },
+        [2] = { xi.magic.spell.DRAIN,    target, false, xi.action.type.DRAIN_HP,          nil,                 0, 100 },
+        [3] = { xi.magic.spell.ASPIR,    target, false, xi.action.type.DRAIN_MP,          nil,                 0, 100 },
+        [4] = { xi.magic.spell.BIO_II,   target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BIO,       4, 100 },
+        [5] = { xi.magic.spell.BLIND,    target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BLINDNESS, 1, 100 },
+        [6] = { xi.magic.spell.SLEEP_II, target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLEEP_I,   2, 100 },
+        [7] = { xi.magic.spell.SLEEPGA,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLEEP_I,   1, 100 },
     }
 
-    return spellList[math.random(1, #spellList)]
+    return xi.combat.behavior.chooseAction(mob, target, nil, spellList)
 end
 
 return entity

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_WD.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diabolos_WD.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Area: The Shrouded Maw
 --  Mob: Diabolos (Waking Dreams)
--- TODO: Waking Dreams specific adjustments
 -----------------------------------
 local ID = zones[xi.zone.THE_SHROUDED_MAW]
 -----------------------------------
@@ -73,8 +72,13 @@ entity.onMobSpawn = function(mob)
     -- Cache instance calculation once on spawn
     local inst = math.floor((mob:getID() - ID.mob.DIABOLOS_WD) / 7)
     mob:setLocalVar('instance', inst)
-    mob:setLocalVar('nightmarePercent', math.random(25, 75))
+    mob:setLocalVar('nightmarePercent', math.random(50, 75))
+    mob:setLocalVar('ruinousOmenPercent', math.random(35, 49))
     mob:setMagicCastingEnabled(false)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
+    mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
+    mob:setMod(xi.mod.REGAIN, 55)
 
     mob:addListener('WEAPONSKILL_STATE_EXIT', 'DIABOLOS_NIGHTMARE_WS', function(mobArg, skillID)
         if
@@ -143,11 +147,13 @@ entity.onMobFight = function(mob, target)
         mob:useMobAbility(xi.mobSkill.NIGHTMARE_1)
     end
 
-    -- Enable regain below 35% HP
-    if currentHP <= 35 then
-        mob:setMod(xi.mod.REGAIN, 55)
-    else
-        mob:setMod(xi.mod.REGAIN, 0)
+    -- Trigger Ruinous Omen at set HP percent once per fight
+    if
+        currentHP <= mob:getLocalVar('ruinousOmenPercent') and
+        mob:getLocalVar('ruinousOmenUsed') == 0
+    then
+        mob:setLocalVar('ruinousOmenUsed', 1)
+        mob:useMobAbility(xi.mobSkill.RUINOUS_OMEN_1)
     end
 
     -- Draw in current target if they exceed the Y threshold
@@ -165,9 +171,14 @@ end
 entity.onMobMobskillChoose = function(mob, target, skillId)
     local skills =
     {
-        { skill = xi.mobSkill.NOCTOSHIELD_1,     weight = 50 },
-        { skill = xi.mobSkill.ULTIMATE_TERROR_1, weight = 30 },
-        { skill = xi.mobSkill.NIGHTMARE_1,       weight = 20 },
+        { skill = xi.mobSkill.NETHER_BLAST_1,    weight = 25 },
+        { skill = xi.mobSkill.NOCTOSHIELD_1,     weight = 10 },
+        { skill = xi.mobSkill.ULTIMATE_TERROR_1, weight = 10 },
+        { skill = xi.mobSkill.SOMNOLENCE_1,      weight = 10 },
+        { skill = xi.mobSkill.CACODEMONIA_1,     weight = 10 },
+        { skill = xi.mobSkill.CAMISADO_2,        weight = 10 },
+        { skill = xi.mobSkill.DREAM_SHROUD_1,    weight = 10 },
+        { skill = xi.mobSkill.NIGHTMARE_1,       weight = 5  },
     }
 
     local roll = math.random(1, 100)
@@ -187,26 +198,31 @@ entity.onMobWeaponSkill = function(mob, target, skill, action)
     local skillId = skill:getID()
 
     if
-        skillId == xi.mobSkill.NIGHTMARE_1 or
-        skillId == xi.mobSkill.ULTIMATE_TERROR_1
+        skillId == xi.mobSkill.ULTIMATE_TERROR_1 or
+        skillId == xi.mobSkill.CACODEMONIA_1 or
+        skillId == xi.mobSkill.NIGHTMARE_1
     then
+        local camisado = math.random(1, 2) == 1 and xi.mobSkill.CAMISADO_1 or xi.mobSkill.CAMISADO_2
         mob:queue(0, function(mobArg)
-            mobArg:useMobAbility(xi.mobSkill.CAMISADO_1)
+            mobArg:useMobAbility(camisado)
         end)
     end
 end
 
-entity.onMobSpellChoose = function(mob, target)
+entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
-        xi.magic.spell.DRAIN,
-        xi.magic.spell.ASPIR,
-        xi.magic.spell.SLEEP_II,
-        xi.magic.spell.SLEEPGA,
-        xi.magic.spell.BLIND,
+        [1] = { xi.magic.spell.DISPELGA, target, false, xi.action.type.DAMAGE_TARGET,     nil,                 0, 100 },
+        [2] = { xi.magic.spell.DISPEL,   target, false, xi.action.type.DAMAGE_TARGET,     nil,                 0, 100 },
+        [3] = { xi.magic.spell.DRAIN,    target, false, xi.action.type.DRAIN_HP,          nil,                 0, 100 },
+        [4] = { xi.magic.spell.ASPIR,    target, false, xi.action.type.DRAIN_MP,          nil,                 0, 100 },
+        [5] = { xi.magic.spell.BIO_III,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BIO,       6, 100 },
+        [6] = { xi.magic.spell.BLIND,    target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BLINDNESS, 1, 100 },
+        [7] = { xi.magic.spell.SLEEP_II, target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLEEP_I,   2, 100 },
+        [8] = { xi.magic.spell.SLEEPGA,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLEEP_I,   1, 100 },
     }
 
-    return spellList[math.random(1, #spellList)]
+    return xi.combat.behavior.chooseAction(mob, target, nil, spellList)
 end
 
 return entity

--- a/scripts/zones/The_Shrouded_Maw/mobs/Diremite_Dominator.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Diremite_Dominator.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Area: The Shrouded Maw
+-- Waking Dreams Avatar Fight
+--  Mob: Diremite Dominator
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobDisengage = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local currentY = mob:getYPos()
+
+    -- Despawn if too far from spawn
+    if math.abs(currentY - spawnPos.y) > 3 or mob:checkDistance(spawnPos) > 15 then
+        DespawnMob(mob:getID())
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    -- Track death time for 10-second respawn
+    mob:setLocalVar('deathTime', GetSystemTime())
+end
+
+return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -569,7 +569,7 @@ INSERT INTO `mob_skills` VALUES (541,285,'gravity_field',2,0.0,10.0,2000,1500,4,
 INSERT INTO `mob_skills` VALUES (542,899,'empty_seed',1,0.0,20.0,2000,2000,4,0,0,7,0,0,0);
 INSERT INTO `mob_skills` VALUES (543,287,'meltdown',1,0.0,15.0,2000,5000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (544,915,'camisado',0,0.0,7.0,2000,1500,4,0,0,3,0,0,0);
--- INSERT INTO `mob_skills` VALUES (545,289,'somnolence',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (545,1126,'somnolence',0,0.0,10.0,641,3000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (546,916,'noctoshield',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (547,917,'ultimate_terror',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (548,292,'blindeye',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -580,7 +580,7 @@ INSERT INTO `mob_skills` VALUES (552,296,'binding_wave',1,0.0,15.0,2000,1500,4,0
 INSERT INTO `mob_skills` VALUES (553,297,'airy_shield',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (554,298,'pet_charm',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (555,299,'magic_barrier',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (556,300,'dream_shroud',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (556,1127,'dream_shroud',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (557,301,'level_5_petrify',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (558,918,'nightmare',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (559,303,'soul_drain',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -606,7 +606,7 @@ INSERT INTO `mob_skills` VALUES (578,912,'nihility_song',1,0.0,12.5,2000,1500,4,
 INSERT INTO `mob_skills` VALUES (579,913,'choke_breath',4,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (580,914,'fantod',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (581,325,'blow',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (582,326,'cacodemonia',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (582,1128,'cacodemonia',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (583,327,'beatdown',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (584,328,'uppercut',0,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (585,329,'hekaton_punch',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -634,13 +634,13 @@ INSERT INTO `mob_skills` VALUES (606,350,'shoulder_attack',0,0.0,7.0,2000,1500,4
 INSERT INTO `mob_skills` VALUES (607,351,'slam_dunk',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (608,352,'arm_block',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (609,353,'battle_dance',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (610,354,'nether_blast',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (610,1129,'nether_blast',0,0.0,10.0,646,3000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (611,355,'ore_toss',0,0.0,10.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (612,356,'head_butt_quadav',0,0.0,7.0,2000,3000,4,0,0,1,0,0,0);
 INSERT INTO `mob_skills` VALUES (613,357,'shell_bash',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (614,358,'shell_guard',0,0.0,7.0,2000,3000,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (615,359,'hellspin',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (616,360,'ruinous_omen',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (616,1125,'ruinous_omen',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (617,361,'feather_storm',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (618,362,'double_kick',0,0.0,7.0,2000,1500,4,0,0,1,0,0,0);
 INSERT INTO `mob_skills` VALUES (619,363,'parry',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
@@ -1578,7 +1578,7 @@ INSERT INTO `mob_skills` VALUES (1549,1142,'horrible_roar',0,0.0,15.0,2000,1500,
 INSERT INTO `mob_skills` VALUES (1551,1136,'megaflare',4,0.0,15.0,6000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1552,1137,'gigaflare',1,0.0,15.0,6000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1553,1138,'teraflare',0,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1554,1298,'camisado',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1554,915,'camisado',0,0.0,7.0,2000,1500,4,0,0,5,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1555,1299,'blessed_radiance',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1556,1300,'regeneration',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1557,1146,'eagle_eye_shot',0,0.0,25.0,2000,0,4,2,0,0,0,0,0); -- ees breath


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reworks existing Waking Dreams logic to be more in line with the recent Darkness Named audit.
- Adds several missing mob skills used specifically by the Lv 75 Diabolos. Updated other Diabolos skill params based on observed behavior.

## Sources
- https://youtu.be/VYWigflF30M
- https://youtu.be/ioDbr44Nziw