### PR TITLE
[core] Fix /servmes login multi-chunking

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -199,6 +199,7 @@ CCharEntity::CCharEntity()
     m_hasArise           = false;
     m_LevelRestriction   = 0;
     m_lastBcnmTimePrompt = 0;
+    servmesLastOffset_   = std::nullopt;
     m_AHHistoryTimestamp = timer::time_point::min();
     m_DeathTimestamp     = timer::time_point::min();
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -460,8 +460,9 @@ public:
     void   erasePackets(uint8 num); // Erase num elements from front of packet list
     bool   isPacketFiltered(std::unique_ptr<CBasicPacket>& packet);
 
-    bool pendingPositionUpdate;
-    bool sendServerStatus_ = false;
+    bool                 pendingPositionUpdate;
+    bool                 sendServerStatus_ = false;
+    std::optional<int32> servmesLastOffset_; // Last /servmes fragment offset we responded to
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override;
 

--- a/src/map/packets/c2s/0x04b_fragments.cpp
+++ b/src/map/packets/c2s/0x04b_fragments.cpp
@@ -45,19 +45,22 @@ void GP_CLI_COMMAND_FRAGMENTS::process(MapSession* PSession, CCharEntity* PChar)
 
     if (msgType == 1) // Standard Server Message
     {
-        std::string loginMessage = luautils::GetServerMessage(msgLanguage);
-
-        PChar->pushPacket<GP_SERV_COMMAND_FRAGMENTS::SERVMES>(loginMessage, msgLanguage, timestamp, offset);
-        PChar->pushPacket<CCharSyncPacket>(PChar);
-
-        // TODO: kill player til theyre dead and bsod
-        const auto rset = db::preparedStmt("SELECT version_mismatch FROM accounts_sessions WHERE charid = (?)", PChar->id);
-        if (rset && rset->rowsCount() > 0 && rset->next())
+        // Deduplicate fragment retries caused by slow zone-in response times.
+        if (PChar->servmesLastOffset_ == offset)
         {
-            if (rset->get<bool>("version_mismatch"))
-            {
-                PChar->pushPacket<GP_SERV_COMMAND_CHAT_STD>(PChar, CHAT_MESSAGE_TYPE::MESSAGE_SYSTEM_1, "Server does not support this client version.");
-            }
+            return;
+        }
+
+        std::string loginMessage = luautils::GetServerMessage(msgLanguage);
+        PChar->pushPacket<GP_SERV_COMMAND_FRAGMENTS::SERVMES>(loginMessage, msgLanguage, timestamp, offset);
+        PChar->servmesLastOffset_ = offset;
+
+        // Reset tracking after the final fragment so /servmes works later
+        const auto msgSize   = loginMessage.length() + 1;
+        const auto sndLength = msgSize - offset > 236 ? 236 : (msgSize - offset);
+        if (offset + sndLength >= msgSize)
+        {
+            PChar->servmesLastOffset_ = std::nullopt;
         }
     }
     else if (msgType == 2) // Fish Ranking Packet

--- a/src/map/packets/s2c/0x04d_fragments_servmes.cpp
+++ b/src/map/packets/s2c/0x04d_fragments_servmes.cpp
@@ -34,14 +34,15 @@ GP_SERV_COMMAND_FRAGMENTS::SERVMES::SERVMES(const std::string& message, int8 lan
     // Ensure we have a message and the requested offset is not outside the bounds
     if (message.length() > 0 && message.length() > message_offset)
     {
-        const auto sndLength = message.length() - message_offset > 236 ? 236 : message.length() - message_offset;
+        const auto msgSize   = message.length() + 1;
+        const auto sndLength = (msgSize - message_offset) > 236 ? 236 : (msgSize - message_offset);
 
-        packet.size_total     = static_cast<int32_t>(message.length()); // Message Length (Total)
-        packet.offset         = message_offset;                         // Message Offset
-        packet.data_size      = static_cast<int32_t>(sndLength);        // Message Length
+        packet.size_total     = static_cast<int32_t>(msgSize);   // Message Length (Total)
+        packet.offset         = message_offset;                  // Message Offset
+        packet.data_size      = static_cast<int32_t>(sndLength); // Message Length
         const auto packetSize = sizeof(GP_SERV_HEADER) + sizeof(PacketData) - sizeof(packet.data) + packet.data_size;
         this->setSize(roundUpToNearestFour(packetSize));
 
-        std::memcpy(packet.data, message.c_str() + message_offset, std::min(sndLength, message.length() - message_offset));
+        std::memcpy(packet.data, message.c_str() + message_offset, sndLength);
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
LSB is slow to respond to FRAGMENTS packet because of the way packets get processed (lack of interleave/prioritization). 

The client emits a retry for the first chunk and then subsequently receive 2 responses for the first chunk which throws it off and it just doesn't process the servmes at all during login (note: /servmes does work). 

Note that even retail is slow to respond for some of the chunks but handles it gracefully by tracking what's been sent - which is what this PR does by tracking the last sent offset and backing out of the C2S request if in a dupe.

Other stuff:
- I added an extra byte to the size as we were not including the null terminator in the calculation which the client doesn't really care for but was obvious when I double checked side-by-side with retail
- Got rid of the mismatched version message in the /servmes handler as it's really not the place for this.

Closes #9604 except for the Shift-JIS stuff which I will explain in the discussion directly.

## Steps to test these changes
<img width="2351" height="344" alt="Screenshot 2026-03-11 182154" src="https://github.com/user-attachments/assets/e90eb064-f39d-4d48-a9e7-506b40ca05ee" />

<!-- Clear and detailed steps to test your changes here -->
