### PR TITLE
[lua] Fix edge cases that report incorrect misses for mob/weaponskill

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -317,12 +317,12 @@ xi.mobskills.mobPhysicalMove = function(mob, target, skill, numHits, accMod, ftp
     end
 
     -- all hits missed
-    if hitslanded == 0 or finaldmg == 0 then
+    if hitslanded == 0 then
         finaldmg   = 0
         hitslanded = 0
         skill:setMsg(xi.msg.basic.SKILL_MISS)
     -- calculate tp return of mob skill and add if hit primary target
-    elseif skill:getPrimaryTargetID() == target:getID() then
+    elseif skill:getPrimaryTargetID() == target:getID() and finaldmg > 0 then
         local tpReturn = xi.combat.tp.getSingleMeleeHitTPReturn(mob, false)
         tpReturn = tpReturn + 10 * (hitslanded - 1) -- extra hits give 10 TP each
         mob:addTP(tpReturn)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -554,7 +554,6 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     -- Do the extra hit for our offhand if applicable
     if calcParams.extraOffhandHit and hitsDone < 8 and finaldmg < targetHp then
-        calcParams.hitsLanded = 0
         local offhandDmg      = calcParams.weaponDamage[2] + calcParams.fSTR + wsc * alpha
         hitdmg, calcParams    = getSingleHitDamage(attacker, target, offhandDmg, ftp, wsParams, calcParams)
 
@@ -590,7 +589,6 @@ xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action,
 
     while hitsDone < 8 and offhandMultiHitsDone < numOffhandMultis and finaldmg < targetHp do
         local offhandDmg      = calcParams.weaponDamage[2] + calcParams.fSTR + wsc * alpha
-        calcParams.hitsLanded = 0
         hitdmg, calcParams    = getSingleHitDamage(attacker, target, offhandDmg, ftp, wsParams, calcParams)
 
         if calcParams.melee then
@@ -920,7 +918,7 @@ end
 xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, primaryMsg, attack, wsResults, action)
     local finaldmg = wsResults.finalDmg
 
-    if wsResults.tpHitsLanded + wsResults.extraHitsLanded > 0 then
+    if wsResults.hitsLanded > 0 then
         if finaldmg >= 0 then
             if primaryMsg then
                 action:messageID(defender:getID(), xi.msg.basic.DAMAGE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Weaponskills and mobskills could report a "miss" even if the WS didn't actually miss, you just dealt zero damage

## Steps to test these changes

Give a mob or yourself invincible, test mobskill/weaponskill reporting 0 damage

also check miss still works
<img width="370" height="150" alt="image" src="https://github.com/user-attachments/assets/a28cdda4-cbd4-4b18-8c2d-4b6600a44592" />
<img width="407" height="161" alt="image" src="https://github.com/user-attachments/assets/6b2c84a4-53f8-4ded-a976-cf16eff9a934" />

