### PR TITLE
[login] Adjust char info management during the lifetime of data_session

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -25,6 +25,32 @@
 #include "common/ipc.h"
 #include "common/utils.h"
 
+void data_session::deleteCharFromCharInfo(uint32_t ffxi_id)
+{
+    for (auto& charInfo : characterInfoResponse.character_info)
+    {
+        if (ffxi_id == charInfo.ffxi_id)
+        {
+            charInfo.status            = 0x01; // Available
+            charInfo.character_name[0] = 0x20; // space to display empty character slot, NULL displays a hume in a slot.
+            charInfo.character_name[1] = 0x00; // Null terminator so the client thinks the name is actually emptied. Otherwise it will display the deleted character.
+        }
+    }
+}
+
+void data_session::addCharIntoCharInfo(const lpkt_chr_info_sub2& charInfo)
+{
+    // Find the first empty slot and fill it in. The client expects this.
+    for (auto& existingCharInfo : characterInfoResponse.character_info)
+    {
+        if (existingCharInfo.character_name[0] == 0x20) // empty - name is a space
+        {
+            existingCharInfo = charInfo;
+            break;
+        }
+    }
+}
+
 void data_session::read_func()
 {
     auto sessionHash = loginHelpers::getHashFromPacket(ipAddress, buffer_.data());
@@ -96,114 +122,137 @@ void data_session::read_func()
                     return;
                 }
 
-                lpkt_chr_info2 characterInfoResponse = {};
-                characterInfoResponse.terminator     = loginPackets::getTerminator();
-                characterInfoResponse.command        = 0x20;
-                loginPackets::clearIdentifier(characterInfoResponse);
                 // server's name that shows in lobby menu
                 const auto serverName = settings::get<std::string>("main.SERVER_NAME");
 
                 char uList[500] = {};
 
-                int i = 0;
+                uint32_t i = 0;
 
