### PR TITLE
[lua] Bug fix quest "Rock Racketeer" wrong prog value check

### DIFF
--- a/scripts/quests/windurst/Rock_Racketeer.lua
+++ b/scripts/quests/windurst/Rock_Racketeer.lua
@@ -94,7 +94,7 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local progress = quest:getVar(player, 'Prog')
 
-                    if progress == 3 then
+                    if progress == 2 then
                         if quest:getVar(player, 'Option') < 2 then
                             return quest:progressEvent(100) -- Optional Dialogue that only places once
                         else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug where the optional dialogue is checking for the wrong Prog value.
Updates the check from Prog == 3 to Prog == 2.
Prog will never be 3 in the current code.

## Steps to test these changes

Start quest.
`!setquestvar <me> 2 26 Prog 2`
Talk to Varun.
