### PR TITLE
[core] Fix stack overflow from reentrant action queue

### DIFF
--- a/src/map/ai/helpers/action_queue.cpp
+++ b/src/map/ai/helpers/action_queue.cpp
@@ -50,8 +50,8 @@ void CAIActionQueue::checkAction(timer::time_point tick)
         if (tick > topaction.start_time + topaction.delay)
         {
             queueAction_t action = timerQueue.top();
-            handleAction(action);
             timerQueue.pop();
+            handleAction(action);
         }
         else
         {
@@ -64,8 +64,8 @@ void CAIActionQueue::checkAction(timer::time_point tick)
         if (tick > topaction.start_time + topaction.delay && (!topaction.checkState || PEntity->PAI->CanChangeState()))
         {
             auto action = actionQueue.top();
-            handleAction(action);
             actionQueue.pop();
+            handleAction(action);
         }
         else
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
`useJobAbility` and `usePetAbility` don't play well with timers because they immediately check the queue after queuing their actions with 0ms. 

```lua
    mob:useJobAbility(xi.ja.CORSAIRS_ROLL, mob)
    mob:timer(5000, function(mobArg)
        mobArg:useJobAbility(xi.ja.DOUBLE_UP, mob)
    end)
```

The stack is popped only after processing the action, which in the code above will just reenter the timer callback over and over again.
The fix is to pop the stack before processing the action.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
