### PR TITLE
[c++]  Fix skillchain resistance formula

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3836,7 +3836,7 @@ int32 TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, i
         PDefender->setModifier(Mod::SENGIKORI_SC_DMG_DEBUFF, 0); // Consume the effect
     }
 
-    float damageReductionMult = (10000.0f - static_cast<float>(resistance)) / 10000.0f;
+    float damageReductionMult = (10000.0f + static_cast<float>(resistance)) / 10000.0f;
 
     damage = std::floor(static_cast<float>(damage) * damageReductionMult);
     damage = MagicDmgTaken(PDefender, damage, appliedEle);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

I was testing something and noticed my light skillchain doing more damage than I expected and I think it’s actually causing it to do more instead of resist and if I flip this logic it works now and matches the formula in `damage_multipliers.lua`:

`local sdt = 1 + target:getMod(xi.data.element.getElementalSDTModifier(magicalElement)) / 10000`

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Perform a skillchain on a mob with an elemental resistance matching the element of the skillchain