### PR TITLE
[Fix] `givemagianitem` GM command

### DIFF
--- a/scripts/commands/givemagianitem.lua
+++ b/scripts/commands/givemagianitem.lua
@@ -11,35 +11,61 @@ commandObj.cmdprops =
     parameters = 'sib'
 }
 
-commandObj.onTrigger = function(player, target, trialId, isRewardItem)
+commandObj.onTrigger = function(player, targetName, trialId, isRewardItem)
+    -- Early return: No target name.
+    if not targetName then
+        player:printToPlayer('You must enter a valid player name.')
+        return
+    end
+
+    -- Early return: No trial ID input.
+    if not trialId then
+        player:printToPlayer('You must enter a valid Trial ID.')
+        return
+    end
+
+    -- Early return: No valid target entity.
+    local targetEntity = GetPlayerByName(targetName)
+    if not targetEntity then
+        player:printToPlayer(string.format('Player named \'%s\' not found!', targetName))
+        return
+    end
+
+    -- Early return: No trial data.
+    local trialData = xi.magian.trials[trialId]
+    if not trialData then
+        player:printToPlayer(string.format('Trial ID \'%u\' was not found.', trialId))
+        return
+    end
+
     local giveRewardItem = isRewardItem and true or false
-
-    if
-        target == nil or
-        trialId == nil
-    then
-        player:printToPlayer('You must enter a valid player name and Trial ID.')
+    local itemData       = giveRewardItem and trialData.rewardItem or trialData.requiredItem
+    if not itemData or not itemData.itemId then
+        player:printToPlayer(string.format('Trial ID \'%u\' does not have a valid %s item.', trialId, giveRewardItem and 'reward' or 'required'))
         return
     end
 
-    local targ = GetPlayerByName(target)
-    if targ == nil then
-        player:printToPlayer(string.format('Player named \'%s\' not found!', target))
+    -- Check target inventory.
+    if targetEntity:getFreeSlotsCount() == 0 then
+        player:printToPlayer(string.format('Player \'%s\' does not have free space for that item!', targetName))
         return
     end
 
-    -- Attempt to give the target the item
-    if targ:getFreeSlotsCount() == 0 then
-        player:printToPlayer(string.format('Player \'%s\' does not have free space for that item!', target))
+    -- Check if target already has the item.
+    if targetEntity:hasItem(itemData.itemId) then
+        player:printToPlayer(string.format('%s already has item %i.', targetEntity:getName(), itemData.itemId))
+        return
+    end
+
+    -- Handle item.
+    if giveRewardItem then
+        xi.magian.giveRewardItem(targetEntity, trialId)
     else
-        if giveRewardItem then
-            xi.magian.giveRewardItem(target, trialId)
-        else
-            xi.magian.giveRequiredItem(target, trialId)
-        end
-
-        player:printToPlayer(string.format('Gave player \'%s\' Item for Trial ID \'%u\' ', target, trialId))
+        xi.magian.giveRequiredItem(targetEntity, trialId, true)
     end
+
+    targetEntity:messageSpecial(zones[targetEntity:getZoneID()].text.ITEM_OBTAINED, itemData.itemId)
+    player:printToPlayer(string.format('Gave player \'%s\' Item for Trial ID \'%u\' ', targetName, trialId))
 end
 
 return commandObj


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the givemagianitem command which was passing text and not the player ID.

## Steps to test these changes

Use `!givemagianitem <t> 1003` on a player and it will give them Spharai with the inscribed trial number
Use `!givemagianitem <t> 1003 true` on a player and it will give them the augment reward Spharai from trial 1003
It will not give the item if the player already has one in their inventory,
