### PR TITLE
Fix EXP recovery from Raise

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5435,7 +5435,7 @@ void AddExperiencePoints(bool expFromRaise, CCharEntity* PChar, CBaseEntity* PMo
 {
     TracyZoneScoped;
 
-    if (PChar->isDead())
+    if (PChar->isDead() && !expFromRaise)
     {
         return;
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates AddExperiencePoints so that players can get EXP returned on raise.

Closes #9398

## Steps to test these changes

Repeat as necessary:
!changejob war 70
EXP is 33999
!hp 0 <me>
EXP is 31599
Use Raise 1 -> 3:
Exp is 32799, 33399, and 33759 respectively
