### PR TITLE
Fix Enhances Drain and Aspir mod

### DIFF
--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -131,7 +131,7 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
     local elementalStaffBonus    = xi.spells.damage.calculateElementalStaffBonus(caster, xi.element.DARK)
     local elementalAffinityBonus = xi.spells.damage.calculateElementalAffinityBonus(caster, xi.element.DARK)
     local dayAndWeather          = xi.spells.damage.calculateDayAndWeather(caster, xi.element.DARK, false)
-    local absorbMultiplier       = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB) / 100
+    local absorbMultiplier       = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB) / 100 + caster:getMod(xi.mod.ENH_DRAIN_ASPIR) / 100
     local liberatorMultiplier    = 1 + caster:getMod(xi.mod.AUGMENTS_ABSORB_LIBERATOR) / 100
     local netherVoidMultiplier   = 1
     if caster:hasStatusEffect(xi.effect.NETHER_VOID) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds ENH_DRAIN_ASPIR mod to drain and aspir magic calculations.
Closes #9100

## Steps to test these changes
!changejob blm 70
!addallspells
!capallskills
!zone Qufim
!hp 200 <me>

Use drain on Clipper (no gear)
~250 hp drained on average

!setmod 315 1000 <me>
!hp 200 <me>

Use drain on Clipper (no gear)
~500 hp drained on average