### PR TITLE
[lua] Abyssea default action and lua clean up

### DIFF
--- a/scripts/effects/visitant.lua
+++ b/scripts/effects/visitant.lua
@@ -101,7 +101,8 @@ effectObject.onEffectLose = function(target, effect)
 
     if
         target:getLocalVar('gameLogin') == 0 and
-        xi.abyssea.isInAbysseaZone(target)
+        xi.abyssea.isInAbysseaZone(target) and
+        zoneID ~= xi.zone.ABYSSEA_EMPYREAL_PARADOX
     then
         target:setLocalVar('finalCountdown', 0)
         target:messageSpecial(ID.text.ABYSSEA_TIME_OFFSET + 8)

--- a/scripts/zones/Abyssea-Empyreal_Paradox/IDs.lua
+++ b/scripts/zones/Abyssea-Empyreal_Paradox/IDs.lua
@@ -24,6 +24,7 @@ zones[xi.zone.ABYSSEA_EMPYREAL_PARADOX] =
         TIME_LIMIT_FOR_THIS_BATTLE_IS = 8029, -- The time limit for this battle is <number> minutes.
         PARTY_MEMBERS_HAVE_FALLEN     = 8065, -- All party members have fallen in battle. Now leaving the battlefield.
         THE_PARTY_WILL_BE_REMOVED     = 8072, -- If all party members' HP are still zero after # minute[/s], the party will be removed from the battlefield.
+        CRIMSON_STONE_DISAPPEARS      = 8080, -- The <keyitem> disappears!
         ENTERING_THE_BATTLEFIELD_FOR  = 8092, -- Entering the battlefield for [The Wyrm God]!
     },
     mob =

--- a/scripts/zones/Port_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Port_Jeuno/DefaultActions.lua
@@ -24,8 +24,6 @@ return {
     ['Inesh']            = { text = ID.text.ARRIVAL_NPC },
     ['Jaha_Amariyo']     = { event = 57 },
     ['Jhuo_Halmanzoh']   = { event = 53 },
-    ['Joachim']          = { text = ID.text.WOULD_YE_MIND },
-    ['Horst']            = { event = 339 },
     ['Karl']             = { event = 58 },
     ['Khumo_Daramasteh'] = { event = 19 },
     ['Kuya-Moya']        = { event = 55 },

--- a/scripts/zones/RuLude_Gardens/DefaultActions.lua
+++ b/scripts/zones/RuLude_Gardens/DefaultActions.lua
@@ -21,7 +21,6 @@ return {
     ['Diradour']             = { event = 10000 },
     ['Elevator_Button']      = { event = 75 },
     ['Enigmatic_Footprints'] = { messageSpecial = ID.text.TEAR_IN_FABRIC_OF_SPACE },
-    ['Fabien']               = { text = ID.text.NOT_ACQUAINTED },
     ['Falreze']              = { event = 121 },
     ['Harith']               = { event = 111 },
     ['High_Wind']            = { event = 164 },
@@ -50,6 +49,5 @@ return {
     ['Taillegeas']           = { event = 10061 },
     ['Tillecoe']             = { event = 70 },
     ['Tsugumi']              = { event = 163 },
-    ['Vincent']              = { event = 10185 },
     ['Yavoraile']            = { event = 118 },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

- Correct visitant status error in Abyssea Empyreal Paradox (since it is a permanent effect in this zone)
- Add missing ID text to the zone
- Remove unnecessary default actions for maw warp/traverser stone NPCs, abyssea global file already handles their dialogues and was forcing it to play round robin with their dialogues

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

No more map error in Abyssea Empyreal Paradox and various NPCs don't have dialogue actions being blocked by default action texts