-                // Extract all the necessary information about each character from the database and load up the struct.
-                while (rset1->next())
+                // Generate on first time read from db
+                if (!generatedCharInfo)
                 {
-                    char strCharName[16] = {}; // 15 characters + null terminator
-                    std::memset(strCharName, 0, sizeof(strCharName));
+                    characterInfoResponse            = {};
+                    characterInfoResponse.terminator = loginPackets::getTerminator();
+                    characterInfoResponse.command    = 0x20;
+                    loginPackets::clearIdentifier(characterInfoResponse);
 
-                    std::string dbCharName = rset1->get<std::string>("charname");
-                    std::memcpy(strCharName, dbCharName.c_str(), dbCharName.length());
-
-                    int32 gmlevel = rset1->get<int32>("gmlevel");
-                    if (maintMode == 0 || gmlevel > 0)
+                    // Extract all the necessary information about each character from the database and load up the struct.
+                    while (rset1->next())
                     {
-                        uint8 worldId = 0; // Use when multiple worlds are supported.
+                        char strCharName[16] = {}; // 15 characters + null terminator
+                        std::memset(strCharName, 0, sizeof(strCharName));
 
-                        uint32 charId    = rset1->get<uint32>("charid");
-                        uint32 contentId = charId; // Reusing the character ID as the content ID (which is also the name of character folder within the USER directory) at the moment
+                        std::string dbCharName = rset1->get<std::string>("charname");
+                        std::memcpy(strCharName, dbCharName.c_str(), dbCharName.length());
 
-                        // The character ID is made up of two parts totalling 24 bits:
-                        uint16 charIdMain  = charId & 0xFFFF;
-                        uint8  charIdExtra = (charId >> 16) & 0xFF;
+                        int32 gmlevel = rset1->get<int32>("gmlevel");
+                        if (maintMode == 0 || gmlevel > 0)
+                        {
+                            uint8 worldId = 0; // Use when multiple worlds are supported.
 
-                        auto& characterInfo = characterInfoResponse.character_info[i];
+                            uint32 charId    = rset1->get<uint32>("charid");
+                            uint32 contentId = charId; // Reusing the character ID as the content ID (which is also the name of character folder within the USER directory) at the moment
 
-                        characterInfo.ffxi_id           = contentId;
-                        characterInfo.ffxi_id_world     = charIdMain;
-                        characterInfo.worldid           = worldId;
-                        characterInfo.status            = 1; // 0 = Invalid/Hidden, 1 = Available, 2 = Disabled (unpaid)
-                        characterInfo.race_change       = 0; // 0 = no race change service, 1 = race change service (gold star icon) (NOT YET SUPPORTED!)
-                        characterInfo.renamef           = 0; // 0 = no rename required, 1 = rename required (NOT YET SUPPORTED!)
-                        characterInfo.ffxi_id_world_tbl = charIdExtra;
+                            // The character ID is made up of two parts totalling 24 bits:
+                            uint16 charIdMain  = charId & 0xFFFF;
+                            uint8  charIdExtra = (charId >> 16) & 0xFF;
 
-                        std::memcpy(characterInfo.character_name, &strCharName, 16);
-                        std::memcpy(characterInfo.world_name, serverName.c_str(), std::clamp<size_t>(serverName.length(), 0, 15));
+                            auto& characterInfo = characterInfoResponse.character_info[i];
 
-                        uint16 zone = rset1->get<uint16>("pos_zone");
+                            characterInfo.ffxi_id           = contentId;
+                            characterInfo.ffxi_id_world     = charIdMain;
+                            characterInfo.worldid           = worldId;
+                            characterInfo.status            = 1; // 0 = Invalid/Hidden, 1 = Available, 2 = Disabled (unpaid)
+                            characterInfo.race_change       = 0; // 0 = no race change service, 1 = race change service (gold star icon) (NOT YET SUPPORTED!)
+                            characterInfo.renamef           = 0; // 0 = no rename required, 1 = rename required (NOT YET SUPPORTED!)
+                            characterInfo.ffxi_id_world_tbl = charIdExtra;
 
-                        uint8 MainJob    = rset1->get<uint8>("mjob");
-                        uint8 lvlMainJob = rset1->get<uint8>(13 + MainJob);
+                            std::memcpy(characterInfo.character_name, &strCharName, 16);
+                            std::memcpy(characterInfo.world_name, serverName.c_str(), std::clamp<size_t>(serverName.length(), 0, 15));
 
-                        characterInfo.character_info.mon_no     = rset1->get<uint16>("race");
-                        characterInfo.character_info.mjob_no    = MainJob;
-                        characterInfo.character_info.mjob_level = lvlMainJob;
-                        characterInfo.character_info.sjob_no    = rset1->get<uint16>("sjob");
-                        characterInfo.character_info.face_no    = rset1->get<uint16>("face"); // may not be calculated correctly?
-                        characterInfo.character_info.town_no    = rset1->get<uint8>("nation");
-                        characterInfo.character_info.zone_no    = static_cast<uint8>(zone);
-                        characterInfo.character_info.zone_no2   = static_cast<uint8>((zone >> 8) & 1);
-                        characterInfo.character_info.hair_no    = rset1->get<uint8>("face"); // may not be calculated correctly?
-                        characterInfo.character_info.size       = rset1->get<uint8>("size");
+                            uint16 zone = rset1->get<uint16>("pos_zone");
 
-                        // TODO: add check for DisplayHeadOffFlg
-                        characterInfo.character_info.GrapIDTbl[0] = rset1->get<uint16>("face"); // may not be calculated correctly?
-                        characterInfo.character_info.GrapIDTbl[1] = rset1->get<uint16>("head");
-                        characterInfo.character_info.GrapIDTbl[2] = rset1->get<uint16>("body");
-                        characterInfo.character_info.GrapIDTbl[3] = rset1->get<uint16>("hands");
-                        characterInfo.character_info.GrapIDTbl[4] = rset1->get<uint16>("legs");
-                        characterInfo.character_info.GrapIDTbl[5] = rset1->get<uint16>("feet");
-                        characterInfo.character_info.GrapIDTbl[6] = rset1->get<uint16>("main");
-                        characterInfo.character_info.GrapIDTbl[7] = rset1->get<uint16>("sub");
+                            uint8 MainJob    = rset1->get<uint8>("mjob");
+                            uint8 lvlMainJob = rset1->get<uint8>(13 + MainJob);
 
+                            characterInfo.character_info.mon_no     = rset1->get<uint16>("race");
+                            characterInfo.character_info.mjob_no    = MainJob;
+                            characterInfo.character_info.mjob_level = lvlMainJob;
+                            characterInfo.character_info.sjob_no    = rset1->get<uint16>("sjob");
+                            characterInfo.character_info.face_no    = rset1->get<uint16>("face"); // may not be calculated correctly?
+                            characterInfo.character_info.town_no    = rset1->get<uint8>("nation");
+                            characterInfo.character_info.zone_no    = static_cast<uint8>(zone);
+                            characterInfo.character_info.zone_no2   = static_cast<uint8>((zone >> 8) & 1);
+                            characterInfo.character_info.hair_no    = rset1->get<uint8>("face"); // may not be calculated correctly?
+                            characterInfo.character_info.size       = rset1->get<uint8>("size");
+
+                            // TODO: add check for DisplayHeadOffFlg
+                            characterInfo.character_info.GrapIDTbl[0] = rset1->get<uint16>("face"); // may not be calculated correctly?
+                            characterInfo.character_info.GrapIDTbl[1] = rset1->get<uint16>("head");
+                            characterInfo.character_info.GrapIDTbl[2] = rset1->get<uint16>("body");
+                            characterInfo.character_info.GrapIDTbl[3] = rset1->get<uint16>("hands");
+                            characterInfo.character_info.GrapIDTbl[4] = rset1->get<uint16>("legs");
+                            characterInfo.character_info.GrapIDTbl[5] = rset1->get<uint16>("feet");
+                            characterInfo.character_info.GrapIDTbl[6] = rset1->get<uint16>("main");
+                            characterInfo.character_info.GrapIDTbl[7] = rset1->get<uint16>("sub");
+
+                            // uList is sent through data socket (to xiloader)
+                            uint32 uListOffset = 16 * (i + 1);
+
+                            ref<uint32>(uList, uListOffset)     = contentId;
+                            ref<uint16>(uList, uListOffset + 4) = charIdMain;
+                            ref<uint8>(uList, uListOffset + 6)  = worldId;     // Ignored in xiloader?
+                            ref<uint8>(uList, uListOffset + 7)  = charIdExtra; // Ignored in xiloader?
+
+                            ++i;
+                            characterInfoResponse.characters++;
+                        }
+                    }
+
+                    generatedCharInfo = true;
+
+                    const auto allowCharacterCreation = settings::get<uint8>("login.CHARACTER_CREATION");
+                    if (allowCharacterCreation)
+                    {
+                        // make extra char slots available if no characters are occupying the slots and their max content IDs supports it
+                        while (characterInfoResponse.characters < numContentIds)
+                        {
+                            characterInfoResponse.character_info[characterInfoResponse.characters].status            = 0x01; // Available
+                            characterInfoResponse.character_info[characterInfoResponse.characters].character_name[0] = 0x20; // space to display empty character slot, NULL displays a hume in a slot.
+                            characterInfoResponse.characters++;
+                        }
+                    }
+
+                    // the filtering above removes any non-GM characters so
+                    // at this point we need to make sure stop players with empty lists
+                    // from logging in or creating new characters
+                    if (maintMode > 0 && i == 0)
+                    {
+                        if (auto viewSession = session.view_session.get())
+                        {
+                            loginHelpers::generateErrorMessage(viewSession->buffer_.data(), loginErrors::errorCode::COULD_NOT_CONNECT_TO_LOBBY_SERVER);
+                            viewSession->do_write(0x24);
+                        }
+                        ShowWarning(fmt::format("char:({}) attmpted login during maintenance mode (0xA2). Sending error to client.", session.accountID));
+                        return;
+                    }
+                }
+                else
+                {
+                    loginPackets::clearIdentifier(characterInfoResponse);
+
+                    for (i = 0; i < characterInfoResponse.characters; i++)
+                    {
+                        auto characterInfo = characterInfoResponse.character_info[i];
                         // uList is sent through data socket (to xiloader)
                         uint32 uListOffset = 16 * (i + 1);
 
-                        ref<uint32>(uList, uListOffset)     = contentId;
-                        ref<uint16>(uList, uListOffset + 4) = charIdMain;
-                        ref<uint8>(uList, uListOffset + 6)  = worldId;     // Ignored in xiloader?
-                        ref<uint8>(uList, uListOffset + 7)  = charIdExtra; // Ignored in xiloader?
-
-                        ++i;
-                        characterInfoResponse.characters++;
+                        ref<uint32>(uList, uListOffset)     = characterInfo.ffxi_id;           // contentId
+                        ref<uint16>(uList, uListOffset + 4) = characterInfo.ffxi_id_world;     // charIdMain
+                        ref<uint8>(uList, uListOffset + 6)  = characterInfo.worldid;           // Ignored in xiloader?
+                        ref<uint8>(uList, uListOffset + 7)  = characterInfo.ffxi_id_world_tbl; // charIdExtra // Ignored in xiloader?
                     }
-                }
-
-                const auto allowCharacterCreation = settings::get<uint8>("login.CHARACTER_CREATION");
-                if (allowCharacterCreation)
-                {
-                    // make extra char slots available if no characters are occupying the slots and their max content IDs supports it
-                    while (characterInfoResponse.characters < numContentIds)
-                    {
-                        characterInfoResponse.character_info[characterInfoResponse.characters].status            = 0x01; // Available
-                        characterInfoResponse.character_info[characterInfoResponse.characters].character_name[0] = 0x20; // space to display empty character slot, NULL displays a hume in a slot.
-                        characterInfoResponse.characters++;
-                    }
-                }
-
-                // the filtering above removes any non-GM characters so
-                // at this point we need to make sure stop players with empty lists
-                // from logging in or creating new characters
-                if (maintMode > 0 && i == 0)
-                {
-                    if (auto viewSession = session.view_session.get())
-                    {
-                        loginHelpers::generateErrorMessage(viewSession->buffer_.data(), loginErrors::errorCode::COULD_NOT_CONNECT_TO_LOBBY_SERVER);
-                        viewSession->do_write(0x24);
-                    }
-                    ShowWarning(fmt::format("char:({}) attmpted login during maintenance mode (0xA2). Sending error to client.", session.accountID));
-                    return;
                 }
 
                 if (auto dataSession = session.data_session.get())

