### PR TITLE
[lua] KS99 Horns of War Updates

### DIFF
--- a/scripts/actions/mobskills/meteor.lua
+++ b/scripts/actions/mobskills/meteor.lua
@@ -27,11 +27,15 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
     end
 
-    -- Animation change happens after mobskill finishes.
-    -- Animation: Chlevnik falls but calls in a final meteor barrage, then dies.
-    skill:setFinalAnimationSub(1)
-
     return info.damage
+end
+
+mobskillObject.onMobSkillFinalize = function(mob, skill)
+    mob:setAnimationSub(1)
+    mob:timer(6000, function(mobArg)
+        mobArg:setUnkillable(false)
+        mobArg:setHP(0)
+    end)
 end
 
 return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -268,6 +268,12 @@ xi.mobSkill =
 
     VULTURE_3                     =  626,
 
+    WILD_HORN                     =  628,
+    THUNDERBOLT_BEHEMOTH          =  629,
+    KICK_OUT                      =  630,
+    SHOCK_WAVE_BEHEMOTH           =  631,
+    FLAME_ARMOR                   =  632,
+    HOWL_BEHEMOTH                 =  633,
     FINAL_METEOR                  =  634, -- Final Meteor Chlevnik
 
     RECOIL_DIVE_1                 =  641,

--- a/scripts/zones/Horlais_Peak/mobs/Chlevnik.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Chlevnik.lua
@@ -3,7 +3,7 @@
 -- Mob: Chlevnik
 -- KSNM99 : Horns of War
 
--- TODO : Update Howl to give 25% Attack instead of 15% - Update Meteor to 1.6 fTP + dINT * 3(!)
+-- TODO : Update Meteor to 1.6 fTP + dINT * 3(!)
 -----------------------------------
 local entity = {}
 
@@ -12,34 +12,26 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.PETRIFY)
     mob:addImmunity(xi.immunity.SILENCE)
-    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
-    mob:addListener('WEAPONSKILL_STATE_EXIT', 'FINAL_METEOR_DEATH', function(mobArg, skillId, wasExecuted)
-        if skillId == xi.mobSkill.FINAL_METEOR then
-            if mobArg:getAnimationSub() ~= 1 then
-                mobArg:setAnimationSub(1)
-            end
-
-            mobArg:timer(6000, function(mobArgTimer)
-                mobArgTimer:setUnkillable(false)
-                mobArgTimer:setHP(0)
-            end)
-        end
-    end)
+    mob:setBehavior(bit.bor(mob:getBehavior(), xi.behavior.NO_TURN))
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.STUN_RES_RANK, 10)
+
+    mob:setMod(xi.mod.TRIPLE_ATTACK, 5)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+    mob:setMod(xi.mod.REGAIN, 50)
+
+    mob:setTP(3000)
     mob:setUnkillable(true)
     mob:setAutoAttackEnabled(true)
     mob:setMagicCastingEnabled(true)
     mob:setMobAbilityEnabled(true)
-    mob:setMod(xi.mod.TRIPLE_ATTACK, 5)
-    mob:addMod(xi.mod.STUNRES, 90)
-    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
-    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMod(xi.mod.REGAIN, 50)
-    mob:setTP(3000)
-    mob:setLocalVar('finalMeteor', 0)
+    mob:setAnimationSub(0)
+
+    mob:setLocalVar('queueFinalMeteor', 0)
 end
 
 entity.onMobEngage = function(mob, target)
@@ -47,28 +39,57 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobFight = function(mob, target)
-    local delay = mob:getLocalVar('meteorDelay')
-    if GetSystemTime() > delay then -- Cooldown on Meteor is 30 seconds.
-        mob:castSpell(xi.magic.spell.METEOR, target)
-        mob:setLocalVar('meteorDelay', GetSystemTime() + 30)
-    end
-
-    if mob:getHP() == 1 and mob:getLocalVar('finalMeteor') == 0 then
+    if
+        mob:getHP() == 1 and
+        mob:getLocalVar('queueFinalMeteor') == 0
+    then
+        mob:setLocalVar('queueFinalMeteor', 1)
         mob:setAutoAttackEnabled(false)
         mob:setMagicCastingEnabled(false)
         mob:setMobAbilityEnabled(false)
         mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-        mob:setLocalVar('finalMeteor', 1)
+        return
     end
 
-    if mob:getLocalVar('finalMeteor') == 1 then
+    if
+        mob:getLocalVar('queueFinalMeteor') == 1 and
+        not xi.combat.behavior.isEntityBusy(mob)
+    then
         mob:useMobAbility(xi.mobSkill.FINAL_METEOR, nil, nil, true) -- Ignoring distance based off retail capture.
-        mob:setLocalVar('finalMeteor', 2)
+        mob:setLocalVar('queueFinalMeteor', 2)
+    end
+
+    local delay = mob:getLocalVar('meteorDelay')
+
+    if GetSystemTime() > delay then -- Cooldown on Meteor is 30 seconds.
+        mob:castSpell(xi.magic.spell.METEOR, target)
+        mob:setLocalVar('meteorDelay', GetSystemTime() + 30)
     end
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.WILD_HORN,
+        xi.mobSkill.THUNDERBOLT_BEHEMOTH,
+        xi.mobSkill.KICK_OUT,
+        xi.mobSkill.SHOCK_WAVE_BEHEMOTH,
+        xi.mobSkill.FLAME_ARMOR,
+        xi.mobSkill.HOWL_BEHEMOTH,
+    }
+
+    return skillList[math.random(1, #skillList)]
+end
+
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.STUN, { chance = 25, duration = 10 }) -- 25% chance to stun for 10 seconds.
+    local pTable =
+    {
+        chance   = 25,
+        effectId = xi.effect.STUN,
+        duration = 10,
+    }
+
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onSpellPrecast = function(mob, spell)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Moves the death logic for Final Meteor into onMobSkillFinalize, removing the need for a listener.

* Adds additional guards to the use of Final Meteor to ensure it is never skipped.

* Updates skill table into LUA

* Converts additional effect into the new framework

* Converts old stun resistance modifier to rank 10 stun resistance rank

* Adds Behemoth skills into the ENUM

## Steps to test these changes

Do Horns of War KS99. Kill him any way possible and see that he no longer bugs out by remaining invincible. 
