### PR TITLE
[trust, lua] tuned AAEV/AAHM/Amchuchu and cleaned up scripts

### DIFF
--- a/scripts/actions/spells/trust/aaev.lua
+++ b/scripts/actions/spells/trust/aaev.lua
@@ -16,6 +16,7 @@ spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
 
     mob:setMobMod(xi.mobMod.CAN_SHIELD_BLOCK, 1)
+    mob:setMobMod(xi.mobMod.CAN_PARRY, 3)
 
     local lvl = mob:getMainLvl()
     local shieldMasteryPower = 0
@@ -103,10 +104,10 @@ spellObject.onMobSpawn = function(mob)
 
     mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.RANDOM, 2000)
 
-    mob:addListener('WEAPONSKILL_USE', 'AAEV_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
-        if wsid == 3710 then
+    mob:addListener('WEAPONSKILL_USE', 'AAEV_WEAPONSKILL_USE', function(mobArg, target, skill, tp, action)
+        if skill:getID() == 3710 then -- Arrogance Incarnate
             xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
-        elseif wsid == 3712 then
+        elseif skill:getID() == 3712 then -- Dominion Slash
             xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_2)
         end
     end)

--- a/scripts/actions/spells/trust/aahm.lua
+++ b/scripts/actions/spells/trust/aahm.lua
@@ -15,13 +15,16 @@ end
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
 
+    mob:addMobMod(xi.mobMod.CAN_PARRY, 3)
+
     mob:addMod(xi.mod.HPP, 20)
     mob:addMod(xi.mod.UTSUSEMI_BONUS, 1)
-
+    mob:addMod(xi.mod.FASTCAST, 30)
+    mob:addMod(xi.mod.DUAL_WIELD, 10)
     local lastSynergyBonus = 0
 
     -- Dynamic modifier that checks party member list on tick to apply
-    mob:addListener('COMBAT_TICK', 'AAEV_CTICK', function(mobArg)
+    mob:addListener('COMBAT_TICK', 'AAHM_CTICK', function(mobArg)
         local synergyMembers =
         {
             xi.magic.spell.AAEV,
@@ -78,8 +81,9 @@ spellObject.onMobSpawn = function(mob)
 
     mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM)
 
-    mob:addListener('WEAPONSKILL_USE', 'AAEV_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
-        if wsid == 3706 then
+    mob:addListener('WEAPONSKILL_USE', 'AAHM_WEAPONSKILL_USE', function(mobArg, target, skill, tp, action)
+        if skill:getID() == 3706 then -- Cross Reaver
+            -- Apathy strikes!
             xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
         end
     end)

--- a/scripts/actions/spells/trust/amchuchu.lua
+++ b/scripts/actions/spells/trust/amchuchu.lua
@@ -15,6 +15,8 @@ end
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
 
+    mob:addMobMod(xi.mobMod.CAN_PARRY, 3)
+
     mob:addMod(xi.mod.INSPIRATION_FAST_CAST, 50)
 
     -----------------------------------
@@ -53,8 +55,8 @@ spellObject.onMobSpawn = function(mob)
 
     mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.HIGHEST, 3000)
 
-    mob:addListener('WEAPONSKILL_USE', 'AMCHUCHU_WEAPONSKILL_USE', function(mobArg, target, wsid, tp, action)
-        if wsid == 61 then -- Dimidation
+    mob:addListener('WEAPONSKILL_USE', 'AMCHUCHU_WEAPONSKILL_USE', function(mobArg, target, skill, tp, action)
+        if skill:getID() == 61 then -- Dimidation
             -- Nothing-wothing wrong with a little mad science now and again!
             xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes some trust that were not using thier special move message.
Tuned AAEV / AAHM and Amchuchu with the addtion of mods and mobmods based on retail observations,
mainly xi.mobMod.CAN_PARRY, added a small fast cast mod to AAHM to match retail cast speeds, he casts super fast.

## Steps to test these changes

Call out each trust and watch to see if they parry/shield block if applicable,
they should act very similar to retail or as close as we can get them at this point.
