### PR TITLE
[core, lua] Fix message ID for Leviathan Slowga

### DIFF
--- a/scripts/actions/abilities/pets/slowga.lua
+++ b/scripts/actions/abilities/pets/slowga.lua
@@ -17,9 +17,9 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
 
     if target:addStatusEffect(xi.effect.SLOW, { power = 3000, duration = duration, origin = pet, tier = 3 }) then
-        petskill:setMsg(xi.msg.basic.SKILL_ENFEEB_IS)
+        petskill:setMsg(xi.msg.basic.JA_RECEIVES_EFFECT_2)
     else
-        petskill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
+        petskill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
     end
 
     -- TODO: Verify enmity gain total

--- a/src/map/enums/msg_basic.h
+++ b/src/map/enums/msg_basic.h
@@ -159,6 +159,7 @@ enum class MsgBasic : uint16_t
     TargetRecoversHP2               = 263, // <target> recovers <amount> HP.
     TargetTakesDamage               = 264, // <target> takes <amount> points of damage.
     TargetGainsEffect               = 266, // <target> gains the effect of <status>.
+    TargetReceivesEffectAbility     = 267, // <target> receives the effect of <status>.
     TargetTeleport                  = 273, // <target> vanishes.
     MagicBurstDrainsHP              = 274, // <caster> casts <spell>. Magic Burst! <amount> HP drained from <target>.
     TargetRecoversMP                = 276, // <target> recovers <amount> MP.
@@ -179,6 +180,8 @@ enum class MsgBasic : uint16_t
     UsesJobAbilityTakeDamage        = 317, // The <player> uses .. <target> takes .. points of damage.
     UsesItemRecoversHPAreaOfEffect2 = 318, // <user> uses <item>. <target> recovers <amount> HP.
     UsesAbilityGainsEffect          = 319, // <user> uses <ability>. <target> gains the effect of <status>.
+    UsesAbilityReceivesEffect       = 320, // <user> uses <ability>. <target> receives the effect of <status>.
+    UsesAbilityNoEffect             = 323, // <user> uses <ability>. No effect on <target>.
     UsesButMisses                   = 324, // The <player> uses .. but misses <target>.
     ReadiesSkill                    = 326, // <entity> readies <skill>.
     StartsCastingTarget             = 327, // <entity> starts casting <spell> on <target>.

--- a/src/map/utils/messageutils.h
+++ b/src/map/utils/messageutils.h
@@ -61,6 +61,8 @@ const std::unordered_map<MsgBasic, MsgBasic> aoeVariants = {
     { MsgBasic::UsesAbilityFortifiedDemons, MsgBasic::TargetFortifiedDemons },
     { MsgBasic::UsesAbilityFortifiedDragons, MsgBasic::TargetFortifiedDragons },
     { MsgBasic::UsesAbilityGainsEffect, MsgBasic::TargetGainsEffect },
+    { MsgBasic::UsesAbilityReceivesEffect, MsgBasic::TargetReceivesEffectAbility },
+    { MsgBasic::UsesAbilityNoEffect, MsgBasic::TargetNoEffect },
     { MsgBasic::UsesAbilityEffect, MsgBasic::ReceivesEffectAbility },
     { MsgBasic::UsesAbilityRecharge, MsgBasic::TargetAbilitiesRecharged },
     { MsgBasic::UsesAbilityRechargeTP, MsgBasic::TargetRechargedTP },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Using the wrong message IDs and it wasnt defined in the map of AoE variants.

Closes #9727 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
<img width="1685" height="921" alt="image" src="https://github.com/user-attachments/assets/a9221824-8d9b-4712-bac5-7dbc55267a0a" />

<!-- Clear and detailed steps to test your changes here -->
