### PR TITLE
[core] ximesh files support [terrain type / limit widescan]

### DIFF
--- a/.github/workflows/docker_test.yml
+++ b/.github/workflows/docker_test.yml
@@ -92,6 +92,7 @@ jobs:
             --network ${{ job.services.database.network }} \
             --mount type=bind,src=./navmeshes,dst=/server/navmeshes \
             --mount type=bind,src=./losmeshes,dst=/server/losmeshes \
+            --mount type=bind,src=./ximeshes,dst=/server/ximeshes \
             --mount type=bind,src=./modules,dst=/server/modules \
             --mount type=bind,src=.,dst=/server/log \
             --env XI_NETWORK_SQL_HOST=database \

--- a/.github/workflows/publish_meshes.yml
+++ b/.github/workflows/publish_meshes.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - './losmeshes/**'
       - './navmeshes/**'
+      - './ximeshes/**'
       - '.gitmodules'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ src/common/stamp-h1
 *.sw?
 
 navmeshes/*.nav
+ximeshes/*.ximesh
 tags
 log/**
 !log/.gitkeep

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,9 @@
 [submodule "navmeshes"]
-	path = navmeshes
-	url = https://github.com/LandSandBoat/xiNavmeshes.git
+    path = navmeshes
+    url = https://github.com/LandSandBoat/xiNavmeshes.git
 [submodule "losmeshes"]
-	path = losmeshes
-	url = https://github.com/LandSandBoat/losmeshes.git
+    path = losmeshes
+    url = https://github.com/LandSandBoat/losmeshes.git
+[submodule "ximeshes"]
+    path = ximeshes
+    url = https://github.com/InoUno/ximeshes.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,16 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 link_libraries(${CMAKE_THREAD_LIBS_INIT})
 
+CPMAddPackage(
+    NAME ZLIB
+    GITHUB_REPOSITORY madler/zlib
+    GIT_TAG v1.3.1
+    OPTIONS "ZLIB_BUILD_EXAMPLES OFF"
+)
+if(ZLIB_ADDED)
+    add_library(ZLIB::ZLIB ALIAS zlibstatic)
+endif()
+
 # Find Python (defines ${Python_EXECUTABLE})
 find_package(Python REQUIRED)
 message(STATUS "Python_EXECUTABLE: ${Python_EXECUTABLE}")

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -138,6 +138,7 @@ COPY --chown=$UNAME:$UGROUP \
     --exclude=.git \
     --exclude=losmeshes/** \
     --exclude=navmeshes/** \
+    --exclude=ximeshes/** \
     --exclude=scripts \
     --exclude=sql \
     . /server

--- a/docker/meshes.Dockerfile
+++ b/docker/meshes.Dockerfile
@@ -2,5 +2,6 @@ FROM --platform=$BUILDPLATFORM busybox:latest
 
 COPY ./losmeshes/*.obj /losmeshes/
 COPY ./navmeshes/*.nav /navmeshes/
+COPY ./ximeshes/*.ximesh /ximeshes/
 
-VOLUME /navmeshes /losmeshes
+VOLUME /navmeshes /losmeshes /ximeshes

--- a/docker/ubuntu.Dockerfile
+++ b/docker/ubuntu.Dockerfile
@@ -150,6 +150,7 @@ COPY --chown=$UNAME:$UGROUP \
     --exclude=.git \
     --exclude=losmeshes/** \
     --exclude=navmeshes/** \
+    --exclude=ximeshes/** \
     --exclude=scripts \
     --exclude=sql \
     . /server

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -295,6 +295,7 @@ set(MAP_ONLY_EXTERNAL_LIBS
     RecastNavigation::Recast
     RecastNavigation::Detour
     fast_obj
+    zlibstatic
 )
 
 set(SEARCH_ONLY_EXTERNAL_LIBS

--- a/scripts/actions/mobskills/tidal_dive.lua
+++ b/scripts/actions/mobskills/tidal_dive.lua
@@ -5,21 +5,29 @@
 --  Type: Physical
 --  Utsusemi/Blink absorb: 2-3 shadows
 --  Range: Unknown radial
---  Notes: Only used over deep water.
+--  Notes: Only used over water.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    local terrain = mob:getZone():getTerrainType(mob:getPos())
+    if
+        terrain ~= xi.terrain.DEEP_WATER and
+        terrain ~= xi.terrain.SHALLOW_WATER -- Al'Taieu is only made of shallow water blocks
+    then
+        return 1
+    end
+
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local numhits = math.random(2, 3)
-    local accmod = 1
-    local ftp    = 1
-    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
-    local dmg = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
+    local accmod  = 1
+    local ftp     = 1
+    local info    = xi.mobskills.mobPhysicalMove(mob, target, skill, numhits, accmod, ftp, xi.mobskills.physicalTpBonus.NO_EFFECT)
+    local dmg     = xi.mobskills.mobFinalAdjustments(info, mob, skill, target, xi.attackType.PHYSICAL, xi.damageType.NONE, info.hitslanded)
 
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.BIND, 1, 0, 60)
     xi.mobskills.mobPhysicalStatusEffectMove(mob, target, skill, xi.effect.WEIGHT, 50, 0, 120)

--- a/scripts/commands/pos.lua
+++ b/scripts/commands/pos.lua
@@ -8,12 +8,46 @@ local commandObj = {}
 commandObj.cmdprops =
 {
     permission = 1,
-    parameters = 's'
+    parameters = 's',
+}
+
+local terrainNames =
+{
+    [xi.terrain.OBJECT]        = 'Object',
+    [xi.terrain.PATH]          = 'Path',
+    [xi.terrain.GRASS]         = 'Grass',
+    [xi.terrain.SAND]          = 'Sand',
+    [xi.terrain.SNOW]          = 'Snow',
+    [xi.terrain.STONE]         = 'Stone',
+    [xi.terrain.METAL]         = 'Metal',
+    [xi.terrain.WOOD]          = 'Wood',
+    [xi.terrain.SHALLOW_WATER] = 'Shallow Water',
+    [xi.terrain.DEEP_WATER]    = 'Deep Water',
+    [xi.terrain.UNKNOWN]       = 'Unknown',
+    [xi.terrain.NONE]          = 'None',
 }
 
 local function error(player, msg)
     player:printToPlayer(msg)
     player:printToPlayer('!pos (x) (y) (z) (zone ID) (player)')
+end
+
+local function printPosition(player, targ)
+    local zone        = targ:getZone()
+    local pos         = targ:getPos()
+    local terrainType = zone:getTerrainType(pos)
+    local terrainName = terrainNames[terrainType] or string.format('Unknown (%d)', terrainType)
+
+    player:printToPlayer(string.format('%s: X %.4f  Y %.4f  Z %.4f  Rot %i  Zone %i  Floor %i  Terrain: %s',
+        targ:getName(),
+        targ:getXPos(),
+        targ:getYPos(),
+        targ:getZPos(),
+        targ:getRotPos(),
+        targ:getZoneID(),
+        zone:getFloorId(pos),
+        terrainName
+    ), xi.msg.channel.SYSTEM_3)
 end
 
 commandObj.onTrigger = function(player, arg)
@@ -25,7 +59,7 @@ commandObj.onTrigger = function(player, arg)
     local targ
 
     if arg == nil then
-        player:printToPlayer(string.format('%s\'s position: X %.4f  Y %.4f  Z %.4f  Rot %i  (Zone: %i)', player:getName(), player:getXPos(), player:getYPos(), player:getZPos(), player:getRotPos(), player:getZoneID()), xi.msg.channel.SYSTEM_3)
+        printPosition(player, player)
         return
     end
 
@@ -77,7 +111,7 @@ commandObj.onTrigger = function(player, arg)
 
     -- report or move position
     if x == nil or y == nil or z == nil then
-        player:printToPlayer(string.format('%s\'s position: X %.4f  Y %.4f  Z %.4f  Rot %i  (Zone: %i)', targ:getName(), targ:getXPos(), targ:getYPos(), targ:getZPos(), targ:getRotPos(), targ:getZoneID()), xi.msg.channel.SYSTEM_3)
+        printPosition(player, targ)
     else
         if zoneId == nil then
             zoneId = targ:getZoneID()

--- a/scripts/enum/terrain.lua
+++ b/scripts/enum/terrain.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Terrain materials
+-----------------------------------
+xi = xi or {}
+
+---@enum xi.terrain
+xi.terrain =
+{
+    OBJECT        = 0,
+    PATH          = 1,
+    GRASS         = 2,
+    SAND          = 3,
+    SNOW          = 4,
+    STONE         = 5,
+    METAL         = 6,
+    WOOD          = 7,
+    SHALLOW_WATER = 8,
+    DEEP_WATER    = 9,
+    UNKNOWN       = 10,
+    NONE          = 255,
+}

--- a/scripts/specs/core/CZone.lua
+++ b/scripts/specs/core/CZone.lua
@@ -97,6 +97,18 @@ end
 function CZone:isNavigablePoint(position)
 end
 
+---@nodiscard
+---@param position table
+---@return xi.terrain
+function CZone:getTerrainType(position)
+end
+
+---@nodiscard
+---@param position table
+---@return integer
+function CZone:getFloorId(position)
+end
+
 ---@class dynamicEntityParams
 ---@field objtype? xi.objType            # Entity type. Default: xi.objType.NPC
 ---@field groupId? integer               # Mob group ID (for TYPE_MOB). Default: 0

--- a/scripts/tests/systems/zone_mesh.lua
+++ b/scripts/tests/systems/zone_mesh.lua
@@ -1,0 +1,54 @@
+describe('Zone Mesh', function()
+    it('AlTaieu below bridge is shallow water', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.ALTAIEU })
+        player:setPos(-1, 0.0, -500.64)
+        local zone = player:getZone()
+        assert(zone)
+        assert(zone:getTerrainType(player:getPos()) == xi.terrain.SHALLOW_WATER)
+    end)
+
+    it('AlTaieu on bridge is stone', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.ALTAIEU })
+        player:setPos(-0.3524, -6.4856, -503.6324)
+        local zone = player:getZone()
+        assert(zone)
+        assert(zone:getTerrainType(player:getPos()) == xi.terrain.STONE)
+    end)
+
+    it('Eldieme Necropolis lower floor is 16', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.THE_ELDIEME_NECROPOLIS })
+        player:setPos(69.84, 0, 18.15)
+        local zone = player:getZone()
+        assert(zone)
+        assert(zone:getFloorId(player:getPos()) == 16)
+    end)
+
+    it('Eldieme Necropolis upper floor is 15', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.THE_ELDIEME_NECROPOLIS })
+        player:setPos(54.84, -27.5, 16)
+        local zone = player:getZone()
+        assert(zone)
+        assert(zone:getFloorId(player:getPos()) == 15)
+    end)
+
+    it('East Ronfaure river positions are water terrain', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.EAST_RONFAURE })
+        local zone = player:getZone()
+        assert(zone)
+
+        local riverPositions =
+        {
+            { 380.4925, -26.5,  -39.9 },
+            { 379.3,    -26.5,  -53.6 },
+            { 379.1167, -26.5,  -77.35 },
+            { 382.1155, -16.50, -114.30 },
+        }
+
+        for _, pos in ipairs(riverPositions) do
+            player:setPos(pos[1], pos[2], pos[3])
+            local terrain = zone:getTerrainType(player:getPos())
+            assert(terrain == xi.terrain.SHALLOW_WATER or terrain == xi.terrain.DEEP_WATER,
+                string.format('Expected water terrain at (%.4f, %.2f, %.2f), got %d', pos[1], pos[2], pos[3], terrain))
+        end
+    end)
+end)

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -118,6 +118,9 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/monstrosity.h
     ${CMAKE_CURRENT_SOURCE_DIR}/navmesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/navmesh.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/zone_mesh.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/zone_mesh.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/ximesh.h
     ${CMAKE_CURRENT_SOURCE_DIR}/notoriety_container.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/notoriety_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/packet_guard.cpp

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -26,5 +26,6 @@ set(ENUMS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/quest_log.h
     ${CMAKE_CURRENT_SOURCE_DIR}/synthesis_effect.h
     ${CMAKE_CURRENT_SOURCE_DIR}/synthesis_result.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/terrain_type.h
     PARENT_SCOPE
 )

--- a/src/map/enums/terrain_type.h
+++ b/src/map/enums/terrain_type.h
@@ -1,0 +1,40 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+enum class TerrainType : uint8
+{
+    Object       = 0,
+    Path         = 1,
+    Grass        = 2,
+    Sand         = 3,
+    Snow         = 4,
+    Stone        = 5,
+    Metal        = 6,
+    Wood         = 7,
+    ShallowWater = 8,
+    DeepWater    = 9,
+    Unknown      = 10,
+    None         = 0xFF,
+};

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -67,6 +67,7 @@
 #include "treasure_pool.h"
 #include "weapon_skill.h"
 #include "zone.h"
+#include "zone_mesh.h"
 
 #include "ai/ai_container.h"
 

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -33,6 +33,7 @@ enum class QuestLog : uint8_t;
 enum class POSMODE : uint8;
 enum class MusicSlot : uint16_t;
 enum class ChocoboColor : uint8_t;
+enum class TerrainType : uint8;
 class CBaseEntity;
 class CCharEntity;
 class CLuaBattlefield;

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -33,6 +33,7 @@
 #include "utils/mobutils.h"
 #include "zone.h"
 #include "zone_entities.h"
+#include "zone_mesh.h"
 
 CLuaZone::CLuaZone(CZone* PZone)
 : m_pLuaZone(PZone)
@@ -320,6 +321,44 @@ sol::table CLuaZone::queryEntitiesByName(const std::string& name)
     return table;
 }
 
+/************************************************************************
+ *  Function: getTerrainType()
+ *  Purpose : Returns the terrain type at the given position
+ *  Example : zone:getTerrainType(player:getPos())
+ ************************************************************************/
+
+auto CLuaZone::getTerrainType(const sol::table& position) -> TerrainType
+{
+    if (auto mesh = m_pLuaZone->zoneMesh())
+    {
+        return (*mesh)->getTerrainAt(
+            position["x"].get_or<float>(0),
+            position["y"].get_or<float>(0),
+            position["z"].get_or<float>(0));
+    }
+
+    return TerrainType::None;
+}
+
+/************************************************************************
+ *  Function: getFloorId()
+ *  Purpose : Returns the floor ID at the given position
+ *  Example : zone:getFloorId(player:getPos())
+ ************************************************************************/
+
+auto CLuaZone::getFloorId(const sol::table& position) -> uint8
+{
+    if (auto mesh = m_pLuaZone->zoneMesh())
+    {
+        return (*mesh)->getFloorId(
+            position["x"].get_or<float>(0),
+            position["y"].get_or<float>(0),
+            position["z"].get_or<float>(0));
+    }
+
+    return 0;
+}
+
 //======================================================//
 
 void CLuaZone::Register()
