### PR TITLE
[lua] Exdata enums and data for Moblin Maze Mongers

### DIFF
--- a/scripts/data/maze.lua
+++ b/scripts/data/maze.lua
@@ -1,0 +1,194 @@
+-----------------------------------
+-- Moblin Maze Mongers
+-- TODO: Unimplemented content.
+-- Treat as documentation and rework as needed.
+-----------------------------------
+xi = xi or {}
+xi.data = xi.data or {}
+xi.data.maze = xi.data.maze or {}
+
+-- Tabula base board layouts (5x5 grid).
+-- false = blocked, 0 = open, xi.element.X = element cell.
+xi.data.maze.tabulaGrid =
+{
+    [xi.item.MAZE_TABULA_M01] =
+    {
+        { 0,     0,     0,     0,     0 },
+        { 0,     false, 0,     0,     0 },
+        { 0,     0,     0,     0,     0 },
+        { 0,     0,     0,     false, 0 },
+        { 0,     0,     0,     0,     0 },
+    },
+
+    [xi.item.MAZE_TABULA_M02] =
+    {
+        { 0,     0,               0,     0,                  false },
+        { 0,     xi.element.FIRE, 0,     xi.element.THUNDER, 0     },
+        { 0,     0,               false, 0,                  0     },
+        { 0,     xi.element.WIND, 0,     xi.element.LIGHT,   0     },
+        { false, 0,               0,     0,                  0     },
+    },
+
+    [xi.item.MAZE_TABULA_M03] =
+    {
+        { 0,     0,                0,     xi.element.ICE,   0      },
+        { 0,     xi.element.DARK,  0,     0,                0      },
+        { false, 0,                false, 0,                false  },
+        { 0,     0,                0,     xi.element.WATER, 0      },
+        { 0,     xi.element.EARTH, 0,     0,                0      },
+    },
+
+    [xi.item.MAZE_TABULA_R01] =
+    {
+        { 0,     0,     0,     0,     0 },
+        { 0,     false, 0,     0,     0 },
+        { 0,     0,     0,     0,     0 },
+        { 0,     0,     0,     false, 0 },
+        { 0,     0,     0,     0,     0 },
+    },
+
+    [xi.item.MAZE_TABULA_R02] =
+    {
+        { 0,     0,               0,     0,                  false },
+        { 0,     xi.element.FIRE, 0,     xi.element.THUNDER, 0     },
+        { 0,     0,               false, 0,                  0     },
+        { 0,     xi.element.WIND, 0,     xi.element.LIGHT,   0     },
+        { false, 0,               0,     0,                  0     },
+    },
+
+    [xi.item.MAZE_TABULA_R03] =
+    {
+        { 0,     0,                0,     xi.element.ICE,   0      },
+        { 0,     xi.element.DARK,  0,     0,                0      },
+        { false, 0,                false, 0,                false  },
+        { 0,     0,                0,     xi.element.WATER, 0      },
+        { 0,     xi.element.EARTH, 0,     0,                0      },
+    },
+}
+
+-- 4x4 grid bitmasks per rotation.
+-- Index by [xi.maze.runeShape][rotation + 1], rotation 0-3.
+-- Source: FFXiMain.dll embedded table. Signature: 01 02 00 88 00 C0 00 88 00 C0 02 02 00 8C 00 C8 00 C4 00 4C
+---@type table<xi.maze.runeShape, integer[]>
+xi.data.maze.runeShapeData =
+{
+    [xi.maze.runeShape.DOMINO] = { 0x8800, 0xC000, 0x8800, 0xC000 },
+    [xi.maze.runeShape.CORNER] = { 0x8C00, 0xC800, 0xC400, 0x4C00 },
+    [xi.maze.runeShape.LINE_3] = { 0x8880, 0xE000, 0x8880, 0xE000 },
+    [xi.maze.runeShape.T]      = { 0x8C80, 0xE400, 0x4C40, 0x4E00 },
+    [xi.maze.runeShape.SQUARE] = { 0xCC00, 0xCC00, 0xCC00, 0xCC00 },
+    [xi.maze.runeShape.L]      = { 0x88C0, 0xE800, 0xC440, 0x2E00 },
+    [xi.maze.runeShape.J]      = { 0x44C0, 0x8E00, 0xC880, 0xE200 },
+    [xi.maze.runeShape.S]      = { 0x8C40, 0x6C00, 0x8C40, 0x6C00 },
+    [xi.maze.runeShape.Z]      = { 0x4C80, 0xC600, 0x4C80, 0xC600 },
+    [xi.maze.runeShape.LINE_4] = { 0x8888, 0xF000, 0x8888, 0xF000 },
+    [xi.maze.runeShape.PLUS]   = { 0x4E40, 0x4E40, 0x4E40, 0x4E40 },
+}
+
+-- Rune item → shape and element mapping.
+-- Source: Item DAT offset 0x14-0x15
+--   byte[0x15] & 0xF = shape index, byte[0x14] & 0xF = element (0-7 → xi.element + 1, 0xF → NONE).
+---@type table<xi.maze.rune, { shape: xi.maze.runeShape, element: xi.element }>
+xi.data.maze.runeInfo =
+{
+    [xi.maze.rune.AQUAN]                  = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.AMORPH]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.BIRD]                   = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.BEAST]                  = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.LIZARD]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.VERMIN]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.PLANTOID]               = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.UNDEAD]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.ARCANA]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.DEMON]                  = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.DRAGON]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.ELEMENTAL]              = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.GREAT_WARRIOR]          = { shape = xi.maze.runeShape.DOMINO, element = xi.element.EARTH   },
+    [xi.maze.rune.TINY_WARRIOR]           = { shape = xi.maze.runeShape.DOMINO, element = xi.element.WIND    },
+    [xi.maze.rune.MOTION]                 = { shape = xi.maze.runeShape.DOMINO, element = xi.element.FIRE    },
+    [xi.maze.rune.STILLNESS]              = { shape = xi.maze.runeShape.DOMINO, element = xi.element.WATER   },
+    [xi.maze.rune.SUPREME_MIGHT]          = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.MIGHT]                  = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.WEAKNESS]               = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.PEON]                   = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.FIRE]                   = { shape = xi.maze.runeShape.CORNER, element = xi.element.FIRE    },
+    [xi.maze.rune.ICE]                    = { shape = xi.maze.runeShape.CORNER, element = xi.element.ICE     },
+    [xi.maze.rune.WIND]                   = { shape = xi.maze.runeShape.CORNER, element = xi.element.WIND    },
+    [xi.maze.rune.EARTH]                  = { shape = xi.maze.runeShape.CORNER, element = xi.element.EARTH   },
+    [xi.maze.rune.THUNDER]                = { shape = xi.maze.runeShape.CORNER, element = xi.element.THUNDER },
+    [xi.maze.rune.WATER]                  = { shape = xi.maze.runeShape.CORNER, element = xi.element.WATER   },
+    [xi.maze.rune.LIGHT]                  = { shape = xi.maze.runeShape.CORNER, element = xi.element.LIGHT   },
+    [xi.maze.rune.DARKNESS]               = { shape = xi.maze.runeShape.CORNER, element = xi.element.DARK    },
+    [xi.maze.rune.STRENGTH]               = { shape = xi.maze.runeShape.LINE_3, element = xi.element.FIRE    },
+    [xi.maze.rune.DEXTERITY]              = { shape = xi.maze.runeShape.LINE_3, element = xi.element.THUNDER },
+    [xi.maze.rune.AGILITY]                = { shape = xi.maze.runeShape.LINE_3, element = xi.element.WIND    },
+    [xi.maze.rune.VITALITY]               = { shape = xi.maze.runeShape.LINE_3, element = xi.element.EARTH   },
+    [xi.maze.rune.INTELLECT]              = { shape = xi.maze.runeShape.LINE_3, element = xi.element.ICE     },
+    [xi.maze.rune.MIND]                   = { shape = xi.maze.runeShape.LINE_3, element = xi.element.WATER   },
+    [xi.maze.rune.CHARISMA]               = { shape = xi.maze.runeShape.LINE_3, element = xi.element.LIGHT   },
+    [xi.maze.rune.HARDINESS]              = { shape = xi.maze.runeShape.LINE_3, element = xi.element.LIGHT   },
+    [xi.maze.rune.MYSTICISM]              = { shape = xi.maze.runeShape.LINE_3, element = xi.element.DARK    },
+    [xi.maze.rune.CONSPICUOUS_BEHAVIOR]   = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.ALTERED_AGGRESSION]     = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.ALTERED_DEFENSE]        = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.DIVINE_MAGIC]           = { shape = xi.maze.runeShape.LINE_3, element = xi.element.LIGHT   },
+    [xi.maze.rune.HEALING_MAGIC]          = { shape = xi.maze.runeShape.LINE_3, element = xi.element.LIGHT   },
+    [xi.maze.rune.ENHANCING_MAGIC]        = { shape = xi.maze.runeShape.LINE_3, element = xi.element.LIGHT   },
+    [xi.maze.rune.ENFEEBLING_MAGIC]       = { shape = xi.maze.runeShape.LINE_3, element = xi.element.DARK    },
+    [xi.maze.rune.ELEMENTAL_MAGIC]        = { shape = xi.maze.runeShape.LINE_3, element = xi.element.DARK    },
+    [xi.maze.rune.DARK_MAGIC]             = { shape = xi.maze.runeShape.LINE_3, element = xi.element.DARK    },
+    [xi.maze.rune.WARRIOR]                = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.MONK]                   = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.WHITE_MAGE]             = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.BLACK_MAGE]             = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.RED_MAGE]               = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.THIEF]                  = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.ONSLAUGHT]              = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.PROTECTION]             = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.ACCURACY]               = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.EVASION]                = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.FORCE_OF_WILL]          = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.STEADY_MIND]            = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.FLURRY_OF_BLOWS]        = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.CRITICAL]               = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.RAPID_STRIKE]           = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.VOLUBILITY]             = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.FLEETFOOT]              = { shape = xi.maze.runeShape.CORNER, element = xi.element.WIND    },
+    [xi.maze.rune.PROSPECTOR]             = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.WOODSMAN]               = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.HARVESTER]              = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.FISHERMAN]              = { shape = xi.maze.runeShape.LINE_4, element = xi.element.NONE    },
+    [xi.maze.rune.CARPENTER]              = { shape = xi.maze.runeShape.SQUARE, element = xi.element.NONE    },
+    [xi.maze.rune.SMITH]                  = { shape = xi.maze.runeShape.SQUARE, element = xi.element.NONE    },
+    [xi.maze.rune.GOLDSMITH]              = { shape = xi.maze.runeShape.L,      element = xi.element.NONE    },
+    [xi.maze.rune.LEATHERCRAFTER]         = { shape = xi.maze.runeShape.J,      element = xi.element.NONE    },
+    [xi.maze.rune.BONECRAFTER]            = { shape = xi.maze.runeShape.S,      element = xi.element.NONE    },
+    [xi.maze.rune.CLOTHIER]               = { shape = xi.maze.runeShape.Z,      element = xi.element.NONE    },
+    [xi.maze.rune.ALCHEMIST]              = { shape = xi.maze.runeShape.SQUARE, element = xi.element.NONE    },
+    [xi.maze.rune.MASTER_CHEF]            = { shape = xi.maze.runeShape.LINE_4, element = xi.element.NONE    },
+    [xi.maze.rune.LOST_AND_FOUND]         = { shape = xi.maze.runeShape.PLUS,   element = xi.element.NONE    },
+    [xi.maze.rune.SWIFT_SYNTHESIS]        = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.SURE_SYNTHESIS]         = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.SUPERIOR_SYNTHESIS]     = { shape = xi.maze.runeShape.LINE_4, element = xi.element.NONE    },
+    [xi.maze.rune.INSURANCE_CONTRACT]     = { shape = xi.maze.runeShape.DOMINO, element = xi.element.NONE    },
+    [xi.maze.rune.REPLENISHMENT_CONTRACT] = { shape = xi.maze.runeShape.SQUARE, element = xi.element.NONE    },
+    [xi.maze.rune.TRIAL_BY_VELOCITY]      = { shape = xi.maze.runeShape.L,      element = xi.element.NONE    },
+    [xi.maze.rune.TRIAL_BY_BUDGET]        = { shape = xi.maze.runeShape.LINE_4, element = xi.element.NONE    },
+    [xi.maze.rune.TRIAL_BY_NUMBERS]       = { shape = xi.maze.runeShape.Z,      element = xi.element.NONE    },
+    [xi.maze.rune.AMNESIACS_TRIAL]        = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.TRIAL_BY_SILENCE]       = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.GUIDANCE_CONTRACT]      = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.REINFORCEMENT_CONTRACT] = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.CONDITIONING_CONTRACT]  = { shape = xi.maze.runeShape.PLUS,   element = xi.element.NONE    },
+    [xi.maze.rune.SUSTENANCE_CONTRACT]    = { shape = xi.maze.runeShape.S,      element = xi.element.NONE    },
+    [xi.maze.rune.CAMARADERIE_CONTRACT]   = { shape = xi.maze.runeShape.PLUS,   element = xi.element.NONE    },
+    [xi.maze.rune.GOLDAGRIKS_GENEROSITY]  = { shape = xi.maze.runeShape.T,      element = xi.element.NONE    },
+    [xi.maze.rune.OBSCURED_ENTRANCE]      = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.SHORTCUT]               = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+    [xi.maze.rune.WALLOPER]               = { shape = xi.maze.runeShape.SQUARE, element = xi.element.NONE    },
+    [xi.maze.rune.BARRAGER]               = { shape = xi.maze.runeShape.L,      element = xi.element.NONE    },
+    [xi.maze.rune.SPELLSLINGER]           = { shape = xi.maze.runeShape.J,      element = xi.element.NONE    },
+    [xi.maze.rune.SALINITY_SHIFT]         = { shape = xi.maze.runeShape.DOMINO, element = xi.element.WATER   },
+    [xi.maze.rune.SKILLCHAIN]             = { shape = xi.maze.runeShape.CORNER, element = xi.element.NONE    },
+    [xi.maze.rune.MAGIC_BURST]            = { shape = xi.maze.runeShape.LINE_3, element = xi.element.NONE    },
+}

