### PR TITLE
[core] adjust usage of std::stack pop calls

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -431,14 +431,34 @@ void CAIContainer::Tick(timer::time_point _tick)
     {
         Controller->Tick(_tick);
     }
-    CState* top = nullptr;
-    while (!m_stateStack.empty() && (top = m_stateStack.top().get())->DoUpdate(_tick))
+
+    while (!m_stateStack.empty())
     {
-        if (top == GetCurrentState())
+        CState* top = m_stateStack.top().get();
+
+        if (top)
         {
-            auto state = std::move(m_stateStack.top());
-            m_stateStack.pop();
-            state->Cleanup(_tick);
+            // If DoUpdate returns true, the state has signaled it's done
+            // Clean it up.
+            // If the state stack is not empty, the next state will be polled.
+            if (top->DoUpdate(_tick))
+            {
+                // the state may change (and get cleaned up) during DoUpdate as a consequence of things it does
+                // Only clean up the state if the current state is still the same one we ran DoUpdate on
+                if (top == GetCurrentState())
+                {
+                    top->Cleanup(_tick);
+                    m_stateStack.pop();
+                }
+            }
+            else // The state isn't done yet, preserve the state stack and bail out
+            {
+                break;
+            }
+        }
+        else // This should be dead code, but just in case...
+        {
+            break;
         }
     }
 

--- a/src/map/ai/helpers/action_queue.cpp
+++ b/src/map/ai/helpers/action_queue.cpp
@@ -50,8 +50,8 @@ void CAIActionQueue::checkAction(timer::time_point tick)
         if (tick > topaction.start_time + topaction.delay)
         {
             queueAction_t action = timerQueue.top();
-            timerQueue.pop();
             handleAction(action);
+            timerQueue.pop();
         }
         else
         {
@@ -64,8 +64,8 @@ void CAIActionQueue::checkAction(timer::time_point tick)
         if (tick > topaction.start_time + topaction.delay && (!topaction.checkState || PEntity->PAI->CanChangeState()))
         {
             auto action = actionQueue.top();
-            actionQueue.pop();
             handleAction(action);
+            actionQueue.pop();
         }
         else
         {


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This may fix use-after-frees as pop() can call destructors.

## Steps to test these changes

should notice no obvious changes, but there was a use-after-free caught by having Zeid fight a quadav that can cast magic (with ludicrious stats like infinite MP, max haste, fast cast, etc on both)
