### PR TITLE
[tests] Adjust Sonic Boom Finish & mobs parrying/guarding tests

### DIFF
--- a/scripts/tests/packets/s2c/0x028_battle2/basic_attacks.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/basic_attacks.lua
@@ -135,10 +135,14 @@ local packets =
             player:equipItem(xi.item.BRONZE_DAGGER, nil, xi.slot.MAIN)
             local warMob = player.entities:moveTo('Vanguard_Footsoldier')
             player.actions:engage(warMob)
+            warMob:updateEnmity(player)
+
             for i = 1, 20 do
                 xi.test.world:tickEntity(player)
                 xi.test.world:skipTime(10)
             end
+
+            warMob:disengage()
         end,
 
         expected =

--- a/scripts/tests/packets/s2c/0x028_battle2/mobskills.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/mobskills.lua
@@ -54,7 +54,8 @@ local packets =
             local bats = player.entities:moveTo('Incubus_Bats') -- Incubus Bats
             bats:addTP(3000)
             bats:useMobAbility(xi.mobSkill.SONIC_BOOM_1, player, 0)
-            xi.test.world:tickEntity(bats) -- Tick the AI so the skill gets readied
+            xi.test.world:skipTime(4)
+            xi.test.world:tickEntity(bats) -- Tick the AI so the skill finishes
         end,
 
         expected =

--- a/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
@@ -174,10 +174,12 @@ local packets =
             mnkMob:setMod(xi.mod.ADDITIVE_GUARD, 100)
 
             player.actions:engage(mnkMob)
+            mnkMob:updateEnmity(player)
             xi.test.world:tickEntity(player)
             xi.test.world:skipTime(1)
             player.actions:useWeaponskill(mnkMob, xi.weaponskill.PYRRHIC_KLEOS)
             xi.test.world:skipTime(3)
+            mnkMob:disengage()
         end,
 
         expected =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sonic Boom was not given time to finish, so I added a skip time that's more than the total ready time in seconds.
Apparently during Guard & Parrying, the mobs were literally just walking away... So I made mobs engage the player (and disengage as a cleanup).

## Steps to test these changes

Run xi_test repeatedly and not see these intermittent failures