### PR TITLE
[mob] Yazquhl ws message placement fix

### DIFF
--- a/scripts/zones/The_Ashu_Talif/mobs/Yazquhl.lua
+++ b/scripts/zones/The_Ashu_Talif/mobs/Yazquhl.lua
@@ -70,7 +70,6 @@ entity.onMobFight = function(mob, target)
         end
 
         yazquhlMob:useMobAbility(xi.mobSkill.VORPAL_BLADE_1, scTarget)
-        mob:showText(mob, ID.text.REST_BENEATH)
 
         -- Only add Emnity if the skillchain closer target is different than its current target
         if
@@ -112,6 +111,22 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
         table.insert(tpTable, xi.mobSkill.VORPAL_BLADE_1)
     end
 
+    return tpTable[math.random(1, #tpTable)]
+end
+
+entity.onMobWeaponSkill = function(mob, target, skill, action)
+    if skill:getID() == xi.mobSkill.MIGHTY_STRIKES_1 then
+        mob:showText(mob, ID.text.YOU_WILL_REGRET)
+        return
+    end
+
+    mob:setMobAbilityEnabled(true)
+
+    local instance = mob:getInstance()
+    if not instance then
+        return
+    end
+
     local weaponskillMessage =
     {
         [1] = ID.text.TAKE_THIS,
@@ -121,21 +136,6 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
 
     if mob:isEngaged() then
         mob:showText(mob, weaponskillMessage[math.random(1, #weaponskillMessage)])
-    end
-
-    return tpTable[math.random(1, #tpTable)]
-end
-
-entity.onMobWeaponSkill = function(mob, target, skill, action)
-    if skill:getID() == xi.mobSkill.MIGHTY_STRIKES_1 then
-        mob:showText(mob, ID.text.YOU_WILL_REGRET)
-    end
-
-    mob:setMobAbilityEnabled(true)
-
-    local instance = mob:getInstance()
-    if not instance then
-        return
     end
 
     local gowam = GetMobByID(ID.mob.GOWAM, instance)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes my mistake of placing the weaponskill messaging and relocates it from onmobskillchoose to onMobWeaponSkill so the message won't play multiple times if the mob is at range.

## Steps to test these changes

Fight Yazquhl while he has 3k tp at range.
