### PR TITLE
[lua] Quest Cleanup Promotion Superior Private

### DIFF
--- a/scripts/quests/ahtUrhgan/Promotion_Superior_Private.lua
+++ b/scripts/quests/ahtUrhgan/Promotion_Superior_Private.lua
@@ -3,6 +3,8 @@
 -- Log ID: 6, Quest ID: 91
 -- Naja Salaheem !pos 26 -8 -45.5 50
 -----------------------------------
+local ahturhganID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
+-----------------------------------
 
 local quest = Quest:new(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.PROMOTION_SUPERIOR_PRIVATE)
 
@@ -27,10 +29,12 @@ quest.sections =
             {
                 [5020] = function(player, csid, option, npc)
                     quest:begin(player)
+                    quest:setMustZone(player)
                 end,
             },
         },
     },
+
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED and not player:hasKeyItem(xi.ki.DARK_RIDER_HOOFPRINT)
@@ -38,7 +42,16 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-            ['Naja_Salaheem'] = quest:event(5021, { text_table = 0 }),
+            ['Naja_Salaheem'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getMustZone(player) then
+                        return quest:event(5021, { [0] = 1, [1] = 1, text_table = 0 }):oncePerZone()
+                    else
+                        return quest:event(5021, { text_table = 0 }):oncePerZone()
+                    end
+                end
+            }
         },
 
         [xi.zone.BHAFLAU_THICKETS] =
@@ -57,8 +70,8 @@ quest.sections =
         {
             ['Warhorse_Hoofprint'] = quest:keyItem(xi.ki.DARK_RIDER_HOOFPRINT)
         },
-
     },
+
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED and player:hasKeyItem(xi.ki.DARK_RIDER_HOOFPRINT)
@@ -75,6 +88,7 @@ quest.sections =
                         player:setCharVar('AssaultPromotion', 0)
                         player:delKeyItem(xi.ki.PFC_WILDCAT_BADGE)
                         player:delKeyItem(xi.ki.DARK_RIDER_HOOFPRINT)
+                        player:messageSpecial(ahturhganID.text.SUPERIOR_PRIVATE)
                     end
                 end,
             },

--- a/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/IDs.lua
@@ -51,6 +51,7 @@ zones[xi.zone.AHT_URHGAN_WHITEGATE] =
         YOU_BETTER_NOT_LOSE_IT_AGAIN  = 5873,  -- You better not lose it again.
         PROMOTION_SERGEANT_MAJOR      = 6178,  -- <player> has been promoted to Sergeant Major!
         NYZUL_FAIL                    = 6195,  -- Your mission was not successful. I regret to inform you that the Imperial Army does not officially recognize your efforts within this Assault area.
+        SUPERIOR_PRIVATE              = 6320,  -- <Player> has been promoted to Superior Private!
         LANCE_CORPORAL                = 6685,  -- <player> has been promoted to Lance Corporal!
         BESIEGED_OFFSET               = 6836,  -- Your Imperial Standing has increased!
         PROMOTION_SERGEANT            = 7744,  -- <player> has been promoted to Sergeant!


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cleans up the quest to be retail accurate.
Adds missing event and message.

## Steps to test these changes

1. `!completequest 6 90`
2. Set charvar AssaultPromotion to 25 or higher.
3. Talk to Naja_Salaheem to flag quest
4. Talk to Naja to see unique event.
5. Hunt down a Warhorse_Hoofprint and get a DARK_RIDER_HOOFPRINT or add it `!addkeyitem DARK_RIDER_HOOFPRINT`
6. Talk to Naja_Salaheem
7. Quest Complete

## Captures
https://youtu.be/ZMHQySGdzgk
https://drive.google.com/file/d/1A1XpZVXtQhLQRfeWzcLzU8fO7JM8v_54/view?usp=sharing
