### PR TITLE
[lua] Changes Leaping Lizzy PHs based on retail research

### DIFF
--- a/scripts/zones/South_Gustaberg/mobs/Leaping_Lizzy.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Leaping_Lizzy.lua
@@ -77,8 +77,8 @@ entity.spawnPoints =
 
 entity.phList =
 {
-    [ID.mob.LEAPING_LIZZY[1] - 1] = ID.mob.LEAPING_LIZZY[1], -- -275.441 20.451 -347.294
-    [ID.mob.LEAPING_LIZZY[2] - 1] = ID.mob.LEAPING_LIZZY[2], -- -322.871 30.052 -401.184
+    [ID.mob.LEAPING_LIZZY[1] - 1] = ID.mob.LEAPING_LIZZY[1], -- Confirmed on retail
+    [ID.mob.LEAPING_LIZZY[1] - 1] = ID.mob.LEAPING_LIZZY[2], -- Confirmed on retail
 }
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Leaping lizzy PHs has been updated. After 28 kills on the 1 PH I can confirm that BHWiki is indeed correct. The top PH (The only PH) can pop both the leaping lizzy IDs. The first screenshot should be proof enough as this is only possible with the 1st PH popping the 2nd LL ID.

<img width="123" height="174" alt="image" src="https://github.com/user-attachments/assets/bf6c1861-1fd9-414a-a1b7-c2da4f5e237c" />

<img width="743" height="185" alt="image" src="https://github.com/user-attachments/assets/7299cd83-0b6a-48ef-8b80-1ecdc3064396" />

<img width="564" height="669" alt="image" src="https://github.com/user-attachments/assets/c7e14639-cdbb-43ab-ac5d-edf74b1c0d3c" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17215867
Kill it over and over until LL spawns either ID
<!-- Clear and detailed steps to test your changes here -->
