### PR TITLE
[lua] TOAU Mission 5 Quest IF Adjustments

### DIFF
--- a/scripts/missions/toau/05_Confessions_of_Royalty.lua
+++ b/scripts/missions/toau/05_Confessions_of_Royalty.lua
@@ -13,12 +13,49 @@ mission.reward =
     nextMission = { xi.mission.log_id.TOAU, xi.mission.id.toau.EASTERLY_WINDS },
 }
 
+local function canEnterChateau(player)
+    local pNation = player:getNation()
+    local pRank   = player:getRank(pNation)
+
+    -- Everyone can enter at rank 3.
+    if pRank >= 3 then
+        return true
+    end
+
+    -- Sandoria citizens gain access at rank 2.
+    if
+        pNation == xi.nation.SANDORIA and
+        pRank >= 2
+    then
+        return true
+    end
+
+    -- Other citizens gain access during "The emisary"/"The three Kingdoms"
+    if
+        pNation ~= xi.nation.SANDORIA and
+        player:getCurrentMission(pNation) >= 5
+    then
+        return true
+    end
+
+    return false
+end
+
 mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId
         end,
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Cacaroon'] = mission:event(3023, { text_table = 0 }),
+
+            ['Nadeey'] = mission:event(3025, { text_table = 0 }),
+
+            ['Naja_Salaheem'] = mission:event(3021, { text_table = 0 }),
+        },
 
         [xi.zone.CHATEAU_DORAGUILLE] =
         {
@@ -31,12 +68,53 @@ mission.sections =
                 end,
             },
 
+            -- Forces the player into the CS if they don't normall have access to the Chateau.
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Option') == 1 then
+                    return 563
+                end
+            end,
+
             onEventFinish =
             {
+                -- Force zones the player out of the Chateau if they don't have access.
+                [563] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.RAILLEFALS_LETTER)
+                    mission:complete(player)
+                    player:setPos(0, 0, 100, 64, xi.zone.NORTHERN_SAN_DORIA)
+                end,
+
                 [564] = function(player, csid, option, npc)
                     if option == 1 then
                         player:delKeyItem(xi.ki.RAILLEFALS_LETTER)
                         mission:complete(player)
+                    end
+                end,
+            },
+        },
+
+        -- Unique interaction IF the player does not have access to the Chateau to gain access to continue the mission.
+        [xi.zone.NORTHERN_SAN_DORIA] =
+        {
+            ['Guilerme'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        player:hasKeyItem(xi.ki.RAILLEFALS_LETTER) and
+                        not canEnterChateau(player)
+                    then
+                        return mission:progressEvent(810)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [810] = function(player, csid, option, npc)
+                    -- Force zones the player into the Chateau
+                    if option == 1 then
+                        mission:setVar(player, 'Option', 1)
+                        player:setPos(0, 0, -13, 192, xi.zone.CHATEAU_DORAGUILLE)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing interactions as observed in captures.

Adds interaction in San d'Oria if the player is on TOAU Mission 5 but does NOT have access to the Chateau.
- Force zones the player into the Chateau
- Force starts the cs with Halver
- Force zones the player out when complete

## Steps to test these changes

`!addmission 4 4`
Interact with the NPCs.
`!setplayernation <me> 2`
`!addmission 2 0`
`!addkeyitem RAILLEFALS_LETTER`
`!zone <Northern San 'Doria>`
Talk to Guilerme.

## Captures
No Chateau interaction is packets only and included in the zip.
https://youtu.be/nt_N82kVSR0
https://drive.google.com/file/d/1lpcibJSs_Qhs49eiN9pLy3BasCxcXOSW/view?usp=sharing