### PR TITLE
[Quest] BRD AF3 Bugfix

### DIFF
--- a/scripts/zones/Monastic_Cavern/mobs/Bugaboo.lua
+++ b/scripts/zones/Monastic_Cavern/mobs/Bugaboo.lua
@@ -32,7 +32,9 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:setCharVar('circleTime', 8) -- Set flag so that final CS will show when you interact with alter again
+    if player:getCharVar('circleTime') == 7 then
+        player:setCharVar('circleTime', 8) -- Set flag so that final CS will show when you interact with alter again
+    end
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a safety check to Bugaboo's death so multiple players attempting the quest can't hard lock themselves from progress if they checked the altar before helping a friend defeat the ghost again.

## Steps to test these changes

Kill ghost, turn in KI's at altar, kill ghost again.  Progress as normal.