--- a/src/login/data_session.h
+++ b/src/login/data_session.h
@@ -43,6 +43,9 @@ public:
         DebugSockets("data_session from IP %s", ipAddress);
     }
 
+    void deleteCharFromCharInfo(uint32_t charid);
+    void addCharIntoCharInfo(const lpkt_chr_info_sub2& charInfo);
+
 protected:
     void read_func() override;
 
@@ -55,4 +58,6 @@ protected:
 
 private:
     ZMQDealerWrapper& zmqDealerWrapper_;
+    lpkt_chr_info2    characterInfoResponse = {}; // Store this for char deletion/creation client behavior. We need to skip slots instead of "flatten" them.
+    bool              generatedCharInfo     = false;
 };

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -213,7 +213,7 @@ int32 saveCharacter(uint32 accid, uint32 charid, char_mini* createchar)
     return 0;
 }
 
-int32 createCharacter(session_t& session, uint8* buf)
+int32 createCharacter(session_t& session, uint8* buf, lpkt_chr_info_sub2& charInfo)
 {
     char_mini createchar{};
 
@@ -303,6 +303,23 @@ int32 createCharacter(session_t& session, uint8* buf)
     {
         return -1;
     }
+
+    // The client expects to fill some data in on character creation. We never _see_ the character, so we don't need to set Race/Face/Model etc.
+    // We are making an assumption on what it wants - so for now just copy what is probably required (name, charid and some other stuff related to IDs.)
+    std::memcpy(&charInfo.character_name, charName.c_str(), std::min(charName.size(), sizeof(charInfo.character_name)));
+
+    uint8  worldId     = 0;      // Use when multiple worlds are supported.
+    uint32 contentId   = charID; // Reusing the character ID as the content ID (which is also the name of character folder within the USER directory) at the moment
+    uint16 charIdMain  = charID & 0xFFFF;
+    uint8  charIdExtra = (charID >> 16) & 0xFF;
+
+    charInfo.ffxi_id           = contentId;
+    charInfo.ffxi_id_world     = charIdMain;
+    charInfo.worldid           = worldId;
+    charInfo.status            = 1; // 0 = Invalid/Hidden, 1 = Available, 2 = Disabled (unpaid)
+    charInfo.race_change       = 0; // 0 = no race change service, 1 = race change service (gold star icon) (NOT YET SUPPORTED!)
+    charInfo.renamef           = 0; // 0 = no rename required, 1 = rename required (NOT YET SUPPORTED!)
+    charInfo.ffxi_id_world_tbl = charIdExtra;
 
     ShowDebug(fmt::format("char <{}> successfully saved", charName));
     return 0;

--- a/src/login/login_helpers.h
+++ b/src/login/login_helpers.h
@@ -30,6 +30,7 @@
 #include <common/xirand.h>
 
 #include "login_errors.h"
+#include "login_packets.h"
 #include "nlohmann/json.hpp"
 #include "session.h"
 
@@ -97,7 +98,7 @@ uint16 generateFeatureBitmask();
 
 int32 saveCharacter(uint32 accid, uint32 charid, char_mini* createchar);
 
-int32 createCharacter(session_t& session, uint8* buf);
+int32 createCharacter(session_t& session, uint8* buf, lpkt_chr_info_sub2& charInfo);
 
 std::string getHashFromPacket(const std::string& ip_str, uint8* data);
 

--- a/src/login/login_packets.h
+++ b/src/login/login_packets.h
@@ -166,3 +166,24 @@ struct lpkt_world_list : packet_t
     uint32_t        sumofworld;    // PS2: sumofworld
     lpkt_world_name world_name[1]; // PS2: world_name // size is 1 as we do not support multiple worlds yet.
 };