@@ -348,6 +387,8 @@ void CLuaZone::Register()
     SOL_REGISTER("getUptime", CLuaZone::getUptime);
     SOL_REGISTER("reloadNavmesh", CLuaZone::reloadNavmesh);
     SOL_REGISTER("isNavigablePoint", CLuaZone::isNavigablePoint);
+    SOL_REGISTER("getTerrainType", CLuaZone::getTerrainType);
+    SOL_REGISTER("getFloorId", CLuaZone::getFloorId);
     SOL_REGISTER("insertDynamicEntity", CLuaZone::insertDynamicEntity);
 
     SOL_REGISTER("getSoloBattleMusic", CLuaZone::getSoloBattleMusic);

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -23,6 +23,7 @@
 #define _LUAZONE_H
 
 #include "common/cbasetypes.h"
+#include "enums/terrain_type.h"
 #include "luautils.h"
 #include "zone.h"
 
@@ -63,6 +64,8 @@ public:
     uint32      getUptime();
     void        reloadNavmesh();
     bool        isNavigablePoint(const sol::table& position);
+    auto        getTerrainType(const sol::table& position) -> TerrainType;
+    auto        getFloorId(const sol::table& position) -> uint8;
     auto        insertDynamicEntity(sol::table table) -> CBaseEntity*;
 
     auto getSoloBattleMusic();

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -782,7 +782,7 @@ auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>
     }
 
     co_await Scheduler::TaskGroup(
-        zoneIds.size() * 2,
+        zoneIds.size() * 3,
         [&](auto& add)
         {
             for (const auto zoneId : zonesIdsToLoad)
@@ -791,6 +791,12 @@ auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>
                     [zoneId]()
                     {
                         g_PZoneList[zoneId]->LoadNavMesh();
+                    }));
+
+                add(scheduler.spawnOnWorkerThread(
+                    [zoneId]()
+                    {
+                        g_PZoneList[zoneId]->LoadZoneMesh();
                     }));
 
                 add(scheduler.spawnOnWorkerThread(

--- a/src/map/ximesh.h
+++ b/src/map/ximesh.h
@@ -1,0 +1,88 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+// Ximesh binary format -- zlib-compressed zone collision geometry.
+// Reference: https://github.com/InoUno/xi-visualizer/blob/main/src/graphics/ximesh.ts
+//
+// After decompression:
+//   [XimeshHeader]                        20 bytes
+//   [u32 x cellCount]                     cell offset table
+//   ...
+//
+// Cell (at offset):
+//   [XimeshCellHeader]                    reserved u32 + entry count u16
+//   [XimeshCellEntry x entryCount]        block offset + placement offset
+//
+// Block (at blockOffset):
+//   [u16 vertexCount] [u16 triangleCount] [u16 barrierFlag] [u16 pad]
+//   [float x vertexCount x 3]             local-space xyz
+//   [u16 x triangleCount x 3]             indices (4-byte aligned)
+//   [TriangleMeta x triangleCount]        material + barrier per tri
+//
+// Placement (at placementOffset):
+//   [PlacementFlags]                      u32 bitfield
+//   [float x 12]                          3x3 rotation (col-major) + vec3 translation
+
+#pragma pack(push, 1)
+struct XimeshHeader
+{
+    uint16 gridWidth{};
+    uint16 gridHeight{};
+    uint32 blockSectionOffset{};
+    uint32 placementSectionOffset{};
+    uint16 blockCount{};
+    uint16 placementCount{};
+    uint32 wideSearch{};
+};
+
+struct XimeshCellHeader
+{
+    uint32 reserved{};
+    uint16 entryCount{};
+};
+
+struct XimeshCellEntry
+{
+    uint32 blockOffset{};
+    uint32 placementOffset{};
+};
+
+struct TriangleMeta
+{
+    uint8 material : 4;
+    uint8 barrier : 1;
+    uint8 padding : 3;
+};
+
+struct PlacementFlags
+{
+    uint32 padding0 : 2;
+    uint32 roofed : 1;
+    uint32 mapIdLow : 3;
+    uint32 padding1 : 20;
+    uint32 mapIdHigh : 2;
+    uint32 padding2 : 4;
+};
+#pragma pack(pop)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -55,6 +55,7 @@ constexpr std::uint16_t WeatherCycle = 2160;
 #include "status_effect_container.h"
 #include "treasure_pool.h"
 #include "zone_entities.h"
+#include "zone_mesh.h"
 
 #include "entities/npcentity.h"
 #include "entities/petentity.h"
@@ -480,6 +481,74 @@ void CZone::LoadNavMesh()
     {
         DebugNavmesh("CZone::LoadNavMesh: Cannot load navmesh file (%s)", file);
         m_navMesh = nullptr;
+    }
+}
+
+auto CZone::zoneMesh() const -> Maybe<CZoneMesh*>
+{
+    if (zoneMesh_ && zoneMesh_->isLoaded())
+    {
+        return zoneMesh_.get();
+    }
+
+    return std::nullopt;
+}
+
+void CZone::LoadZoneMesh()
+{
+    TracyZoneScoped;
+
+    if (zoneMesh_ == nullptr)
+    {
+        zoneMesh_ = std::make_unique<CZoneMesh>();
+    }
+
+    // TODO: Align ximesh filenames with zone_settings names so this isn't needed.
+    auto meshName = std::string(getName());
+
+    // Rala_Waterways_U -> Rala_Waterways_[U]
+    // Yorcia_Weald_U -> Yorcia_Weald_[U]
+    // Cirdas_Caverns_U -> Cirdas_Caverns_[U]
+    if (meshName.size() >= 2 && meshName.substr(meshName.size() - 2) == "_U")
+    {
+        meshName.replace(meshName.size() - 2, 2, "_[U]");
+    }
+
+    // Escha_ZiTah -> Escha-ZiTah
+    // Escha_RuAun -> Escha-RuAun
+    if (meshName.starts_with("Escha_"))
+    {
+        meshName.replace(5, 1, "-");
+    }
+
+    // Desuetia_Empyreal_Paradox -> Desuetia-Empyreal_Paradox
+    if (meshName.starts_with("Desuetia_"))
+    {
+        meshName.replace(8, 1, "-");
+    }
+
+    // Ship_bound_for_Selbina_Pirates -> Ship_bound_for_Selbina_ID-227, Ship_bound_for_Mhaura_Pirates -> Ship_bound_for_Mhaura_ID-228
+    if (meshName == "Ship_bound_for_Selbina_Pirates")
+    {
+        meshName = "Ship_bound_for_Selbina_ID-227";
+    }
+    else if (meshName == "Ship_bound_for_Mhaura_Pirates")
+    {
+        meshName = "Ship_bound_for_Mhaura_ID-228";
+    }
+
+    // Maquette_Abdhaljs-Legion_A -> Maquette_Abdhaljs-Legion
+    // Maquette_Abdhaljs-Legion_B -> Maquette_Abdhaljs-Legion
+    if (meshName.starts_with("Maquette_Abdhaljs-Legion_"))
+    {
+        meshName = "Maquette_Abdhaljs-Legion";
+    }
+
+    const auto file = fmt::format("ximeshes/{}.ximesh", meshName);
+    if (!zoneMesh_->load(file))
+    {
+        DebugNavmesh("CZone::LoadZoneMesh: Cannot load zone mesh (%s)", file.c_str());
+        zoneMesh_ = nullptr;
     }
 }
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -26,6 +26,7 @@
 #include <common/mmo.h>
 #include <common/scheduler.h>
 #include <common/timer.h>
+#include <common/types/maybe.h>
 #include <common/vana_time.h>
 
 #include <list>
@@ -45,6 +46,7 @@
 
 enum class Weather : uint16_t;
 class CNavMesh;
+class CZoneMesh;
 class SpawnHandler;
 class ZoneLos;
 
@@ -674,11 +676,14 @@ public:
     std::unique_ptr<CNavMesh> m_navMesh;
     std::unique_ptr<ZoneLos>  lineOfSight;
 
+    auto zoneMesh() const -> Maybe<CZoneMesh*>;
+
     std::map<uint32_t, std::unique_ptr<SpawnSlot>> m_spawnSlots; // add unique slots to zone
 
     timer::time_point m_LoadedAt; // The time the zone was loaded
 
     void LoadNavMesh();
+    void LoadZoneMesh();
     void LoadZoneLos();
 
 protected:
@@ -698,6 +703,8 @@ protected:
     std::unordered_map<std::string, uint32> localVars_;
 
 private:
+    std::unique_ptr<CZoneMesh> zoneMesh_;
+
     ZONEID         m_zoneID;
     ZONE_TYPE      m_zoneType;
     REGION_TYPE    m_regionID;

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -31,6 +31,7 @@
 #include "status_effect_container.h"
 #include "trade_container.h"
 #include "treasure_pool.h"
+#include "zone_mesh.h"
 
 #include "ai/ai_container.h"
 #include "ai/controllers/mob_controller.h"
@@ -1578,12 +1579,27 @@ void CZoneEntities::WideScan(CCharEntity* PChar, uint16 radius)
 {
     TracyZoneScoped;
 
+    const auto  maybeZoneMesh = m_zone->zoneMesh();
+    const auto& charPos       = PChar->loc.p;
+    const auto  charFloor     = maybeZoneMesh ? (*maybeZoneMesh)->getFloorId(charPos.x, charPos.y, charPos.z) : uint8{ 0 };
+
+    auto isSameFloor = [&](const CBaseEntity* PEntity) -> bool
+    {
+        if (!maybeZoneMesh)
+        {
+            return true;
+        }
+
+        const auto& pos = PEntity->loc.p;
+        return (*maybeZoneMesh)->getFloorId(pos.x, pos.y, pos.z) == charFloor;
+    };
+
     PChar->pushPacket<GP_SERV_COMMAND_TRACKING_STATE>(GP_TRACKING_STATE::ListStart);
     for (const auto& entityList : { m_npcList, m_mobList })
     {
         for (const auto& [_, PEntity] : entityList)
         {
-            if (PEntity->isWideScannable() && isWithinDistance(PChar->loc.p, PEntity->loc.p, radius))
+            if (PEntity->isWideScannable() && isWithinDistance(PChar->loc.p, PEntity->loc.p, radius) && isSameFloor(PEntity))
             {
                 PChar->pushPacket<GP_SERV_COMMAND_TRACKING_LIST>(PChar, PEntity);
             }

--- a/src/map/zone_mesh.cpp
+++ b/src/map/zone_mesh.cpp
@@ -1,0 +1,445 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "zone_mesh.h"
+
+#include "common/logging.h"
+#include "common/tracy.h"
+#include "common/utils.h"
+
+#include <DetourCommon.h>
+#include <array>
+#include <fstream>
+#include <span>
+#include <unordered_map>
+#include <zlib.h>
+
+namespace
+{
+template <typename T>
+auto readAt(const std::span<const uint8> buf, const uint32 offset) -> T
+{
+    if (offset + sizeof(T) > buf.size())
+    {
+        return T{};
+    }
+
+    T val{};
+    std::memcpy(&val, buf.data() + offset, sizeof(T));
+    return val;
+}
+
+constexpr uint32 BYTES_PER_VERTEX   = 3 * sizeof(float);  // x, y, z
+constexpr uint32 BYTES_PER_TRIANGLE = 3 * sizeof(uint16); // 3 indices
+
+auto zlibDecompress(std::vector<uint8>& rawData) -> std::vector<uint8>
+{
+    constexpr size_t CHUNK_SIZE            = 32 * 1024;        // 32 KB
+    constexpr size_t MAX_DECOMPRESSED_SIZE = 64 * 1024 * 1024; // 64 MB
+
+    z_stream stream{};
+    if (inflateInit(&stream) != Z_OK)
+    {
+        return {};
+    }
+
+    stream.next_in  = rawData.data();
+    stream.avail_in = static_cast<uInt>(rawData.size());
+
+    std::vector<uint8> result;
+    result.reserve(rawData.size() * 4);
+    std::array<uint8, CHUNK_SIZE> chunk{};
+
+    int rc = Z_OK;
+    while (rc != Z_STREAM_END)
+    {
+        stream.next_out  = chunk.data();
+        stream.avail_out = static_cast<uInt>(chunk.size());
+
+        rc = inflate(&stream, Z_NO_FLUSH);
+        if (rc != Z_OK && rc != Z_STREAM_END)
+        {
+            inflateEnd(&stream);
+            return {};
+        }
+
+        const size_t bytesWritten = chunk.size() - stream.avail_out;
+        result.insert(result.end(), chunk.data(), chunk.data() + bytesWritten);
+
+        if (result.size() > MAX_DECOMPRESSED_SIZE)
+        {
+            inflateEnd(&stream);
+            return {};
+        }
+    }
+
+    inflateEnd(&stream);
+    return result;
+}
+
+// Local to world space.
+auto transform(const std::array<float, 9>& rot, const std::array<float, 3>& trans, const float* vertex) -> std::array<float, 3>
+{
+    return {
+        rot[0] * vertex[0] + rot[3] * vertex[1] + rot[6] * vertex[2] + trans[0],
+        rot[1] * vertex[0] + rot[4] * vertex[1] + rot[7] * vertex[2] + trans[1],
+        rot[2] * vertex[0] + rot[5] * vertex[1] + rot[8] * vertex[2] + trans[2],
+    };
+}
+
+} // namespace
+
+auto CZoneMesh::load(const std::string& filename) -> bool
+{
+    TracyZoneScoped;
+
+    // Step 1. Read the file
+    std::ifstream file(filename, std::ios::binary | std::ios::ate);
+    if (!file.good())
+    {
+        return false;
+    }
+
+    auto fileSize = static_cast<size_t>(file.tellg());
+    file.seekg(0, std::ios::beg);
+
+    std::vector<uint8> rawData(fileSize);
+    file.read(reinterpret_cast<char*>(rawData.data()), fileSize);
+    if (file.fail())
+    {
+        ShowErrorFmt("CZoneMesh::load: Failed to read file ({})", filename);
+        return false;
+    }
+
+    // Step 2. Decompress ximesh zlib
+    const std::vector<uint8> decompressed = zlibDecompress(rawData);
+    if (decompressed.empty())
+    {
+        ShowErrorFmt("CZoneMesh::load: zlib decompression failed ({})", filename);
+        return false;
+    }
+
+    const std::span buf = decompressed;
+
+    // Step 3. Load in the header containing the size of the grid and prepare final vector
+    if (buf.size() < sizeof(XimeshHeader))
+    {
+        ShowErrorFmt("CZoneMesh::load: File too small ({})", filename);
+        return false;
+    }
+
+    std::memcpy(&header_, buf.data(), sizeof(XimeshHeader));
+    if (header_.gridWidth == 0 || header_.gridHeight == 0)
+    {
+        ShowErrorFmt("CZoneMesh::load: Invalid grid {}x{} ({})", header_.gridWidth, header_.gridHeight, filename);
+        return false;
+    }
+
+    const uint32 cellCount = static_cast<uint32>(header_.gridWidth) * header_.gridHeight;
+    cells_.resize(cellCount);
+    blocks_.reserve(header_.blockCount);
+    placements_.reserve(header_.placementCount);
+
+    uint32 totalEntries = 0;
+    for (uint32 cellIndex = 0; cellIndex < cellCount; ++cellIndex)
+    {
+        const uint32 cellDataOffset = readAt<uint32>(buf, sizeof(XimeshHeader) + cellIndex * 4);
+        if (cellDataOffset != 0 && cellDataOffset + sizeof(XimeshCellHeader) <= buf.size())
+        {
+            totalEntries += readAt<XimeshCellHeader>(buf, cellDataOffset).entryCount;
+        }
+    }
+    entries_.reserve(totalEntries);
+
+    // Step 3a. Define block and placement parsers (deduplicated by file offset)
+    std::unordered_map<uint32, uint16> blockCache;
+    std::unordered_map<uint32, uint16> placeCache;
+
+    auto getOrParseBlock = [&](const uint32 fileOffset) -> std::optional<uint16>
+    {
+        auto [it, inserted] = blockCache.try_emplace(fileOffset, static_cast<uint16>(blocks_.size()));
+        if (!inserted)
+        {
+            return it->second;
+        }
+
+        MeshBlock    block;
+        const uint16 vertexCount   = readAt<uint16>(buf, fileOffset);
+        const uint16 triangleCount = readAt<uint16>(buf, fileOffset + 2);
+        const uint16 barrierFlag   = readAt<uint16>(buf, fileOffset + 4);
+        block.hasBarriers          = barrierFlag > 0;
+
+        const uint32 vertexBytes = vertexCount * BYTES_PER_VERTEX;
+        const uint32 indexBytes  = triangleCount * BYTES_PER_TRIANGLE;
+        const uint32 metaBytes   = triangleCount; // 1 byte per triangle
+
+        const uint32 vertexOffset = fileOffset + 8;
+        const uint32 indexOffset  = roundUpToNearestFour(vertexOffset + vertexBytes);
+        const uint32 metaOffset   = roundUpToNearestFour(indexOffset + indexBytes);
+
+        if (vertexOffset + vertexBytes > buf.size() ||
+            indexOffset + indexBytes > buf.size() ||
+            metaOffset + metaBytes > buf.size())
+        {
+            ShowErrorFmt("CZoneMesh: Block OOB at offset 0x{:X} (bufSize={})", fileOffset, buf.size());
+            return std::nullopt;
+        }
+
+        block.vertices.resize(vertexCount * 3);
+        std::memcpy(block.vertices.data(), buf.data() + vertexOffset, vertexBytes);
+
+        block.indices.resize(triangleCount * 3);
+        std::memcpy(block.indices.data(), buf.data() + indexOffset, indexBytes);
+
+        block.metas.resize(metaBytes);
+        std::memcpy(block.metas.data(), buf.data() + metaOffset, metaBytes);
+
+        blocks_.emplace_back(std::move(block));
+        return it->second;
+    };
+
+    auto getOrParsePlacement = [&](const uint32 fileOffset) -> std::optional<uint16>
+    {
+        auto [it, inserted] = placeCache.try_emplace(fileOffset, static_cast<uint16>(placements_.size()));
+        if (!inserted)
+        {
+            return it->second;
+        }
+
+        const auto    flags = readAt<PlacementFlags>(buf, fileOffset);
+        MeshPlacement placement{
+            .mapId  = static_cast<uint8>(flags.mapIdHigh << 3 | flags.mapIdLow),
+            .roofed = flags.roofed != 0,
+        };
+
+        constexpr size_t TRANSFORM_BYTES = sizeof(placement.rotation) + sizeof(placement.translation);
+        if (fileOffset + 4 + TRANSFORM_BYTES > buf.size())
+        {
+            ShowErrorFmt("CZoneMesh: Placement OOB at offset 0x{:X} (bufSize={})", fileOffset, buf.size());
+            return std::nullopt;
+        }
+
+        std::memcpy(placement.rotation.data(), buf.data() + fileOffset + 4, TRANSFORM_BYTES);
+
+        placements_.emplace_back(placement);
+        return it->second;
+    };
+
+    // Step 3b. Parse cells
+    for (uint32 cellIndex = 0; cellIndex < cellCount; ++cellIndex)
+    {
+        const uint32 cellDataOffset = readAt<uint32>(buf, sizeof(XimeshHeader) + cellIndex * 4);
+        if (cellDataOffset == 0 || cellDataOffset + sizeof(XimeshCellHeader) > buf.size())
+        {
+            continue;
+        }
+
+        const auto cellHeader = readAt<XimeshCellHeader>(buf, cellDataOffset);
+        auto&      cell       = cells_[cellIndex];
+        cell.offset           = static_cast<uint32>(entries_.size());
+        cell.count            = 0;
+
+        for (uint16 entryIndex = 0; entryIndex < cellHeader.entryCount; ++entryIndex)
+        {
+            const uint32 entryOffset = cellDataOffset + sizeof(XimeshCellHeader) + entryIndex * sizeof(XimeshCellEntry);
+            if (entryOffset + sizeof(XimeshCellEntry) > buf.size())
+            {
+                break;
+            }
+
+            const auto rawEntry     = readAt<XimeshCellEntry>(buf, entryOffset);
+            const auto blockIdx     = getOrParseBlock(rawEntry.blockOffset);
+            const auto placementIdx = getOrParsePlacement(rawEntry.placementOffset);
+            if (!blockIdx || !placementIdx)
+            {
+                ShowErrorFmt("CZoneMesh::load: Corrupt block/placement data ({})", filename);
+                return false;
+            }
+
+            entries_.push_back({ *blockIdx, *placementIdx });
+            cell.count++;
+        }
+    }
+
+    // Step 4. Pre-compute Y bounds per placement
+    for (uint32 cellIndex = 0; cellIndex < cellCount; ++cellIndex)
+    {
+        const auto& cell = cells_[cellIndex];
+        for (uint16 ref = 0; ref < cell.count; ++ref)
+        {
+            const auto& [blockIdx, placementIdx] = entries_[cell.offset + ref];
+            const auto& block                    = blocks_[blockIdx];
+            auto&       place                    = placements_[placementIdx];
+
+            for (size_t v = 0; v < block.vertices.size(); v += 3)
+            {
+                const auto  world = transform(place.rotation, place.translation, &block.vertices[v]);
+                const float wy    = world[1];
+
+                place.yMin = std::min(place.yMin, wy);
+                place.yMax = std::max(place.yMax, wy);
+            }
+        }
+    }
+
+    loaded_ = true;
+    return true;
+}
+
+// World position to cell grid index. Each cell covers 4x4 world units.
+auto CZoneMesh::worldToCell(const float x, const float z) const -> std::pair<int, int>
+{
+    return {
+        static_cast<int>(std::floor(x / 4.0f)) + header_.gridWidth / 2,
+        static_cast<int>(std::floor(z / 4.0f)) + header_.gridHeight / 2,
+    };
+}
+
+// Returns the triangle under (x, z) closest above y.
+auto CZoneMesh::query(const float x, const float y, const float z) const -> std::optional<CellHit>
+{
+    const auto [cx, cz]    = worldToCell(x, z);
+    const std::array point = { x, 0.0f, z };
+
+    auto searchCell = [&](const int cellX, const int cellZ) -> std::optional<CellHit>
+    {
+        if (cellX < 0 || cellX >= header_.gridWidth || cellZ < 0 || cellZ >= header_.gridHeight)
+        {
+            return std::nullopt;
+        }
+
+        const auto& cell = cells_[static_cast<uint32>(cellZ) * header_.gridWidth + cellX];
+        if (cell.count == 0)
+        {
+            return std::nullopt;
+        }
+
+        std::optional<CellHit> best;
+        for (uint16 ref = 0; ref < cell.count; ++ref)
+        {
+            constexpr float EPSILON              = 0.01f;
+            const auto& [blockIdx, placementIdx] = entries_[cell.offset + ref];
+            const auto& block                    = blocks_[blockIdx];
+            const auto& place                    = placements_[placementIdx];
+
+            // Skip placements entirely above query point
+            if (place.yMax < y - EPSILON)
+            {
+                continue;
+            }
+
+            for (size_t triIdx = 0; triIdx < block.metas.size(); ++triIdx)
+            {
+                const uint16 i0 = block.indices[triIdx * 3 + 0];
+                const uint16 i1 = block.indices[triIdx * 3 + 1];
+                const uint16 i2 = block.indices[triIdx * 3 + 2];
+
+                const auto world0 = transform(place.rotation, place.translation, &block.vertices[i0 * 3]);
+                const auto world1 = transform(place.rotation, place.translation, &block.vertices[i1 * 3]);
+                const auto world2 = transform(place.rotation, place.translation, &block.vertices[i2 * 3]);
+
+                float triY = 0.0f;
+                if (!dtClosestHeightPointTriangle(point.data(), world0.data(), world1.data(), world2.data(), triY))
+                {
+                    continue;
+                }
+
+                // Pick the closest triangle above the query point (Y is negative-up).
+                if (triY >= y - EPSILON && (!best || triY < best->y))
+                {
+                    const auto& meta = block.metas[triIdx];
+                    best             = CellHit{
+                                    .type    = static_cast<TerrainType>(meta.material),
+                                    .mapId   = place.mapId,
+                                    .roofed  = place.roofed,
+                                    .barrier = meta.barrier != 0,
+                                    .y       = triY,
+                    };
+                }
+            }
+        }
+
+        return best;
+    };
+
+    // Check target cell first
+    if (const auto best = searchCell(cx, cz))
+    {
+        return best;
+    }
+
+    // Miss — check neighbors
+    std::optional<CellHit> best;
+    for (int dz = -1; dz <= 1; ++dz)
+    {
+        for (int dx = -1; dx <= 1; ++dx)
+        {
+            if (dx == 0 && dz == 0)
+            {
+                continue;
+            }
+
+            if (const auto hit = searchCell(cx + dx, cz + dz))
+            {
+                if (!best || hit->y < best->y)
+                {
+                    best = hit;
+                }
+            }
+        }
+    }
+
+    return best;
+}
+
+auto CZoneMesh::getTerrainAt(const float x, const float y, const float z) const -> TerrainType
+{
+    TracyZoneScoped;
+
+    if (!loaded_)
+    {
+        return TerrainType::None;
+    }
+
+    if (const auto hit = query(x, y, z))
+    {
+        return hit->type;
+    }
+
+    return TerrainType::None;
+}
+
+auto CZoneMesh::getFloorId(const float x, const float y, const float z) const -> uint8
+{
+    TracyZoneScoped;
+
+    if (!loaded_)
+    {
+        return 0;
+    }
+
+    if (const auto hit = query(x, y, z))
+    {
+        return hit->mapId;
+    }
+
+    return 0;
+}

--- a/src/map/zone_mesh.h
+++ b/src/map/zone_mesh.h
@@ -1,0 +1,97 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+#include "enums/terrain_type.h"
+#include "ximesh.h"
+
+#include <array>
+#include <limits>
+#include <optional>
+#include <string>
+#include <vector>
+
+struct MeshBlock
+{
+    std::vector<float>        vertices;      // x,y,z interleaved (vertexCount * 3)
+    std::vector<uint16>       indices;       // 3 per triangle
+    std::vector<TriangleMeta> metas;         // 1 per triangle
+    bool                      hasBarriers{}; // true if any triangle in this block is a barrier
+};
+
+struct MeshPlacement
+{
+    std::array<float, 9> rotation{}; // 3x3 column-major
+    std::array<float, 3> translation{};
+    uint8                mapId{};
+    bool                 roofed{};
+    float                yMin{ std::numeric_limits<float>::max() };
+    float                yMax{ std::numeric_limits<float>::lowest() };
+};
+
+struct CellEntry
+{
+    uint16 blockIdx;
+    uint16 placementIdx;
+};
+
+struct CellSpan
+{
+    uint32 offset : 24;
+    uint32 count : 8;
+};
+
+struct CellHit
+{
+    TerrainType type{ TerrainType::None };
+    uint8       mapId{};
+    bool        roofed{};
+    bool        barrier{};
+    float       y{};
+};
+
+class CZoneMesh
+{
+public:
+    CZoneMesh() = default;
+
+    auto load(const std::string& filename) -> bool;
+    auto query(float x, float y, float z) const -> std::optional<CellHit>;
+    auto getTerrainAt(float x, float y, float z) const -> TerrainType;
+    auto getFloorId(float x, float y, float z) const -> uint8;
+    auto isLoaded() const -> bool
+    {
+        return loaded_;
+    }
+
+private:
+    auto worldToCell(float x, float z) const -> std::pair<int, int>;
+
+    bool         loaded_{};
+    XimeshHeader header_{};
+
+    std::vector<MeshBlock>     blocks_;
+    std::vector<MeshPlacement> placements_;
+    std::vector<CellEntry>     entries_;
+    std::vector<CellSpan>      cells_;
+};


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
### Credits
I'll start with this because I legitimately can't claim credit for any of this, I am merely the plumber here.
- @InoUno for creating the ximeshes files and making them available - also for the excellent [xi-visualizer](https://inouno.github.io/xi-visualizer/#/) tool from which the bulk of the logic has been lifted
- Aamace (not on GitHub), the creator of [Xim](https://xim.pages.dev), which has been useful in figuring out the actual MZB format (ref src/jsMain/kotlin/xim/resource/ZoneDefParser.kt)
- @Xenonsmurf for [NavMesh-Builder](https://github.com/LandSandBoat/FFXI-NavMesh-Builder) which I referenced for similar purposes
- @atom0s for general code snippets here and there and other client decomps relating to client handling of zone data

### Description
Wires in a new `CZoneMesh` class on CZone that loads, decompresses and prepares ximesh data for consumption. 
Exposes a general query API to get a cell information starting from world coords and a handful of helpers for terrain and floorId.

There's a lot of data in there which we are not using at the moment, such as barriers but they may come in useful when we swap LOS to use this. 
I didn't port the [raycast from xi-visualizer](https://github.com/InoUno/xi-visualizer/blob/bbf904bf33d166e97ba8ceb582e126afc08041bc/src/graphics/ximesh.ts#L610) at this time.

Note that this introduces zlibstatic as a dependency.
Note that the zone_mesh.cpp code defers to Detour for `dtClosestHeightPointTriangle` but it is **not** a hard dependency,

### What this enables
- Get terrain material at a given world coor. 
  - Includes an example of restricting Phuabo Tidal Wave to only occur over water.
  - This will be key to making scent-based tracking work accurately
- Get floor id at a given coord
  - Restricts Widescan to only entities on same floor as PC.
  - May be useful to start segmenting entities queries by floor in the future?

!pos has been updated to display the information.

### Memory
568MB usage for all zones on a single process
The key optimization is the deduplication done at load time to reuse blocks and packed everything tightly.

### Perf
As a test I added `query` in the AI tick path to see how it would cope under future load. About 2us per call in most of  my testing.

<img width="1199" height="1058" alt="Screenshot 2026-03-30 012007" src="https://github.com/user-attachments/assets/50f77abd-c015-4c33-b618-740765d8481c" />

Loading itself is around 100ms per zone

<img width="1121" height="584" alt="Screenshot 2026-03-30 012246" src="https://github.com/user-attachments/assets/5398018f-1ed0-4a2f-8b60-85b445c6e6ff" />

## Steps to test these changes
xi_test has terrain tests.

~~Draft because there's a slight issue with a dozen zone name not matching the ximesh filename, need to fix that first.~~
Added temporary rewriting of mesh filename for the few odd zones. Will work out the real fix in ximeshes repository at some point.

<!-- Clear and detailed steps to test your changes here -->
