### PR TITLE
[login] Increment key after char deletion

### DIFF
--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -142,6 +142,9 @@ void view_session::read_func()
                              session.accountID,
                              charID,
                              session.accountID);
+
+            // Increment key after delete
+            session.incrementKeyValue += 4;
         }
         break;
         case 0x21: // 33: Registering character name onto the lobby server


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This prevents blackscreens when trying to login after deleting char(s)

## Steps to test these changes

Login to lobby, delete char(s), login to normal char, don't black screen