### PR TITLE
[core] Support floating activation time on usable items

### DIFF
--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -20,7 +20,7 @@ CREATE TABLE `item_usable` (
   `itemid` smallint(5) unsigned NOT NULL,
   `name` text NOT NULL,
   `validTargets` smallint(3) unsigned NOT NULL DEFAULT '0',
-  `activation` tinyint(3) unsigned NOT NULL DEFAULT '0',
+  `activation` float unsigned NOT NULL DEFAULT '0',
   `animation` smallint(4) unsigned NOT NULL DEFAULT '0',
   `animationTime` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `maxCharges` tinyint(3) unsigned NOT NULL DEFAULT '0',

--- a/src/map/utils/itemutils.cpp
+++ b/src/map/utils/itemutils.cpp
@@ -335,7 +335,7 @@ void LoadItemList()
                 (!(PItem->isType(ITEM_EQUIPMENT) || PItem->isType(ITEM_WEAPON)) || !rset->isNull("validTargets")))
             {
                 static_cast<CItemUsable*>(PItem)->setValidTarget(rset->get<uint16>("validTargets"));
-                static_cast<CItemUsable*>(PItem)->setActivationTime(std::chrono::seconds(rset->get<uint32>("activation")));
+                static_cast<CItemUsable*>(PItem)->setActivationTime(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::duration<float>(rset->get<float>("activation"))));
                 static_cast<CItemUsable*>(PItem)->setAnimationID(rset->get<uint16>("animation"));
                 static_cast<CItemUsable*>(PItem)->setAnimationTime(std::chrono::seconds(rset->get<uint32>("animationTime")));
                 static_cast<CItemUsable*>(PItem)->setMaxCharges(rset->get<uint8>("maxCharges"));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Grabs the activation time from item_usable as a float since some items are legitimately 0.25/0.5 timer and are currently being set to 0. 

I will publish updated values in a separate commit.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Modified an item to be 12.5s and verified with a breakpoint.

<!-- Clear and detailed steps to test your changes here -->
