### PR TITLE
[trust, lua, sql] AAHM: Added gambits/mods/tp usage

### DIFF
--- a/scripts/actions/spells/trust/aahm.lua
+++ b/scripts/actions/spells/trust/aahm.lua
@@ -14,6 +14,75 @@ end
 
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
+
+    mob:addMod(xi.mod.HPP, 20)
+    mob:addMod(xi.mod.UTSUSEMI_BONUS, 1)
+
+    local lastSynergyBonus = 0
+
+    -- Dynamic modifier that checks party member list on tick to apply
+    mob:addListener('COMBAT_TICK', 'AAEV_CTICK', function(mobArg)
+        local synergyMembers =
+        {
+            xi.magic.spell.AAEV,
+            xi.magic.spell.AAMR,
+            xi.magic.spell.AATT,
+            xi.magic.spell.AAGK
+        }
+
+        local synergyCount = 0
+        local party = mobArg:getMaster():getPartyWithTrusts()
+
+        for _, member in pairs(party) do
+            if member:getObjType() == xi.objType.TRUST then
+                local trustId = member:getTrustID()
+                for _, sId in ipairs(synergyMembers) do
+                    if trustId == sId then
+                        synergyCount = synergyCount + 1
+                        break
+                    end
+                end
+            end
+        end
+
+        -- Determine what the bonus should be
+        local targetBonus = (synergyCount == #synergyMembers) and 50 or 0
+
+        -- Only update if the state has changed
+        if targetBonus ~= lastSynergyBonus then
+            -- Subtract exactly what we added last time
+            mobArg:delMod(xi.mod.MEVA, lastSynergyBonus)
+            -- Add the new bonus
+            mobArg:addMod(xi.mod.MEVA, targetBonus)
+
+            -- Update lastSynergyBonus
+            lastSynergyBonus = targetBonus
+        end
+    end)
+
+    -----------------------------------
+    -- Gambits
+    -----------------------------------
+    -- 1 condition
+    mob:addGambit(ai.t.SELF,    { ai.c.NOT_STATUS,         xi.effect.MIGAWARI   }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.MIGAWARI_ICHI               })
+    mob:addGambit(ai.t.SELF,    { ai.c.NOT_STATUS,         xi.effect.COPY_IMAGE }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.UTSUSEMI              })
+    mob:addGambit(ai.t.TARGET,  { ai.c.ALWAYS,             0                    }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE                              })
+    mob:addGambit(ai.t.TARGET,  { ai.c.NOT_HAS_TOP_ENMITY, 0                    }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.HOJO                  }, 45)
+    mob:addGambit(ai.t.TARGET,  { ai.c.NOT_HAS_TOP_ENMITY, 0                    }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.KURAYAMI              }, 45)
+
+    -- 2 conditions
+    mob:addGambit(ai.t.SELF,    { { ai.c.PT_HAS_TANK,      0                    }, { ai.c.NOT_STATUS, xi.effect.YONIN   }, }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.YONIN   })
+    mob:addGambit(ai.t.SELF,    { { ai.c.PT_HAS_TANK,      0                    }, { ai.c.NOT_STATUS, xi.effect.WARCRY  }, }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.WARCRY  })
+    mob:addGambit(ai.t.SELF,    { { ai.c.NOT_PT_HAS_TANK,  0                    }, { ai.c.NOT_STATUS, xi.effect.INNIN   }, }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.INNIN   })
+    mob:addGambit(ai.t.SELF,    { { ai.c.NOT_PT_HAS_TANK,  0                    }, { ai.c.NOT_STATUS, xi.effect.BERSERK }, }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.BERSERK })
+
+    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
+
+    mob:addListener('WEAPONSKILL_USE', 'AAEV_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
+        if wsid == 3706 then
+            xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
+        end
+    end)
 end
 
 spellObject.onMobDespawn = function(mob)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -3732,10 +3732,10 @@ INSERT INTO `mob_skills` VALUES (3703,406,'unceasing_dread',0,0.0,7.0,2000,1500,
 INSERT INTO `mob_skills` VALUES (3704,407,'dignified_awe',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3705,408,'naakuals_vengeance',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- Trust: AAHM
-INSERT INTO `mob_skills` VALUES (3706,633,'cross_reaver',4,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3706,633,'cross_reaver',4,0.0,7.0,2000,500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3707,3451,'circle_blade',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3708,641,'swift_blade',0,0.0,7.0,2000,1500,4,0,0,0,9,0,0);
-INSERT INTO `mob_skills` VALUES (3709,2283,'chant_du_cygne',0,0.0,7.0,2000,1500,4,0,0,0,13,10,0); -- Capture shows 235. Adding 2048 for it to work properly.
+INSERT INTO `mob_skills` VALUES (3708,641,'swift_blade',0,0.0,7.0,2000,500,4,0,0,0,9,0,0);
+INSERT INTO `mob_skills` VALUES (3709,2283,'chant_du_cygne',0,0.0,7.0,2000,500,4,0,0,0,13,10,0); -- Capture shows 235. Adding 2048 for it to work properly.
 -- Trust: AAEV
 INSERT INTO `mob_skills` VALUES (3710,2285,'arrogance_incarnate',1,0.0,7.0,2000,1000,4,0,0,0,0,0,0); -- Capture shows 237. Adding 2048 for it to work properly.
 INSERT INTO `mob_skills` VALUES (3711,643,'vorpal_blade',0,0.0,7.0,2000,1000,4,0,0,0,4,8,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds full functionality of AAHM
https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Ark_Angel_HM

## Steps to test these changes

Call AAHM, 
Attack a mob,
He should now tank if no other tank is in the party and use  Innin and Berserk, or Yonin and Warcry if a tank is in the party and backup tank.
