### PR TITLE
[Quest] Remove unneeded THF AF1 stew code

### DIFF
--- a/scripts/quests/windurst/THF_AF1_The_Tenshodo_Showdown.lua
+++ b/scripts/quests/windurst/THF_AF1_The_Tenshodo_Showdown.lua
@@ -132,45 +132,6 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_ACCEPTED and
-                not player:hasItem(xi.item.BOWL_OF_QUADAV_STEW)
-        end,
-
-        [xi.zone.BEADEAUX] =
-        {
-            ['Bronze_Quadav'] =
-            {
-                onSteal = function(player, target, ability, action)
-                    return xi.item.BOWL_OF_QUADAV_STEW
-                end
-            },
-
-            ['Garnet_Quadav'] =
-            {
-                onSteal = function(player, target, ability, action)
-                    return xi.item.BOWL_OF_QUADAV_STEW
-                end
-            },
-
-            ['Silver_Quadav'] =
-            {
-                onSteal = function(player, target, ability, action)
-                    return xi.item.BOWL_OF_QUADAV_STEW
-                end
-            },
-
-            ['Zircon_Quadav'] =
-            {
-                onSteal = function(player, target, ability, action)
-                    return xi.item.BOWL_OF_QUADAV_STEW
-                end
-            }
-        },
-
-    },
-
-    {
-        check = function(player, status, vars)
             return status == xi.questStatus.QUEST_COMPLETED and
                 player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.AS_THICK_AS_THIEVES) == xi.questStatus.QUEST_AVAILABLE and
                 player:getMainJob() == xi.job.THF and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Didn't notice this was actually in the quest itself earlier.
This PR deletes the unneeded stew steal code from the THF AF1 quest as the stew is stealable if the quest is active or not.

## Steps to test these changes

Steal a stew
