### PR TITLE
[lua] WoTG Sword Module Bugfix

### DIFF
--- a/modules/wotg/lua/weaponskills/sword.lua
+++ b/modules/wotg/lua/weaponskills/sword.lua
@@ -143,11 +143,12 @@ m:addOverride('xi.actions.weaponskills.spirits_within.onUseWeaponSkill', functio
     local calcParams =
     {
         wsID = wsID,
-        criticalHit = false,
-        tpHitsLanded = 0,
+        criticalHit     = false,
+        hitsLanded      = 1,
+        tpHitsLanded    = 0,
         extraHitsLanded = 0,
         shadowsAbsorbed = 0,
-        bonusTP = 0
+        bonusTP         = 0
     }
 
     local playerHP = player:getHP()
@@ -157,7 +158,7 @@ m:addOverride('xi.actions.weaponskills.spirits_within.onUseWeaponSkill', functio
     dmg = math.floor(playerHP * ftp)
 
     local damage = dmg
-    damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+    damage = math.floor(damage * xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false))
     damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, true))
     damage = math.floor(target:handleSevereDamage(damage, false))
@@ -270,6 +271,7 @@ m:addOverride('xi.actions.weaponskills.atonement.onUseWeaponSkill', function(pla
     {
         wsID            = wsID,
         criticalHit     = false,
+        hitsLanded      = 1,
         tpHitsLanded    = 0,
         extraHitsLanded = 0,
         shadowsAbsorbed = 0,
@@ -294,7 +296,7 @@ m:addOverride('xi.actions.weaponskills.atonement.onUseWeaponSkill', function(pla
 
     -- This is here to account for damage adjustments needed because it is breath damage.
     damage = dmg
-    damage = math.floor(damage * xi.spells.damage.calculateDamageAdjustment(target, false, false, false, true))
+    damage = math.floor(damage * xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false))
     damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, true))
     damage = math.floor(target:handleSevereDamage(damage, false))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates Spirits Within & Atonement to use xi.combat instead of xi.spells as well as adds the hitsLanded = 1 from Winters recent PR. 

## Steps to test these changes

Enable wotg/lua in the init, test Spirits Within & Atonement, see damage works and no error thrown. 
