### PR TITLE
[cpp, combat] Fix Ranged Weapon Rank Calculations

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -794,14 +794,29 @@ uint16 CBattleEntity::GetSubWeaponRank()
 
 uint16 CBattleEntity::GetRangedWeaponRank()
 {
-    uint16 wDamage = GetRangedWeaponDmg();
-    // Check ranged slot first, otherwise use ammo if it's null
+    // Weapon rank uses only the ranged weapon's damage (or ammo for throwing),
+    // not the combined ranged + ammo total that GetRangedWeaponDmg() returns.
+    uint16 wDamage = 0;
+
+    // Check ranged slot first, otherwise use ammo if it's null (throwing weapons)
     CItemEquipment* item = m_Weapons[SLOT_RANGED] ? m_Weapons[SLOT_RANGED] : m_Weapons[SLOT_AMMO];
 
     if (auto* weapon = dynamic_cast<CItemWeapon*>(item))
     {
+        if ((weapon->getReqLvl() > GetMLevel()) && objtype == TYPE_PC)
+        {
+            uint16 scaleddmg = weapon->getDamage();
+            scaleddmg *= GetMLevel() * 3;
+            scaleddmg /= 4;
+            scaleddmg /= weapon->getReqLvl();
+            wDamage = scaleddmg;
+        }
+        else
+        {
+            wDamage = weapon->getDamage();
+        }
+
         wDamage += weapon->getModifier(Mod::RANGED_DMG_RANK);
-        wDamage -= weapon->getModifier(Mod::DMG_RATING); // Company sword, Maneater, etc don't boost weapon rank
     }
 
     return wDamage / 9;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the Weapon Rank calculation for Ranged weapons to use only the Ranged Weapon, instead of Ranged Weapon + Ammo

## Steps to test these changes

- Equip Yoichinoyumi and Demon Arrow and confirm weapon rank is only 9
- Equip Annihilator and Silver Bullet and confirm weapon rank is only 5
- Or more broadly, make sure Weapon Rank is `floor(RANGE_WEAPON_DMG / 9)` and doesn't include ammo (unless the throwable is an ammo, in which case it uses the throwable damage)

| Before (Yoichinoyumi + Annihilator) | After (Yoichinoyumi + Annihilator) |
|-|-|
| <img width="530" height="191" alt="image" src="https://github.com/user-attachments/assets/da2de1e8-befe-463c-9aa7-3cc7ce2fd8ab" /> | <img width="978" height="309" alt="image" src="https://github.com/user-attachments/assets/c54b2be6-82b2-44c4-ba36-c93e2dd6b666" /> |