### PR TITLE
[lua] Exdata enums for Chocobo Racing/Raising, Mannequins

### DIFF
--- a/scripts/enum/chocobo_racing.lua
+++ b/scripts/enum/chocobo_racing.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Chocobo Racing
+-----------------------------------
+xi = xi or {}
+xi.chocoboRacing = xi.chocoboRacing or {}
+
+-- Stored in Chocobet and Completion Certificates exdata
+---@enum xi.chocoboRacing.raceGrade
+xi.chocoboRacing.raceGrade =
+{
+    ALTANA_CUP_II = 11,
+    C1            = 12,
+    C2            = 13,
+    C3            = 14,
+    C4            = 15,
+}
+
+-- Stored in Egg and Chococards exdata
+---@enum xi.chocoboRacing.jockeySize
+xi.chocoboRacing.jockeySize =
+{
+    GALKA      = 0,
+    HUME_M     = 1,
+    HUME_F     = 2,
+    ELVAAN_M   = 3,
+    ELVAAN_F   = 4,
+    TARUTARU_M = 5,
+    TARUTARU_F = 6,
+    MITHRA     = 7,
+}

--- a/scripts/enum/chocobo_raising.lua
+++ b/scripts/enum/chocobo_raising.lua
@@ -1,0 +1,82 @@
+-----------------------------------
+-- Chocobo Raising
+-----------------------------------
+xi = xi or {}
+xi.chocoboRaising = xi.chocoboRaising or {}
+
+---@enum xi.chocoboRaising.color
+xi.chocoboRaising.color =
+{
+    YELLOW = 0,
+    BLACK  = 1,
+    BLUE   = 2,
+    RED    = 3,
+    GREEN  = 4,
+}
+
+---@enum xi.chocoboRaising.honeymoonPlan
+xi.chocoboRaising.honeymoonPlan =
+{
+    GOURMET    = 1, -- Plan A
+    SPORTS     = 2, -- Plan B
+    HIKING     = 3, -- Plan C
+    JEUNO_TOUR = 4, -- Plan D
+}
+
+---@enum xi.chocoboRaising.statRank
+xi.chocoboRaising.statRank =
+{
+    POOR            = 0, -- F
+    SUBSTANDARD     = 1, -- E
+    A_BIT_DEFICIENT = 2, -- D
+    AVERAGE         = 3, -- C
+    BETTER_THAN_AVG = 4, -- B
+    IMPRESSIVE      = 5, -- A
+    OUTSTANDING     = 6, -- S
+    FIRST_CLASS     = 7, -- SS
+}
+
+---@enum xi.chocoboRaising.ability
+xi.chocoboRaising.ability =
+{
+    NONE            = 0,
+    GALLOP          = 1,
+    CANTER          = 2,
+    BURROW          = 3,
+    BORE            = 4,
+    AUTO_REGEN      = 5,
+    TREASURE_FINDER = 6,
+}
+
+---@enum xi.chocoboRaising.temperament
+xi.chocoboRaising.temperament =
+{
+    VERY_EASYGOING  = 0,
+    ILL_TEMPERED    = 1,
+    VERY_PATIENT    = 2,
+    QUITE_SENSITIVE = 3,
+    ENIGMATIC       = 4,
+}
+
+---@enum xi.chocoboRaising.gender
+xi.chocoboRaising.gender =
+{
+    MALE   = 0,
+    FEMALE = 1,
+}
+
+---@enum xi.chocoboRaising.weather
+xi.chocoboRaising.weather =
+{
+    CLEAR        = 0,  -- Prefers clear, dislikes none
+    HOT_SUNNY    = 1,  -- Prefers hot sunny, dislikes rainy
+    RAINY        = 2,  -- Prefers rainy, dislikes thunderstorms
+    SANDSTORMS   = 3,  -- Prefers sandstorms, dislikes windy
+    WINDY        = 4,  -- Prefers windy, dislikes snowy
+    SNOWY        = 5,  -- Prefers snowy, dislikes hot sunny
+    THUNDERSTORM = 6,  -- Prefers thunderstorms, dislikes sandstorms
+    AURORAS      = 7,  -- Prefers auroras, dislikes dark
+    DARK         = 8,  -- Prefers dark, dislikes auroras
+    NONE         = 9,  -- Prefers none, dislikes none
+    CLOUDY       = 10, -- Prefers cloudy, dislikes none
+}

