### PR TITLE
[core] Exclude mobs from Martial Arts calculations

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -467,8 +467,9 @@ uint32 CBattleEntity::GetWeaponDelay(bool tp)
         float hasteMultiplier     = 1.0f;
         float delayModMultiplier  = 1.0f + getMod(Mod::DELAYP) / 100.0f;
 
-        // H2H
-        if (weapon->isHandToHand())
+        // H2H (Mobs do not benefit from Martial Arts)
+        // TODO: Do Trusts benefit from Martial Arts?
+        if (weapon->isHandToHand() && objtype != TYPE_MOB)
         {
             martialArts = getMod(Mod::MARTIAL_ARTS) * 1000 / 60; // TODO: Job points?
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Excludes mobs from Martial Arts auto attack delay reductions. This was a root cause of various "bugs" in past and currently where higher level MNK mobs will have what seems like permanent Hundred Fists since their delay becomes so low.

Tests to support that mobs don't benefit from Martial Arts:

1. Go to Uleguerand Range and find a Molech near the top (I-5). Capture its attack delay/TP
2. Go to Phomiuna Aqueducts and find a low level Taurus. Capture its attack delay/TP
3. Both of their delays should be the same.

## Steps to test these changes

1. Go to I-5 Uleguerand Range and find a Molech. Use captain to record its attack delay. It should be around 390~ (What the mobs delay is set in mob_pools.sql). See that its attacks are not machine gunning you down faster than normal.

For reference: On current LSB(Not this PR), Molech hits at least 2 times (MNK H2H) at 240 Delay.

Note: Other references to Martial Arts in terms of TP lua scripts are already gated behind a player character check.