+
+// PS2: lpkt_deletechr https://github.com/atom0s/XiPackets/blob/main/lobby/C2S_0x0014_RequestDeleteChr.md
+struct lpkt_deletechr
+{
+    //
+    // Packet Header
+    //
+
+    uint32_t packet_size;   // PS2: packet_size
+    uint32_t terminator;    // PS2: terminator
+    uint32_t command;       // PS2: command
+    uint8_t  identifer[16]; // PS2: identifer
+
+    //
+    // Packet Data
+    //
+
+    uint32_t ffxi_id;       // PS2: ffxi_id
+    uint32_t ffxi_id_world; // PS2: ffxi_id_world
+    uint8_t  passwd[16];    // PS2: passwd
+};

--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -21,6 +21,8 @@
 
 #include "view_session.h"
 
+#include "data_session.h"
+
 #include <common/lua.h>
 #include <common/settings.h>
 #include <common/utils.h>
@@ -96,6 +98,9 @@ void view_session::read_func()
                 return;
             }
 
+            lpkt_deletechr deleteCharPacket = {};
+            std::memcpy(&deleteCharPacket, buffer_.data(), sizeof(lpkt_deletechr));
+
             std::memset(buffer_.data(), 0, 0x20);
             buffer_.data()[0] = 0x20; // size
 
