### PR TITLE
[core] Limit delivery box to 128 items in flight

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -291,6 +291,9 @@ xi.settings.map =
     AUDIT_PLAYER_DBOX   = false,
     AUDIT_PLAYER_VENDOR = false,
 
+    -- Maximum number of in-flight items (slots) allowed in a player's delivery box for PC-to-PC transfers.
+    DELIVERY_BOX_MAX_INFLIGHT = 128,
+
     -- Seconds between healing ticks. Default is 10
     HEALING_TICK_DELAY = 10,
 

--- a/src/map/utils/dboxutils.cpp
+++ b/src/map/utils/dboxutils.cpp
@@ -38,6 +38,17 @@
 #include "packets/s2c/0x04b_pbx_result.h"
 #include "universal_container.h"
 
+namespace
+{
+auto isDeliveryBoxInflightAtCapacity(uint32 charid) -> bool
+{
+    static const uint32 maxInflight = settings::get<uint32>("map.DELIVERY_BOX_MAX_INFLIGHT");
+
+    const auto rset = db::preparedStmt("SELECT COUNT(*) AS cnt FROM delivery_box WHERE charid = ? AND box = 1 AND slot >= 8", charid);
+    return rset && rset->next() && rset->get<uint32>("cnt") >= maxInflight;
+}
+} // anonymous namespace
+
 void dboxutils::SendOldItems(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO BoxNo)
 {
     DebugDeliveryBoxFmt("DBOX: SendOldItems: player: {} ({}), BoxNo: {}", PChar->name, PChar->id, static_cast<int8_t>(BoxNo));
@@ -214,11 +225,22 @@ void dboxutils::SendConfirmation(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO Bo
 
         if (PItem && !PItem->isSent())
         {
+            uint32 charid = charutils::getCharIdFromName(PItem->getReceiver());
+            if (!charid)
+            {
+                return;
+            }
+
+            if (isDeliveryBoxInflightAtCapacity(charid))
+            {
+                PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Send, BoxNo, PItem, PostWorkNo, send_items, 0x02);
+                PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Send, BoxNo, PItem, PostWorkNo, send_items, 0xFE);
+                return;
+            }
+
             // clang-format off
             const auto success = db::transaction([&]()
             {
-                uint32 charid = charutils::getCharIdFromName(PItem->getReceiver());
-
                 const auto rset = db::preparedStmt("UPDATE delivery_box SET sent = 1 WHERE charid = ? AND senderid = ? AND slot = ? AND box = ?",
                                                                                    PChar->id, charid, PostWorkNo, 2);
                 if (rset && rset->rowsAffected())
@@ -547,9 +569,7 @@ void dboxutils::ReturnToSender(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO BoxN
                                                    PChar->id, PostWorkNo);
                 FOR_DB_SINGLE_RESULT(rset)
                 {
-                    const auto senderID = rset->get<uint32>("senderid");
-                    const auto senderName = rset->get<std::string>("sender");
-                    return std::make_pair(senderID, senderName);
+                    return std::make_pair(rset->get<uint32>("senderid"), rset->get<std::string>("sender"));
                 }
 
                 return std::make_pair(0, std::string());
@@ -557,6 +577,13 @@ void dboxutils::ReturnToSender(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO BoxN
 
             if (senderID)
             {
+                if (isDeliveryBoxInflightAtCapacity(senderID))
+                {
+                    PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Reject, BoxNo, PItem, PostWorkNo, PChar->UContainer->GetItemsCount(), 0x02);
+                    PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Reject, BoxNo, PItem, PostWorkNo, PChar->UContainer->GetItemsCount(), 0xFE);
+                    return;
+                }
+
                 // NOTE: This will trigger SQL trigger: delivery_box_insert
                 const auto rset = db::preparedStmt("INSERT INTO delivery_box (charid, charname, box, itemid, itemsubid, quantity, extra, senderid, sender) "
                                                                                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)",
@@ -568,7 +595,8 @@ void dboxutils::ReturnToSender(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO BoxN
                     if (rset2 && rset2->rowsAffected())
                     {
                         PChar->UContainer->SetItem(PostWorkNo, nullptr);
-                        PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Reject, BoxNo, PItem, PostWorkNo, PChar->UContainer->GetItemsCount(), 1);
+                        PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Reject, BoxNo, PItem, PostWorkNo, PChar->UContainer->GetItemsCount(), 0x02);
+                        PChar->pushPacket<GP_SERV_COMMAND_PBX_RESULT>(GP_CLI_COMMAND_PBX_COMMAND::Reject, BoxNo, PItem, PostWorkNo, PChar->UContainer->GetItemsCount(), 0x01);
 
                         DebugDeliveryBoxFmt("DBOX: ReturnToSender: player: {} ({}) returned item: {} ({}) to sender: {} ({})",
                                             PChar->getName(), PChar->id, PItem->getName(), itemId, senderName, senderID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Limits dbox to 128+8 slots mirroring retail. 
Adds appropriate error packet when recipient dbox is full when attempting to send OR return
Adds an extra packet to dbox flows as I noticed retail did. Doesn't appear to change much though.

Notes:
- Return error packet WILL NOT PRINT AN ERROR MESSAGE - this is the client behaving as coded and is not a bug
- **Unlike retail**, this does not **destroy** AH gil and returned items because that change is a little more involved and I don't feel there's any good reason for it.

<img width="756" height="74" alt="image" src="https://github.com/user-attachments/assets/69e732f3-dd1f-420e-ab4c-088b5365e652" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Reduce the limit to 3 and send yourself 4 items...

<!-- Clear and detailed steps to test your changes here -->
