### PR TITLE
[lua] Add 'hitsLanded' = 1 to calcparams of magic ws

### DIFF
--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -44,6 +44,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     {
         wsID            = wsID,
         criticalHit     = false,
+        hitsLanded      = 1,
         tpHitsLanded    = 0,
         extraHitsLanded = 0,
         shadowsAbsorbed = 0,

--- a/scripts/actions/weaponskills/spirits_within.lua
+++ b/scripts/actions/weaponskills/spirits_within.lua
@@ -30,6 +30,7 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     {
         wsID = wsID, -- need 'calcParams.wsID' passed to global
         criticalHit = false,
+        hitsLanded = 1,
         tpHitsLanded = 0,
         extraHitsLanded = 0,
         shadowsAbsorbed = 0,

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -820,6 +820,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
     local calcParams =
     {
         ['shadowsAbsorbed'] = 0,
+        ['hitsLanded']      = 1,
         ['tpHitsLanded']    = 1,
         ['extraHitsLanded'] = 0,
         ['bonusTP']         = wsParams.bonusTP or 0,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`hitsLanded` is checked when finalizing the action now and apparently magic ws was not setting it, so we have to set it now.

## Steps to test these changes

Use magic WS with no error