@@ -113,7 +118,7 @@ void view_session::read_func()
 
             do_write(0x20);
 
-            uint32 charID = ref<uint32>(buffer_.data(), 0x20);
+            uint32 charID = deleteCharPacket.ffxi_id;
 
             ShowInfo(fmt::format("attempt to delete char:<{}> from ip:<{}>",
                                  charID,
@@ -129,9 +134,14 @@ void view_session::read_func()
 
             if (accountID != session.accountID)
             {
-                ShowError(fmt::format("Account ID {} tried to delete character not in their account. (Note: there is a known issue that the client does not send the whole ID for characters above ID 65535 and this may not be their fault.)", session.accountID));
+                ShowError(fmt::format("Account ID {} tried to delete character not in their account.", session.accountID));
                 socket_.lowest_layer().close();
                 return;
+            }
+
+            if (auto data = dynamic_cast<data_session*>(session.data_session.get()))
+            {
+                data->deleteCharFromCharInfo(charID);
             }
 
             // Perform character deletion.
@@ -149,11 +159,17 @@ void view_session::read_func()
         break;
         case 0x21: // 33: Registering character name onto the lobby server
         {
+            lpkt_chr_info_sub2 charInfo = {};
             // creating new char
-            if (loginHelpers::createCharacter(session, buffer_.data()) == -1)
+            if (loginHelpers::createCharacter(session, buffer_.data(), charInfo) == -1)
             {
                 socket_.lowest_layer().close();
                 return;
+            }
+
+            if (auto data = dynamic_cast<data_session*>(session.data_session.get()))
+            {
+                data->addCharIntoCharInfo(charInfo);
             }
 
             session.justCreatedNewChar = true;


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes a bug with multi-deletion or deletion->char creation

Fixes #9739

Basically, the client keeps track of the first char info you send and expects slots to be emptied and filled in. For some reason it does not always refresh the list with the new data.

## Steps to test these changes

Delete multiple characters, get the correct char ID deletion for the 2nd+
Delete a character that's not the last of the IDs, create a new one and log in as that character instead of a different one