--- a/scripts/enum/maze.lua
+++ b/scripts/enum/maze.lua
@@ -1,0 +1,185 @@
+-----------------------------------
+-- Moblin Maze Mongers
+-----------------------------------
+xi = xi or {}
+xi.maze = xi.maze or {}
+
+---@enum xi.maze.runeShape
+xi.maze.runeShape =
+{
+    -- #
+    -- #
+    DOMINO  = 0,
+
+    -- #.
+    -- ##
+    CORNER  = 1,
+
+    -- #
+    -- #
+    -- #
+    LINE_3  = 2,
+
+    -- #.
+    -- ##
+    -- #.
+    T       = 3,
+
+    -- ##
+    -- ##
+    SQUARE  = 4,
+
+    -- #.
+    -- #.
+    -- ##
+    L       = 5,
+
+    -- .#
+    -- .#
+    -- ##
+    J       = 6,
+
+    -- #.
+    -- ##
+    -- .#
+    S       = 7,
+
+    -- .#
+    -- ##
+    -- #.
+    Z       = 8,
+
+    -- #
+    -- #
+    -- #
+    -- #
+    LINE_4  = 9,
+
+    -- .#.
+    -- ###
+    -- .#.
+    PLUS    = 10,
+}
+
+-- MMM Voucher names extracted from item descriptions
+-- Stored in Tabula exdata
+---@enum xi.maze.voucher
+xi.maze.voucher =
+{
+    SANITIZATION_TEAM_ALPHA     = 1, -- Voucher 01
+    SANITIZATION_TEAM_BETA      = 2, -- Voucher 02
+    SANITIZATION_TEAM_GAMMA     = 3, -- Voucher 03
+    MATERIALIZATION_TEAM        = 4, -- Voucher 04
+    ACTUALIZATION_TEAM          = 5, -- Voucher 05
+    APPROPRIATION_TEAM          = 6, -- Voucher 06
+    LIQUIDATION_TEAM            = 7, -- Voucher 07
+    AQUATIC_DEPOPULATION_TEAM   = 8, -- Voucher 08
+    REVITALIZATION_TEAM         = 9, -- Voucher 09
+}
+
+-- MMM Rune names extracted from item descriptions
+-- Stored in Tabula exdata
+---@enum xi.maze.rune
+xi.maze.rune =
+{
+    AQUAN                  =   1, -- Rune 001
+    AMORPH                 =   2, -- Rune 002
+    BIRD                   =   3, -- Rune 003
+    BEAST                  =   4, -- Rune 004
+    LIZARD                 =   5, -- Rune 005
+    VERMIN                 =   6, -- Rune 006
+    PLANTOID               =   7, -- Rune 007
+    UNDEAD                 =   8, -- Rune 008
+    ARCANA                 =   9, -- Rune 009
+    DEMON                  =  10, -- Rune 010
+    DRAGON                 =  11, -- Rune 011
+    ELEMENTAL              =  12, -- Rune 012
+    GREAT_WARRIOR          =  13, -- Rune 013
+    TINY_WARRIOR           =  14, -- Rune 014
+    MOTION                 =  15, -- Rune 015
+    STILLNESS              =  16, -- Rune 016
+    SUPREME_MIGHT          =  17, -- Rune 017
+    MIGHT                  =  18, -- Rune 018
+    WEAKNESS               =  19, -- Rune 019
+    PEON                   =  20, -- Rune 020
+    FIRE                   =  21, -- Rune 021
+    ICE                    =  22, -- Rune 022
+    WIND                   =  23, -- Rune 023
+    EARTH                  =  24, -- Rune 024
+    THUNDER                =  25, -- Rune 025
+    WATER                  =  26, -- Rune 026
+    LIGHT                  =  27, -- Rune 027
+    DARKNESS               =  28, -- Rune 028
+    STRENGTH               =  29, -- Rune 029
+    DEXTERITY              =  30, -- Rune 030
+    AGILITY                =  31, -- Rune 031
+    VITALITY               =  32, -- Rune 032
+    INTELLECT              =  33, -- Rune 033
+    MIND                   =  34, -- Rune 034
+    CHARISMA               =  35, -- Rune 035
+    HARDINESS              =  36, -- Rune 036
+    MYSTICISM              =  37, -- Rune 037
+    CONSPICUOUS_BEHAVIOR   =  38, -- Rune 038
+    ALTERED_AGGRESSION     =  39, -- Rune 039
+    ALTERED_DEFENSE        =  40, -- Rune 040
+    DIVINE_MAGIC           =  41, -- Rune 041
+    HEALING_MAGIC          =  42, -- Rune 042
+    ENHANCING_MAGIC        =  43, -- Rune 043
+    ENFEEBLING_MAGIC       =  44, -- Rune 044
+    ELEMENTAL_MAGIC        =  45, -- Rune 045
+    DARK_MAGIC             =  46, -- Rune 046
+    WARRIOR                =  51, -- Rune 051
+    MONK                   =  52, -- Rune 052
+    WHITE_MAGE             =  53, -- Rune 053
+    BLACK_MAGE             =  54, -- Rune 054
+    RED_MAGE               =  55, -- Rune 055
+    THIEF                  =  56, -- Rune 056
+    ONSLAUGHT              =  71, -- Rune 071
+    PROTECTION             =  72, -- Rune 072
+    ACCURACY               =  73, -- Rune 073
+    EVASION                =  74, -- Rune 074
+    FORCE_OF_WILL          =  75, -- Rune 075
+    STEADY_MIND            =  76, -- Rune 076
+    FLURRY_OF_BLOWS        =  77, -- Rune 077
+    CRITICAL               =  78, -- Rune 078
+    RAPID_STRIKE           =  79, -- Rune 079
+    VOLUBILITY             =  80, -- Rune 080
+    FLEETFOOT              =  81, -- Rune 081
+    PROSPECTOR             =  82, -- Rune 082
+    WOODSMAN               =  83, -- Rune 083
+    HARVESTER              =  84, -- Rune 084
+    FISHERMAN              =  85, -- Rune 085
+    CARPENTER              =  86, -- Rune 086
+    SMITH                  =  87, -- Rune 087
+    GOLDSMITH              =  88, -- Rune 088
+    LEATHERCRAFTER         =  89, -- Rune 089
+    BONECRAFTER            =  90, -- Rune 090
+    CLOTHIER               =  91, -- Rune 091
+    ALCHEMIST              =  92, -- Rune 092
+    MASTER_CHEF            =  93, -- Rune 093
+    LOST_AND_FOUND         =  94, -- Rune 094
+    SWIFT_SYNTHESIS        =  95, -- Rune 095
+    SURE_SYNTHESIS         =  96, -- Rune 096
+    SUPERIOR_SYNTHESIS     =  97, -- Rune 097
+    INSURANCE_CONTRACT     =  98, -- Rune 098
+    REPLENISHMENT_CONTRACT =  99, -- Rune 099
+    TRIAL_BY_VELOCITY      = 100, -- Rune 100
+    TRIAL_BY_BUDGET        = 101, -- Rune 101
+    TRIAL_BY_NUMBERS       = 102, -- Rune 102
+    AMNESIACS_TRIAL        = 103, -- Rune 103
+    TRIAL_BY_SILENCE       = 104, -- Rune 104
+    GUIDANCE_CONTRACT      = 106, -- Rune 106
+    REINFORCEMENT_CONTRACT = 107, -- Rune 107
+    CONDITIONING_CONTRACT  = 108, -- Rune 108
+    SUSTENANCE_CONTRACT    = 109, -- Rune 109
+    CAMARADERIE_CONTRACT   = 110, -- Rune 110
+    GOLDAGRIKS_GENEROSITY  = 111, -- Rune 111
+    OBSCURED_ENTRANCE      = 112, -- Rune 112
+    SHORTCUT               = 113, -- Rune 113
+    WALLOPER               = 114, -- Rune 114
+    BARRAGER               = 115, -- Rune 115
+    SPELLSLINGER           = 116, -- Rune 116
+    SALINITY_SHIFT         = 117, -- Rune 117
+    SKILLCHAIN             = 118, -- Rune 118
+    MAGIC_BURST            = 119, -- Rune 119
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Enums for MMM exdata and dumped the data for all runes from item DATs. 
Should be enough to hook up the packets and validate legitimate tabulas are being constructed.

Credits @atom0s for some decomps

## Steps to test these changes
No code change.
<!-- Clear and detailed steps to test your changes here -->
