### PR TITLE
[c++] Fix Moghouse entry in WoTG + SoA

### DIFF
--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -21,6 +21,8 @@
 
 #include "0x05e_maprect.h"
 
+#include <string_view>
+
 #include "common/utils.h"
 #include "entities/charentity.h"
 #include "enums/msg_std.h"
@@ -63,8 +65,13 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
 
     PChar->ClearTrusts();
 
-    auto isMogHouseExit     = std::memcmp(&this->RectID, "zmrq", 4) == 0; // zmrq is the universal Mog House exit zoneline
-    auto isMogHouseEntrance = std::memcmp(&this->RectID, "zmr", 3) == 0;  // zmr* are zone-specific Mog House entry zonelines
+    // RectID is a uint32_t holding a 4-character zoneline tag (fourcc); reinterpret as exactly 4 bytes (no trailing NUL).
+    const std::string_view rectView(reinterpret_cast<const char*>(&this->RectID), 4);
+
+    const auto isMogHouseExit = rectView == "zmrq"; // universal Mog House exit zoneline
+
+    const std::string_view mogEntrancePrefix  = rectView.substr(0, 3);
+    const auto             isMogHouseEntrance = mogEntrancePrefix == "zmr" || mogEntrancePrefix == "zms"; // zmr* classic cities; zms* WoTG [S] + Adoulin
 
     if (PChar->status == STATUS_TYPE::NORMAL)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Tried zoning into Moghouses in WoTG and SoA zones and would just get sent back to entry zoneline (all zones enabled on my test server), fixes the issue.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Zone into WoTG and SoA moghouses before and after change.
