### PR TITLE
[lua, sql] Fixes COP 7-1 full inventory message and NPC

### DIFF
--- a/scripts/missions/cop/7_1_Chains_and_Bonds.lua
+++ b/scripts/missions/cop/7_1_Chains_and_Bonds.lua
@@ -6,6 +6,8 @@
 -- Walnut Door    : !pos 111 -41 41 26
 -- Sewer Entrance : !pos 28 -12 44 26
 -----------------------------------
+local lufaiseID = zones[xi.zone.LUFAISE_MEADOWS]
+-----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.COP, xi.mission.id.cop.CHAINS_AND_BONDS)
 
@@ -23,6 +25,15 @@ mission.sections =
 
         [xi.zone.LUFAISE_MEADOWS] =
         {
+            ['qm3'] =
+            {
+                onTrigger = function(player, npc)
+                    if mission:getVar(player, 'RingStashed') == 1 then
+                        return mission:progressEvent(114)
+                    end
+                end,
+            },
+
             onZoneIn = function(player, prevZone)
                 if mission:getVar(player, 'Status') == 0 then
                     return 111
@@ -39,7 +50,17 @@ mission.sections =
             onEventFinish =
             {
                 [111] = function(player, csid, option, npc)
+                    if player:getFreeSlotsCount() == 0 then
+                        player:messageSpecial(lufaiseID.text.NO_ROOM_COME_BACK_LATER, xi.item.DUCAL_GUARDS_RING)
+                        mission:setVar(player, 'RingStashed', 1)
+                    elseif npcUtil.giveItem(player, xi.item.DUCAL_GUARDS_RING) then
+                        mission:setVar(player, 'Status', 1)
+                    end
+                end,
+
+                [114] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.item.DUCAL_GUARDS_RING) then
+                        mission:setVar(player, 'RingStashed', 0)
                         mission:setVar(player, 'Status', 1)
                     end
                 end,

--- a/scripts/zones/Lufaise_Meadows/DefaultActions.lua
+++ b/scripts/zones/Lufaise_Meadows/DefaultActions.lua
@@ -5,4 +5,5 @@ return {
     ['qm_hard_days_knight'] = { messageSpecial = ID.text.YOU_CAN_SEE_FOR_MALMS },
     ['qm_bitter_past']      = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm_baumesel']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm_chains_and_bonds'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Lufaise_Meadows/IDs.lua
+++ b/scripts/zones/Lufaise_Meadows/IDs.lua
@@ -23,6 +23,7 @@ zones[xi.zone.LUFAISE_MEADOWS] =
         CONQUEST                      = 7237, -- You've earned conquest points!
         FISHING_MESSAGE_OFFSET        = 7571, -- You can't fish here.
         KI_STOLEN                     = 7700, -- The <keyitem> has been stolen!
+        NO_ROOM_COME_BACK_LATER       = 7716, -- You do not have any room in your bag, so you hide the <item> in the grass nearby. Come and retrieve it later.
         LOGGING_IS_POSSIBLE_HERE      = 7748, -- Logging is possible here if you have <item>.
         SURVEY_THE_SURROUNDINGS       = 7755, -- You survey the surroundings but see nothing out of the ordinary.
         MURDEROUS_PRESENCE            = 7756, -- Wait, you sense a murderous presence...!


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds full inventory message for Ducal Guards Ring acquisition
- Implements the NPC from where you get the ring and its default message

Event dump: https://github.com/sruon/FFXI-EventsDump/blob/main/dumps/Lufaise%20Meadows/16875854.md
ID String: https://github.com/sruon/FFXI-Strings/blob/main/dumps/Lufaise_Meadows/Text.lua

Retail capture:
<img width="1452" height="420" alt="image" src="https://github.com/user-attachments/assets/7bc97e27-56dd-4d6b-945c-4c5532d4b3f9" />

Default action:
<img width="1034" height="658" alt="image" src="https://github.com/user-attachments/assets/3c186606-ba72-4592-bc02-394cf57be244" />


Testing: 
<img width="1284" height="335" alt="image" src="https://github.com/user-attachments/assets/5de7e4e3-cd2d-43e3-bb89-a9dc917b949a" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Fill your inventory: !additem 5 100

!addmission 6 638
!pos -12 -12 1 237
!pos 612 132 774 32
Complete the really long fight

This will zone you into Lufaise meadows and start 7-1 cutscene

See the message to check the bush
Check the ??? in front of you after dropping an item and receive the rustle messages and the item
<!-- Clear and detailed steps to test your changes here -->