--- a/scripts/enum/mannequin.lua
+++ b/scripts/enum/mannequin.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Mannequin
+-----------------------------------
+xi = xi or {}
+xi.mannequin = xi.mannequin or {}
+
+-- Stored in Mannequin exdata
+---@enum xi.mannequin.type
+xi.mannequin.type =
+{
+    HUME_M   = 0x01,
+    HUME_F   = 0x02,
+    ELVAAN_M = 0x04,
+    ELVAAN_F = 0x08,
+    TARU_M   = 0x10,
+    TARU_F   = 0x20,
+    MITHRA   = 0x40,
+    GALKA    = 0x80,
+}
+
+-- Stored in Mannequin exdata
+---@enum xi.mannequin.pose
+xi.mannequin.pose =
+{
+    NORMAL    = 0x00,
+    SIT       = 0x01,
+    SALUTE_S  = 0x02, -- San d'Orian salute
+    SALUTE_B  = 0x03, -- Bastokan salute
+    SALUTE_W  = 0x04, -- Windurstian salute
+    HURRAY    = 0x08,
+    SPECIAL   = 0x10,
+}

--- a/scripts/globals/chocobo_raising.lua
+++ b/scripts/globals/chocobo_raising.lua
@@ -542,59 +542,6 @@ local stage =
     ADULT_4    = 7, -- Retired?
 }
 
-local color =
-{
-    YELLOW = 0,
-    BLACK  = 1,
-    BLUE   = 2,
-    RED    = 3,
-    GREEN  = 4,
-}
-
-local sex =
-{
-    MALE   = 0,
-    FEMALE = 1,
-}
-utils.unused(sex)
-
-local abilities =
-{
-    NONE            = 0,
-    GALLOP          = 1,
-    CANTER          = 2,
-    BURROW          = 3,
-    BORE            = 4,
-    AUTO_REGEN      = 5,
-    TREASURE_FINDER = 6,
-}
-utils.unused(abilities)
-
-local personality =
-{
-    EASYGOING    = 0,
-    ILL_TEMPERED = 1,
-    PATIENT      = 2,
-    SENSITIVE    = 3,
-    ENIGMATIC    = 4,
-}
-utils.unused(personality)
-
--- NOTE: Dislikes are just the next weather in the cycle after the likes
-local weather =
-{
-    CLEAR_DAYS = 0,
-    HOT_DAYS   = 1,
-    RAINY_DAYS = 2,
-    SANDSTORMS = 3,
-    WINDY      = 4,
-    SNOW       = 5,
-    THUNDER    = 6,
-    AURORAS    = 7,
-    DARK       = 8,
-}
-utils.unused(weather)
-
 local affectionRank =
 {
     DOESNT_CARE       = 0,
@@ -606,7 +553,6 @@ local affectionRank =
     ALL_THE_TIME      = 6,
     PARENT            = 7,
 }
-utils.unused(affectionRank)
 
 local hunger =
 {
@@ -742,7 +688,7 @@ xi.chocoboRaising.newChocobo = function(player, egg)
     newChoco.recessive_gene = 0 -- TODO
 
     -- TODO: Pick various stats based on genetics
-    newChoco.color             = color.YELLOW
+    newChoco.color              = xi.chocoboRaising.color.YELLOW
     newChoco.strength           = 0
     newChoco.endurance          = 0
     newChoco.discernment        = 0

--- a/scripts/globals/mannequins.lua
+++ b/scripts/globals/mannequins.lua
@@ -5,29 +5,6 @@
 xi = xi or {}
 xi.mannequin = xi.mannequin or {}
 
-xi.mannequin.type =
-{
-    HUME_M   = 0x01,
-    HUME_F   = 0x02,
-    ELVAAN_M = 0x04,
-    ELVAAN_F = 0x08,
-    TARU_M   = 0x10,
-    TARU_F   = 0x20,
-    MITHRA   = 0x40,
-    GALKA    = 0x80,
-}
-
-xi.mannequin.pose =
-{
-    NORMAL    = 0x00,
-    SIT       = 0x01,
-    SALUTE_S  = 0x02,
-    SALUTE_B  = 0x03,
-    SALUTE_W  = 0x04,
-    HURRAY    = 0x08,
-    SPECIAL   = 0x10,
-}
-
 xi.mannequin.cost =
 {
     PURCHASE  = 100000,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Moves mannequin enums into enum folder
- Moves some locals from the global chocobo raising file into enums folder
- Adds missing enums for certain exdata fields on various items related to Chocobo Raising and Racing

Credits @Ivaar for [chococard addon](https://github.com/Ivaar/Windower-addons/tree/master/chococard)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
