### PR TITLE
[lua] Fix Fast Blade mobskill message and add safety to COR AF3

### DIFF
--- a/scripts/actions/mobskills/fast_blade.lua
+++ b/scripts/actions/mobskills/fast_blade.lua
@@ -10,7 +10,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    mob:messageBasic(xi.msg.basic.READIES_WS, 0, 37)
+    mob:messageBasic(xi.msg.basic.READIES_WS, 0, xi.weaponskill.FAST_BLADE)
     return 0
 end
 

--- a/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Raqtibahl.lua
@@ -3,8 +3,6 @@
 --  NPC: Raqtibahl
 -- (Corsair's Frac) !pos -59 -4 -39 232
 -----------------------------------
-local ID = zones[xi.zone.PORT_SAN_DORIA]
------------------------------------
 ---@type TNpcEntity
 local entity = {}
 
@@ -65,9 +63,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('LeleroonsLetterRed', 4)
         player:setCharVar('corAfSubmitDay', VanadielUniqueDay())
     elseif csid == 756 then
-        player:setCharVar('LeleroonsLetterRed', 5)
-        player:addItem(xi.item.CORSAIRS_FRAC)
-        player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.CORSAIRS_FRAC)
+        if npcUtil.giveItem(player, xi.item.CORSAIRS_FRAC) then
+            player:setCharVar('LeleroonsLetterRed', 5)
+        end
     end
 end
 

--- a/scripts/zones/Windurst_Waters/IDs.lua
+++ b/scripts/zones/Windurst_Waters/IDs.lua
@@ -66,6 +66,7 @@ zones[xi.zone.WINDURST_WATERS] =
         CHEF_IN_TRAINING              = 10701, -- I'm a chef-in-training, don'taru you know? One day I'll be as famous-wamous as that Rycharde character in Mhaura.
         NESSRUGETOMALL_SHOP_DIALOG    = 11504, -- Welcome to the Rarab Tail Hostelry.
         DIABOLOS_UNLOCKED             = 11933, -- You are now able to summon Diabolos!
+        DOOR_FIRMLY_SHUT              = 12341, -- The door is firmly shut...
     },
 
     mob =

--- a/scripts/zones/Windurst_Waters/npcs/Door_House.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Door_House.lua
@@ -51,6 +51,8 @@ entity.onTrigger = function(player, npc)
             else
                 player:startEvent(945) -- patience. need to wait for vana'diel day
             end
+        else
+            player:messageSpecial(ID.text.DOOR_FIRMLY_SHUT)
         end
     end
 end
@@ -67,9 +69,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('LeleroonsLetterGreen', 4)
         player:setCharVar('corAfSubmitDay', VanadielUniqueDay())
     elseif csid == 944 then
-        player:setCharVar('LeleroonsLetterGreen', 5)
-        player:addItem(xi.item.CORSAIRS_GANTS) -- corsair's gants
-        player:messageSpecial(ID.text.ITEM_OBTAINED, xi.item.CORSAIRS_GANTS)
+        if npcUtil.giveItem(player, xi.item.CORSAIRS_GANTS) then
+            player:setCharVar('LeleroonsLetterGreen', 5)
+        end
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the mobskill fastblade to show the correct ready message.

This PR also runs the COR AF3 armor pickup completion through the item util and updates the door default interaction.

## Steps to test these changes

Give yourself the appropriate variables for the COR AF3 quest and pickup the armor.

See that Raubahn correctly readies "Fast Blade" when using Fast Blade.
