### PR TITLE
[core] Filter additional bad equip packets

### DIFF
--- a/src/map/enums/msg_basic.h
+++ b/src/map/enums/msg_basic.h
@@ -63,6 +63,7 @@ enum class MsgBasic : uint16_t
     LoseSight                       = 36,  // You lose sight of <target>.
     TooFarForExp                    = 37,  // You are too far from the battle to gain experience.
     SkillGain                       = 38,  // <target>'s <skill> skill rises X points.
+    NeedDualWield                   = 39,  // You need the Dual Wield ability to equip <name of item> as a sub-weapon
     CannotInThisArea                = 40,  // cannot use in this area
     ReadiesWeaponskill              = 43,  // <entity> readies <skill>.
     SpikesEffectDmg                 = 44,  // <target>'s spikes deal <number> damage to <attacker>

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3140,7 +3140,72 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         return;
     }
 
-    // if player attempts to change thier ranged weapon during a ranged state then prevent equip
+    // slotID of zero = unequip
+    if (slotID > 0)
+    {
+        // skip the rest of the function if we are trying to equip the same item to a different slot
+        switch (static_cast<SLOTTYPE>(equipSlotID))
+        {
+            case SLOT_MAIN:
+            {
+                auto PSub = PChar->getEquip(SLOT_SUB);
+                if (PItem == PSub)
+                {
+                    return;
+                }
+                break;
+            }
+            case SLOT_SUB:
+            {
+                auto PMain = PChar->getEquip(SLOT_MAIN);
+                if (PItem == PMain)
+                {
+                    return;
+                }
+                break;
+            }
+            case SLOT_EAR1:
+            {
+                auto PEar2 = PChar->getEquip(SLOT_EAR2);
+                if (PItem == PEar2)
+                {
+                    return;
+                }
+                break;
+            }
+            case SLOT_EAR2:
+            {
+                auto PEar1 = PChar->getEquip(SLOT_EAR1);
+                if (PItem == PEar1)
+                {
+                    return;
+                }
+                break;
+            }
+            case SLOT_RING1:
+            {
+                auto PRing2 = PChar->getEquip(SLOT_RING2);
+                if (PItem == PRing2)
+                {
+                    return;
+                }
+                break;
+            }
+            case SLOT_RING2:
+            {
+                auto PRing1 = PChar->getEquip(SLOT_RING1);
+                if (PItem == PRing1)
+                {
+                    return;
+                }
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    // if player attempts to change their ranged weapon during a ranged state then prevent equip
     // this prevents players from starting a RA with short delay x-bow and ending with high dmg longbow
     if (equipSlotID == SLOT_RANGED || (equipSlotID == SLOT_AMMO && !PChar->getEquip(SLOT_RANGED)))
     {
@@ -3154,10 +3219,28 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
     {
         auto PItemWeapon = dynamic_cast<CItemWeapon*>(PItem);
         auto PMainItem   = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_MAIN));
+
         if (PItemWeapon && PItemWeapon->getSkillType() == SKILL_NONE && (!PMainItem || !PMainItem->isTwoHanded()))
         {
             PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, 0, MsgBasic::Requires2HForGrip);
             return;
+        }
+
+        if (PItemWeapon && PItemWeapon->getSkillType() != SKILL_NONE)
+        {
+            // Don't attempt to equip item in equip menu if you don't have dual wield trait (client sees BLU, THF, DNC, NIN, /DNC or /NIN etc as able to equip sub weapons even if sub is too low or no trait on BLU)
+            if (!PChar->hasTrait(TRAIT_DUAL_WIELD))
+            {
+                PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, PItemWeapon->getID(), 0, MsgBasic::NeedDualWield);
+                return;
+            }
+
+            // Don't allow Dual Wield injections to offhand when you dont have a mainahdn (this was visual only)
+            // Don't allow non-shields in offhand with no weapon
+            if ((PMainItem && PMainItem->isTwoHanded()) || !PMainItem)
+            {
+                return;
+            }
         }
 
         // Disallow everything but shields if you're using H2H


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There were some unhandled cases in the equip packet where we would do pending equip screen updates for invalid equips so I filtered them out. I also discovered a missing packet emission if your client allows you to equip dual wield items but you dont have dual wield. This can happen naturally on retail if you are BLU main, THF main, DNC or /DNC, NIN or /NIN but didnt set the Dual Wield trait or are too low to dual wield. It also happens if you inject on a job combo that can't dual wield at all.

This has a side effect of not resetting TP when you were trying to do an invalid equip since the code path exits early. This seems accurate to retail on testing.

## Steps to test these changes

when dual wielding, try to equip a dagger in main and offhand (a single item) and see the offhand not appear as a "phantom equip"
try to equip single ring/earring in two slots and see no "phantom" equips

try to equip a dagger in offhand via injection to sub slot when 2 handing and not see a "phantom" equip
`/lac equip sub "Ceremonial dagger"` will do the trick
try to equip a dagger when you don't have dual wield in the sub slot and get a message telling you that you can't do that
<img width="1086" height="590" alt="image" src="https://github.com/user-attachments/assets/8e54bb26-0dc2-48ad-82b1-e52deaf6c046" />
<img width="652" height="21" alt="image" src="https://github.com/user-attachments/assets/c27341db-decb-425f-9cfb-f6c0cf09c60c" />



