### PR TITLE
[lua] KS30 ODS Fix

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Platoon_Scorpion.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Platoon_Scorpion.lua
@@ -94,47 +94,49 @@ entity.onMobFight = function(mob)
 end
 
 entity.onMobWeaponSkill = function(mob, target, skill, action)
-    local battlefield = mob:getBattlefield()
+    if target:getID() == action:getPrimaryTargetID() then
+        local battlefield = mob:getBattlefield()
 
-    if not battlefield then
-        return
+        if not battlefield then
+            return
+        end
+
+        -- Store the skill we are using
+        local skillId = skill:getID()
+
+        -- Apply debuff based on skill used and record the time we used it - play flavor text with a 3 second delay to allow skill to finish.
+        if skillId == xi.mobSkill.WILD_RAGE then
+            mob:setAutoAttackEnabled(false)
+            mob:setLocalVar('disableEnd', GetSystemTime() + math.random(10, 25))
+            mob:setLocalVar('isDisabled', 1)
+            mob:timer(3000, function(mobArg)
+                mobArg:messageText(mobArg, ID.text.SCORPION_IS_STUNNED, false)
+            end)
+
+        elseif skillId == xi.mobSkill.EARTH_POUNDER then
+            mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+            mob:setLocalVar('disableEnd', GetSystemTime() + math.random(10, 25))
+            mob:setLocalVar('isDisabled', 1)
+            mob:timer(3000, function(mobArg)
+                mobArg:messageText(mobArg, ID.text.SCORPION_IS_BOUND, false)
+            end)
+        end
+
+        -- If mimic is active, nothing to do here
+        if battlefield:getLocalVar('mimicActive') == 1 then
+            return
+        end
+
+        -- If we make it here, we are the leader of a new mimic round, set it up!
+        local nextRound = battlefield:getLocalVar('mimicRound') + 1
+
+        battlefield:setLocalVar('mimicActive', 1)
+        battlefield:setLocalVar('mimicSkill', skillId)
+        battlefield:setLocalVar('mimicLeader', mob:getID())
+        battlefield:setLocalVar('mimicRound', nextRound)
+
+        mob:setLocalVar('mimicRound', nextRound)
     end
-
-    -- Store the skill we are using
-    local skillId = skill:getID()
-
-    -- Apply debuff based on skill used and record the time we used it - play flavor text with a 3 second delay to allow skill to finish.
-    if skillId == xi.mobSkill.WILD_RAGE then
-        mob:setAutoAttackEnabled(false)
-        mob:setLocalVar('disableEnd', GetSystemTime() + math.random(10, 25))
-        mob:setLocalVar('isDisabled', 1)
-        mob:timer(3000, function(mobArg)
-            mobArg:messageText(mobArg, ID.text.SCORPION_IS_STUNNED, false)
-        end)
-
-    elseif skillId == xi.mobSkill.EARTH_POUNDER then
-        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-        mob:setLocalVar('disableEnd', GetSystemTime() + math.random(10, 25))
-        mob:setLocalVar('isDisabled', 1)
-        mob:timer(3000, function(mobArg)
-            mobArg:messageText(mobArg, ID.text.SCORPION_IS_BOUND, false)
-        end)
-    end
-
-    -- If mimic is active, nothing to do here
-    if battlefield:getLocalVar('mimicActive') == 1 then
-        return
-    end
-
-    -- If we make it here, we are the leader of a new mimic round, set it up!
-    local nextRound = battlefield:getLocalVar('mimicRound') + 1
-
-    battlefield:setLocalVar('mimicActive', 1)
-    battlefield:setLocalVar('mimicSkill', skillId)
-    battlefield:setLocalVar('mimicLeader', mob:getID())
-    battlefield:setLocalVar('mimicRound', nextRound)
-
-    mob:setLocalVar('mimicRound', nextRound)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* OnMobWeaponSkill runs for every target hit by the ability. - This PR wraps the onMobWeaponSkill logic inside of a primary target check, preventing the AoE TP moves like Wild Rage & Earth Pounder running the code for every target hit.

## Steps to test these changes

Run ODS as a group, see that the messages only play once. 
