### PR TITLE
[lua] Fix: Apply Barspell bonus MDEF

### DIFF
--- a/scripts/effects/baraero.lua
+++ b/scripts/effects/baraero.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.WIND_MEVA, effect:getPower())
+    effect:addMod(xi.mod.WIND_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.WIND_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/barblizzard.lua
+++ b/scripts/effects/barblizzard.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ICE_MEVA, effect:getPower())
+    effect:addMod(xi.mod.ICE_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ICE_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/barfire.lua
+++ b/scripts/effects/barfire.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.FIRE_MEVA, effect:getPower())
+    effect:addMod(xi.mod.FIRE_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.FIRE_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/barstone.lua
+++ b/scripts/effects/barstone.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.EARTH_MEVA, effect:getPower())
+    effect:addMod(xi.mod.EARTH_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.EARTH_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/barthunder.lua
+++ b/scripts/effects/barthunder.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.THUNDER_MEVA, effect:getPower())
+    effect:addMod(xi.mod.THUNDER_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.THUNDER_MEVA, effect:getPower())
 end
 
 return effectObject

--- a/scripts/effects/barwater.lua
+++ b/scripts/effects/barwater.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.WATER_MEVA, effect:getPower())
+    effect:addMod(xi.mod.WATER_MEVA, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getSubPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.WATER_MEVA, effect:getPower())
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The magic defense bonus that elemental bar-spells are supposed to apply if you have barspell merits or Blessed Bliaut equipped is quietly dropped after the effect's subpower is set in enhancing_spell.lua. This PR applies the missing MDEF bonus to each elemental barspell effect.

## Steps to test these changes
* Wear Blessed Bliaut
* Use Barfira
* Observe that you get MDEF + 5