### PR TITLE
[sql] Items audit [usable / equipment / weapons]

### DIFF
--- a/sql/item_equipment.sql
+++ b/sql/item_equipment.sql
@@ -10730,18 +10730,18 @@ INSERT INTO `item_equipment` VALUES (21645,'caliburnus',99,119,32848,545,0,0,3,0
 INSERT INTO `item_equipment` VALUES (21646,'caliburnus',99,119,32848,545,0,0,3,0,0,0);
 INSERT INTO `item_equipment` VALUES (21647,'dathaba_hanger',99,119,34977,0,0,0,3,0,0,0);   -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (21648,'dathaba_sword',99,119,2097345,0,0,0,1,0,0,0);  -- TODO: Not implemented, verify model
-INSERT INTO `item_equipment` VALUES (21649,'helheim',99,119,2097345,546,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (21650,'prime_blade',99,119,2097345,65,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (21651,'helheim',99,119,2097345,546,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (21652,'helheim',99,119,2097345,546,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (21653,'helheim',99,119,2097345,546,0,0,3,0,0,0);
+INSERT INTO `item_equipment` VALUES (21649,'helheim',99,119,2097345,546,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21650,'prime_blade',99,119,2097345,65,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21651,'helheim',99,119,2097345,546,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21652,'helheim',99,119,2097345,546,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21653,'helheim',99,119,2097345,546,0,0,1,0,0,0);
 INSERT INTO `item_equipment` VALUES (21654,'arasy_claymore',99,119,2097345,69,0,0,1,0,0,1);
 INSERT INTO `item_equipment` VALUES (21655,'arasy_claymore_+1',99,119,2097345,69,0,0,1,0,0,1);
-INSERT INTO `item_equipment` VALUES (21656,'dyrnwyn',99,119,128,321,0,0,1,0,0,0);
-INSERT INTO `item_equipment` VALUES (21657,'dyrnwyn_+1',99,119,128,321,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21656,'dyrnwyn',99,119,128,321,0,0,1,0,0,2);
+INSERT INTO `item_equipment` VALUES (21657,'dyrnwyn_+1',99,119,128,321,0,0,1,0,0,2);
 INSERT INTO `item_equipment` VALUES (21658,'brave_blade_ii',1,0,4194303,792,0,0,1,0,0,0);
 INSERT INTO `item_equipment` VALUES (21659,'beryllium_sword',99,119,2097345,65,0,0,1,0,0,2);
-INSERT INTO `item_equipment` VALUES (21660,'bery._sword_+1',99,119,2097345,65,0,0,1,0,0,0);
+INSERT INTO `item_equipment` VALUES (21660,'bery._sword_+1',99,119,2097345,65,0,0,1,0,0,2);
 INSERT INTO `item_equipment` VALUES (21661,'rune_algol',70,0,2097345,386,0,0,1,0,0,0);
 INSERT INTO `item_equipment` VALUES (21662,'raetic_algol',99,119,2097345,386,0,0,1,0,0,3);
 INSERT INTO `item_equipment` VALUES (21663,'raetic_algol_+1',99,119,2097345,386,0,0,1,0,0,3);
@@ -11039,9 +11039,9 @@ INSERT INTO `item_equipment` VALUES (22036,'bagua_wand',99,119,1048576,218,0,0,3
 INSERT INTO `item_equipment` VALUES (22037,'sifang_wand',99,119,1048576,218,0,0,3,0,0,4);
 INSERT INTO `item_equipment` VALUES (22038,'bhima',99,119,1048576,818,0,0,3,0,0,5);
 INSERT INTO `item_equipment` VALUES (22039,'floral_hagoita',1,0,4194303,835,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (22040,'daybreak',99,0,1589788,532,0,1,3,0,0,0);
+INSERT INTO `item_equipment` VALUES (22040,'daybreak',99,119,1589788,532,0,1,3,0,0,0);
 INSERT INTO `item_equipment` VALUES (22041,'bunzis_rod',99,119,1622044,884,0,0,3,0,0,0);
-INSERT INTO `item_equipment` VALUES (22042,'wizards_rod',99,119,1605656,845,0,0,3,0,0,0);
+INSERT INTO `item_equipment` VALUES (22042,'wizards_rod',99,119,1572888,845,0,0,3,0,0,0);
 INSERT INTO `item_equipment` VALUES (22043,'apkallu_scepter',1,0,4194303,897,0,0,3,0,0,0);
 INSERT INTO `item_equipment` VALUES (22044,'tengu_war_fan',1,0,4194303,899,0,0,3,0,0,0);
 INSERT INTO `item_equipment` VALUES (22045,'feline_hagoita',1,0,4194303,835,0,0,3,0,0,0);
@@ -11147,21 +11147,21 @@ INSERT INTO `item_equipment` VALUES (22146,'ethereal_bow',1,0,4194303,0,0,0,4,0,
 INSERT INTO `item_equipment` VALUES (22147,'scouts_crossbow',99,119,1024,52,0,0,4,0,0,4);
 INSERT INTO `item_equipment` VALUES (22148,'arke_crossbow',99,119,1024,52,0,0,4,0,0,4);
 INSERT INTO `item_equipment` VALUES (22149,'sharanga',99,119,1024,142,0,0,4,0,0,5);
-INSERT INTO `item_equipment` VALUES (22150,'gletis_crossbow',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22151,'mpacas_bow',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22152,'exeter',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22150,'gletis_crossbow',99,119,1024,0,0,0,4,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22151,'mpacas_bow',99,119,1024,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22152,'exeter',99,119,66560,0,0,0,4,0,0,0);          -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (22153,'silver_gun',1,0,4194303,139,0,0,4,0,0,0);
 INSERT INTO `item_equipment` VALUES (22154,'silver_gun+1',1,0,4194303,139,0,0,4,0,0,0);
-INSERT INTO `item_equipment` VALUES (22155,'prime_bow',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22156,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22157,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22158,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22159,'prime_gun',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22160,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22161,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22162,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22163,'pinaka',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22164,'earp',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22155,'prime_bow',99,119,1024,0,0,0,4,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22156,'pinaka',99,119,1024,0,0,0,4,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22157,'pinaka',99,119,1024,0,0,0,4,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22158,'pinaka',99,119,1024,0,0,0,4,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22159,'prime_gun',99,119,66560,0,0,0,4,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22160,'earp',99,119,66560,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22161,'earp',99,119,66560,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22162,'earp',99,119,66560,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22163,'pinaka',99,119,1024,0,0,0,4,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22164,'earp',99,119,66560,0,0,0,4,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (22165,'ethereal_gun',1,0,4194303,0,0,0,4,0,0,0);      -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (22166,'dathaba_bow',99,119,7665,0,0,0,4,0,0,0);       -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (22167,'dathaba_crossbow',99,119,1185,0,0,0,4,0,0,0);  -- TODO: Not implemented, verify model
@@ -11243,15 +11243,15 @@ INSERT INTO `item_equipment` VALUES (22297,'aurgelmir_orb',99,0,2473971,0,0,0,8,
 INSERT INTO `item_equipment` VALUES (22298,'aurgelmir_orb_+1',99,0,2473971,0,0,0,8,0,0,0);
 INSERT INTO `item_equipment` VALUES (22299,'per._lucky_egg',99,0,4194303,0,0,0,8,0,0,0);
 INSERT INTO `item_equipment` VALUES (22300,'crepuscular_pebble',99,0,4194303,0,0,0,8,4,0,0);
-INSERT INTO `item_equipment` VALUES (22301,'sroda_tathlum',99,0,4194303,0,0,0,8,4,0,0);
-INSERT INTO `item_equipment` VALUES (22302,'oshashas_treatise',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22303,'prime_horn',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22304,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22305,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22306,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22307,'loughnashade',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22308,'bayeux_bullet',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (22309,'bayeux_arrow',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22301,'sroda_tathlum',99,0,1572888,0,0,0,8,4,0,0);
+INSERT INTO `item_equipment` VALUES (22302,'oshashas_treatise',99,0,4194303,0,0,0,8,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22303,'prime_horn',99,0,512,0,0,0,4,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22304,'loughnashade',99,0,512,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22305,'loughnashade',99,0,512,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22306,'loughnashade',99,0,512,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22307,'loughnashade',99,0,512,0,0,0,4,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22308,'bayeux_bullet',99,0,66560,0,0,0,8,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (22309,'bayeux_arrow',99,0,1024,0,0,0,8,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (22310,'hoxne_ampulla',99,0,4194303,0,0,0,8,0,0,0);  -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (23040,'pummelers_mask_+2',99,119,1,64,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23041,'anch._crown_+2',99,119,2,66,0,0,16,0,0,0);
@@ -11298,28 +11298,28 @@ INSERT INTO `item_equipment` VALUES (23081,'horos_tiara_+2',99,119,262144,304,0,
 INSERT INTO `item_equipment` VALUES (23082,'peda._m.board_+2',99,119,524288,215,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23083,'bagua_galero_+2',99,119,1048576,310,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23084,'fu._bandeau_+2',99,119,2097152,339,0,0,16,0,0,0);
-INSERT INTO `item_equipment` VALUES (23085,'boii_mask_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23086,'bhikku_crown_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23085,'boii_mask_+2',99,119,1,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23086,'bhikku_crown_+2',99,119,2,0,0,0,16,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23087,'ebers_cap_+2',99,119,4,284,0,0,16,0,0,0);
-INSERT INTO `item_equipment` VALUES (23088,'wicce_petasos_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23089,'lethargy_chappel_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23090,'skulkers_bonnet_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23091,'chevaliers_armet_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23092,'heathens_burgeonet_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23093,'nukumi_cabasset_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23094,'fili_calot_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23095,'amini_gapette_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23096,'kasuga_kabuto_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23097,'hattori_zukin_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23098,'peltasts_mezail_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23099,'beckoners_horn_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23100,'hashishin_kavuk_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23101,'chasseurs_tricorne_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23102,'karagoz_cappello_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23103,'maculele_tiara_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23104,'arbatel_bonnet_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23105,'azimuth_hood_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23106,'erilaz_galea_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23088,'wicce_petasos_+2',99,119,8,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23089,'lethargy_chappel_+2',99,119,16,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23090,'skulkers_bonnet_+2',99,119,32,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23091,'chevaliers_armet_+2',99,119,64,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23092,'heathens_burgeonet_+2',99,119,128,0,0,0,16,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23093,'nukumi_cabasset_+2',99,119,256,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23094,'fili_calot_+2',99,119,512,0,0,0,16,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23095,'amini_gapette_+2',99,119,1024,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23096,'kasuga_kabuto_+2',99,119,2048,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23097,'hattori_zukin_+2',99,119,4096,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23098,'peltasts_mezail_+2',99,119,8192,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23099,'beckoners_horn_+2',99,119,16384,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23100,'hashishin_kavuk_+2',99,119,32768,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23101,'chasseurs_tricorne_+2',99,119,65536,0,0,0,16,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23102,'karagoz_cappello_+2',99,119,131072,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23103,'maculele_tiara_+2',99,119,262144,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23104,'arbatel_bonnet_+2',99,119,524288,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23105,'azimuth_hood_+2',99,119,1048576,0,0,0,16,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23106,'erilaz_galea_+2',99,119,2097152,0,0,0,16,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23107,'pumm._lorica_+2',99,119,1,64,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23108,'anch._cyclas_+2',99,119,2,66,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23109,'theo._bliaut_+2',99,119,4,68,0,0,32,0,0,0);
@@ -11365,28 +11365,28 @@ INSERT INTO `item_equipment` VALUES (23148,'horos_casaque_+2',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23149,'peda._gown_+2',99,119,524288,217,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23150,'bagua_tunic_+2',99,119,1048576,310,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23151,'futhark_coat_+2',99,119,2097152,339,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (23152,'boii_lorica_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23153,'bhikku_cyclas_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23154,'ebers_bliaut_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23155,'wicce_coat_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23156,'lethargy_sayon_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23157,'skulkers_vest_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23158,'chevaliers_cuirass_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23159,'heathens_cuirass_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23160,'nukumi_gausape_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23161,'fili_hongreline_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23162,'amini_caban_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23163,'kasuga_domaru_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23164,'hattori_ningi_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23165,'peltasts_plackart_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23166,'beckoners_doublet_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23167,'hashishin_mintan_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23168,'chasseurs_frac_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23169,'karagoz_farsetto_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23170,'maculele_casaque_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23171,'arbatel_gown_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23172,'azimuth_coat_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23173,'erilaz_surcoat_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23152,'boii_lorica_+2',99,119,1,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23153,'bhikku_cyclas_+2',99,119,2,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23154,'ebers_bliaut_+2',99,119,4,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23155,'wicce_coat_+2',99,119,8,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23156,'lethargy_sayon_+2',99,119,16,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23157,'skulkers_vest_+2',99,119,32,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23158,'chevaliers_cuirass_+2',99,119,64,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23159,'heathens_cuirass_+2',99,119,128,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23160,'nukumi_gausape_+2',99,119,256,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23161,'fili_hongreline_+2',99,119,512,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23162,'amini_caban_+2',99,119,1024,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23163,'kasuga_domaru_+2',99,119,2048,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23164,'hattori_ningi_+2',99,119,4096,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23165,'peltasts_plackart_+2',99,119,8192,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23166,'beckoners_doublet_+2',99,119,16384,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23167,'hashishin_mintan_+2',99,119,32768,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23168,'chasseurs_frac_+2',99,119,65536,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23169,'karagoz_farsetto_+2',99,119,131072,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23170,'maculele_casaque_+2',99,119,262144,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23171,'arbatel_gown_+2',99,119,524288,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23172,'azimuth_coat_+2',99,119,1048576,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23173,'erilaz_surcoat_+2',99,119,2097152,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23174,'pumm._mufflers_+2',99,119,1,64,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23175,'anchor._gloves_+2',99,119,2,66,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23176,'theophany_mitts_+2',99,119,4,68,0,0,64,0,0,0);
@@ -11432,28 +11432,28 @@ INSERT INTO `item_equipment` VALUES (23215,'horos_bangles_+2',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23216,'peda._bracers_+2',99,119,524288,215,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23217,'bagua_mitaines_+2',99,119,1048576,310,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23218,'futhark_mitons_+2',99,119,2097152,339,0,0,64,0,0,0);
-INSERT INTO `item_equipment` VALUES (23219,'boii_mufflers_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23220,'bhikku_gloves_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23221,'ebers_mitts_+2',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23222,'wicce_gloves_+2',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23223,'lethargy_gantherots_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23224,'skulkers_armlets_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23225,'chevaliers_gauntlets_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23226,'heathens_gauntlets_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23227,'nukumi_manoplas_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23228,'fili_manchettes_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23229,'amini_glovelettes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23230,'kasuga_kote_+2',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23231,'hattori_tekko_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23232,'peltasts_vambraces_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23233,'beckoners_bracers_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23234,'hashishin_bazubands_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23235,'chasseurs_gants_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23236,'karagoz_guanti_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23237,'maculele_bangles_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23238,'arbatel_bracers_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23239,'azimuth_gloves_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23240,'erilaz_gauntlets_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23219,'boii_mufflers_+2',99,119,1,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23220,'bhikku_gloves_+2',99,119,2,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23221,'ebers_mitts_+2',99,119,4,0,0,0,64,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23222,'wicce_gloves_+2',99,119,8,0,0,0,64,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23223,'lethargy_gantherots_+2',99,119,16,0,0,0,64,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23224,'skulkers_armlets_+2',99,119,32,0,0,0,64,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23225,'chevaliers_gauntlets_+2',99,119,64,0,0,0,64,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23226,'heathens_gauntlets_+2',99,119,128,0,0,0,64,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23227,'nukumi_manoplas_+2',99,119,256,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23228,'fili_manchettes_+2',99,119,512,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23229,'amini_glovelettes_+2',99,119,1024,0,0,0,64,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23230,'kasuga_kote_+2',99,119,2048,0,0,0,64,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23231,'hattori_tekko_+2',99,119,4096,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23232,'peltasts_vambraces_+2',99,119,8192,0,0,0,64,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23233,'beckoners_bracers_+2',99,119,16384,0,0,0,64,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23234,'hashishin_bazubands_+2',99,119,32768,0,0,0,64,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23235,'chasseurs_gants_+2',99,119,65536,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23236,'karagoz_guanti_+2',99,119,131072,0,0,0,64,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23237,'maculele_bangles_+2',99,119,262144,0,0,0,64,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23238,'arbatel_bracers_+2',99,119,524288,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23239,'azimuth_gloves_+2',99,119,1048576,0,0,0,64,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23240,'erilaz_gauntlets_+2',99,119,2097152,0,0,0,64,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23241,'pumm._cuisses_+2',99,119,1,64,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23242,'anch._hose_+2',99,119,2,66,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23243,'th._pantaloons_+2',99,119,4,68,0,0,128,0,0,0);
@@ -11499,28 +11499,28 @@ INSERT INTO `item_equipment` VALUES (23282,'horos_tights_+2',99,119,262144,304,0
 INSERT INTO `item_equipment` VALUES (23283,'peda._pants_+2',99,119,524288,215,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23284,'bagua_pants_+2',99,119,1048576,310,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23285,'futhark_trousers_+2',99,119,2097152,339,0,0,128,0,0,0);
-INSERT INTO `item_equipment` VALUES (23286,'boii_cuisses_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23287,'bhikku_hose_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23288,'ebers_pantaloons_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23289,'wicce_chausses_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23290,'lethargy_fuseau_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23291,'skulkers_culottes_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23292,'chevaliers_cuisses_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23293,'heathens_flanchard_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23294,'nukumi_quijotes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23295,'fili_rhingrave_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23296,'amini_bragues_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23297,'kasuga_haidate_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23298,'hattori_hakama_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23299,'peltasts_cuissots_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23300,'beckoners_spats_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23301,'hashishin_tayt_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23302,'chasseurs_culottes_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23286,'boii_cuisses_+2',99,119,1,0,0,0,128,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23287,'bhikku_hose_+2',99,119,2,0,0,0,128,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23288,'ebers_pantaloons_+2',99,119,4,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23289,'wicce_chausses_+2',99,119,8,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23290,'lethargy_fuseau_+2',99,119,16,0,0,0,128,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23291,'skulkers_culottes_+2',99,119,32,0,0,0,128,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23292,'chevaliers_cuisses_+2',99,119,64,0,0,0,128,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23293,'heathens_flanchard_+2',99,119,128,0,0,0,128,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23294,'nukumi_quijotes_+2',99,119,256,0,0,0,128,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23295,'fili_rhingrave_+2',99,119,512,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23296,'amini_bragues_+2',99,119,1024,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23297,'kasuga_haidate_+2',99,119,2048,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23298,'hattori_hakama_+2',99,119,4096,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23299,'peltasts_cuissots_+2',99,119,8192,0,0,0,128,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23300,'beckoners_spats_+2',99,119,16384,0,0,0,128,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23301,'hashishin_tayt_+2',99,119,32768,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23302,'chasseurs_culottes_+2',99,119,65536,0,0,0,128,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23303,'kara._pantaloni_+2',99,119,131072,299,0,0,128,0,0,0);
-INSERT INTO `item_equipment` VALUES (23304,'maculele_tights_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23305,'arbatel_pants_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23306,'azimuth_tights_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23307,'erilaz_leg_guards_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23304,'maculele_tights_+2',99,119,262144,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23305,'arbatel_pants_+2',99,119,524288,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23306,'azimuth_tights_+2',99,119,1048576,0,0,0,128,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23307,'erilaz_leg_guards_+2',99,119,2097152,0,0,0,128,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23308,'pumm._calligae_+2',99,119,1,64,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23309,'anch._gaiters_+2',99,119,2,66,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23310,'theo._duckbills_+2',99,119,4,68,0,0,256,0,0,0);
@@ -11566,28 +11566,28 @@ INSERT INTO `item_equipment` VALUES (23349,'horos_t._shoes_+2',99,119,262144,304
 INSERT INTO `item_equipment` VALUES (23350,'peda._loafers_+2',99,119,524288,215,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23351,'bagua_sandals_+2',99,119,1048576,310,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23352,'futhark_boots_+2',99,119,2097152,339,0,0,256,0,0,0);
-INSERT INTO `item_equipment` VALUES (23353,'boii_calligae_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23354,'bhikku_gaiters_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23355,'ebers_duckbills_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23356,'wicce_sabots_+2',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23357,'lethargy_houseaux_+2',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23358,'skulkers_poulaines_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23359,'chevaliers_sabatons_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23360,'heathens_sollerets_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23361,'nukumi_ocreae_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23362,'fili_cothurnes_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23363,'amini_bottillons_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23353,'boii_calligae_+2',99,119,1,0,0,0,256,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23354,'bhikku_gaiters_+2',99,119,2,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23355,'ebers_duckbills_+2',99,119,4,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23356,'wicce_sabots_+2',99,119,8,0,0,0,256,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23357,'lethargy_houseaux_+2',99,119,16,0,0,0,256,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23358,'skulkers_poulaines_+2',99,119,32,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23359,'chevaliers_sabatons_+2',99,119,64,0,0,0,256,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23360,'heathens_sollerets_+2',99,119,128,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23361,'nukumi_ocreae_+2',99,119,256,0,0,0,256,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23362,'fili_cothurnes_+2',99,119,512,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23363,'amini_bottillons_+2',99,119,1024,0,0,0,256,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23364,'kas._sune-ate_+2',99,119,2048,293,0,0,256,0,0,0);
-INSERT INTO `item_equipment` VALUES (23365,'hattori_kyahan_+2',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23366,'peltasts_schynbalds_+2',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23367,'beckoners_pigaches_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23368,'hashishin_basmak_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23369,'chasseurs_bottes_+2',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23370,'karagoz_scarpe_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23371,'maculele_toe_shoes_+2',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23372,'arbatel_loafers_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23373,'azimuth_gaiters_+2',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23374,'erilaz_greaves_+2',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23365,'hattori_kyahan_+2',99,119,4096,0,0,0,256,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23366,'peltasts_schynbalds_+2',99,119,8192,0,0,0,256,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23367,'beckoners_pigaches_+2',99,119,16384,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23368,'hashishin_basmak_+2',99,119,32768,0,0,0,256,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23369,'chasseurs_bottes_+2',99,119,65536,0,0,0,256,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23370,'karagoz_scarpe_+2',99,119,131072,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23371,'maculele_toe_shoes_+2',99,119,262144,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23372,'arbatel_loafers_+2',99,119,524288,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23373,'azimuth_gaiters_+2',99,119,1048576,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23374,'erilaz_greaves_+2',99,119,2097152,0,0,0,256,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23375,'pummelers_mask_+3',99,119,1,64,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23376,'anch._crown_+3',99,119,2,66,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23377,'theophany_cap_+3',99,119,4,68,0,0,16,0,0,0);
@@ -11633,28 +11633,28 @@ INSERT INTO `item_equipment` VALUES (23416,'horos_tiara_+3',99,119,262144,304,0,
 INSERT INTO `item_equipment` VALUES (23417,'peda._m.board_+3',99,119,524288,215,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23418,'bagua_galero_+3',99,119,1048576,310,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23419,'fu._bandeau_+3',99,119,2097152,339,0,0,16,0,0,0);
-INSERT INTO `item_equipment` VALUES (23420,'boii_mask_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23421,'bhikku_crown_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23422,'ebers_cap_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23423,'wicce_petasos_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23424,'lethargy_chappel_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23425,'skulkers_bonnet_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23426,'chevaliers_armet_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23427,'heathens_burgeonet_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23428,'nukumi_cabasset_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23429,'fili_calot_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23430,'amini_gapette_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23431,'kasuga_kabuto_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23432,'hattori_zukin_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23433,'peltasts_mezail_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23434,'beckoners_horn_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23435,'hashishin_kavuk_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23436,'chasseurs_tricorne_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23437,'karagoz_cappello_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23438,'maculele_tiara_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23439,'arbatel_bonnet_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23440,'azimuth_hood_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23441,'erilaz_galea_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23420,'boii_mask_+3',99,119,1,0,0,0,16,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23421,'bhikku_crown_+3',99,119,2,0,0,0,16,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23422,'ebers_cap_+3',99,119,4,0,0,0,16,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23423,'wicce_petasos_+3',99,119,8,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23424,'lethargy_chappel_+3',99,119,16,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23425,'skulkers_bonnet_+3',99,119,32,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23426,'chevaliers_armet_+3',99,119,64,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23427,'heathens_burgeonet_+3',99,119,128,0,0,0,16,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23428,'nukumi_cabasset_+3',99,119,256,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23429,'fili_calot_+3',99,119,512,0,0,0,16,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23430,'amini_gapette_+3',99,119,1024,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23431,'kasuga_kabuto_+3',99,119,2048,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23432,'hattori_zukin_+3',99,119,4096,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23433,'peltasts_mezail_+3',99,119,8192,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23434,'beckoners_horn_+3',99,119,16384,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23435,'hashishin_kavuk_+3',99,119,32768,0,0,0,16,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23436,'chasseurs_tricorne_+3',99,119,65536,0,0,0,16,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23437,'karagoz_cappello_+3',99,119,131072,0,0,0,16,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23438,'maculele_tiara_+3',99,119,262144,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23439,'arbatel_bonnet_+3',99,119,524288,0,0,0,16,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23440,'azimuth_hood_+3',99,119,1048576,0,0,0,16,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23441,'erilaz_galea_+3',99,119,2097152,0,0,0,16,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23442,'pumm._lorica_+3',99,119,1,64,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23443,'anch._cyclas_+3',99,119,2,66,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23444,'theo._bliaut_+3',99,119,4,68,0,0,32,0,0,0);
@@ -11700,28 +11700,28 @@ INSERT INTO `item_equipment` VALUES (23483,'horos_casaque_+3',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23484,'peda._gown_+3',99,119,524288,217,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23485,'bagua_tunic_+3',99,119,1048576,310,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23486,'futhark_coat_+3',99,119,2097152,339,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (23487,'boii_lorica_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23488,'bhikku_cyclas_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23489,'ebers_bliaut_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23490,'wicce_coat_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23491,'lethargy_sayon_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23492,'skulkers_vest_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23493,'chevaliers_cuirass_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23494,'heathens_cuirass_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23495,'nukumi_gausape_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23496,'fili_hongreline_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23497,'amini_caban_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23498,'kasuga_domaru_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23499,'hattori_ningi_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23500,'peltasts_plackart_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23501,'beckoners_doublet_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23502,'hashishin_mintan_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23503,'chasseurs_frac_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23504,'karagoz_farsetto_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23505,'maculele_casaque_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23506,'arbatel_gown_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23507,'azimuth_coat_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23508,'erilaz_surcoat_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23487,'boii_lorica_+3',99,119,1,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23488,'bhikku_cyclas_+3',99,119,2,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23489,'ebers_bliaut_+3',99,119,4,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23490,'wicce_coat_+3',99,119,8,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23491,'lethargy_sayon_+3',99,119,16,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23492,'skulkers_vest_+3',99,119,32,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23493,'chevaliers_cuirass_+3',99,119,64,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23494,'heathens_cuirass_+3',99,119,128,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23495,'nukumi_gausape_+3',99,119,256,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23496,'fili_hongreline_+3',99,119,512,0,0,0,32,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23497,'amini_caban_+3',99,119,1024,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23498,'kasuga_domaru_+3',99,119,2048,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23499,'hattori_ningi_+3',99,119,4096,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23500,'peltasts_plackart_+3',99,119,8192,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23501,'beckoners_doublet_+3',99,119,16384,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23502,'hashishin_mintan_+3',99,119,32768,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23503,'chasseurs_frac_+3',99,119,65536,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23504,'karagoz_farsetto_+3',99,119,131072,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23505,'maculele_casaque_+3',99,119,262144,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23506,'arbatel_gown_+3',99,119,524288,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23507,'azimuth_coat_+3',99,119,1048576,0,0,0,32,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23508,'erilaz_surcoat_+3',99,119,2097152,0,0,0,32,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23509,'pumm._mufflers_+3',99,119,1,64,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23510,'anchor._gloves_+3',99,119,2,66,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23511,'theophany_mitts_+3',99,119,4,68,0,0,64,0,0,0);
@@ -11767,28 +11767,28 @@ INSERT INTO `item_equipment` VALUES (23550,'horos_bangles_+3',99,119,262144,304,
 INSERT INTO `item_equipment` VALUES (23551,'peda._bracers_+3',99,119,524288,215,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23552,'bagua_mitaines_+3',99,119,1048576,310,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23553,'futhark_mitons_+3',99,119,2097152,339,0,0,64,0,0,0);
-INSERT INTO `item_equipment` VALUES (23554,'boii_mufflers_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23555,'bhikku_gloves_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23556,'ebers_mitts_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23557,'wicce_gloves_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23558,'lethargy_gantherots_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23559,'skulkers_armlets_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23560,'chevaliers_gauntlets_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23561,'heathens_gauntlets_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23562,'nukumi_manoplas_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23563,'fili_manchettes_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23564,'amini_glovelettes_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23565,'kasuga_kote_+3',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23566,'hattori_tekko_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23567,'peltasts_vambraces_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23568,'beckoners_bracers_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23569,'hashishin_bazubands_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23570,'chasseurs_gants_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23571,'karagoz_guanti_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23572,'maculele_bangles_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23573,'arbatel_bracers_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23574,'azimuth_gloves_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23575,'erilaz_gauntlets_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23554,'boii_mufflers_+3',99,119,1,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23555,'bhikku_gloves_+3',99,119,2,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23556,'ebers_mitts_+3',99,119,4,0,0,0,64,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23557,'wicce_gloves_+3',99,119,8,0,0,0,64,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23558,'lethargy_gantherots_+3',99,119,16,0,0,0,64,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23559,'skulkers_armlets_+3',99,119,32,0,0,0,64,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23560,'chevaliers_gauntlets_+3',99,119,64,0,0,0,64,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23561,'heathens_gauntlets_+3',99,119,128,0,0,0,64,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23562,'nukumi_manoplas_+3',99,119,256,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23563,'fili_manchettes_+3',99,119,512,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23564,'amini_glovelettes_+3',99,119,1024,0,0,0,64,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23565,'kasuga_kote_+3',99,119,2048,0,0,0,64,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23566,'hattori_tekko_+3',99,119,4096,0,0,0,64,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23567,'peltasts_vambraces_+3',99,119,8192,0,0,0,64,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23568,'beckoners_bracers_+3',99,119,16384,0,0,0,64,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23569,'hashishin_bazubands_+3',99,119,32768,0,0,0,64,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23570,'chasseurs_gants_+3',99,119,65536,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23571,'karagoz_guanti_+3',99,119,131072,0,0,0,64,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23572,'maculele_bangles_+3',99,119,262144,0,0,0,64,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23573,'arbatel_bracers_+3',99,119,524288,0,0,0,64,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23574,'azimuth_gloves_+3',99,119,1048576,0,0,0,64,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23575,'erilaz_gauntlets_+3',99,119,2097152,0,0,0,64,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23576,'pumm._cuisses_+3',99,119,1,64,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23577,'anch._hose_+3',99,119,2,66,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23578,'th._pant._+3',99,119,4,68,0,0,128,0,0,0);
@@ -11834,28 +11834,28 @@ INSERT INTO `item_equipment` VALUES (23617,'horos_tights_+3',99,119,262144,304,0
 INSERT INTO `item_equipment` VALUES (23618,'peda._pants_+3',99,119,524288,215,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23619,'bagua_pants_+3',99,119,1048576,310,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23620,'futhark_trousers_+3',99,119,2097152,339,0,0,128,0,0,0);
-INSERT INTO `item_equipment` VALUES (23621,'boii_cuisses_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23622,'bhikku_hose_+3',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23623,'ebers_pantaloons_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23624,'wicce_chausses_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23625,'lethargy_fuseau_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23626,'skulkers_culottes_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23627,'chevaliers_cuisses_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23628,'heathens_flanchards_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23629,'nukumi_quijotes_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23630,'fili_rhingrave_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23631,'amini_bragues_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23632,'kasuga_haidate_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23633,'hattori_hakama_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23634,'peltasts_cuissots_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23635,'beckoners_spats_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23636,'hashishin_tayt_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23637,'chasseurs_culottes_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23638,'karagoz_pantaloni_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23639,'maculele_tights_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23640,'arbatel_pants_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23641,'azimuth_tights_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23642,'erilaz_leg_guards_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23621,'boii_cuisses_+3',99,119,1,0,0,0,128,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23622,'bhikku_hose_+3',99,119,2,0,0,0,128,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23623,'ebers_pantaloons_+3',99,119,4,0,0,0,128,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23624,'wicce_chausses_+3',99,119,8,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23625,'lethargy_fuseau_+3',99,119,16,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23626,'skulkers_culottes_+3',99,119,32,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23627,'chevaliers_cuisses_+3',99,119,64,0,0,0,128,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23628,'heathens_flanchards_+3',99,119,128,0,0,0,128,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23629,'nukumi_quijotes_+3',99,119,256,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23630,'fili_rhingrave_+3',99,119,512,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23631,'amini_bragues_+3',99,119,1024,0,0,0,128,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23632,'kasuga_haidate_+3',99,119,2048,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23633,'hattori_hakama_+3',99,119,4096,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23634,'peltasts_cuissots_+3',99,119,8192,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23635,'beckoners_spats_+3',99,119,16384,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23636,'hashishin_tayt_+3',99,119,32768,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23637,'chasseurs_culottes_+3',99,119,65536,0,0,0,128,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23638,'karagoz_pantaloni_+3',99,119,131072,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23639,'maculele_tights_+3',99,119,262144,0,0,0,128,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23640,'arbatel_pants_+3',99,119,524288,0,0,0,128,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23641,'azimuth_tights_+3',99,119,1048576,0,0,0,128,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23642,'erilaz_leg_guards_+3',99,119,2097152,0,0,0,128,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23643,'pumm._calligae_+3',99,119,1,64,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23644,'anch._gaiters_+3',99,119,2,66,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23645,'theo._duckbills_+3',99,119,4,68,0,0,256,0,0,0);
@@ -11901,28 +11901,28 @@ INSERT INTO `item_equipment` VALUES (23684,'horos_t._shoes_+3',99,119,262144,304
 INSERT INTO `item_equipment` VALUES (23685,'peda._loafers_+3',99,119,524288,215,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23686,'bagua_sandals_+3',99,119,1048576,310,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (23687,'futhark_boots_+3',99,119,2097152,339,0,0,256,0,0,0);
-INSERT INTO `item_equipment` VALUES (23688,'boii_calligae_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23689,'bhikku_gaiters_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23690,'ebers_duckbills_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23691,'wicce_sabots_+3',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23692,'lethargy_houseaux_+3',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23693,'skulkers_poulaines_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23694,'chevaliers_sabatons_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23695,'heathens_sollerets_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23696,'nukumi_ocreae_+3',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23697,'fili_cothurnes_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23698,'amini_bottillons_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23699,'kasuga_sune-ate_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23700,'hattori_kyahan_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23701,'peltasts_schynbalds_+3',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23702,'beckoners_pigaches_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23703,'hashishin_basmak_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23704,'chasseurs_bottes_+3',99,0,0,0,0,0,32,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23705,'karagoz_scarpe_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23706,'maculele_toe_shoes_+3',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23707,'arbatel_loafers_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23708,'azimuth_gaiters_+3',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23709,'erilaz_greaves_+3',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23688,'boii_calligae_+3',99,119,1,0,0,0,256,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23689,'bhikku_gaiters_+3',99,119,2,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23690,'ebers_duckbills_+3',99,119,4,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23691,'wicce_sabots_+3',99,119,8,0,0,0,256,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23692,'lethargy_houseaux_+3',99,119,16,0,0,0,256,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23693,'skulkers_poulaines_+3',99,119,32,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23694,'chevaliers_sabatons_+3',99,119,64,0,0,0,256,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23695,'heathens_sollerets_+3',99,119,128,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23696,'nukumi_ocreae_+3',99,119,256,0,0,0,256,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23697,'fili_cothurnes_+3',99,119,512,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23698,'amini_bottillons_+3',99,119,1024,0,0,0,256,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23699,'kasuga_sune-ate_+3',99,119,2048,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23700,'hattori_kyahan_+3',99,119,4096,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23701,'peltasts_schynbalds_+3',99,119,8192,0,0,0,256,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23702,'beckoners_pigaches_+3',99,119,16384,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23703,'hashishin_basmak_+3',99,119,32768,0,0,0,256,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23704,'chasseurs_bottes_+3',99,119,65536,0,0,0,256,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23705,'karagoz_scarpe_+3',99,119,131072,0,0,0,256,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23706,'maculele_toe_shoes_+3',99,119,262144,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23707,'arbatel_loafers_+3',99,119,524288,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23708,'azimuth_gaiters_+3',99,119,1048576,0,0,0,256,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23709,'erilaz_greaves_+3',99,119,2097152,0,0,0,256,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23710,'volte_beret',99,119,1589788,132,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23711,'volte_tiara',99,119,2605043,128,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23712,'volte_salade',99,119,193,164,0,0,16,0,0,0);
@@ -11950,7 +11950,7 @@ INSERT INTO `item_equipment` VALUES (23733,'malignance_tabard',99,119,496946,458
 INSERT INTO `item_equipment` VALUES (23734,'malignance_gloves',99,119,496946,458,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23735,'malignance_tights',99,119,496946,458,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23736,'malignance_boots',99,119,496946,458,0,0,256,0,0,0);
-INSERT INTO `item_equipment` VALUES (23737,'byakko_masque',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23737,'byakko_masque',1,0,4194303,0,0,0,16,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23738,'hervor_galea',99,119,10689,276,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23739,'heidrek_mask',99,119,2462754,252,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23740,'angantyr_beret',99,119,1720860,267,0,0,16,0,0,0);
@@ -11987,10 +11987,10 @@ INSERT INTO `item_equipment` VALUES (23770,'gletis_gauntlets',99,119,303392,465,
 INSERT INTO `item_equipment` VALUES (23771,'sakpatas_gauntlets',99,119,193,466,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23772,'mpacas_gloves',99,119,137218,467,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23773,'agwus_gages',99,119,3670024,468,0,0,64,0,0,0);
-INSERT INTO `item_equipment` VALUES (23774,'bunzis_gloves',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23774,'bunzis_gloves',99,119,16916,0,0,0,64,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23775,'nyame_gauntlets',99,119,4194303,470,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23776,'ikengas_trousers',99,119,66560,464,0,0,128,0,0,0);
-INSERT INTO `item_equipment` VALUES (23777,'gletis_breeches',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23777,'gletis_breeches',99,119,303392,0,0,0,128,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23778,'sakpatas_cuisses',99,119,193,466,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23779,'mpacas_hose',99,119,137218,467,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23780,'agwus_slops',99,119,3670024,468,0,0,128,0,0,0);
@@ -12010,31 +12010,31 @@ INSERT INTO `item_equipment` VALUES (23793,'ziamet_peti',1,0,4194303,172,0,0,32,
 INSERT INTO `item_equipment` VALUES (23794,'ziamet_bazubands',1,0,4194303,172,0,0,64,0,0,0);
 INSERT INTO `item_equipment` VALUES (23795,'ziamet_salvars',1,0,4194303,172,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (23796,'ziamet_nails',1,0,4194303,172,0,0,256,0,0,0);
-INSERT INTO `item_equipment` VALUES (23797,'crepuscular_helm',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23798,'crepuscular_mail',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23799,'crepuscular_cloak',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23797,'crepuscular_helm',99,119,10689,0,0,0,16,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23798,'crepuscular_mail',99,119,10689,0,0,0,32,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23799,'crepuscular_cloak',99,119,1589404,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23800,'cancrine_apron',1,0,4194303,475,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (23801,'cancrine_apron_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23802,'aucuba_crown',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23801,'cancrine_apron_+1',1,0,4194303,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23802,'aucuba_crown',1,0,4194303,0,0,0,16,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23803,'poroggo_cassock',1,0,4194303,477,0,0,32,16,0,0);
 INSERT INTO `item_equipment` VALUES (23804,'poroggo_cass._+1',1,0,4194303,477,0,0,32,16,0,0);
 INSERT INTO `item_equipment` VALUES (23805,'morbol_apron',1,0,4194303,478,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (23806,'vaquero_hat',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23806,'vaquero_hat',1,0,4194303,0,0,0,16,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23807,'esthetes_masque',1,0,4194303,480,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23808,'esthetes_coat',1,0,4194303,480,0,0,32,64,0,0);
 INSERT INTO `item_equipment` VALUES (23809,'esthetes_hose',1,0,4194303,480,0,0,128,256,0,0);
-INSERT INTO `item_equipment` VALUES (23810,'knit_cap',99,0,0,0,0,0,32,0,0,0);           -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23811,'knit_cap_+1',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23812,'sapphire_mask',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23813,'sapphire_platemail',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23814,'sapphire_gauntlets',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23815,'sapphire_trousers',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23816,'sapphire_leggings',99,0,0,0,0,0,32,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23817,'jadeite_visor',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23818,'jadeite_cuirie',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23819,'jadeite_gloves',99,0,0,0,0,0,32,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23820,'jadeite_chausses',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23821,'jadeite_jambeaux',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23810,'knit_cap',1,0,4194303,0,0,0,16,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23811,'knit_cap_+1',1,0,4194303,0,0,0,16,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23812,'sapphire_mask',1,0,4194303,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23813,'sapphire_platemail',1,0,4194303,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23814,'sapphire_gauntlets',1,0,4194303,0,0,0,64,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23815,'sapphire_trousers',1,0,4194303,0,0,0,128,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23816,'sapphire_leggings',1,0,4194303,0,0,0,256,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23817,'jadeite_visor',1,0,4194303,0,0,0,16,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23818,'jadeite_cuirie',1,0,4194303,0,0,0,32,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23819,'jadeite_gloves',1,0,4194303,0,0,0,64,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23820,'jadeite_chausses',1,0,4194303,0,0,0,128,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23821,'jadeite_jambeaux',1,0,4194303,0,0,0,256,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23822,'diamond_somen',1,0,4194303,0,0,0,16,0,0,0);       -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (23823,'diamond_haramaki',1,0,4194303,0,0,0,32,0,0,0);    -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (23824,'diamond_kote',1,0,4194303,0,0,0,64,0,0,0);        -- TODO: Not implemented, verify model
@@ -12045,11 +12045,11 @@ INSERT INTO `item_equipment` VALUES (23828,'emerald_jubbah',1,0,4194303,0,0,0,32
 INSERT INTO `item_equipment` VALUES (23829,'emerald_dastanas',1,0,4194303,0,0,0,64,0,0,0);    -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (23830,'emerald_shalwar',1,0,4194303,0,0,0,128,0,0,0);    -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (23831,'emerald_crackows',1,0,4194303,0,0,0,256,0,0,0);   -- TODO: Not implemented, verify model
-INSERT INTO `item_equipment` VALUES (23832,'ruby_coronal',99,0,0,0,0,0,32,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23833,'ruby_robe',99,0,0,0,0,0,32,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23834,'ruby_cuffs',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23835,'ruby_slops',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (23836,'ruby_pigaches',99,0,0,0,0,0,32,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23832,'ruby_coronal',1,0,4194303,0,0,0,16,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23833,'ruby_robe',1,0,4194303,0,0,0,32,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23834,'ruby_cuffs',1,0,4194303,0,0,0,64,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23835,'ruby_slops',1,0,4194303,0,0,0,128,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (23836,'ruby_pigaches',1,0,4194303,0,0,0,256,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (23837,'apathy_mask',1,0,4194303,4587,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (23838,'apathy_platemail',1,0,4194303,8683,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (23839,'apathy_gauntlets',1,0,4194303,12779,0,0,64,0,0,0);
@@ -12661,8 +12661,8 @@ INSERT INTO `item_equipment` VALUES (25588,'aya._zucchetto',99,119,2130452,159,0
 INSERT INTO `item_equipment` VALUES (25589,'aya._zucchetto_+1',99,119,2130452,159,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25590,'taliah_turban',99,119,147712,160,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25591,'taliah_turban_+1',99,119,147712,160,0,0,16,0,0,0);
-INSERT INTO `item_equipment` VALUES (25592,'hjarrandi_helm',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (25593,'cath_palug_crown',99,0,1589276,53,0,0,16,0,0,0);
+INSERT INTO `item_equipment` VALUES (25592,'hjarrandi_helm',99,119,8385,0,0,0,16,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (25593,'cath_palug_crown',99,119,1589788,53,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25600,'maiitsoh_haube',99,119,14785,218,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25601,'blistering_sallet',99,119,4194303,29,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (25602,'blistering_sallet_+1',99,119,4194303,29,0,0,16,0,0,0);
@@ -12945,7 +12945,7 @@ INSERT INTO `item_equipment` VALUES (25898,'arke_cosc._+1',99,119,8257,136,0,0,1
 INSERT INTO `item_equipment` VALUES (25899,'pinga_pants',99,119,557060,57,0,0,128,0,0,3);
 INSERT INTO `item_equipment` VALUES (25900,'pinga_pants_+1',99,119,557060,57,0,0,128,0,0,3);
 INSERT INTO `item_equipment` VALUES (25901,'mousai_seraweels',99,119,512,135,0,0,128,0,0,3);
-INSERT INTO `item_equipment` VALUES (25902,'mou._seraweels_+1',99,119,512,135,0,0,128,0,0,0);
+INSERT INTO `item_equipment` VALUES (25902,'mou._seraweels_+1',99,119,512,135,0,0,128,0,0,3);
 INSERT INTO `item_equipment` VALUES (25903,'heyoka_subligar',99,119,131328,110,0,0,128,0,0,3);
 INSERT INTO `item_equipment` VALUES (25904,'heyoka_subligar_+1',99,119,131328,110,0,0,128,0,0,3);
 INSERT INTO `item_equipment` VALUES (25905,'baayami_slops',99,119,16384,115,0,0,128,0,0,3);
@@ -12955,7 +12955,7 @@ INSERT INTO `item_equipment` VALUES (25908,'turms_subligar_+1',99,119,2359328,14
 INSERT INTO `item_equipment` VALUES (25909,'morbol_subligar',1,0,4194303,461,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (25910,'cait_sith_subligar',1,0,4194303,463,0,0,128,0,0,0);
 INSERT INTO `item_equipment` VALUES (25911,'denim_pants',1,0,4194303,479,0,0,128,0,0,0);
-INSERT INTO `item_equipment` VALUES (25912,'denim_pants_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (25912,'denim_pants_+1',1,0,4194303,0,0,0,128,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (25920,'ahosi_leggings',99,119,2593826,110,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (25921,'skaoi_boots',99,119,3850780,168,0,0,256,0,0,0);
 INSERT INTO `item_equipment` VALUES (25922,'navon_crackows',99,119,1589788,186,0,0,256,0,0,0);
@@ -13001,13 +13001,13 @@ INSERT INTO `item_equipment` VALUES (25961,'ea_pigaches_+1',99,119,1048600,101,0
 INSERT INTO `item_equipment` VALUES (25962,'ratri_sollerets',99,119,128,151,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25963,'rat._sollerets_+1',99,119,128,151,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25964,'arke_gambieras',99,119,8257,136,0,0,256,0,0,3);
-INSERT INTO `item_equipment` VALUES (25965,'ar._gambieras_+1',99,119,8257,136,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (25965,'ar._gambieras_+1',99,119,8257,136,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25966,'pinga_pumps',99,119,557060,57,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25967,'pinga_pumps_+1',99,119,557060,57,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25968,'mousai_crackows',99,119,512,135,0,0,256,0,0,3);
-INSERT INTO `item_equipment` VALUES (25969,'mou._crackows_+1',99,119,512,135,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (25969,'mou._crackows_+1',99,119,512,135,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25970,'heyoka_leggings',99,119,131328,110,0,0,256,0,0,3);
-INSERT INTO `item_equipment` VALUES (25971,'he._leggings_+1',99,119,131328,110,0,0,256,0,0,0);
+INSERT INTO `item_equipment` VALUES (25971,'he._leggings_+1',99,119,131328,110,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25972,'baayami_sabots',99,119,16384,115,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25973,'baaya._sabots_+1',99,119,16384,115,0,0,256,0,0,3);
 INSERT INTO `item_equipment` VALUES (25974,'turms_leggings',99,119,2359328,148,0,0,256,0,0,3);
@@ -13021,13 +13021,13 @@ INSERT INTO `item_equipment` VALUES (25981,'ea_cuffs_+1',99,119,1048600,101,0,0,
 INSERT INTO `item_equipment` VALUES (25982,'ratri_gadlings',99,119,128,151,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25983,'rat._gadlings_+1',99,119,128,151,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25984,'arke_manopolas',99,119,8257,136,0,0,64,0,0,3);
-INSERT INTO `item_equipment` VALUES (25985,'ar._manopolas_+1',99,119,8257,136,0,0,64,0,0,0);
+INSERT INTO `item_equipment` VALUES (25985,'ar._manopolas_+1',99,119,8257,136,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25986,'pinga_mittens',99,119,557060,57,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25987,'pinga_mittens_+1',99,119,557060,57,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25988,'mousai_gages',99,119,512,135,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25989,'mousai_gages_+1',99,119,512,135,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25990,'heyoka_mittens',99,119,131328,110,0,0,64,0,0,3);
-INSERT INTO `item_equipment` VALUES (25991,'he._mittens_+1',99,119,131328,110,0,0,64,0,0,0);
+INSERT INTO `item_equipment` VALUES (25991,'he._mittens_+1',99,119,131328,110,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25992,'baayami_cuffs',99,119,16384,115,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25993,'baayami_cuffs_+1',99,119,16384,115,0,0,64,0,0,3);
 INSERT INTO `item_equipment` VALUES (25994,'turms_mittens',99,119,2359328,148,0,0,64,0,0,3);
@@ -13106,7 +13106,7 @@ INSERT INTO `item_equipment` VALUES (26103,'dellingr_earring',99,0,4194303,0,0,0
 INSERT INTO `item_equipment` VALUES (26104,'njordr_earring',99,0,4194303,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26105,'gna_earring',99,0,4194303,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26106,'fulla_earring',99,0,4194303,0,0,0,6144,0,0,0);
-INSERT INTO `item_equipment` VALUES (26107,'thrud_earring',99,0,4194303,0,0,0,6144,0,0,0);
+INSERT INTO `item_equipment` VALUES (26107,'thrud_earring',99,0,10689,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26108,'odr_earring',99,0,2462754,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26109,'snotra_earring',99,0,16,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26110,'sjofn_earring',99,0,2514972,0,0,0,6144,0,0,0);
@@ -13117,7 +13117,7 @@ INSERT INTO `item_equipment` VALUES (26114,'balder_earring',99,0,4194303,0,0,0,6
 INSERT INTO `item_equipment` VALUES (26115,'balder_earring_+1',99,0,4194303,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26116,'schere_earring',99,0,133251,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26117,'crep._earring',99,119,4194303,0,0,0,6144,0,0,0);
-INSERT INTO `item_equipment` VALUES (26118,'sroda_earring',99,119,4194303,0,0,0,6144,0,0,0);
+INSERT INTO `item_equipment` VALUES (26118,'sroda_earring',99,119,155904,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (26119,'alabaster_earring',99,0,4194303,0,0,0,6144,0,0,0);  -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (26120,'hoxne_earring',99,0,4194303,0,0,0,6144,0,0,0);      -- TODO: Not implemented, verify model
 INSERT INTO `item_equipment` VALUES (26160,'evanescence_ring',99,0,4194303,0,0,0,24576,0,0,0);
@@ -13180,11 +13180,11 @@ INSERT INTO `item_equipment` VALUES (26216,'dreki_ring',99,0,8192,0,0,0,24576,0,
 INSERT INTO `item_equipment` VALUES (26217,'ligeia_ring',99,0,4194303,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (26218,'beithir_ring',99,0,441827,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (26219,'najis_loop',1,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (26220,'crepuscular_ring',1,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (26221,'sroda_ring',99,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (26222,'seabirds_ring',99,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (26223,'patissieres_ring',99,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (26224,'confectioners_ring',99,0,4194303,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (26220,'crepuscular_ring',99,0,4194303,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (26221,'sroda_ring',99,0,2605043,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (26222,'seabirds_ring',30,0,4194303,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (26223,'patissieres_ring',1,0,4194303,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (26224,'confectioners_ring',1,0,4194303,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (26225,'medadas_ring',99,0,4194303,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (26226,'gurebus_ring',99,0,4194303,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (26227,'cornelias_ring',99,0,4194303,0,0,0,24576,0,0,0);
@@ -13274,8 +13274,8 @@ INSERT INTO `item_equipment` VALUES (26356,'skrymir_cord',99,0,4194303,0,0,0,102
 INSERT INTO `item_equipment` VALUES (26357,'skrymir_cord_+1',99,0,4194303,0,0,0,1024,0,0,0); -- FFXI clopedia BGWiki and JPWiki all in agreement
 INSERT INTO `item_equipment` VALUES (26358,'ligeia_sash',99,0,16384,0,0,0,1024,0,0,0);
 INSERT INTO `item_equipment` VALUES (26359,'orpheuss_sash',99,0,4194303,0,0,0,1024,0,0,0);
-INSERT INTO `item_equipment` VALUES (26360,'gerdr_belt',99,0,4194303,0,0,0,1024,0,0,0);
-INSERT INTO `item_equipment` VALUES (26361,'gerdr_belt_+1',99,0,4194303,0,0,0,1024,0,0,0);
+INSERT INTO `item_equipment` VALUES (26360,'gerdr_belt',99,0,2472947,0,0,0,1024,0,0,0);
+INSERT INTO `item_equipment` VALUES (26361,'gerdr_belt_+1',99,0,2472947,0,0,0,1024,0,0,0);
 INSERT INTO `item_equipment` VALUES (26362,'tellen_belt',99,0,66560,0,0,0,1024,0,0,0);
 INSERT INTO `item_equipment` VALUES (26363,'obstin._sash',99,0,524820,0,0,0,1024,0,0,0);
 INSERT INTO `item_equipment` VALUES (26364,'sroda_belt',99,0,2097216,0,0,0,1024,0,0,0);
@@ -13289,7 +13289,7 @@ INSERT INTO `item_equipment` VALUES (26403,'srivatsa',99,119,64,658,5,0,2,0,0,0)
 INSERT INTO `item_equipment` VALUES (26406,'kupo_shield',1,0,4194303,56,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26409,'dullahan_shield',1,0,4194303,669,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26410,'diamond_buckler',1,0,4194303,659,1,0,2,0,0,0);
-INSERT INTO `item_equipment` VALUES (26411,'diamond_buckler_+1',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26411,'diamond_buckler_+1',1,0,4194303,0,1,0,2,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26412,'kamalanauts_shield',1,0,4194303,668,1,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26413,'voluspa_shield',99,119,193,30,3,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26414,'twinned_shield',1,0,4194303,672,2,0,2,0,0,0);
@@ -13361,23 +13361,23 @@ INSERT INTO `item_equipment` VALUES (26483,'brewers_shield_-1',1,0,4194303,25,3,
 INSERT INTO `item_equipment` VALUES (26484,'chefs_ecu_-1',1,0,4194303,46,2,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26485,'chefs_scutum_-1',1,0,4194303,33,4,0,2,0,0,0);
 INSERT INTO `item_equipment` VALUES (26486,'chefs_shield_-1',1,0,4194303,25,3,0,2,0,0,0);
-INSERT INTO `item_equipment` VALUES (26487,'sacro_bulwark',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26488,'diamond_aspis',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26489,'troth',99,0,0,0,0,0,32,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26487,'sacro_bulwark',99,119,337,0,3,0,2,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26488,'diamond_aspis',99,119,373,0,2,0,2,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26489,'troth',1,0,4194303,0,1,0,2,0,0,0);         -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26490,'ark_shield',1,0,4194303,674,4,0,2,0,0,0);
-INSERT INTO `item_equipment` VALUES (26491,'prime_shield',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26492,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26493,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26494,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_equipment` VALUES (26495,'duban',99,0,0,0,0,0,32,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26491,'prime_shield',99,119,64,0,3,0,2,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26492,'duban',99,119,64,0,6,0,2,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26493,'duban',99,119,64,0,6,0,2,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26494,'duban',99,119,64,0,6,0,2,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26495,'duban',99,119,64,0,6,0,2,0,0,0);        -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26496,'ageist',1,0,4194303,677,3,0,2,0,0,0);
-INSERT INTO `item_equipment` VALUES (26497,'regis',99,0,0,0,0,0,32,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26497,'regis',1,0,4194303,0,3,0,2,0,0,0);             -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26514,'poroggo_fleece',1,0,4194303,8652,0,0,32,16,16,0);
 INSERT INTO `item_equipment` VALUES (26515,'poroggo_fleece_+1',1,0,4194303,8652,0,0,32,16,16,0);
-INSERT INTO `item_equipment` VALUES (26516,'citrullus_shirt',99,0,0,0,0,0,32,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26516,'citrullus_shirt',1,0,4194303,0,0,0,32,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26517,'shadow_lord_shirt',1,0,4194303,588,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26518,'jody_shirt',1,0,4194303,587,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (26519,'mandragora_shirt',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26519,'mandragora_shirt',1,0,4194303,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26520,'akitu_shirt',1,0,4194303,582,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26521,'ilm_weskit',1,0,4194303,8635,0,0,32,0,0,0);
 INSERT INTO `item_equipment` VALUES (26522,'tajawwul',1,0,4194303,0,0,0,32,0,0,0);     -- TODO: Not implemented, verify model
@@ -13396,15 +13396,15 @@ INSERT INTO `item_equipment` VALUES (26534,'arke_corazza_+1',99,119,8257,136,0,0
 INSERT INTO `item_equipment` VALUES (26535,'pinga_tunic',99,119,557060,57,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26536,'pinga_tunic_+1',99,119,557060,57,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26537,'mousai_manteel',99,119,512,135,0,0,32,0,0,3);
-INSERT INTO `item_equipment` VALUES (26538,'mou._manteel_+1',99,119,512,135,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (26538,'mou._manteel_+1',99,119,512,135,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26539,'heyoka_harness',99,119,131328,110,0,0,32,0,0,3);
-INSERT INTO `item_equipment` VALUES (26540,'he._harness_+1',99,119,131328,110,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (26540,'he._harness_+1',99,119,131328,110,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26541,'baayami_robe',99,119,16384,115,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26542,'baayami_robe_+1',99,119,16384,115,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26543,'turms_harness',99,119,2359328,148,0,0,32,0,0,3);
-INSERT INTO `item_equipment` VALUES (26544,'tu._harness_+1',99,119,2359328,148,0,0,32,0,0,0);
+INSERT INTO `item_equipment` VALUES (26544,'tu._harness_+1',99,119,2359328,148,0,0,32,0,0,3);
 INSERT INTO `item_equipment` VALUES (26545,'mithkabob_shirt',1,0,4194303,8782,0,0,32,0,0,0);
-INSERT INTO `item_equipment` VALUES (26546,'moogle_shirt',99,0,0,0,0,0,32,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_equipment` VALUES (26546,'moogle_shirt',1,0,4194303,0,0,0,32,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_equipment` VALUES (26624,'agoge_mask',99,109,1,65,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (26625,'agoge_mask_+1',99,119,1,65,0,0,16,0,0,0);
 INSERT INTO `item_equipment` VALUES (26626,'hes._crown',99,109,2,67,0,0,16,0,0,0);
@@ -15218,7 +15218,7 @@ INSERT INTO `item_equipment` VALUES (28467,'dynamic_belt_+1',99,0,2473969,0,0,0,
 INSERT INTO `item_equipment` VALUES (28468,'matanki_earring',99,0,4194303,0,0,0,6144,0,0,0);
 INSERT INTO `item_equipment` VALUES (28469,'endorsement_ring',99,0,4194303,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (28470,'emporoxs_ring',99,0,4194303,0,0,0,24576,0,0,0);
-INSERT INTO `item_equipment` VALUES (28471,'gere_ring',99,0,2494754,0,0,0,24576,0,0,0);
+INSERT INTO `item_equipment` VALUES (28471,'gere_ring',99,0,397602,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (28472,'freke_ring',99,0,1589276,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (28473,'c._palug_ring',99,0,155904,0,0,0,24576,0,0,0);
 INSERT INTO `item_equipment` VALUES (28474,'mendi._earring',99,0,4194303,0,0,0,6144,0,0,0);

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -141,13 +141,13 @@ INSERT INTO `item_usable` VALUES (4198,'page_from_the_dragon_chronicles',1,5,34,
 INSERT INTO `item_usable` VALUES (4199,'strength_potion',1,2,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4200,'bottle_of_mana_boost',1,1,9,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4201,'dexterity_potion',1,2,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4202,'daedalus_wing',1,1,34,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4202,'daedalus_wing',1,2,34,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4203,'vitality_potion',1,2,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4204,'petra_eater',1,2,67,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4205,'agility_potion',1,2,24,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4206,'bottle_of_catholicon',29,1,64,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4206,'bottle_of_catholicon',75,2,64,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4207,'intelligence_potion',1,2,26,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4208,'bottle_of_catholicon_+1',29,1,66,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4208,'bottle_of_catholicon_+1',75,2,66,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4209,'mind_potion',1,2,27,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4210,'bottle_of_lethe_water',4,2,65,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4211,'charisma_potion',1,2,10,0,0,0,0,0);
@@ -176,7 +176,7 @@ INSERT INTO `item_usable` VALUES (4233,'new_years_gift',1,10,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4234,'bottle_of_cursed_beverage',1,1,75,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4235,'bowl_of_cursed_soup',1,1,75,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4236,'timeless_hourglass',0,0,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4237,'perpetual_hourglass',1,0,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4237,'perpetual_hourglass',1,0.25,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4238,'inferno_crystal',1,0,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4239,'glacier_crystal',1,0,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4240,'cyclone_crystal',1,0,0,0,0,0,0,0);
@@ -193,8 +193,8 @@ INSERT INTO `item_usable` VALUES (4250,'crackler',1,1,58,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4251,'festive_fan',1,1,61,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4252,'summer_fan',1,1,62,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4253,'spirit_masque',1,1,63,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4254,'megalixir',1,1,34,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (4255,'pinch_of_mana_powder',1,1,89,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4254,'megalixir',1,3,34,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (4255,'pinch_of_mana_powder',1,3,89,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4256,'ouka_ranman',1,1,56,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4257,'papillion',1,1,57,12,0,0,0,0);
 INSERT INTO `item_usable` VALUES (4258,'red_drop',1,2,28,0,0,0,0,0);
@@ -1111,9 +1111,9 @@ INSERT INTO `item_usable` VALUES (5239,'prime_seafood_stewpot',1,1,25,0,0,0,0,1)
 INSERT INTO `item_usable` VALUES (5240,'prized_seafood_stewpot',1,1,25,0,0,0,0,1);
 INSERT INTO `item_usable` VALUES (5241,'bottle_of_giants_drink',1,2,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5242,'bottle_of_wizards_drink',1,2,26,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5243,'container_of_carnal_incense',1,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5244,'container_of_spiritual_incense',1,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5245,'container_of_celestial_incense',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5243,'container_of_carnal_incense',1,0.5,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5244,'container_of_spiritual_incense',1,0.5,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5245,'container_of_celestial_incense',1,0.5,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5246,'vial_of_drachenessence',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5247,'dose_of_barfire_ointment',1,2,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5248,'dose_of_barblizzard_ointment',1,2,0,0,0,0,0,0);
@@ -1123,7 +1123,7 @@ INSERT INTO `item_usable` VALUES (5251,'dose_of_barthunder_ointment',1,2,0,0,0,0
 INSERT INTO `item_usable` VALUES (5252,'dose_of_barwater_ointment',1,2,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5253,'hermes_quencher',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5254,'hyper_potion',1,1,31,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5255,'hyper_ether',1,2,33,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5255,'hyper_ether',1,1.5,33,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5256,'fire_feather',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5257,'blaze_feather',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5258,'revive_feather',1,1,0,0,0,0,0,0);
@@ -1133,8 +1133,8 @@ INSERT INTO `item_usable` VALUES (5261,'bottle_of_psychoanima',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5262,'bottle_of_hysteroanima',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5263,'bottle_of_terroanima',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5264,'bottle_of_yellow_liquid',4,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5265,'mistmelt',4,2,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5266,'blackened_muddy_siredon',4,0,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5265,'mistmelt',4,1.5,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5266,'blackened_muddy_siredon',4,0.25,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5267,'chunk_of_shumeyo_salt',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5268,'ccb_polymer_pump',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5269,'special_present',1,1,0,0,0,0,0,0);
@@ -1190,13 +1190,13 @@ INSERT INTO `item_usable` VALUES (5318,'toolbag_kodoku',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5319,'toolbag_shinobi-tabi',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5320,'chunk_of_smelling_salts',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5321,'bottle_of_romance_potion',1,3,24,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5322,'flask_of_healing_powder',1,1,30,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5322,'flask_of_healing_powder',1,3,30,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5323,'copy_of_the_brenner_bluebook',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5324,'page_of_the_brenner_bluebook',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5325,'copy_of_the_brenner_blackbook',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5326,'page_of_the_brenner_blackbook',1,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5327,'bottle_of_potion_drops',1,2,30,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5328,'bottle_of_hi-potion_drops',1,2,31,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5327,'bottle_of_potion_drops',1,1.5,30,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5328,'bottle_of_hi-potion_drops',1,1.5,31,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5329,'tarutaru_snare',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5330,'mithra_snare',4,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5331,'qiqirn_mine',1,1,55,0,0,0,0,0);
@@ -1225,8 +1225,8 @@ INSERT INTO `item_usable` VALUES (5353,'iron_bullet_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5354,'flask_of_walahra_water',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5355,'elixir_vitae',1,1,34,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5356,'jar_of_remedy_ointment',1,1,7,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5357,'bottle_of_ether_drops',1,2,32,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5358,'bottle_of_hi-ether_drops',1,2,33,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5357,'bottle_of_ether_drops',1,1.5,32,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5358,'bottle_of_hi-ether_drops',1,1.5,33,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5359,'bronze_bullet_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5360,'muteppo',1,10,102,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5361,'datechochin',1,1,101,0,0,0,0,0);
@@ -1282,7 +1282,7 @@ INSERT INTO `item_usable` VALUES (5410,'virtue_stone_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5411,'bottle_of_dawn_mulsum',1,1,34,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5412,'scapegoat',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5413,'smouldering_lamp',0,0,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5414,'glowing_lamp',1,0,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5414,'glowing_lamp',1,0.25,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5415,'page_from_balrahns_reflections',1,5,34,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5416,'steel_bullet_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5417,'toolbag_sanjaku-tenugui',1,1,55,0,0,0,0,0);
@@ -1295,7 +1295,7 @@ INSERT INTO `item_usable` VALUES (5423,'bottled_fay',1,10,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5424,'serene_serinette',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5425,'joyous_serinette',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5426,'maze_compass',1,10,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5427,'maze_pearl',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5427,'maze_pearl',1,0.5,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5428,'scroll_of_instant_retrace',1,10,82,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5429,'clump_of_tandjana_wildgrass',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5430,'bottle_of_viper_potion',1,1,68,0,0,0,0,0);
@@ -1304,7 +1304,7 @@ INSERT INTO `item_usable` VALUES (5432,'dusty_ether',1,1,32,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5433,'dusty_elixir',1,1,34,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5434,'bottle_of_fanatics_drink',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5435,'bottle_of_fools_drink',1,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5436,'dusty_scroll_of_reraise',1,1,33,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5436,'dusty_scroll_of_reraise',1,3,33,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5437,'flask_of_strange_milk',1,1,27,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5438,'bottle_of_strange_juice',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5439,'bottle_of_vicars_drink',1,1,26,0,0,0,0,0);
@@ -1676,20 +1676,20 @@ INSERT INTO `item_usable` VALUES (5806,'bhefhel_marlin',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5807,'bladefish',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5808,'rhinochimera',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5809,'three-eyed_fish',1,1,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5810,'creel_of_moat_carp',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5811,'creel_of_forest_carp',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5812,'blowfish',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5813,'dorado_gar',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5814,'crocodilos',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5815,'pelazoea',1,4,25,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5816,'king_perch',1,4,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5810,'creel_of_moat_carp',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5811,'creel_of_forest_carp',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5812,'blowfish',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5813,'dorado_gar',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5814,'crocodilos',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5815,'pelazoea',1,1,25,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5816,'king_perch',1,1,25,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5817,'tiger_shark',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5818,'aurora_bass',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5819,'antlion_quiver',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5820,'darkling_bolt_quiver',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5821,'fusion_bolt_quiver',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5822,'dweomer_bullet_pouch',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5823,'oberon_bullet_pouch',1,4,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5819,'antlion_quiver',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5820,'darkling_bolt_quiver',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5821,'fusion_bolt_quiver',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5822,'dweomer_bullet_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5823,'oberon_bullet_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5824,'lucid_potion_i',1,1,30,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5825,'lucid_potion_ii',1,1,31,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5826,'lucid_potion_iii',1,1,31,0,0,0,0,0);
@@ -1719,16 +1719,16 @@ INSERT INTO `item_usable` VALUES (5849,'bottle_of_berserkers_drink',1,1,0,0,0,0,
 INSERT INTO `item_usable` VALUES (5850,'bottle_of_swiftshot_drink',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5851,'bottle_of_berserkers_tonic',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5852,'bottle_of_swiftshot_tonic',1,1,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5853,'flask_of_primeval_brew',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5854,'frayed_pouch_of_birth',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5855,'frayed_pouch_of_advancement',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5856,'frayed_pouch_of_glory',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5857,'frayed_pouch_of_decay',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5858,'frayed_pouch_of_ruin',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5859,'galkan_sausage_+1',1,4,28,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5860,'galkan_sausage_+2',1,4,28,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5861,'galkan_sausage_+3',1,4,28,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5862,'galkan_sausage_-1',1,4,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5853,'flask_of_primeval_brew',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5854,'frayed_pouch_of_birth',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5855,'frayed_pouch_of_advancement',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5856,'frayed_pouch_of_glory',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5857,'frayed_pouch_of_decay',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5858,'frayed_pouch_of_ruin',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5859,'galkan_sausage_+1',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5860,'galkan_sausage_+2',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5861,'galkan_sausage_+3',1,1,28,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5862,'galkan_sausage_-1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5863,'toolbag_kabenro',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5864,'toolbag_jinko',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5865,'toolbag_ryuno',1,1,55,0,0,0,0,0);
@@ -1736,16 +1736,16 @@ INSERT INTO `item_usable` VALUES (5866,'toolbag_mokujin',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5867,'toolbag_inoshishinofuda',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5868,'toolbag_shikanofuda',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5869,'toolbag_chonofuda',1,1,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5870,'trump_card_case',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5871,'ruszor_quiver',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5872,'dark_adaman_bolt_quiver',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5873,'dark_adaman_bullet_pouch',1,4,55,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5875,'galette_des_rois',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5876,'phial_of_petrify_screen',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5877,'phial_of_terror_screen',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5878,'phial_of_amnesia_screen',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5879,'phial_of_doom_screen',1,4,0,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5880,'phial_of_poison_screen',1,4,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5870,'trump_card_case',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5871,'ruszor_quiver',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5872,'dark_adaman_bolt_quiver',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5873,'dark_adaman_bullet_pouch',1,1,55,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5875,'galette_des_rois',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5876,'phial_of_petrify_screen',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5877,'phial_of_terror_screen',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5878,'phial_of_amnesia_screen',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5879,'phial_of_doom_screen',1,1,0,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5880,'phial_of_poison_screen',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5881,'shisai_kaboku',1,1,110,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5882,'marine_bliss',1,1,108,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5883,'falling_star',1,1,109,0,0,0,0,0);
@@ -1760,18 +1760,18 @@ INSERT INTO `item_usable` VALUES (5891,'seafood_pitaru',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5892,'b.e.w._pitaru',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5893,'marine_stewpot',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5894,'prime_marine_stewpot',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5895,'odorless_fungus',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5896,'clump_of_absorbent_moss',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5897,'redolent_root',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5898,'shadescale_skull',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5899,'shadescale_femur',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5900,'shadescale_talon',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5901,'shadescale_heart',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5902,'vial_of_cagebeast_blood',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5903,'vial_of_sea_monk_venom',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5904,'perforated_wing',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5905,'undying_moiety',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5906,'page_from_abdhaljs_on_war',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5895,'odorless_fungus',4,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5896,'clump_of_absorbent_moss',4,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5897,'redolent_root',4,1,0,0,0,0,0,0);             -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5898,'shadescale_skull',4,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5899,'shadescale_femur',4,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5900,'shadescale_talon',4,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5901,'shadescale_heart',4,1,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5902,'vial_of_cagebeast_blood',4,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5903,'vial_of_sea_monk_venom',4,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5904,'perforated_wing',4,1,0,0,0,0,0,0);           -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5905,'undying_moiety',4,1,0,0,0,0,0,0);            -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5906,'page_from_abdhaljs_on_war',1,5,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5907,'winterflower',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5908,'butterpear',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5909,'pickled_rarab_tail',1,1,0,0,0,0,0,0); -- TODO: Not implemented
@@ -1803,8 +1803,8 @@ INSERT INTO `item_usable` VALUES (5934,'chocobiscuit',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5935,'bowl_of_moogurt',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5936,'mog_missile',1,1,112,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5937,'bubble_breeze',1,1,113,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5938,'hiatus_whistle',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5939,'terminus_whistle',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5938,'hiatus_whistle',1,10,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5939,'terminus_whistle',1,10,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5940,'trail_cookie',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5941,'bar_of_campfire_chocolate',1,1,29,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5942,'piece_of_cascade_candy',1,1,29,0,0,0,0,0);
@@ -1851,56 +1851,56 @@ INSERT INTO `item_usable` VALUES (5984,'branch_of_gnatbane',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5985,'sprig_of_hemlock',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5986,'coalition_potion',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5987,'coalition_ether',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5988,'scroll_of_instant_protect',1,7,30,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5989,'scroll_of_instant_shell',1,7,32,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5988,'scroll_of_instant_protect',1,2.5,30,0,0,0,0,0);
+INSERT INTO `item_usable` VALUES (5989,'scroll_of_instant_shell',1,2.5,32,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5990,'scroll_of_instant_stoneskin',1,7,8,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (5991,'farewell_fly',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (5992,'fenestral_key',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5991,'farewell_fly',1,10,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (5992,'fenestral_key',1,10,0,0,0,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5993,'senroh_frog',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5995,'malicious_perch',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5997,'shen',1,1,0,0,0,0,0,0);            -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (5998,'bowl_of_adoulinian_soup',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (5999,'bowl_of_adoulinian_soup_+1',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6001,'clotflagration',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6002,'trailblazing_pickaxe',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6003,'trailblazing_pickaxe_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6004,'trailblazing_hatchet',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6005,'trailblazing_hatchet_+1',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6006,'trailblazing_sickle',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6007,'trailblazing_sickle_+1',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6002,'trailblazing_pickaxe',68,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6003,'trailblazing_pickaxe_+1',68,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6004,'trailblazing_hatchet',68,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6005,'trailblazing_hatchet_+1',68,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6006,'trailblazing_sickle',68,1,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6007,'trailblazing_sickle_+1',68,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6008,'piece_of_copse_candy',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6009,'bowl_of_mog_pudding',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6010,'sakura_biscuit',1,1,28,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (6011,'celadon_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6012,'celadon_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6013,'celadon_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6014,'celadon_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6015,'celadon_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6016,'zaffre_yggrete_shard_i',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6017,'zaffre_yggrete_shard_ii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6018,'zaffre_yggrete_shard_iii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6019,'zaffre_yggrete_shard_iv',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6020,'zaffre_yggrete_shard_v',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6021,'alizarin_yggrete_shard_i',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6022,'alizarin_yggrete_shard_ii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6023,'alizarin_yggrete_shard_iii',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6024,'alizarin_yggrete_shard_iv',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6025,'alizarin_yggrete_shard_v',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6026,'celadon_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6027,'celadon_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6028,'celadon_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6029,'celadon_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6030,'celadon_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6031,'zaffre_yggzi_bead_i',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6032,'zaffre_yggzi_bead_ii',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6033,'zaffre_yggzi_bead_iii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6034,'zaffre_yggzi_bead_iv',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6035,'zaffre_yggzi_bead_v',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6036,'alizarin_yggzi_bead_i',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6037,'alizarin_yggzi_bead_ii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6038,'alizarin_yggzi_bead_iii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6039,'alizarin_yggzi_bead_iv',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6040,'alizarin_yggzi_bead_v',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6011,'celadon_yggrete_shard_i',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6012,'celadon_yggrete_shard_ii',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6013,'celadon_yggrete_shard_iii',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6014,'celadon_yggrete_shard_iv',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6015,'celadon_yggrete_shard_v',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6016,'zaffre_yggrete_shard_i',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6017,'zaffre_yggrete_shard_ii',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6018,'zaffre_yggrete_shard_iii',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6019,'zaffre_yggrete_shard_iv',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6020,'zaffre_yggrete_shard_v',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6021,'alizarin_yggrete_shard_i',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6022,'alizarin_yggrete_shard_ii',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6023,'alizarin_yggrete_shard_iii',1,3,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6024,'alizarin_yggrete_shard_iv',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6025,'alizarin_yggrete_shard_v',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6026,'celadon_yggzi_bead_i',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6027,'celadon_yggzi_bead_ii',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6028,'celadon_yggzi_bead_iii',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6029,'celadon_yggzi_bead_iv',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6030,'celadon_yggzi_bead_v',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6031,'zaffre_yggzi_bead_i',1,3,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6032,'zaffre_yggzi_bead_ii',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6033,'zaffre_yggzi_bead_iii',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6034,'zaffre_yggzi_bead_iv',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6035,'zaffre_yggzi_bead_v',1,3,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6036,'alizarin_yggzi_bead_i',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6037,'alizarin_yggzi_bead_ii',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6038,'alizarin_yggzi_bead_iii',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6039,'alizarin_yggzi_bead_iv',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6040,'alizarin_yggzi_bead_v',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6041,'pyrohelix_schema',1,1,12,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6042,'hydrohelix_schema',1,1,12,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6043,'ionohelix_schema',1,1,12,5,0,0,0,0);
@@ -1925,7 +1925,7 @@ INSERT INTO `item_usable` VALUES (6063,'fruit_parfait',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6064,'queens_crown',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6065,'tiny_macaron',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6066,'tiny_rusk',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6067,'ontic_extremity',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6067,'ontic_extremity',1,10,0,0,0,0,0,0);        -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6068,'slice_of_gabbrath_meat',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6069,'bowl_of_riverfin_soup',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6070,'bowl_of_oceanfin_soup',1,1,26,0,0,0,0,0);
@@ -2081,36 +2081,36 @@ INSERT INTO `item_usable` VALUES (6223,'cehuetzi_snow_cone',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6224,'apingaut_snow_cone',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6225,'cyclical_coalescence',1,1,26,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6226,'loaf_of_pixioche',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6227,'phlox_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6228,'phlox_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6229,'phlox_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6230,'phlox_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6231,'phlox_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6232,'russet_yggrete_shard_i',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6233,'russet_yggrete_shard_ii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6234,'russet_yggrete_shard_iii',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6235,'russet_yggrete_shard_iv',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6236,'russet_yggrete_shard_v',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6237,'aster_yggrete_shard_i',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6238,'aster_yggrete_shard_ii',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6239,'aster_yggrete_shard_iii',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6240,'aster_yggrete_shard_iv',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6241,'aster_yggrete_shard_v',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6242,'phlox_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6243,'phlox_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6244,'phlox_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6245,'phlox_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6246,'phlox_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6247,'russet_yggzi_bead_i',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6248,'russet_yggzi_bead_ii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6249,'russet_yggzi_bead_iii',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6250,'russet_yggzi_bead_iv',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6251,'russet_yggzi_bead_v',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6252,'aster_yggzi_bead_i',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6253,'aster_yggzi_bead_ii',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6254,'aster_yggzi_bead_iii',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6255,'aster_yggzi_bead_iv',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6256,'aster_yggzi_bead_v',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6227,'phlox_yggrete_shard_i',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6228,'phlox_yggrete_shard_ii',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6229,'phlox_yggrete_shard_iii',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6230,'phlox_yggrete_shard_iv',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6231,'phlox_yggrete_shard_v',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6232,'russet_yggrete_shard_i',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6233,'russet_yggrete_shard_ii',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6234,'russet_yggrete_shard_iii',1,3,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6235,'russet_yggrete_shard_iv',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6236,'russet_yggrete_shard_v',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6237,'aster_yggrete_shard_i',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6238,'aster_yggrete_shard_ii',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6239,'aster_yggrete_shard_iii',1,3,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6240,'aster_yggrete_shard_iv',1,3,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6241,'aster_yggrete_shard_v',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6242,'phlox_yggzi_bead_i',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6243,'phlox_yggzi_bead_ii',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6244,'phlox_yggzi_bead_iii',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6245,'phlox_yggzi_bead_iv',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6246,'phlox_yggzi_bead_v',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6247,'russet_yggzi_bead_i',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6248,'russet_yggzi_bead_ii',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6249,'russet_yggzi_bead_iii',1,3,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6250,'russet_yggzi_bead_iv',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6251,'russet_yggzi_bead_v',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6252,'aster_yggzi_bead_i',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6253,'aster_yggzi_bead_ii',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6254,'aster_yggzi_bead_iii',1,3,0,0,0,0,0,0);     -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6255,'aster_yggzi_bead_iv',1,3,0,0,0,0,0,0);      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6256,'aster_yggzi_bead_v',1,3,0,0,0,0,0,0);       -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6257,'jar_of_jungle_nectar',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6258,'piece_of_shiromochi',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6259,'piece_of_shiromochi_+1',1,1,28,0,0,0,0,0);
@@ -2137,20 +2137,20 @@ INSERT INTO `item_usable` VALUES (6279,'righteous_bolt_quiver',1,1,0,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6280,'rakaznar_quiver',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6281,'rakaznar_bolt_quiver',1,1,0,0,0,0,0,0);      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6282,'rakaznar_bullet_pouch',1,1,0,0,0,0,0,0);     -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6283,'velkk_coffer',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6284,'grand_velkk_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6285,'ymmr-ulvids_coffer',1,1,0,0,0,0,0,0);        -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6286,'ymmr-ulvids_grand_coffer',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6287,'ignor-mnts_coffer',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6288,'ignor-mnts_grand_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6289,'durs-vikes_coffer',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6290,'durs-vikes_grand_coffer',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6291,'tryl-wujs_coffer',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6292,'tryl-wujs_grand_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6293,'liij-voks_coffer',1,1,0,0,0,0,0,0);          -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6294,'liij-voks_grand_coffer',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6295,'gramk-droogs_coffer',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6296,'gramk-droogs_grand_coffer',1,1,0,0,0,0,0,0); -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6283,'velkk_coffer',1,0.5,0,0,0,0,0,0);              -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6284,'grand_velkk_coffer',1,0.5,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6285,'ymmr-ulvids_coffer',1,0.5,0,0,0,0,0,0);        -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6286,'ymmr-ulvids_grand_coffer',1,0.5,0,0,0,0,0,0);  -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6287,'ignor-mnts_coffer',1,0.5,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6288,'ignor-mnts_grand_coffer',1,0.5,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6289,'durs-vikes_coffer',1,0.5,0,0,0,0,0,0);         -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6290,'durs-vikes_grand_coffer',1,0.5,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6291,'tryl-wujs_coffer',1,0.5,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6292,'tryl-wujs_grand_coffer',1,0.5,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6293,'liij-voks_coffer',1,0.5,0,0,0,0,0,0);          -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6294,'liij-voks_grand_coffer',1,0.5,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6295,'gramk-droogs_coffer',1,0.5,0,0,0,0,0,0);       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6296,'gramk-droogs_grand_coffer',1,0.5,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6297,'juji_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6298,'manji_shuriken_pouch',1,1,55,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6299,'shuriken_pouch',1,1,55,0,0,0,0,0);
@@ -2252,7 +2252,7 @@ INSERT INTO `item_usable` VALUES (6394,'pork_cutlet',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6395,'pork_cutlet_+1',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6396,'cutlet_sandwich',1,1,24,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6397,'cutlet_sandwich_+1',1,1,24,0,0,0,0,0);
-INSERT INTO `item_usable` VALUES (6398,'cage_of_arena_fireflies',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6398,'cage_of_arena_fireflies',1,10,0,0,0,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6399,'bottle_of_saviors_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6400,'bottle_of_mirrors_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6401,'bottle_of_monetas_tonic',1,1,0,0,0,0,0,0);    -- TODO: Not implemented
@@ -2331,7 +2331,7 @@ INSERT INTO `item_usable` VALUES (6510,'bolt_crystal',1,1,0,0,0,0,0,0);         
 INSERT INTO `item_usable` VALUES (6511,'fluid_crystal',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6512,'glimmer_crystal',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6513,'shadow_crystal',1,1,0,0,0,0,0,0);                -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6514,'reisenjima_cage',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6514,'reisenjima_cage',1,10,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6515,'large_tail',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6516,'large_stone',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6517,'large_leaf',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
@@ -2348,7 +2348,7 @@ INSERT INTO `item_usable` VALUES (6527,'decanter_august',1,1,0,0,0,0,0,0);      
 INSERT INTO `item_usable` VALUES (6528,'decanter_sajjaka',1,1,0,0,0,0,0,0);              -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6529,'decanter_arciela_ii',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6530,'rolanberry_pickled_rarab_tail',1,1,0,0,0,0,0,0); -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6531,'black_hourglass',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6531,'black_hourglass',1,10,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6532,'pluton_coffer',1,1,0,0,0,0,0,0);                 -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6533,'beitetsu_coffer',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6534,'rift_boulder_coffer',1,1,0,0,0,0,0,0);           -- TODO: Not implemented
@@ -2391,7 +2391,7 @@ INSERT INTO `item_usable` VALUES (6570,'scroll_of_paralyze_ii',1,1,11,5,0,0,0,0)
 INSERT INTO `item_usable` VALUES (6571,'scroll_of_phalanx_ii',1,1,11,5,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6572,'coffer_of_swart_astral_detritus',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6573,'coffer_of_murky_astral_detritus',1,1,0,0,0,0,0,0);  -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6574,'coffer_of_beit_astral_detritus',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6574,'coffer_of_beit_astral_detritus',1,10,0,0,0,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6575,'cheesesteak_sandwich',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6576,'turkey_with_rolanberry_sauce',1,1,28,0,0,0,0,0);    -- TODO: verify animation from retail
 INSERT INTO `item_usable` VALUES (6577,'bowl_of_clam_chowder',1,1,0,0,0,0,0,0);             -- TODO: Not implemented
@@ -2413,7 +2413,7 @@ INSERT INTO `item_usable` VALUES (6592,'dragon_stewpot',1,1,0,0,0,0,0,0);       
 INSERT INTO `item_usable` VALUES (6593,'deep_yellow_curry',1,1,0,0,0,0,0,0);               -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6594,'seafood_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6595,'chicken_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6596,'duck_curry',1,1,0,0,0,0,0,0);                      -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6596,'duck_curry',1,10,0,0,0,0,0,0);                      -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6597,'mutton_curry',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,0,0,0,0,0,0);                       -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6599,'egg_sandwich',1,1,28,0,0,0,0,0);
@@ -2424,7 +2424,7 @@ INSERT INTO `item_usable` VALUES (6603,'bottle_of_rolanberry_854',1,1,0,0,0,0,0,
 INSERT INTO `item_usable` VALUES (6604,'bottle_of_rolanberry_874',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6605,'bottle_of_rolanberry_894',1,1,0,0,0,0,0,0); -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6606,'plate_of_mapo_tofu',1,1,0,0,0,0,0,0);       -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6607,'hydra_kofte_(survival)',1,1,0,0,0,0,0,0);   -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6607,'hydra_kofte_(survival)',1,10,0,0,0,0,0,0);   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6608,'moogle_amplifier',1,1,0,0,0,0,0,0);         -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6609,'serving_of_popotoes_con_queso',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6610,'serving_of_popotoes_con_queso_+1',1,1,28,0,0,0,0,0);
@@ -2537,24 +2537,43 @@ INSERT INTO `item_usable` VALUES (6716,'trust_magic_primer',1,1,0,0,0,0,0,0);   
 INSERT INTO `item_usable` VALUES (6717,'trust_magic_tome',1,1,0,0,0,0,0,0);                  -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (6718,'copy_of_marjorys_thesis',1,1,0,0,0,0,0,0);           -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (6719,'regines_fifth_eye',1,1,0,0,0,0,0,0);                 -- TODO: verify animation
-INSERT INTO `item_usable` VALUES (10250,'moogle_suit',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10253,'decennial_coat_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10254,'decennial_dress_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10264,'marine_gilet_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10265,'marine_top_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10266,'woodsy_gilet_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10267,'woodsy_top_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10268,'creek_maillot_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10269,'creek_top_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10270,'river_top_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10271,'dune_gilet_+1',1,8,0,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (10293,'chocobo_shirt',1,8,0,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (10250,'moogle_suit',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10253,'decennial_coat_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10254,'decennial_dress_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10264,'marine_gilet_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10265,'marine_top_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10266,'woodsy_gilet_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10267,'woodsy_top_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10268,'creek_maillot_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10269,'creek_top_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10270,'river_top_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10271,'dune_gilet_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10293,'chocobo_shirt',1,2,0,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (10383,'dream_mittens_+1',1,6,24,0,1,30,7200,0);
 INSERT INTO `item_usable` VALUES (10385,'cumulus_masque_+1',1,8,79,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (10432,'decennial_crown_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10433,'decennial_tiara_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10595,'decennial_tights_+1',1,6,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10596,'decennial_hose_+1',1,6,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10775,'gaiardas_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10776,'gaubious_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10777,'caloussu_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10778,'nanger_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10779,'sophia_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10780,'quies_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10781,'cynosure_ring',1,3,0,0,5,15,300,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (10796,'decennial_ring',1,3,76,0,10,15,3600,0);
-INSERT INTO `item_usable` VALUES (10812,'chocobo_shield_+1',1,8,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10808,'janus_guard',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10810,'moogle_guard_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10812,'chocobo_shield_+1',1,2,0,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (10847,'orc_belt',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (10848,'quadav_belt',1,1,0,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (10849,'yagudo_belt',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10850,'leech_belt',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10851,'slime_belt',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (10852,'hecteyes_belt',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (10875,'snowman_cap',1,1,0,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (10963,'airmids_gorget',1,8,0,0,10,30,60,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (11002,'dragon_tank',1,1,55,0,5,30,60,0);
 INSERT INTO `item_usable` VALUES (11273,'custom_gilet_+1',1,8,79,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (11274,'custom_top_+1',1,8,79,0,1,30,72000,0);
@@ -2572,13 +2591,14 @@ INSERT INTO `item_usable` VALUES (11491,'snow_bunny_hat_+1',1,1,0,0,1,30,3600,0)
 INSERT INTO `item_usable` VALUES (11500,'chocobo_beret',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (11538,'nexus_cape',1,8,79,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (11666,'novennial_ring',1,3,76,0,10,15,3600,0);
-INSERT INTO `item_usable` VALUES (11788,'jesters_hat',1,3,0,0,1,30,600,0);
-INSERT INTO `item_usable` VALUES (11811,'destrier_beret',1,4,0,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (11788,'jesters_hat',3,2.25,0,0,1,30,600,0);
+INSERT INTO `item_usable` VALUES (11811,'destrier_beret',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (11861,'hikogami_yukata',1,2,0,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (11862,'himegami_yukata',1,2,0,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (12406,'coated_shield',1,2,0,0,20,30,1800,0);
-INSERT INTO `item_usable` VALUES (12408,'absorbing_shield',20,2,0,0,20,30,3600,0);
+INSERT INTO `item_usable` VALUES (12408,'absorbing_shield',4,2,0,0,20,30,3600,0);
 INSERT INTO `item_usable` VALUES (12411,'dominus_shield',1,10,0,0,15,30,180,0);
+INSERT INTO `item_usable` VALUES (13078,'portafurnace',1,5,0,0,1,15,60,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (13144,'wing_gorget',1,3,91,0,10,30,1800,0);
 INSERT INTO `item_usable` VALUES (13170,'stoneskin_torque',1,14,29,0,20,30,30,0);
 INSERT INTO `item_usable` VALUES (13171,'reraise_gorget',1,10,33,0,10,30,120,0);
@@ -2586,7 +2606,7 @@ INSERT INTO `item_usable` VALUES (13173,'memento_muffler',1,1,0,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (13179,'kingdom_stables_collar',1,8,79,0,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (13180,'republic_stables_medal',1,8,79,0,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (13181,'federation_stables_scarf',1,8,79,0,10,30,3600,0);
-INSERT INTO `item_usable` VALUES (13182,'oscar_scarf',20,3,0,0,50,30,900,0);
+INSERT INTO `item_usable` VALUES (13182,'oscar_scarf',4,3,0,0,50,30,900,0);
 INSERT INTO `item_usable` VALUES (13682,'ether_tank',1,1,55,0,5,30,60,0);
 INSERT INTO `item_usable` VALUES (13683,'water_tank',1,1,55,0,40,30,60,0);
 INSERT INTO `item_usable` VALUES (13684,'potion_tank',1,1,55,0,11,30,60,0);
@@ -2623,7 +2643,7 @@ INSERT INTO `item_usable` VALUES (14663,'teleport_ring_mea',1,8,79,5,10,30,3600,
 INSERT INTO `item_usable` VALUES (14664,'teleport_ring_vahzl',1,8,79,5,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (14665,'teleport_ring_yhoat',1,8,79,5,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (14666,'teleport_ring_altep',1,8,79,5,10,30,3600,0);
-INSERT INTO `item_usable` VALUES (14671,'allied_ring',1,3,76,0,5,5,900,0);
+INSERT INTO `item_usable` VALUES (14671,'allied_ring',1,1,76,0,5,5,900,0);
 INSERT INTO `item_usable` VALUES (14672,'tavnazian_ring',1,8,79,5,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (14677,'sanation_ring',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (14678,'assassins_ring',1,3,0,0,20,30,1800,0);
@@ -2637,8 +2657,8 @@ INSERT INTO `item_usable` VALUES (14787,'deadeye_earring',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (14788,'gamushara_earring',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (14789,'naruko_earring',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (14790,'reraise_earring',1,8,33,0,10,30,60,0);
-INSERT INTO `item_usable` VALUES (14810,'signal_pearl',1,3,0,0,1,30,72000,0);
-INSERT INTO `item_usable` VALUES (14811,'tactics_pearl',1,3,0,0,4,30,600,0);
+INSERT INTO `item_usable` VALUES (14810,'signal_pearl',1,3,0,0,1,10,21600,0);
+INSERT INTO `item_usable` VALUES (14811,'tactics_pearl',1,3,0,0,50,10,180,0);
 INSERT INTO `item_usable` VALUES (14855,'mist_mitts',1,1,24,0,10,30,600,0);
 INSERT INTO `item_usable` VALUES (14864,'palmers_bangles',1,1,0,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (14925,'hydra_mittens',1,3,25,0,1,30,72000,0);
@@ -2653,16 +2673,16 @@ INSERT INTO `item_usable` VALUES (15018,'ritterhentzes',1,3,28,0,50,30,300,0);
 INSERT INTO `item_usable` VALUES (15071,'spartan_hoplon',1,6,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (15162,'mist_crown',1,1,24,0,5,30,600,0);
 INSERT INTO `item_usable` VALUES (15170,'blink_band',1,12,24,0,50,30,20,0);
-INSERT INTO `item_usable` VALUES (15175,'revilers_helm',20,1,0,0,100,30,300,0);
+INSERT INTO `item_usable` VALUES (15175,'revilers_helm',4,1,0,0,100,30,300,0);
 INSERT INTO `item_usable` VALUES (15179,'dream_hat_+1',1,2,0,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (15182,'zoolater_hat',1,3,33,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (15194,'maats_cap',1,8,79,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (15198,'sprout_beret',1,3,76,0,1,5,72000,0);
-INSERT INTO `item_usable` VALUES (15199,'guide_beret',1,3,76,0,1,5,72000,0);
+INSERT INTO `item_usable` VALUES (15198,'sprout_beret',1,1,76,0,1,5,72000,0);
+INSERT INTO `item_usable` VALUES (15199,'guide_beret',1,1,76,0,1,5,72000,0);
 INSERT INTO `item_usable` VALUES (15204,'mandragora_beret',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (15211,'reraise_hairpin',1,8,33,0,10,30,60,0);
-INSERT INTO `item_usable` VALUES (15212,'stars_cap',1,8,79,0,1,30,3600,0);
-INSERT INTO `item_usable` VALUES (15213,'laurel_crown',1,8,79,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (15212,'stars_cap',1,8,79,0,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (15213,'laurel_crown',1,8,79,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (15214,'gadzradds_helm',1,3,0,0,30,30,72000,0);
 INSERT INTO `item_usable` VALUES (15215,'davhus_barbut',1,3,0,0,30,30,72000,0);
 INSERT INTO `item_usable` VALUES (15216,'tsoo_hajas_headgear',1,3,0,0,30,30,72000,0);
@@ -2680,7 +2700,7 @@ INSERT INTO `item_usable` VALUES (15299,'mandragora_belt',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (15300,'nebimonite_belt',1,3,0,0,50,30,86400,0);
 INSERT INTO `item_usable` VALUES (15312,'mist_pumps',1,1,24,0,10,30,600,0);
 INSERT INTO `item_usable` VALUES (15320,'powder_boots',1,3,24,0,20,30,600,0);
-INSERT INTO `item_usable` VALUES (15326,'gargoyle_boots',0x101,7,24,0,20,30,60,0);
+INSERT INTO `item_usable` VALUES (15326,'gargoyle_boots',1,7,24,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (15328,'root_sabots',1,2,24,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (15372,'magic_slacks',1,10,0,0,50,30,36,0);
 INSERT INTO `item_usable` VALUES (15444,'carpenters_belt',1,2,0,0,25,30,180,0);
@@ -2726,18 +2746,18 @@ INSERT INTO `item_usable` VALUES (15698,'sneaking_boots',1,6,24,0,15,30,3600,0);
 INSERT INTO `item_usable` VALUES (15708,'earth_greaves',1,7,29,0,20,30,60,0);
 INSERT INTO `item_usable` VALUES (15753,'dream_boots_+1',1,6,24,0,1,30,7200,0);
 INSERT INTO `item_usable` VALUES (15754,'sprinters_shoes',1,5,24,0,15,15,300,0);
-INSERT INTO `item_usable` VALUES (15761,'chariot_band',1,3,76,0,7,5,900,0);
-INSERT INTO `item_usable` VALUES (15762,'empress_band',1,3,76,0,7,5,900,0);
-INSERT INTO `item_usable` VALUES (15763,'emperor_band',1,3,76,0,3,5,900,0);
+INSERT INTO `item_usable` VALUES (15761,'chariot_band',1,1,76,0,7,5,900,0);
+INSERT INTO `item_usable` VALUES (15762,'empress_band',1,1,76,0,7,5,900,0);
+INSERT INTO `item_usable` VALUES (15763,'emperor_band',1,1,76,0,3,5,900,0);
 INSERT INTO `item_usable` VALUES (15769,'olduum_ring',1,3,79,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (15770,'random_ring',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (15782,'manashell_ring',1,3,32,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (15783,'armored_ring',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (15793,'anniversary_ring',1,3,76,0,10,15,3600,0);
 INSERT INTO `item_usable` VALUES (15817,'ecphoria_ring',1,3,0,0,100,30,300,0);
-INSERT INTO `item_usable` VALUES (15834,'blind_ring',20,2,70,0,100,30,60,0);
+INSERT INTO `item_usable` VALUES (15834,'blind_ring',4,2,70,0,100,30,60,0);
 INSERT INTO `item_usable` VALUES (15838,'protect_ring',1,3,30,0,30,30,1800,0);
-INSERT INTO `item_usable` VALUES (15840,'kupofrieds_ring',1,3,76,0,11,5,900,0);
+INSERT INTO `item_usable` VALUES (15840,'kupofrieds_ring',1,1,76,0,11,5,900,0);
 INSERT INTO `item_usable` VALUES (15841,'recall_ring_jugner',1,8,79,5,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (15842,'recall_ring_pashhow',1,8,79,5,10,30,3600,0);
 INSERT INTO `item_usable` VALUES (15843,'recall_ring_meriphataud',1,8,79,5,10,30,3600,0);
@@ -2762,9 +2782,9 @@ INSERT INTO `item_usable` VALUES (15926,'bronze_bandolier',1,2,0,0,50,30,86400,0
 INSERT INTO `item_usable` VALUES (15927,'pinwheel_belt',1,2,0,0,50,30,86400,0);
 INSERT INTO `item_usable` VALUES (15929,'goblin_belt',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (15933,'stirge_belt',1,1,55,0,30,15,600,0);
-INSERT INTO `item_usable` VALUES (15956,'temple_knights_quiver',1,1,55,0,1,30,604800,0);
-INSERT INTO `item_usable` VALUES (15957,'iron_musketeers_quiver',1,1,55,0,1,30,604800,0);
-INSERT INTO `item_usable` VALUES (15958,'combat_casters_quiver',1,1,55,0,1,30,604800,0);
+INSERT INTO `item_usable` VALUES (15956,'temple_knights_quiver',1,10,55,0,1,30,604800,0);
+INSERT INTO `item_usable` VALUES (15957,'iron_musketeers_quiver',1,10,55,0,1,30,604800,0);
+INSERT INTO `item_usable` VALUES (15958,'combat_casters_quiver',1,10,55,0,1,30,604800,0);
 INSERT INTO `item_usable` VALUES (15998,'koccos_earring',1,8,0,0,5,30,60,0);
 INSERT INTO `item_usable` VALUES (16003,'raising_earring',1,8,0,0,10,30,600,0);
 INSERT INTO `item_usable` VALUES (16007,'protect_earring',1,2,0,0,100,30,900,0);
@@ -2788,7 +2808,7 @@ INSERT INTO `item_usable` VALUES (16118,'moogle_cap',1,8,79,0,1,30,72000,1);
 INSERT INTO `item_usable` VALUES (16119,'nomad_cap',1,8,79,0,1,30,72000,1);
 INSERT INTO `item_usable` VALUES (16120,'redeyes',1,2,0,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (16145,'lunar_cap',1,3,0,0,1,15,3600,0);
-INSERT INTO `item_usable` VALUES (16153,'reikyo_hairpin',20,3,0,0,50,30,900,0);
+INSERT INTO `item_usable` VALUES (16153,'reikyo_hairpin',4,3,0,0,50,30,900,0);
 INSERT INTO `item_usable` VALUES (16182,'town_moogle_shield',1,5,0,0,1,15,57600,0);
 INSERT INTO `item_usable` VALUES (16183,'nomad_moogle_shield',1,5,0,0,1,15,57600,0);
 INSERT INTO `item_usable` VALUES (16223,'orange_au_lait_tank',1,1,55,0,8,30,60,0);
@@ -2807,171 +2827,290 @@ INSERT INTO `item_usable` VALUES (16550,'hallowed_sword',1,3,7,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (16603,'halo_claymore',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (16613,'spirit_sword',1,3,78,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (16858,'sacred_lance',1,3,78,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (16954,'pealing_nagan',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (16954,'pealing_nagan',4,2,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17031,'shell_scepter',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (17032,'gobbie_gavel',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (17040,'warp_cudgel',1,8,80,3,30,3,60,0);
-INSERT INTO `item_usable` VALUES (17468,'raise_rod',9,3,33,0,20,30,60,0);
-INSERT INTO `item_usable` VALUES (17469,'raise_ii_rod',9,4,33,0,20,30,60,0);
-INSERT INTO `item_usable` VALUES (17470,'pealing_buzdygan',20,1,0,0,50,30,600,0);
-INSERT INTO `item_usable` VALUES (17583,'kingdom_signet_staff',29,1,52,0,25,30,10,0);
-INSERT INTO `item_usable` VALUES (17584,'republic_signet_staff',29,1,52,0,25,30,10,0);
-INSERT INTO `item_usable` VALUES (17585,'federation_signet_staff',29,1,52,0,25,30,10,0);
-INSERT INTO `item_usable` VALUES (17587,'trick_staff_ii',1,2,0,0,10,30,3600,0);
-INSERT INTO `item_usable` VALUES (17588,'treat_staff_ii',1,2,0,0,1,30,72000,0);
-INSERT INTO `item_usable` VALUES (17592,'kinkobo',1,2,0,0,20,30,1800,0);
-INSERT INTO `item_usable` VALUES (17596,'steel-splitter',20,1,0,0,50,30,600,0);
-INSERT INTO `item_usable` VALUES (17624,'anubiss_knife',1,1,0,0,50,30,1800,0);
-INSERT INTO `item_usable` VALUES (17625,'ponderous_gully',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17468,'raise_rod',107,10,33,0,20,30,60,0);
+INSERT INTO `item_usable` VALUES (17469,'raise_ii_rod',107,15,33,0,20,30,60,0);
+INSERT INTO `item_usable` VALUES (17470,'pealing_buzdygan',4,2,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17583,'kingdom_signet_staff',75,1,52,0,25,30,10,0);
+INSERT INTO `item_usable` VALUES (17584,'republic_signet_staff',75,1,52,0,25,30,10,0);
+INSERT INTO `item_usable` VALUES (17585,'federation_signet_staff',75,1,52,0,25,30,10,0);
+INSERT INTO `item_usable` VALUES (17587,'trick_staff_ii',1,8,0,0,10,30,3600,0);
+INSERT INTO `item_usable` VALUES (17588,'treat_staff_ii',1,8,0,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (17592,'kinkobo',1,6,0,0,20,30,1800,0);
+INSERT INTO `item_usable` VALUES (17596,'steel-splitter',4,2,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17624,'anubiss_knife',1,2,0,0,50,30,1800,0);
+INSERT INTO `item_usable` VALUES (17625,'ponderous_gully',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (17682,'sacred_sword',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (17683,'sacred_degen',1,3,0,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (17703,'pealing_anelace',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17703,'pealing_anelace',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (17704,'vulcan_sword',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (17705,'vulcan_degen',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (17706,'vulcan_blade',1,3,0,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (17748,'ibushi_shinai',1,0,10,0,1,10,15,0);
-INSERT INTO `item_usable` VALUES (17797,'seito',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (17826,'messhikimaru',1,0,0,0,30,30,600,0);
+INSERT INTO `item_usable` VALUES (17748,'ibushi_shinai',1,0.25,10,0,1,10,15,0);
+INSERT INTO `item_usable` VALUES (17797,'seito',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (17826,'messhikimaru',1,1,0,0,30,30,600,0);
 INSERT INTO `item_usable` VALUES (17828,'koen',1,3,0,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (17949,'furnace_tabarzin',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (17949,'furnace_tabarzin',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (17954,'jolt_axe',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (17957,'navy_axe',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (17961,'lion_tamer',1,3,0,0,50,30,300,0);
-INSERT INTO `item_usable` VALUES (18008,'hushed_dagger',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18010,'melt_dagger',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18011,'melt_knife',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18012,'melt_baselard',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18013,'melt_kukri',1,1,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18008,'hushed_dagger',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18010,'melt_dagger',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18011,'melt_knife',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18012,'melt_baselard',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18013,'melt_kukri',1,2,0,0,15,30,600,0);
 INSERT INTO `item_usable` VALUES (18029,'piercing_dagger',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18035,'deathbone_knife',1,3,0,0,100,30,600,0);
-INSERT INTO `item_usable` VALUES (18060,'blizzard_scythe',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18060,'blizzard_scythe',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18062,'lucent_scythe',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18067,'keen_zaghnal',1,3,0,0,50,30,1800,0);
-INSERT INTO `item_usable` VALUES (18095,'dispel_couse',20,2,0,0,50,30,30,0);
-INSERT INTO `item_usable` VALUES (18107,'ponderous_lance',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18095,'dispel_couse',4,6,0,0,50,30,30,0);
+INSERT INTO `item_usable` VALUES (18107,'ponderous_lance',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18108,'lucent_lance',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18117,'gimlet_spear',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18122,'broach_lance',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (18216,'twicer',1,3,0,0,20,30,300,0);
 INSERT INTO `item_usable` VALUES (18220,'prominence_axe',1,3,0,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (18225,'blizzard_toporok',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18225,'blizzard_toporok',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18231,'death_chakram',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (18239,'healing_feather',1,3,30,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (18240,'spirit_lantern',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (18241,'vial_of_refresh_musk',1,3,33,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (18242,'bag_of_wyvern_feed',1,3,0,0,20,30,1800,0);
 INSERT INTO `item_usable` VALUES (18243,'astral_pot',1,3,0,0,20,30,1800,0);
-INSERT INTO `item_usable` VALUES (18355,'hushed_baghnakhs',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18357,'melt_claws',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18361,'ponderous_manoples',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18355,'hushed_baghnakhs',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18357,'melt_claws',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18361,'ponderous_manoples',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18379,'vulcan_claymore',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (18381,'prominence_sword',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (18384,'lucent_sword',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18391,'sacred_mace',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (18392,'sacred_maul',1,3,0,0,30,30,300,0);
 INSERT INTO `item_usable` VALUES (18393,'sacred_wand',1,3,0,0,30,30,300,0);
-INSERT INTO `item_usable` VALUES (18398,'raphaels_rod',1,2,0,0,8,30,120,0);
-INSERT INTO `item_usable` VALUES (18399,'charm_wand',4,2,0,0,10,30,86400,0);
-INSERT INTO `item_usable` VALUES (18400,'charm_wand_+1',4,2,0,0,1,30,432000,0);
-INSERT INTO `item_usable` VALUES (18401,'moogle_rod',4,3,0,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (18398,'raphaels_rod',1,8,0,0,8,30,120,0);
+INSERT INTO `item_usable` VALUES (18399,'charm_wand',2,8,0,0,10,30,86400,0);
+INSERT INTO `item_usable` VALUES (18400,'charm_wand_+1',2,8,0,0,1,30,432000,0);
+INSERT INTO `item_usable` VALUES (18401,'moogle_rod',2,3,0,0,1,30,72000,0);
 INSERT INTO `item_usable` VALUES (18402,'mana_wand',1,3,32,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18403,'high_mana_wand',1,3,33,0,50,30,1800,0);
-INSERT INTO `item_usable` VALUES (18410,'melt_katana',1,1,0,0,15,30,600,0);
-INSERT INTO `item_usable` VALUES (18415,'tojaku',20,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18410,'melt_katana',1,2,0,0,15,30,600,0);
+INSERT INTO `item_usable` VALUES (18415,'tojaku',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18427,'hanafubuki',1,3,0,0,100,30,600,0);
-INSERT INTO `item_usable` VALUES (18433,'kagiroi',4,1,0,0,50,30,600,0);
+INSERT INTO `item_usable` VALUES (18433,'kagiroi',4,2,0,0,50,30,600,0);
 INSERT INTO `item_usable` VALUES (18444,'tsurugitachi',1,3,0,0,100,30,600,0);
+INSERT INTO `item_usable` VALUES (18464,'ark_tachi',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (18469,'pouch_of_moogle_moolah',1,3,0,0,11,10,259200,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (18481,'lucent_axe',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18488,'assailants_axe',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18493,'regiment_kheten',1,3,0,0,100,30,600,0);
+INSERT INTO `item_usable` VALUES (18545,'ark_tabar',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (18551,'twilight_scythe',1,1,0,0,1,10,600,0);
-INSERT INTO `item_usable` VALUES (18581,'carbuncles_pole',1,1,0,0,30,30,600,0);
+INSERT INTO `item_usable` VALUES (18563,'ark_scythe',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (18566,'crepuscular_scythe',1,1,0,0,1,10,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (18581,'carbuncles_pole',1,4,0,0,30,30,600,0);
 INSERT INTO `item_usable` VALUES (18586,'flexible_pole',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18591,'pastoral_staff',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (18612,'ram_staff',1,8,80,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (18613,'fourth_staff',1,8,80,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (18614,'cobra_staff',1,8,80,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (18679,'soulgauger_sgr-1',20,0,0,0,12,10,30,0);
+INSERT INTO `item_usable` VALUES (18679,'soulgauger_sgr-1',4,1,0,0,12,10,30,0);
 INSERT INTO `item_usable` VALUES (18692,'mamoolbane',1,3,0,0,15,30,86400,0);
 INSERT INTO `item_usable` VALUES (18693,'lamiabane',1,3,0,0,15,30,3600,0);
 INSERT INTO `item_usable` VALUES (18694,'trollbane',1,3,0,0,15,30,86400,0);
-INSERT INTO `item_usable` VALUES (18721,'soultrapper',20,0,104,0,12,10,60,0);
-INSERT INTO `item_usable` VALUES (18724,'soultrapper_2000',20,0,104,0,48,10,30,0);
+INSERT INTO `item_usable` VALUES (18721,'soultrapper',4,1,104,0,12,10,60,0);
+INSERT INTO `item_usable` VALUES (18724,'soultrapper_2000',4,1,104,0,48,10,30,0);
 INSERT INTO `item_usable` VALUES (18747,'smash_cesti',1,3,0,0,50,30,1800,0);
 INSERT INTO `item_usable` VALUES (18755,'noble_himantes',1,3,0,0,100,30,600,0);
-INSERT INTO `item_usable` VALUES (18842,'nomad_moogle_rod',4,3,0,0,50,30,72000,0);
-INSERT INTO `item_usable` VALUES (18844,'miracle_wand',4,3,0,0,10,30,7200,0);
-INSERT INTO `item_usable` VALUES (18845,'miracle_wand_+1',4,3,0,0,1,30,432000,0);
+INSERT INTO `item_usable` VALUES (18842,'nomad_moogle_rod',2,3,0,0,50,30,72000,0);
+INSERT INTO `item_usable` VALUES (18844,'miracle_wand',2,3,0,0,10,30,7200,0);
+INSERT INTO `item_usable` VALUES (18845,'miracle_wand_+1',2,3,0,0,1,30,432000,0);
 INSERT INTO `item_usable` VALUES (18853,'spirit_maul',1,3,0,0,100,30,600,0);
 INSERT INTO `item_usable` VALUES (18867,'daedalus_hammer',1,3,0,0,50,30,1800,0);
-INSERT INTO `item_usable` VALUES (18871,'kitty_rod',1,0,0,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (18871,'kitty_rod',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (18879,'rounsey_wand',1,8,0,0,1,30,604800,0);
 INSERT INTO `item_usable` VALUES (18880,'maestros_baton',1,1,0,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (18881,'melomane_mallet',1,1,0,0,1,30,3600,0);
+INSERT INTO `item_usable` VALUES (18888,'ankylosis_wand',1,2,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (18912,'ark_saber',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (18913,'ark_sword',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (18945,'jet_sickle',1,3,0,0,100,30,600,0);
-INSERT INTO `item_usable` VALUES (19181,'moogles_largesse',1,12,0,0,9,10,259200,0);
-INSERT INTO `item_usable` VALUES (19204,'fiendtrapper',20,0,0,0,12,10,30,0);
+INSERT INTO `item_usable` VALUES (19181,'moogles_largesse',1,3,0,0,9,10,259200,0);
+INSERT INTO `item_usable` VALUES (19204,'fiendtrapper',4,1,0,0,12,10,30,0);
 INSERT INTO `item_usable` VALUES (19246,'moggiebag',1,3,0,0,8,10,259200,0);
--- INSERT INTO `item_usable` VALUES (20533,'worm_feelers_+1',1,1,55,0,1,30,86400,0); -- item's lua still needs made
--- INSERT INTO `item_usable` VALUES (20568,'wind_knife_+1',4,1,0,0,1,30,600,0); -- untested
-INSERT INTO `item_usable` VALUES (20953,'escritorio',1,1,55,0,1,30,86400,0); -- Dispenses: Cone Calamary
-INSERT INTO `item_usable` VALUES (21074,'kupo_rod',1,3,55,0,1,30,72000,0);
-INSERT INTO `item_usable` VALUES (21266,'gastraphetes',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (21267,'annihilator',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (21268,'death_penalty',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (21269,'armageddon',1,1,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (19776,'mogratuity',1,3,0,0,10,10,259200,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (20533,'worm_feelers_+1',1,2,55,0,1,30,86400,0); -- item's lua still needs made
+INSERT INTO `item_usable` VALUES (20568,'wind_knife_+1',4,2,0,0,1,30,600,0); -- untested
+INSERT INTO `item_usable` VALUES (20667,'blizzard_brand_+1',4,2,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (20669,'firetongue_+1',4,2,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (20953,'escritorio',1,2,55,0,1,30,86400,0); -- Dispenses: Cone Calamary
+INSERT INTO `item_usable` VALUES (21074,'kupo_rod',1,8,55,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (21087,'heartstopper_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21096,'heartbeater_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21098,'leafkin_bopper_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21117,'hagoita',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21154,'malice_masher_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21266,'gastraphetes',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (21267,'annihilator',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (21268,'death_penalty',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (21269,'armageddon',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (21280,'decazoom_mk-xi',1,6,0,0,1,30,7200,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21369,'moggie_goodie_bag',1,3,0,0,12,10,259200,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21370,'gobbie_goodie_bag',1,3,0,0,12,10,259200,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (21485,'fomalhaut',1,2,0,0,1,10,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (21760,'dispatchers_axe',1,1,0,0,1,30,3600,0);     -- TODO: verify animation
-INSERT INTO `item_usable` VALUES (21868,'sha_wujings_la._+1',1,55,0,0,1,30,72000,0); -- Dispenses: Distilled Water x 12
+INSERT INTO `item_usable` VALUES (21868,'sha_wujings_la._+1',1,2,0,0,1,30,72000,0); -- Dispenses: Distilled Water x 12
 INSERT INTO `item_usable` VALUES (21997,'magicians_rod_+1',1,3,0,0,1,30,1800,0);    -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (22003,'arthros_scepter',1,1,0,0,1,30,3600,0);     -- TODO: verify animation
--- INSERT INTO `item_usable` VALUES (22018,'seika_uchiwa_+1',1,1,55,0,1,30,300,0);  -- Enchantment: Cool Breeze
--- INSERT INTO `item_usable` VALUES (22020,'jingly_rod_+1',1,1,55,0,1,30,3600,0);   -- Costume: lamb or Chacharoon
-INSERT INTO `item_usable` VALUES (22115,'yoichinoyumi',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (22116,'gandiva',1,1,55,0,1,10,3600,0);
-INSERT INTO `item_usable` VALUES (22117,'fail-not',1,1,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (22018,'seika_uchiwa_+1',1,6,55,0,1,30,300,0);  -- Enchantment: Cool Breeze
+INSERT INTO `item_usable` VALUES (22020,'jingly_rod_+1',1,1,55,0,1,30,3600,0);   -- Costume: lamb or Chacharoon
+INSERT INTO `item_usable` VALUES (22032,'thunder_hammer',4,2,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22043,'apkallu_scepter',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22044,'tengu_war_fan',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22047,'korrigan_mallet',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22048,'adenium_mallet',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22049,'citrullus_mallet',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22051,'lycopodium_mallet',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22069,'hapy_staff',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22101,'pandits_staff',1,1,0,0,1,10,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22115,'yoichinoyumi',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (22116,'gandiva',1,2,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (22117,'fail-not',1,2,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22129,'yoichinoyumi',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22130,'gandiva',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22131,'fail-not',1,1,55,0,1,10,3600,0);
+INSERT INTO `item_usable` VALUES (22132,'artemiss_bow_+1',1,8,0,0,1,30,72000,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (22139,'gastraphetes',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22140,'annihilator',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22141,'death_penalty',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22142,'armageddon',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22143,'fomalhaut',1,1,55,0,1,10,3600,0);
 INSERT INTO `item_usable` VALUES (22168,'pandits_staff',1,1,0,0,1,10,72000,0);      -- TODO: verify animation
--- INSERT INTO `item_usable` VALUES (22288,'mandragora_pouch',1,2,55,0,1,10,216000,0);  -- Enchantment: Tiny Allowance (Enchantment gives a random small amount of gil (<2,000))
+INSERT INTO `item_usable` VALUES (22284,'abdhaljs_tome',1,2,0,0,1,10,216000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (22288,'mandragora_pouch',1,3,55,0,1,10,216000,0);  -- Enchantment: Tiny Allowance (Enchantment gives a random small amount of gil (<2,000))
 INSERT INTO `item_usable` VALUES (22310,'hoxne_ampulla',1,1,0,0,1,5,60,0);          -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (23714,'volte_doublet',1,1,0,0,1,5,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (23715,'volte_harness',1,1,0,0,1,5,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (23754,'sandogasa_+1',1,2,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (23801,'cancrine_apron_+1',1,6,0,0,1,30,300,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (23870,'eyre_cap',1,2,0,0,1,10,3600,0);            -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (23871,'hebenus_gilet',1,2,0,0,1,30,86400,0);      -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (23873,'hebenus_top',1,2,0,0,1,30,86400,0);        -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (24271,'prishes_boots_+1',1,1,0,0,1,5,216000,0);   -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (24273,'sobu_houou_kabuto',1,3,0,0,1,30,72000,0);  -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (25585,'black_chocobo_cap',1,8,79,0,1,30,72000,0);
-INSERT INTO `item_usable` VALUES (25658,'wyrmking_masque_+1',1,1,55,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (25587,'kakai_cap_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25604,'buffalo_cap',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25638,'pachypodium_masque',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25639,'korrigan_masque',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25645,'kupo_masque',1,1,0,0,1,8,1800,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25658,'wyrmking_masque_+1',1,2,55,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (25669,'crab_cap_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25671,'rarab_cap_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25673,'snoll_masque_+1',1,2,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25678,'arthros_cap_+1',1,2,0,0,1,30,72000,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (25679,'white_rarab_cap_+1',1,8,33,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (25712,'botulus_suit_+1',1,2,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (25715,'korrigan_suit',1,2,0,0,1,30,72000,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (25757,'wyrmking_suit_+1',1,8,79,0,1,30,3600,0);
 INSERT INTO `item_usable` VALUES (25774,'fancy_gilet',1,2,55,0,1,30,86400,0); -- Dispense: persikos snow cone
 INSERT INTO `item_usable` VALUES (25775,'fancy_top',1,2,55,0,1,30,86400,0); -- Dispense: persikos snow cone
-INSERT INTO `item_usable` VALUES (26164,'caliber_ring',1,3,76,0,3,5,900,0);
-INSERT INTO `item_usable` VALUES (26165,'facility_ring',1,3,76,0,3,5,900,0);
+INSERT INTO `item_usable` VALUES (26164,'caliber_ring',1,1,76,0,3,5,900,0);
+INSERT INTO `item_usable` VALUES (26165,'facility_ring',1,1,76,0,3,5,900,0);
+INSERT INTO `item_usable` VALUES (26166,'invisible_ring',1,1,0,0,1,5,900,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26167,'sneak_ring',1,1,0,0,1,5,900,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26168,'deodorize_ring',1,1,0,0,1,5,900,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26169,'reraise_ring',1,2,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26176,'dimensional_ring_holla',1,8,0,0,1,8,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26177,'dimensional_ring_dem',1,8,0,0,1,8,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26178,'dimensional_ring_mea',1,8,0,0,1,8,600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (26235,'arrapago_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (26271,'hi-elixir_tank',1,2,55,0,3,30,60,0);
 INSERT INTO `item_usable` VALUES (26272,'super_reraiser_tank',1,2,55,0,5,30,60,0);
+INSERT INTO `item_usable` VALUES (26273,'tengu_shawl',1,6,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26330,'wailing_belt',1,1,0,0,250,5,28800,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26343,'yoichis_quiver',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26344,'artemiss_quiver',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26345,'chrono_quiver',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26346,'quelling_bolt_quiver',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26347,'eradicating_bullet_pouch',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26348,'living_bullet_pouch',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26349,'devastating_bullet_pouch',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26350,'chrono_bullet_pouch',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26352,'moogle_sacoche',1,2,0,0,1,10,216000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26411,'diamond_buckler_+1',1,2,0,0,1,10,1800,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26427,'joiners_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26432,'smythes_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26437,'toreutic_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26442,'plaiters_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26447,'bevelers_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26452,'ossifiers_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26457,'brewers_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26462,'chefs_escutcheon',1,2,0,0,1,10,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26497,'regis',1,3,0,0,1,30,1800,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26516,'citrullus_shirt',1,2,0,0,1,30,72000,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (26517,'shadow_lord_shirt',1,8,79,0,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (26523,'delegates_garb',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26546,'moogle_shirt',1,2,0,0,1,30,604800,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26694,'cassies_cap',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26704,'lycopodium_masque_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26706,'mandragora_masque_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26708,'flan_masque_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (26720,'sheep_cap_+1',1,2,55,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (26788,'rabbit_cap',1,1,55,8,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (26728,'frosty_cap',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26739,'leafkin_cap_+1',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26788,'rabbit_cap',1,2,55,8,1,30,72000,0);
+INSERT INTO `item_usable` VALUES (26789,'shobuhouou_kabuto',107,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26799,'behemoth_masque_+1',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26890,'heart_apron_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (26955,'behemoth_suit_+1',1,2,55,0,1,30,72000,0);
-INSERT INTO `item_usable` VALUES (27556,'echad_ring',1,3,76,0,1,5,7200,0);
-INSERT INTO `item_usable` VALUES (27557,'trizek_ring',1,3,76,0,1,5,7200,0);
+INSERT INTO `item_usable` VALUES (26963,'onca_suit',4,8,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26966,'ta_moko_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26968,'cossie_top_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26974,'agent_coat',1,8,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (26975,'starlet_jabot',4,8,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27220,'miasmic_pants',1,2,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27292,'swimming_togs_+1',1,3,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27294,'cossie_bottom_+1',1,3,0,0,1,30,600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27556,'echad_ring',1,1,76,0,1,5,7200,0);
+INSERT INTO `item_usable` VALUES (27557,'trizek_ring',1,1,76,0,1,5,7200,0);
+INSERT INTO `item_usable` VALUES (27623,'jody_shield',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27626,'cassies_shield',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27718,'worm_masque_+1',1,1,0,0,1,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (27726,'she_slime_hat',1,2,55,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (27727,'metal_slime_hat',1,2,55,0,1,30,86400,0);
 INSERT INTO `item_usable` VALUES (27756,'slime_cap',1,2,55,0,1,30,86400,0);
-INSERT INTO `item_usable` VALUES (28469,'endorsement_ring',1,3,76,0,1,5,7200,0);
+INSERT INTO `item_usable` VALUES (27758,'bomb_masque_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27759,'korrigan_beret',1,1,0,0,1,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27760,'chocobo_masque_+1',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27805,'rustic_maillot_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27806,'shoal_maillot_+1',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27855,'mandragora_suit_+1',1,8,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27872,'purple_spriggan_coat',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27873,'red_spriggan_coat',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27902,'green_spriggan_coat',1,2,0,0,1,30,86400,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (27906,'chocobo_suit_+1',1,2,0,0,1,30,72000,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28469,'endorsement_ring',1,1,76,0,1,5,7200,0);
+INSERT INTO `item_usable` VALUES (28470,'emporoxs_ring',1,1,0,0,3,5,7200,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (28528,'undecennial_ring',1,3,76,0,11,15,3600,0);
 INSERT INTO `item_usable` VALUES (28540,'warp_ring',1,8,80,3,1,8,600,0);
-INSERT INTO `item_usable` VALUES (28546,'capacity_ring',1,3,76,0,7,5,900,0);
+INSERT INTO `item_usable` VALUES (28546,'capacity_ring',1,1,76,0,7,5,900,0);
+INSERT INTO `item_usable` VALUES (28555,'ceizak_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28556,'yahse_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28557,'hennetiel_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28558,'morimar_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28559,'marjami_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28560,'yorcia_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28561,'kamihr_ring',1,8,0,0,10,30,3600,0); -- TODO: verify animation
 INSERT INTO `item_usable` VALUES (28562,'duodecennial_ring',1,3,76,0,12,15,3600,0);
 INSERT INTO `item_usable` VALUES (28563,'vocation_ring',1,3,76,0,12,15,3600,0);
-INSERT INTO `item_usable` VALUES (28568,'resolution_ring',1,3,76,0,5,5,900,0);
-INSERT INTO `item_usable` VALUES (28569,'expertise_ring',1,3,76,0,10,5,900,0);
-INSERT INTO `item_usable` VALUES (28652,'hatchling_shield',1,1,55,8,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (28568,'resolution_ring',1,1,76,0,5,5,900,0);
+INSERT INTO `item_usable` VALUES (28569,'expertise_ring',1,1,76,0,10,5,900,0);
+INSERT INTO `item_usable` VALUES (28570,'duck_ring',1,3,0,0,50,10,60,0); -- TODO: verify animation
+INSERT INTO `item_usable` VALUES (28652,'hatchling_shield',1,2,55,8,1,30,86400,0);
+INSERT INTO `item_usable` VALUES (28653,'mundus_shield',1,2,0,0,1,30,86400,0); -- TODO: verify animation
 
 /*!40000 ALTER TABLE `item_usable` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -2190,7 +2190,7 @@ INSERT INTO `item_weapon` VALUES (18562,'yhatdhara_+1',7,0,0,0,0,2,1,466,120,0);
 INSERT INTO `item_weapon` VALUES (18563,'ark_scythe',7,0,0,0,0,2,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (18564,'devilish_scythe',7,0,0,0,0,2,1,528,130,0);
 INSERT INTO `item_weapon` VALUES (18565,'adflictio',7,0,0,0,0,2,1,513,134,0);
-INSERT INTO `item_weapon` VALUES (18566,'crepuscular_scythe',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (18566,'crepuscular_scythe',7,0,0,0,0,1,1,513,360,0); -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (18571,'daurdabla',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18572,'gjallarhorn',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18573,'pyf_harp',41,0,0,0,0,0,1,240,0,0);
@@ -4535,7 +4535,7 @@ INSERT INTO `item_weapon` VALUES (21516,'ajja_knuckles',1,0,223,223,223,4,1,576,
 INSERT INTO `item_weapon` VALUES (21517,'eletta_knuckles',1,0,231,231,231,4,1,576,151,0); -- DMG:+151 Delay:+96
 INSERT INTO `item_weapon` VALUES (21518,'kaja_knuckles',1,0,242,242,242,4,1,576,165,0);   -- DMG:+165 Delay:+96
 INSERT INTO `item_weapon` VALUES (21519,'karambit',1,0,250,250,250,4,1,576,180,0);        -- DMG:+180 Delay:+96
-INSERT INTO `item_weapon` VALUES (21520,'ethereal_fists',1,0,0,0,0,4,3,336,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21520,'ethereal_fists',1,0,0,0,0,4,3,576,-2,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21521,'melee_fists',1,0,242,242,228,4,1,606,190,0);     -- DMG:+190 Delay:+126
 INSERT INTO `item_weapon` VALUES (21522,'hes._fists',1,0,255,255,242,4,1,601,191,0);      -- DMG:+191 Delay:+121
 INSERT INTO `item_weapon` VALUES (21523,'sagitta',1,0,269,269,255,4,1,601,192,0);         -- DMG:+192 Delay:+121
@@ -4551,12 +4551,12 @@ INSERT INTO `item_weapon` VALUES (21532,'varga_purnikawa',1,0,252,252,252,4,1,59
 INSERT INTO `item_weapon` VALUES (21533,'varga_purnikawa',1,0,260,260,260,4,1,596,192,0); -- DMG:+192 Delay:+116
 INSERT INTO `item_weapon` VALUES (21534,'varga_purnikawa',1,0,269,269,269,4,1,596,202,0); -- DMG:+202 Delay:+116
 INSERT INTO `item_weapon` VALUES (21535,'varga_purnikawa',1,0,277,277,277,4,1,596,213,0); -- DMG:+213 Delay:+116
-INSERT INTO `item_weapon` VALUES (21536,'dazbogs_knuckles',1,0,0,0,0,4,3,336,4,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21537,'lizard_fangs',1,0,0,0,0,4,3,366,4,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21538,'lizard_fangs_+1',1,0,0,0,0,4,3,361,5,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21539,'dathaba_claws',1,0,0,0,0,4,3,306,132,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21540,'dragon_fangs',1,0,0,0,0,4,3,366,220,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21541,'premium_hearts',1,0,0,0,0,4,3,336,198,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21536,'dazbogs_knuckles',1,0,0,0,0,4,3,576,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21537,'lizard_fangs',1,0,0,0,0,4,3,606,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21538,'lizard_fangs_+1',1,0,0,0,0,4,3,601,2,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21539,'dathaba_claws',1,0,0,0,0,4,3,546,129,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21540,'dragon_fangs',1,0,0,0,0,4,3,606,217,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21541,'premium_hearts',1,0,0,0,0,4,3,576,195,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21554,'arasy_knife',2,0,242,242,188,1,1,183,94,0);
 INSERT INTO `item_weapon` VALUES (21555,'arasy_knife_+1',2,0,242,242,188,1,1,178,95,0);
 INSERT INTO `item_weapon` VALUES (21556,'beryllium_kris',2,0,228,228,188,1,1,192,125,0);  -- DMG:125 Delay:192
@@ -4571,7 +4571,7 @@ INSERT INTO `item_weapon` VALUES (21564,'kaja_knife',2,0,242,242,242,1,1,180,117
 INSERT INTO `item_weapon` VALUES (21565,'tauret',2,0,250,250,250,1,1,180,125,0);          -- DMG:125 Delay:180
 INSERT INTO `item_weapon` VALUES (21566,'voluspa_knife',2,0,215,215,215,1,1,195,104,0);
 INSERT INTO `item_weapon` VALUES (21567,'gletis_knife',2,0,255,255,242,1,1,200,133,0);  -- DMG:133 Delay:200
-INSERT INTO `item_weapon` VALUES (21568,'acrontica',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21568,'acrontica',2,0,0,0,0,1,1,201,138,0);             -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21569,'chocobo_knife',2,0,269,269,269,1,1,176,121,0); -- DMG:121 Delay:176
 INSERT INTO `item_weapon` VALUES (21570,'air_knife',2,0,269,269,269,1,1,150,103,0);
 INSERT INTO `item_weapon` VALUES (21571,'ethereal_dagger',2,0,0,0,0,1,1,180,1,0);         -- TODO: Not implemented
@@ -4633,19 +4633,19 @@ INSERT INTO `item_weapon` VALUES (21636,'nihility',3,0,0,0,0,2,1,240,1,0);      
 INSERT INTO `item_weapon` VALUES (21637,'sakpatas_sword',3,0,248,248,248,2,1,240,160,0); -- DMG:160 Delay:240
 INSERT INTO `item_weapon` VALUES (21638,'extinction',3,0,0,0,0,2,1,240,1,0); -- DMG:1 Delay:240
 INSERT INTO `item_weapon` VALUES (21640,'onion_sword_iii',3,0,269,269,269,2,1,240,165,0);
-INSERT INTO `item_weapon` VALUES (21641,'save_the_queen_iii',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21642,'prime_sword',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21643,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21644,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21645,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21646,'caliburnus',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21641,'save_the_queen_iii',3,0,0,0,0,1,1,264,182,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21642,'prime_sword',3,0,0,0,0,1,1,233,156,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21643,'caliburnus',3,0,0,0,0,1,1,233,156,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21644,'caliburnus',3,0,0,0,0,1,1,233,165,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21645,'caliburnus',3,0,0,0,0,1,1,233,172,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21646,'caliburnus',3,0,0,0,0,1,1,233,181,0);         -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21647,'dathaba_hanger',3,0,0,0,0,2,1,225,150,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21648,'dathaba_sword',4,0,0,0,0,2,1,456,304,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21649,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21650,'prime_blade',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21651,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21652,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21653,'helheim',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21649,'helheim',4,0,0,0,0,1,1,431,336,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21650,'prime_blade',4,0,0,0,0,1,1,431,288,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21651,'helheim',4,0,0,0,0,1,1,431,288,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21652,'helheim',4,0,0,0,0,1,1,431,306,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21653,'helheim',4,0,0,0,0,1,1,431,318,0);            -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21654,'arasy_claymore',4,0,242,242,188,2,1,489,251,0);
 INSERT INTO `item_weapon` VALUES (21655,'arasy_claymore_+1',4,0,242,242,188,2,1,475,252,0);
 INSERT INTO `item_weapon` VALUES (21656,'dyrnwyn',4,0,228,228,228,2,1,480,313,0);
@@ -4656,7 +4656,7 @@ INSERT INTO `item_weapon` VALUES (21660,'bery._sword_+1',4,0,242,242,118,2,1,431
 INSERT INTO `item_weapon` VALUES (21661,'rune_algol',4,0,0,0,0,2,1,489,80,0);             -- DMG:80 Delay:489
 INSERT INTO `item_weapon` VALUES (21662,'raetic_algol',4,0,242,242,215,2,1,489,326,0);    -- DMG:326 Delay:489
 INSERT INTO `item_weapon` VALUES (21663,'raetic_algol_+1',4,0,242,242,215,2,1,474,327,0); -- DMG:327 Delay:474
-INSERT INTO `item_weapon` VALUES (21664,'zantetsuken_x',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21664,'zantetsuken_x',4,0,0,0,0,1,1,456,323,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21665,'voluspa_blade',4,0,215,215,215,2,1,480,260,0);
 INSERT INTO `item_weapon` VALUES (21666,'ethereal_great_sword',4,0,0,0,0,2,1,480,1,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21667,'futhark_claymore',4,0,242,242,228,2,1,494,330,0); -- DMG:330 Delay:494
@@ -4667,10 +4667,10 @@ INSERT INTO `item_weapon` VALUES (21671,'ajja_claymore',4,0,223,223,223,2,1,480,
 INSERT INTO `item_weapon` VALUES (21672,'eletta_claymore',4,0,231,231,231,2,1,480,293,0);  -- DMG:293 Delay:480
 INSERT INTO `item_weapon` VALUES (21673,'kaja_claymore',4,0,242,242,242,2,1,480,313,0);    -- DMG:313 Delay:480
 INSERT INTO `item_weapon` VALUES (21674,'nandaka',4,0,250,250,250,2,1,480,333,0);          -- DMG:333 Delay:480
-INSERT INTO `item_weapon` VALUES (21675,'agwus_claymore',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21676,'brave_blade_iii',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21675,'agwus_claymore',4,0,0,0,0,1,1,480,320,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21676,'brave_blade_iii',4,0,0,0,0,1,1,480,331,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21677,'brave_blade_iii',4,0,0,0,0,2,1,480,366,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21680,'goujian',1,0,0,0,0,1,1,999,1,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21680,'goujian',4,0,0,0,0,1,1,480,1,0);                  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21681,'ophidian_sword',4,0,0,0,0,2,1,480,1,0);           -- DMG:1 Delay:480
 INSERT INTO `item_weapon` VALUES (21682,'lament',4,0,0,0,0,2,1,430,1,0);                   -- DMG:1 Delay:430
 INSERT INTO `item_weapon` VALUES (21683,'ragnarok',4,0,269,269,242,2,1,431,304,0);
@@ -4711,14 +4711,14 @@ INSERT INTO `item_weapon` VALUES (21719,'ajja_axe',5,0,223,223,223,2,1,288,168,0
 INSERT INTO `item_weapon` VALUES (21720,'eletta_axe',5,0,231,231,231,2,1,288,176,0);  -- DMG:176 Delay:288
 INSERT INTO `item_weapon` VALUES (21721,'kaja_axe',5,0,242,242,242,2,1,288,188,0);    -- DMG:188 Delay:288
 INSERT INTO `item_weapon` VALUES (21722,'dolichenus',5,0,250,250,250,2,1,288,200,0);  -- DMG:200 Delay:288
-INSERT INTO `item_weapon` VALUES (21723,'ikengas_axe',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21724,'agwus_axe',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21723,'ikengas_axe',5,0,0,0,0,1,1,288,192,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21724,'agwus_axe',5,0,0,0,0,1,1,288,192,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21725,'malefic_axe',5,0,269,269,269,2,1,340,234,0);
-INSERT INTO `item_weapon` VALUES (21726,'prime_pickaxe',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21727,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21728,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21729,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21730,'spalirisos',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21726,'prime_pickaxe',5,0,0,0,0,1,1,280,187,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21727,'spalirisos',5,0,0,0,0,1,1,280,187,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21728,'spalirisos',5,0,0,0,0,1,1,280,198,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21729,'spalirisos',5,0,0,0,0,1,1,280,207,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21730,'spalirisos',5,0,0,0,0,1,1,280,218,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21731,'dathaba_axe',5,0,0,0,0,2,1,276,184,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21732,'demonic_axe',5,0,0,0,0,2,1,340,259,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21741,'demonic_axe',5,0,0,0,0,2,1,288,1,0);   -- DMG:1 Delay:288
@@ -4760,14 +4760,14 @@ INSERT INTO `item_weapon` VALUES (21776,'ajja_chopper',6,0,223,223,223,2,1,508,2
 INSERT INTO `item_weapon` VALUES (21777,'eletta_chopper',6,0,231,231,231,2,1,508,317,0); -- DMG:317 Delay:508
 INSERT INTO `item_weapon` VALUES (21778,'kaja_chopper',6,0,242,242,242,2,1,508,338,0);   -- DMG:338 Delay:508
 INSERT INTO `item_weapon` VALUES (21779,'lycurgos',6,0,250,250,250,2,1,508,359,0);       -- DMG:359 Delay:508
-INSERT INTO `item_weapon` VALUES (21780,'bunzis_chopper',1,0,0,0,0,1,1,999,1,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21781,'prime_great_axe',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21782,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21783,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21784,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21785,'laphria',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21786,'poison_axe',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21787,'poison_axe_+1',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21780,'bunzis_chopper',6,0,0,0,0,1,1,504,336,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21781,'prime_great_axe',6,0,0,0,0,1,1,488,326,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21782,'laphria',6,0,0,0,0,1,1,488,326,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21783,'laphria',6,0,0,0,0,1,1,488,346,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21784,'laphria',6,0,0,0,0,1,1,488,361,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21785,'laphria',6,0,0,0,0,1,1,488,380,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21786,'poison_axe',6,0,0,0,0,1,1,504,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21787,'poison_axe_+1',6,0,0,0,0,1,1,489,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21788,'dathaba_voulge',6,0,0,0,0,2,1,504,336,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21789,'drastic_axe',6,0,0,0,0,2,1,504,385,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21804,'obschine',7,0,242,242,188,2,1,501,295,0);
@@ -4795,20 +4795,20 @@ INSERT INTO `item_weapon` VALUES (21827,'ajja_scythe',7,0,223,223,223,2,1,528,30
 INSERT INTO `item_weapon` VALUES (21828,'eletta_scythe',7,0,231,231,231,2,1,528,322,0);  -- DMG:322 Delay:528
 INSERT INTO `item_weapon` VALUES (21829,'kaja_scythe',7,0,242,242,242,2,1,528,344,0);    -- DMG:344 Delay:528
 INSERT INTO `item_weapon` VALUES (21830,'drepanum',7,0,250,250,250,2,1,528,366,0);       -- DMG:366 Delay:528
-INSERT INTO `item_weapon` VALUES (21831,'ligeia_scythe',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21831,'ligeia_scythe',7,0,0,0,0,1,1,528,300,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21832,'agwus_scythe',7,0,248,248,248,2,1,528,352,0);   -- DMG:352 Delay:528
-INSERT INTO `item_weapon` VALUES (21833,'prime_scythe',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21834,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21835,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21836,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21837,'foenaria',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21833,'prime_scythe',7,0,0,0,0,1,1,513,343,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21834,'foenaria',7,0,0,0,0,1,1,513,343,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21835,'foenaria',7,0,0,0,0,1,1,513,364,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21836,'foenaria',7,0,0,0,0,1,1,513,379,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21837,'foenaria',7,0,0,0,0,1,1,513,400,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21838,'ethereal_scythe',7,0,0,0,0,2,1,480,1,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21840,'mavens_scythe',7,0,0,0,0,2,1,480,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21841,'dathaba_sickle',7,0,0,0,0,2,1,501,334,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21842,'final_sickle',7,0,0,0,0,2,1,528,403,0);         -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21854,'reienkyo',8,0,242,242,188,2,1,480,282,0);       -- DMG:282 Delay:480
 INSERT INTO `item_weapon` VALUES (21855,'lembing',8,0,242,242,188,2,1,492,313,0);        -- DMG:313 Delay:492
-INSERT INTO `item_weapon` VALUES (21856,'geirrothr',1,0,0,0,0,1,1,999,1,0);              -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21856,'geirrothr',8,0,0,0,0,1,1,492,348,0);              -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21857,'gungnir',8,0,269,269,228,2,1,492,347,0);        -- DMG:347 Delay:492
 INSERT INTO `item_weapon` VALUES (21858,'ryunohige',8,0,269,269,228,2,1,492,307,0);      -- DMG:307 Delay:492
 INSERT INTO `item_weapon` VALUES (21859,'rhongomiant',8,0,269,269,228,2,1,492,347,0);    -- DMG:347 Delay:492
@@ -4834,14 +4834,14 @@ INSERT INTO `item_weapon` VALUES (21880,'ajja_lance',8,0,223,223,223,1,1,480,280
 INSERT INTO `item_weapon` VALUES (21881,'eletta_lance',8,0,231,231,231,1,1,480,293,0);      -- DMG:293 Delay:480
 INSERT INTO `item_weapon` VALUES (21882,'kaja_lance',8,0,242,242,242,1,1,480,313,0);        -- DMG:313 Delay:480
 INSERT INTO `item_weapon` VALUES (21883,'shining_one',8,0,250,250,250,1,1,480,333,0);       -- DMG:333 Delay:480
-INSERT INTO `item_weapon` VALUES (21884,'ikengas_lance',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21885,'hebos_spear',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21884,'ikengas_lance',8,0,0,0,0,1,1,492,328,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21885,'hebos_spear',8,0,0,0,0,1,1,492,339,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21886,'iapetus',8,0,0,0,0,1,1,492,1,0);
-INSERT INTO `item_weapon` VALUES (21887,'prime_lance',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21888,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21889,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21890,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21891,'gae_buide',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21887,'prime_lance',8,0,0,0,0,1,1,492,329,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21888,'gae_buide',8,0,0,0,0,1,1,492,329,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21889,'gae_buide',8,0,0,0,0,1,1,492,349,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21890,'gae_buide',8,0,0,0,0,1,1,492,364,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21891,'gae_buide',8,0,0,0,0,1,1,492,383,0);   -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21892,'dathaba_spear',8,0,0,0,0,1,1,396,264,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21893,'hebos_spear',8,0,0,0,0,1,1,492,375,0);             -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21904,'kanaria',9,0,242,242,188,2,1,227,127,0);
@@ -4863,14 +4863,14 @@ INSERT INTO `item_weapon` VALUES (21921,'kaja_katana',9,0,242,242,242,2,1,227,14
 INSERT INTO `item_weapon` VALUES (21922,'gokotai',9,0,250,250,250,2,1,227,157,0);       -- DMG:157 Delay:227
 INSERT INTO `item_weapon` VALUES (21923,'debahocho',9,0,0,0,0,2,1,227,1,0);             -- DMG:1 Delay:227
 INSERT INTO `item_weapon` VALUES (21924,'debahocho_+1',9,0,0,0,0,2,1,222,2,0);          -- DMG:2 Delay:222
-INSERT INTO `item_weapon` VALUES (21925,'kunimitsu',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21926,'tsuru',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21927,'yagyu_darkblade',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21928,'genshitanto',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21929,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21930,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21931,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21932,'dokoku',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21925,'kunimitsu',9,0,0,0,0,1,1,227,151,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21926,'tsuru',9,0,0,0,0,1,1,190,131,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21927,'yagyu_darkblade',9,0,0,0,0,1,1,227,156,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21928,'genshitanto',9,0,0,0,0,1,1,210,140,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21929,'dokoku',9,0,0,0,0,1,1,210,140,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21930,'dokoku',9,0,0,0,0,1,1,210,149,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21931,'dokoku',9,0,0,0,0,1,1,210,155,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21932,'dokoku',9,0,0,0,0,1,1,210,163,0);                -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21933,'yagyu_shortblade',9,0,0,0,0,2,1,227,1,0);      -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21934,'yagyu_shortblade_+1',9,0,0,0,0,2,1,222,2,0);   -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21935,'dathaba_blade',9,0,0,0,0,2,1,190,126,0);       -- TODO: Not implemented
@@ -4899,15 +4899,15 @@ INSERT INTO `item_weapon` VALUES (21974,'kaja_tachi',10,0,242,242,242,2,1,450,30
 INSERT INTO `item_weapon` VALUES (21975,'hachimonji',10,0,250,250,250,2,1,450,318,0);     -- DMG:318 Delay:450
 INSERT INTO `item_weapon` VALUES (21976,'voluspa_tachi',10,0,215,215,215,2,1,450,243,0);
 INSERT INTO `item_weapon` VALUES (21977,'mutsunokami',10,0,0,0,0,2,1,450,1,0);            -- DMG:1 Delay:450
-INSERT INTO `item_weapon` VALUES (21978,'mutsunokami_+1',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21979,'gekkei',1,0,0,0,0,1,1,999,1,0);                  -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21980,'zanmato_+2',1,0,0,0,0,1,1,999,1,0);              -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21981,'mutsu-no-kami_yoshiyuki',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21982,'genshito',1,0,0,0,0,1,1,999,1,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21983,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21984,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21985,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21986,'kusanagi-no-tsurugi',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21978,'mutsunokami_+1',10,0,0,0,0,1,1,437,2,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21979,'gekkei',10,0,0,0,0,1,1,450,300,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21980,'zanmato_+2',10,0,0,0,0,1,1,464,320,0);              -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21981,'mutsu-no-kami_yoshiyuki',10,0,0,0,0,1,1,450,310,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21982,'genshito',10,0,0,0,0,1,1,437,292,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21983,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,292,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21984,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,310,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21985,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,323,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21986,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,340,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21990,'dathaba_tachi',10,0,0,0,0,2,1,420,280,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21991,'wizards_rod',11,0,0,0,0,3,1,216,165,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21992,'dathaba_wand',11,0,0,0,0,3,1,216,144,0);         -- TODO: Not implemented
@@ -4916,11 +4916,11 @@ INSERT INTO `item_weapon` VALUES (21994,'erudites_staff_+1',12,0,0,0,0,3,1,399,2
 INSERT INTO `item_weapon` VALUES (21995,'mavens_staff',12,0,0,0,0,3,1,288,1,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21996,'magicians_rod',11,0,0,0,0,3,1,216,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21997,'magicians_rod_+1',11,0,0,0,0,3,1,210,2,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21998,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21999,'prime_maul',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22000,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22001,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22002,'lorg_mor',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21998,'lorg_mor',11,0,0,0,0,1,1,308,240,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21999,'prime_maul',11,0,0,0,0,1,1,308,206,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22000,'lorg_mor',11,0,0,0,0,1,1,308,206,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22001,'lorg_mor',11,0,0,0,0,1,1,308,218,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22002,'lorg_mor',11,0,0,0,0,1,1,308,227,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22003,'arthros_scepter',11,0,0,0,0,3,1,288,1,0);  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22004,'soulflayers_wand',11,0,0,0,0,3,1,264,1,0); -- DMG:1 Delay:264
 INSERT INTO `item_weapon` VALUES (22005,'burrowers_wand',11,0,0,0,0,3,1,264,1,0);   -- DMG:1 Delay:264
@@ -4942,7 +4942,7 @@ INSERT INTO `item_weapon` VALUES (22028,'ajja_rod',11,0,223,223,223,3,1,288,168,
 INSERT INTO `item_weapon` VALUES (22029,'eletta_rod',11,0,231,231,231,3,1,288,176,0);        -- DMG:176 Delay:288
 INSERT INTO `item_weapon` VALUES (22030,'kaja_rod',11,0,242,242,242,3,1,288,188,0);          -- DMG:188 Delay:288
 INSERT INTO `item_weapon` VALUES (22031,'maxentius',11,0,250,250,250,3,1,288,200,0);         -- DMG:200 Delay:288
-INSERT INTO `item_weapon` VALUES (22032,'thunder_hammer',1,0,0,0,0,1,1,999,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22032,'thunder_hammer',11,0,0,0,0,1,1,216,1,0);             -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22033,'clerics_wand',11,0,228,228,242,3,1,288,192,0);      -- DMG:192 Delay:288
 INSERT INTO `item_weapon` VALUES (22034,'piety_wand',11,0,242,242,255,3,1,280,193,0);        -- DMG:193 Delay:280
 INSERT INTO `item_weapon` VALUES (22035,'asclepius',11,0,255,255,269,3,1,280,194,0);         -- DMG:194 Delay:280
@@ -4951,18 +4951,18 @@ INSERT INTO `item_weapon` VALUES (22037,'sifang_wand',11,0,242,242,255,3,1,280,1
 INSERT INTO `item_weapon` VALUES (22038,'bhima',11,0,255,255,269,3,1,280,194,0);             -- DMG:194 Delay:280
 INSERT INTO `item_weapon` VALUES (22039,'floral_hagoita',11,0,0,0,0,3,1,264,2,0);            -- DMG:2 Delay:264
 INSERT INTO `item_weapon` VALUES (22040,'daybreak',11,0,228,228,242,3,1,216,150,0);
-INSERT INTO `item_weapon` VALUES (22041,'bunzis_rod',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22042,'wizards_rod',11,0,250,250,250,3,1,216,200,0);
-INSERT INTO `item_weapon` VALUES (22043,'apkallu_scepter',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22044,'tengu_war_fan',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22045,'feline_hagoita',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22046,'feline_hagoita_+1',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22047,'korrigan_mallet',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22048,'adenium_mallet',1,0,0,0,0,1,1,999,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22049,'citrullus_mallet',1,0,0,0,0,1,1,999,1,0);  -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22050,'chac-chacs',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22051,'lycopodium_mallet',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22052,'summer_uchiwa',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22041,'bunzis_rod',11,0,0,0,0,1,1,216,144,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22042,'wizards_rod',11,0,250,250,250,3,1,216,149,0);
+INSERT INTO `item_weapon` VALUES (22043,'apkallu_scepter',11,0,0,0,0,1,1,216,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22044,'tengu_war_fan',11,0,0,0,0,1,1,216,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22045,'feline_hagoita',11,0,0,0,0,1,1,264,2,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22046,'feline_hagoita_+1',11,0,0,0,0,1,1,257,3,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22047,'korrigan_mallet',11,0,0,0,0,1,1,288,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22048,'adenium_mallet',11,0,0,0,0,1,1,288,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22049,'citrullus_mallet',11,0,0,0,0,1,1,288,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22050,'chac-chacs',11,0,0,0,0,1,1,288,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22051,'lycopodium_mallet',11,0,0,0,0,1,1,288,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22052,'summer_uchiwa',11,0,0,0,0,1,1,216,1,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22053,'ethereal_club',11,0,0,0,0,3,1,288,1,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22054,'grioavolr',12,0,242,242,228,3,1,366,202,0);
 INSERT INTO `item_weapon` VALUES (22055,'oranyan',12,0,242,242,228,3,1,366,230,0);
@@ -4980,7 +4980,7 @@ INSERT INTO `item_weapon` VALUES (22067,'levin',12,0,0,0,0,3,1,366,1,0);        
 INSERT INTO `item_weapon` VALUES (22068,'savage._pole',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22069,'hapy_staff',12,0,0,0,0,3,1,366,1,0);    -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22070,'ranine_staff',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22071,'profane_staff',1,0,0,0,0,1,1,999,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22071,'profane_staff',12,0,0,0,0,1,1,366,1,0);  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22072,'lamia_staff',12,0,0,0,0,3,1,366,1,0);   -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22074,'arasy_staff',12,0,242,242,228,3,1,366,188,0);
 INSERT INTO `item_weapon` VALUES (22075,'arasy_staff_+1',12,0,242,242,228,3,1,356,189,0);
@@ -5010,11 +5010,11 @@ INSERT INTO `item_weapon` VALUES (22098,'pedagogy_staff',12,0,242,242,255,3,1,39
 INSERT INTO `item_weapon` VALUES (22099,'musa',12,0,255,255,269,3,1,399,276,0);           -- DMG:276 Delay:399
 INSERT INTO `item_weapon` VALUES (22100,'mpacas_staff',12,0,242,242,255,3,1,402,268,0); -- DMG:268 Delay:402
 INSERT INTO `item_weapon` VALUES (22101,'pandits_staff',12,0,269,269,269,3,1,412,284,0);
-INSERT INTO `item_weapon` VALUES (22102,'prime_staff',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22103,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22104,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22105,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22106,'opashoro',1,0,0,0,0,1,1,999,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22102,'prime_staff',12,0,0,0,0,1,1,390,261,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22103,'opashoro',12,0,0,0,0,1,1,390,261,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22104,'opashoro',12,0,0,0,0,1,1,390,276,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22105,'opashoro',12,0,0,0,0,1,1,390,288,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22106,'opashoro',12,0,0,0,0,1,1,390,304,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22107,'ullr',25,0,250,0,0,1,1,360,178,0);         -- DMG:178 Delay:360
 INSERT INTO `item_weapon` VALUES (22108,'tokko_bow',25,0,215,0,0,1,1,360,136,0);    -- DMG:136 Delay:360
 INSERT INTO `item_weapon` VALUES (22109,'ajja_bow',25,0,223,0,0,1,1,360,147,0);     -- DMG:147 Delay:360
@@ -5058,21 +5058,21 @@ INSERT INTO `item_weapon` VALUES (22146,'ethereal_bow',25,0,0,0,0,1,1,540,1,0); 
 INSERT INTO `item_weapon` VALUES (22147,'scouts_crossbow',26,0,242,0,0,1,1,288,126,0); -- DMG:126 Delay:288
 INSERT INTO `item_weapon` VALUES (22148,'arke_crossbow',26,0,255,0,0,1,1,280,127,0);   -- DMG:127 Delay:280
 INSERT INTO `item_weapon` VALUES (22149,'sharanga',26,0,269,0,0,1,1,280,128,0);        -- DMG:128 Delay:280
-INSERT INTO `item_weapon` VALUES (22150,'gletis_crossbow',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22151,'mpacas_bow',1,0,0,0,0,1,1,999,1,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22152,'exeter',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22150,'gletis_crossbow',26,0,0,0,0,1,1,432,115,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22151,'mpacas_bow',25,0,0,0,0,1,1,540,271,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22152,'exeter',26,0,0,0,0,1,1,600,150,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22153,'silver_gun',26,1,0,0,0,1,1,600,1,0);          -- DMG:1 Delay:600
 INSERT INTO `item_weapon` VALUES (22154,'silver_gun_+1',26,1,0,0,0,1,1,582,2,0);       -- DMG:2 Delay:582
-INSERT INTO `item_weapon` VALUES (22155,'prime_bow',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22156,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22157,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22158,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22159,'prime_gun',1,0,0,0,0,1,1,999,1,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22160,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22161,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22162,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22163,'pinaka',1,0,0,0,0,1,1,999,1,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22164,'earp',1,0,0,0,0,1,1,999,1,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22155,'prime_bow',25,0,0,0,0,1,1,524,277,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22156,'pinaka',25,0,0,0,0,1,1,524,277,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22157,'pinaka',25,0,0,0,0,1,1,524,293,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22158,'pinaka',25,0,0,0,0,1,1,524,309,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22159,'prime_gun',26,0,0,0,0,1,1,582,128,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22160,'earp',26,0,0,0,0,1,1,582,128,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22161,'earp',26,0,0,0,0,1,1,582,139,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22162,'earp',26,0,0,0,0,1,1,582,151,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22163,'pinaka',25,0,0,0,0,1,1,524,324,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22164,'earp',26,0,0,0,0,1,1,582,162,0);                 -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22165,'ethereal_gun',26,0,0,0,0,1,1,600,1,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22166,'dathaba_bow',25,0,0,0,0,1,1,360,210,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22167,'dathaba_crossbow',26,0,0,0,0,1,1,288,128,0);  -- TODO: Not implemented
@@ -5156,13 +5156,13 @@ INSERT INTO `item_weapon` VALUES (22299,'per._lucky_egg',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22300,'crepuscular_pebble',0,0,0,0,0,0,0,0,0,0);
 INSERT INTO `item_weapon` VALUES (22301,'sroda_tathlum',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22302,'oshashas_treatise',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22303,'prime_horn',1,0,0,0,0,1,1,999,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22304,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22305,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22306,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22307,'loughnashade',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22308,'bayeux_bullet',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22309,'bayeux_arrow',1,0,0,0,0,1,1,999,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22303,'prime_horn',1,0,0,0,0,1,1,240,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22304,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22305,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22306,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22307,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22308,'bayeux_bullet',26,0,0,0,0,1,1,240,315,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22309,'bayeux_arrow',25,0,0,0,0,1,1,90,116,0);      -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22310,'hoxne_ampulla',0,0,0,0,0,0,1,999,0,0);     -- TODO: Not implemented
 
 /*!40000 ALTER TABLE `item_weapon` ENABLE KEYS */;

--- a/sql/item_weapon.sql
+++ b/sql/item_weapon.sql
@@ -952,24 +952,24 @@ INSERT INTO `item_weapon` VALUES (17313,'grenade',27,0,0,0,0,1,1,300,13,0);
 INSERT INTO `item_weapon` VALUES (17314,'quake_grenade',27,0,0,0,0,1,1,300,18,0);
 INSERT INTO `item_weapon` VALUES (17315,'riot_grenade',27,0,0,0,0,1,1,300,21,0);
 INSERT INTO `item_weapon` VALUES (17316,'bomb_arm',27,0,0,0,0,1,1,300,6,0);
-INSERT INTO `item_weapon` VALUES (17317,'gold_arrow',25,0,0,0,0,0,1,93,17,0);
-INSERT INTO `item_weapon` VALUES (17318,'wooden_arrow',25,0,0,0,0,0,1,120,5,0);
-INSERT INTO `item_weapon` VALUES (17319,'bone_arrow',25,0,0,0,0,0,1,120,9,0);
-INSERT INTO `item_weapon` VALUES (17320,'iron_arrow',25,0,0,0,0,0,1,120,14,0);
-INSERT INTO `item_weapon` VALUES (17321,'silver_arrow',25,0,0,0,0,0,1,120,19,0);
-INSERT INTO `item_weapon` VALUES (17322,'fire_arrow',25,0,0,0,0,0,1,120,29,0);
-INSERT INTO `item_weapon` VALUES (17323,'ice_arrow',25,0,0,0,0,0,1,120,29,0);
-INSERT INTO `item_weapon` VALUES (17324,'lightning_arrow',25,0,0,0,0,0,1,120,29,0);
-INSERT INTO `item_weapon` VALUES (17325,'kabura_arrow',25,0,0,0,0,0,1,90,38,0);
-INSERT INTO `item_weapon` VALUES (17326,'judges_arrow',25,0,0,0,0,0,1,120,100,0);
-INSERT INTO `item_weapon` VALUES (17327,'gnd.kgt._arrow',25,0,0,0,0,0,1,50,10,0);
+INSERT INTO `item_weapon` VALUES (17317,'gold_arrow',25,0,0,0,0,1,1,93,17,0);
+INSERT INTO `item_weapon` VALUES (17318,'wooden_arrow',25,0,0,0,0,1,1,120,5,0);
+INSERT INTO `item_weapon` VALUES (17319,'bone_arrow',25,0,0,0,0,1,1,120,9,0);
+INSERT INTO `item_weapon` VALUES (17320,'iron_arrow',25,0,0,0,0,1,1,120,14,0);
+INSERT INTO `item_weapon` VALUES (17321,'silver_arrow',25,0,0,0,0,1,1,120,19,0);
+INSERT INTO `item_weapon` VALUES (17322,'fire_arrow',25,0,0,0,0,1,1,120,29,0);
+INSERT INTO `item_weapon` VALUES (17323,'ice_arrow',25,0,0,0,0,1,1,120,29,0);
+INSERT INTO `item_weapon` VALUES (17324,'lightning_arrow',25,0,0,0,0,1,1,120,29,0);
+INSERT INTO `item_weapon` VALUES (17325,'kabura_arrow',25,0,0,0,0,1,1,90,38,0);
+INSERT INTO `item_weapon` VALUES (17326,'judges_arrow',25,0,0,0,0,1,1,120,100,0);
+INSERT INTO `item_weapon` VALUES (17327,'gnd.kgt._arrow',25,0,0,0,0,1,1,50,10,0);
 INSERT INTO `item_weapon` VALUES (17328,'gld.msk._bolt',26,0,0,0,0,1,1,140,60,0);
-INSERT INTO `item_weapon` VALUES (17329,'ptr.prt._arrow',25,0,0,0,0,0,1,120,40,0);
-INSERT INTO `item_weapon` VALUES (17330,'stone_arrow',25,0,0,0,0,0,1,120,5,0);
-INSERT INTO `item_weapon` VALUES (17331,'old_arrow',25,0,0,0,0,0,1,126,4,0);
-INSERT INTO `item_weapon` VALUES (17332,'fang_arrow',25,0,0,0,0,0,1,90,15,0);
-INSERT INTO `item_weapon` VALUES (17333,'rune_arrow',25,0,0,0,0,0,1,120,32,0);
-INSERT INTO `item_weapon` VALUES (17334,'platinum_arrow',25,0,0,0,0,0,1,93,20,0);
+INSERT INTO `item_weapon` VALUES (17329,'ptr.prt._arrow',25,0,0,0,0,1,1,120,40,0);
+INSERT INTO `item_weapon` VALUES (17330,'stone_arrow',25,0,0,0,0,1,1,120,5,0);
+INSERT INTO `item_weapon` VALUES (17331,'old_arrow',25,0,0,0,0,1,1,126,4,0);
+INSERT INTO `item_weapon` VALUES (17332,'fang_arrow',25,0,0,0,0,1,1,90,15,0);
+INSERT INTO `item_weapon` VALUES (17333,'rune_arrow',25,0,0,0,0,1,1,120,32,0);
+INSERT INTO `item_weapon` VALUES (17334,'platinum_arrow',25,0,0,0,0,1,1,93,20,0);
 INSERT INTO `item_weapon` VALUES (17335,'rusty_bolt',26,0,0,0,0,1,1,200,9,0);
 INSERT INTO `item_weapon` VALUES (17336,'crossbow_bolt',26,0,0,0,0,1,1,192,10,0);
 INSERT INTO `item_weapon` VALUES (17337,'mythril_bolt',26,0,0,0,0,1,1,192,40,0);
@@ -1489,8 +1489,8 @@ INSERT INTO `item_weapon` VALUES (17851,'storm_fife',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17852,'requiem_flute',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17853,'iron_ram_horn',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17854,'cradle_horn',42,0,0,0,0,0,1,240,0,0);
-INSERT INTO `item_weapon` VALUES (17855,'ney',42,0,0,0,0,1,1,240,0,0);
-INSERT INTO `item_weapon` VALUES (17856,'syrinx',42,0,0,0,0,1,1,240,0,0);
+INSERT INTO `item_weapon` VALUES (17855,'ney',42,0,0,0,0,0,1,240,0,0);
+INSERT INTO `item_weapon` VALUES (17856,'syrinx',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17857,'animator_+1',0,10,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17858,'turbo_animator',0,10,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (17859,'animator',0,10,0,0,0,0,1,240,0,0);
@@ -1788,12 +1788,12 @@ INSERT INTO `item_weapon` VALUES (18150,'blind_bolt',26,0,0,0,0,1,1,192,18,0);
 INSERT INTO `item_weapon` VALUES (18151,'bloody_bolt',26,0,0,0,0,1,1,240,1,0);
 INSERT INTO `item_weapon` VALUES (18152,'venom_bolt',26,0,0,0,0,1,1,192,29,0);
 INSERT INTO `item_weapon` VALUES (18153,'holy_bolt',26,0,0,0,0,1,1,192,32,0);
-INSERT INTO `item_weapon` VALUES (18154,'beetle_arrow',25,0,0,0,0,0,1,90,12,0);
-INSERT INTO `item_weapon` VALUES (18155,'scorpion_arrow',25,0,0,0,0,0,1,90,24,0);
-INSERT INTO `item_weapon` VALUES (18156,'horn_arrow',25,0,0,0,0,0,1,90,17,0);
-INSERT INTO `item_weapon` VALUES (18157,'poison_arrow',25,0,0,0,0,0,1,120,16,0);
-INSERT INTO `item_weapon` VALUES (18158,'sleep_arrow',25,0,0,0,0,0,1,90,1,0);
-INSERT INTO `item_weapon` VALUES (18159,'demon_arrow',25,0,0,0,0,0,1,90,34,0);
+INSERT INTO `item_weapon` VALUES (18154,'beetle_arrow',25,0,0,0,0,1,1,90,12,0);
+INSERT INTO `item_weapon` VALUES (18155,'scorpion_arrow',25,0,0,0,0,1,1,90,24,0);
+INSERT INTO `item_weapon` VALUES (18156,'horn_arrow',25,0,0,0,0,1,1,90,17,0);
+INSERT INTO `item_weapon` VALUES (18157,'poison_arrow',25,0,0,0,0,1,1,120,16,0);
+INSERT INTO `item_weapon` VALUES (18158,'sleep_arrow',25,0,0,0,0,1,1,90,1,0);
+INSERT INTO `item_weapon` VALUES (18159,'demon_arrow',25,0,0,0,0,1,1,90,34,0);
 INSERT INTO `item_weapon` VALUES (18160,'spartan_bullet',26,1,0,0,0,1,1,240,1,0);
 INSERT INTO `item_weapon` VALUES (18161,'arctic_wind',27,0,0,0,0,1,1,276,250,0);
 INSERT INTO `item_weapon` VALUES (18162,'east_wind',27,0,0,0,0,1,1,276,250,0);
@@ -1812,16 +1812,16 @@ INSERT INTO `item_weapon` VALUES (18174,'mantra_coin',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18175,'optical_needle',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18176,'nazar_bonjuk',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18177,'kakanpu',0,0,0,0,0,0,1,999,0,0);
-INSERT INTO `item_weapon` VALUES (18178,'bodkin_arrow',25,0,0,0,0,0,1,90,28,0);
+INSERT INTO `item_weapon` VALUES (18178,'bodkin_arrow',25,0,0,0,0,1,1,90,28,0);
 INSERT INTO `item_weapon` VALUES (18180,'goblin_grenade',0,0,0,0,0,0,1,999,0,0);
-INSERT INTO `item_weapon` VALUES (18181,'crude_arrow',25,0,0,0,0,0,1,126,7,0);
-INSERT INTO `item_weapon` VALUES (18182,'crude_arrow_+1',25,0,0,0,0,0,1,126,12,0);
-INSERT INTO `item_weapon` VALUES (18183,'crude_arrow_+2',25,0,0,0,0,0,1,126,14,0);
-INSERT INTO `item_weapon` VALUES (18184,'crude_arrow_+3',25,0,0,0,0,0,1,126,15,0);
-INSERT INTO `item_weapon` VALUES (18185,'crude_arrow_+4',25,0,0,0,0,0,1,126,20,0);
-INSERT INTO `item_weapon` VALUES (18186,'crude_arrow_+5',25,0,0,0,0,0,1,126,23,0);
-INSERT INTO `item_weapon` VALUES (18187,'crude_arrow_+6',25,0,0,0,0,0,1,126,26,0);
-INSERT INTO `item_weapon` VALUES (18188,'crude_arrow_+7',25,0,0,0,0,0,1,126,30,0);
+INSERT INTO `item_weapon` VALUES (18181,'crude_arrow',25,0,0,0,0,1,1,126,7,0);
+INSERT INTO `item_weapon` VALUES (18182,'crude_arrow_+1',25,0,0,0,0,1,1,126,12,0);
+INSERT INTO `item_weapon` VALUES (18183,'crude_arrow_+2',25,0,0,0,0,1,1,126,14,0);
+INSERT INTO `item_weapon` VALUES (18184,'crude_arrow_+3',25,0,0,0,0,1,1,126,15,0);
+INSERT INTO `item_weapon` VALUES (18185,'crude_arrow_+4',25,0,0,0,0,1,1,126,20,0);
+INSERT INTO `item_weapon` VALUES (18186,'crude_arrow_+5',25,0,0,0,0,1,1,126,23,0);
+INSERT INTO `item_weapon` VALUES (18187,'crude_arrow_+6',25,0,0,0,0,1,1,126,26,0);
+INSERT INTO `item_weapon` VALUES (18188,'crude_arrow_+7',25,0,0,0,0,1,1,126,30,0);
 INSERT INTO `item_weapon` VALUES (18189,'dogbolt',26,0,0,0,0,1,1,200,16,0);
 INSERT INTO `item_weapon` VALUES (18190,'dogbolt_+1',26,0,0,0,0,1,1,200,18,0);
 INSERT INTO `item_weapon` VALUES (18191,'dogbolt_+2',26,0,0,0,0,1,1,200,25,0);
@@ -2190,7 +2190,7 @@ INSERT INTO `item_weapon` VALUES (18562,'yhatdhara_+1',7,0,0,0,0,2,1,466,120,0);
 INSERT INTO `item_weapon` VALUES (18563,'ark_scythe',7,0,0,0,0,2,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (18564,'devilish_scythe',7,0,0,0,0,2,1,528,130,0);
 INSERT INTO `item_weapon` VALUES (18565,'adflictio',7,0,0,0,0,2,1,513,134,0);
-INSERT INTO `item_weapon` VALUES (18566,'crepuscular_scythe',7,0,0,0,0,1,1,513,360,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (18566,'crepuscular_scythe',7,0,0,0,0,2,1,513,360,0); -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (18571,'daurdabla',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18572,'gjallarhorn',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18573,'pyf_harp',41,0,0,0,0,0,1,240,0,0);
@@ -2315,11 +2315,11 @@ INSERT INTO `item_weapon` VALUES (18692,'mamoolbane',27,0,0,0,0,1,1,294,1,0);
 INSERT INTO `item_weapon` VALUES (18693,'lamiabane',27,0,0,0,0,1,1,294,1,0);
 INSERT INTO `item_weapon` VALUES (18694,'trollbane',27,0,0,0,0,1,1,294,1,0);
 INSERT INTO `item_weapon` VALUES (18695,'cerberus_bow',25,4,0,0,0,1,1,600,72,0);
-INSERT INTO `item_weapon` VALUES (18696,'paralysis_arrow',25,0,0,0,0,0,1,90,1,0);
-INSERT INTO `item_weapon` VALUES (18697,'marid_arrow',25,0,0,0,0,0,1,90,36,0);
-INSERT INTO `item_weapon` VALUES (18698,'water_arrow',25,0,0,0,0,0,1,90,27,0);
-INSERT INTO `item_weapon` VALUES (18699,'earth_arrow',25,0,0,0,0,0,1,90,27,0);
-INSERT INTO `item_weapon` VALUES (18700,'wind_arrow',25,0,0,0,0,0,1,90,27,0);
+INSERT INTO `item_weapon` VALUES (18696,'paralysis_arrow',25,0,0,0,0,1,1,90,1,0);
+INSERT INTO `item_weapon` VALUES (18697,'marid_arrow',25,0,0,0,0,1,1,90,36,0);
+INSERT INTO `item_weapon` VALUES (18698,'water_arrow',25,0,0,0,0,1,1,90,27,0);
+INSERT INTO `item_weapon` VALUES (18699,'earth_arrow',25,0,0,0,0,1,1,90,27,0);
+INSERT INTO `item_weapon` VALUES (18700,'wind_arrow',25,0,0,0,0,1,1,90,27,0);
 INSERT INTO `item_weapon` VALUES (18701,'cerberus_bow_+1',25,4,0,0,0,1,1,582,73,0);
 INSERT INTO `item_weapon` VALUES (18702,'trump_gun',26,1,0,0,0,1,1,480,28,0);
 INSERT INTO `item_weapon` VALUES (18703,'shark_gun',26,1,0,0,0,1,1,582,39,0);
@@ -2349,7 +2349,7 @@ INSERT INTO `item_weapon` VALUES (18726,'peiste_dart',27,0,0,0,0,1,1,162,15,0);
 INSERT INTO `item_weapon` VALUES (18727,'fourth_gun',26,1,0,0,0,1,1,582,37,0);
 INSERT INTO `item_weapon` VALUES (18728,'cobra_bow',25,4,0,0,0,1,1,524,77,0);
 INSERT INTO `item_weapon` VALUES (18729,'djinn_arm',27,0,0,0,0,1,1,300,8,0);
-INSERT INTO `item_weapon` VALUES (18730,'obsidian_arrow',25,0,0,0,0,0,1,90,30,0);
+INSERT INTO `item_weapon` VALUES (18730,'obsidian_arrow',25,0,0,0,0,1,1,90,30,0);
 INSERT INTO `item_weapon` VALUES (18731,'automaton_oil',0,10,0,0,0,542,1,84,527,0);
 INSERT INTO `item_weapon` VALUES (18732,'automat._oil_+1',0,10,0,0,0,572,1,84,542,0);
 INSERT INTO `item_weapon` VALUES (18733,'automat._oil_+2',0,10,0,0,0,602,1,84,557,0);
@@ -2357,9 +2357,9 @@ INSERT INTO `item_weapon` VALUES (18734,'sturms_report',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18735,'sonias_plectrum',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (18736,'fay_gendawa',25,4,0,0,0,1,1,540,72,0);
 INSERT INTO `item_weapon` VALUES (18737,'fane_hexagun',26,1,0,0,0,1,1,480,28,0);
-INSERT INTO `item_weapon` VALUES (18738,'t.k._arrow',25,0,0,0,0,0,1,50,10,0);
-INSERT INTO `item_weapon` VALUES (18739,'irn.msk._bolt',26,0,0,0,0,0,1,140,60,0);
-INSERT INTO `item_weapon` VALUES (18740,'cmb.cst._arrow',25,0,0,0,0,0,1,120,40,0);
+INSERT INTO `item_weapon` VALUES (18738,'t.k._arrow',25,0,0,0,0,1,1,50,10,0);
+INSERT INTO `item_weapon` VALUES (18739,'irn.msk._bolt',26,0,0,0,0,1,1,140,60,0);
+INSERT INTO `item_weapon` VALUES (18740,'cmb.cst._arrow',25,0,0,0,0,1,1,120,40,0);
 INSERT INTO `item_weapon` VALUES (18741,'scogans_knuckles',1,0,0,0,0,4,1,576,15,0);
 INSERT INTO `item_weapon` VALUES (18742,'puppet_claws',1,0,0,0,0,4,1,546,12,0);
 INSERT INTO `item_weapon` VALUES (18743,'darksteel_sainti',1,0,0,0,0,4,1,531,12,0);
@@ -2445,8 +2445,8 @@ INSERT INTO `item_weapon` VALUES (18828,'oxossi_facon_+1',2,0,0,0,0,1,1,194,51,0
 INSERT INTO `item_weapon` VALUES (18829,'blustery_dagger',2,0,0,0,0,1,1,205,49,0);
 INSERT INTO `item_weapon` VALUES (18830,'gusterion',2,0,0,0,0,1,1,200,50,0);
 INSERT INTO `item_weapon` VALUES (18831,'crooners_cithara',41,0,0,0,0,0,1,240,0,0);
-INSERT INTO `item_weapon` VALUES (18832,'apollos_flute',42,0,0,0,0,1,1,240,0,0);
-INSERT INTO `item_weapon` VALUES (18833,'cantabanks_horn',42,0,0,0,0,1,1,240,0,0);
+INSERT INTO `item_weapon` VALUES (18832,'apollos_flute',42,0,0,0,0,0,1,240,0,0);
+INSERT INTO `item_weapon` VALUES (18833,'cantabanks_horn',42,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18834,'vihuela',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18839,'daurdabla',41,0,0,0,0,0,1,240,0,0);
 INSERT INTO `item_weapon` VALUES (18840,'gjallarhorn',42,0,0,0,0,0,1,240,0,0);
@@ -2694,7 +2694,7 @@ INSERT INTO `item_weapon` VALUES (19087,'liberator',7,0,0,0,0,2,1,528,122,0);
 INSERT INTO `item_weapon` VALUES (19088,'aymur',5,0,0,0,0,2,1,312,69,0);
 INSERT INTO `item_weapon` VALUES (19089,'carnwenhan',2,0,0,0,0,1,1,186,39,0);
 INSERT INTO `item_weapon` VALUES (19090,'gastraphetes',26,0,0,0,0,1,1,432,62,0);
-INSERT INTO `item_weapon` VALUES (19091,'kogarasumaru',10,0,0,0,0,1,1,450,104,0);
+INSERT INTO `item_weapon` VALUES (19091,'kogarasumaru',10,0,0,0,0,2,1,450,104,0);
 INSERT INTO `item_weapon` VALUES (19092,'nagi',9,0,0,0,0,2,1,227,51,0);
 INSERT INTO `item_weapon` VALUES (19093,'ryunohige',8,0,0,0,0,1,1,492,118,0);
 INSERT INTO `item_weapon` VALUES (19094,'nirvana',12,0,0,0,0,3,1,402,85,0);
@@ -2783,11 +2783,11 @@ INSERT INTO `item_weapon` VALUES (19176,'irasya',4,0,0,0,0,2,1,480,132,0);
 INSERT INTO `item_weapon` VALUES (19177,'etourdissante',4,0,0,0,0,2,1,456,120,0);
 INSERT INTO `item_weapon` VALUES (19178,'etourdissante_+1',4,0,0,0,0,2,1,443,121,0);
 INSERT INTO `item_weapon` VALUES (19179,'dervish_sword',4,0,0,0,0,2,1,504,130,0);
-INSERT INTO `item_weapon` VALUES (19180,'omphalos_bullet',26,1,0,0,0,0,1,240,89,0);
+INSERT INTO `item_weapon` VALUES (19180,'omphalos_bullet',26,1,0,0,0,1,1,240,89,0);
 INSERT INTO `item_weapon` VALUES (19181,'moogles_largesse',0,0,0,0,0,0,1,999,0,0);
-INSERT INTO `item_weapon` VALUES (19182,'ruszor_arrow',25,0,0,0,0,0,1,90,46,0);
-INSERT INTO `item_weapon` VALUES (19183,'drk._adm._bolt',26,0,0,0,0,0,1,192,67,0);
-INSERT INTO `item_weapon` VALUES (19184,'drk._adm._bullet',26,1,0,0,0,0,1,240,105,0);
+INSERT INTO `item_weapon` VALUES (19182,'ruszor_arrow',25,0,0,0,0,1,1,90,46,0);
+INSERT INTO `item_weapon` VALUES (19183,'drk._adm._bolt',26,0,0,0,0,1,1,192,67,0);
+INSERT INTO `item_weapon` VALUES (19184,'drk._adm._bullet',26,1,0,0,0,1,1,240,105,0);
 INSERT INTO `item_weapon` VALUES (19185,'automat._oil_+3',0,10,0,0,0,0,1,84,572,0);
 INSERT INTO `item_weapon` VALUES (19186,'tiny_tathlum',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (19187,'murti_bow',25,0,0,0,0,1,1,524,91,0);
@@ -2812,7 +2812,7 @@ INSERT INTO `item_weapon` VALUES (19205,'blank_f._plate',0,0,0,0,0,0,1,15,0,0);
 INSERT INTO `item_weapon` VALUES (19206,'silver_cassandra',26,1,0,0,0,1,1,480,33,0);
 INSERT INTO `item_weapon` VALUES (19207,'great_cassandra',26,1,0,0,0,1,1,466,34,0);
 INSERT INTO `item_weapon` VALUES (19208,'grand_crossbow',26,0,0,0,0,1,1,288,38,0);
-INSERT INTO `item_weapon` VALUES (19209,'molybdosis',26,0,242,0,0,0,1,480,103,0);
+INSERT INTO `item_weapon` VALUES (19209,'molybdosis',26,0,242,0,0,1,1,480,103,0);
 INSERT INTO `item_weapon` VALUES (19210,'stygian_ash',27,0,0,0,0,1,1,168,21,0);
 INSERT INTO `item_weapon` VALUES (19211,'reacton_arm',0,0,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (19212,'black_tathlum',0,0,0,0,0,0,1,999,0,0);
@@ -3400,10 +3400,10 @@ INSERT INTO `item_weapon` VALUES (19796,'rosschinder',8,0,0,0,0,1,1,396,95,0);
 INSERT INTO `item_weapon` VALUES (19797,'rosschinder_+1',8,0,0,0,0,1,1,385,96,0);
 INSERT INTO `item_weapon` VALUES (19798,'drakaina_lance',8,0,0,0,0,1,1,492,131,0);
 INSERT INTO `item_weapon` VALUES (19799,'herjas_fork',8,0,0,0,0,1,1,492,141,0);
-INSERT INTO `item_weapon` VALUES (19800,'gargouille_arrow',25,0,0,0,0,0,1,90,51,0);
-INSERT INTO `item_weapon` VALUES (19801,'adaman_bolt',26,0,0,0,0,0,1,192,81,0);
-INSERT INTO `item_weapon` VALUES (19802,'orichalc._bullet',26,1,0,0,0,0,1,240,89,0);
-INSERT INTO `item_weapon` VALUES (19803,'adaman_bullet',26,1,0,0,0,0,1,240,127,0);
+INSERT INTO `item_weapon` VALUES (19800,'gargouille_arrow',25,0,0,0,0,1,1,90,51,0);
+INSERT INTO `item_weapon` VALUES (19801,'adaman_bolt',26,0,0,0,0,1,1,192,81,0);
+INSERT INTO `item_weapon` VALUES (19802,'orichalc._bullet',26,1,0,0,0,1,1,240,89,0);
+INSERT INTO `item_weapon` VALUES (19803,'adaman_bullet',26,1,0,0,0,1,1,240,127,0);
 INSERT INTO `item_weapon` VALUES (19805,'verethragna',1,0,0,0,0,4,1,531,42,0);
 INSERT INTO `item_weapon` VALUES (19806,'twashtar',2,0,0,0,0,1,1,176,55,0);
 INSERT INTO `item_weapon` VALUES (19807,'almace',3,0,0,0,0,2,1,224,70,0);
@@ -3753,10 +3753,10 @@ INSERT INTO `item_weapon` VALUES (20702,'emissary',3,0,242,242,201,2,1,240,123,0
 INSERT INTO `item_weapon` VALUES (20703,'deacon_saber',3,0,242,242,201,2,1,240,145,0);
 INSERT INTO `item_weapon` VALUES (20704,'deacon_sword',3,0,242,242,188,2,1,264,158,0);
 INSERT INTO `item_weapon` VALUES (20705,'brilliance',3,0,242,242,201,2,1,228,120,0);
-INSERT INTO `item_weapon` VALUES (20706,'vampirism',3,0,242,242,201,2,1,240,127,0);
+INSERT INTO `item_weapon` VALUES (20706,'vampirism',3,0,242,242,201,1,1,240,127,0);
 INSERT INTO `item_weapon` VALUES (20707,'medeina_kilij',3,0,242,242,201,2,1,236,130,0);
-INSERT INTO `item_weapon` VALUES (20708,'demersal_degen',3,0,242,242,188,2,2,224,109,0);
-INSERT INTO `item_weapon` VALUES (20709,'demers._degen_+1',3,0,242,242,188,2,2,218,110,0);
+INSERT INTO `item_weapon` VALUES (20708,'demersal_degen',3,0,242,242,188,1,2,224,109,0);
+INSERT INTO `item_weapon` VALUES (20709,'demers._degen_+1',3,0,242,242,188,1,2,218,110,0);
 INSERT INTO `item_weapon` VALUES (20710,'nibiru_blade',3,0,242,242,188,2,1,236,133,0);
 INSERT INTO `item_weapon` VALUES (20711,'blurred_sword',3,0,242,242,188,2,1,268,135,0);
 INSERT INTO `item_weapon` VALUES (20712,'blurred_sword_+1',3,0,242,242,188,2,2,250,115,0);
@@ -3764,7 +3764,7 @@ INSERT INTO `item_weapon` VALUES (20713,'excalipoor',3,0,0,0,0,2,1,240,1,0);
 INSERT INTO `item_weapon` VALUES (20714,'excalipoor_ii',3,0,0,0,0,2,1,233,2,0);
 INSERT INTO `item_weapon` VALUES (20715,'acclimator',3,0,242,242,188,2,1,240,130,0);
 INSERT INTO `item_weapon` VALUES (20716,'perfervid_sword',3,0,242,242,188,2,1,236,110,0);
-INSERT INTO `item_weapon` VALUES (20717,'arendsi_fleuret',3,0,228,228,188,2,1,224,119,0);
+INSERT INTO `item_weapon` VALUES (20717,'arendsi_fleuret',3,0,228,228,188,1,1,224,119,0);
 INSERT INTO `item_weapon` VALUES (20718,'claidheamh_soluis',3,0,242,242,188,2,1,270,142,0);
 INSERT INTO `item_weapon` VALUES (20719,'homestead_blade',3,0,228,228,188,2,1,247,133,0); -- DMG:133 Delay:247 Attack+26 Sword skill +228 Parrying skill +228 Magic Accuracy skill +188 Reives: "Save TP"+400 Occasionally attacks twice
 INSERT INTO `item_weapon` VALUES (20720,'egeking',3,0,242,242,188,2,1,236,124,0);
@@ -3774,7 +3774,7 @@ INSERT INTO `item_weapon` VALUES (20723,'dija_sword',3,0,203,203,167,2,1,272,139
 INSERT INTO `item_weapon` VALUES (20724,'dija_sword_+1',3,0,215,215,177,2,1,264,140,0);
 INSERT INTO `item_weapon` VALUES (20725,'iztaasu_+2',3,0,242,242,188,2,1,236,115,0);
 INSERT INTO `item_weapon` VALUES (20726,'eminent_scimitar',3,0,215,215,167,2,1,264,122,0);
-INSERT INTO `item_weapon` VALUES (20727,'tabahi_fleuret',3,0,102,102,84,2,1,221,89,0);
+INSERT INTO `item_weapon` VALUES (20727,'tabahi_fleuret',3,0,102,102,84,1,1,221,89,0);
 INSERT INTO `item_weapon` VALUES (20728,'kheshig_blade',3,0,108,108,84,2,1,240,96,0);
 INSERT INTO `item_weapon` VALUES (20729,'vivifiante',3,0,108,108,84,2,1,225,90,0);
 INSERT INTO `item_weapon` VALUES (20730,'predatrice',3,0,108,108,84,2,1,236,95,0);
@@ -3787,8 +3787,8 @@ INSERT INTO `item_weapon` VALUES (20736,'iztaasu_+1',3,0,162,162,126,2,1,236,97,
 INSERT INTO `item_weapon` VALUES (20737,'forefront_blade',3,0,63,63,52,2,1,247,71,0);
 INSERT INTO `item_weapon` VALUES (20738,'buramenkah',3,0,242,242,188,2,1,240,130,0);
 INSERT INTO `item_weapon` VALUES (20739,'halachuinic_sword',3,0,162,162,126,2,1,228,104,0);
-INSERT INTO `item_weapon` VALUES (20740,'camatlatia',3,0,67,67,52,1,1,240,76,0);
-INSERT INTO `item_weapon` VALUES (20741,'coalition_blade',3,0,0,0,0,1,1,240,60,0);
+INSERT INTO `item_weapon` VALUES (20740,'camatlatia',3,0,67,67,52,2,1,240,76,0);
+INSERT INTO `item_weapon` VALUES (20741,'coalition_blade',3,0,0,0,0,2,1,240,60,0);
 INSERT INTO `item_weapon` VALUES (20742,'iztaasu',3,0,54,54,42,2,1,236,68,0);
 INSERT INTO `item_weapon` VALUES (20743,'bihkah_sword_+1',3,0,0,0,0,2,1,225,63,0);
 INSERT INTO `item_weapon` VALUES (20744,'bihkah_sword',3,0,0,0,0,2,1,231,62,0);
@@ -4291,7 +4291,7 @@ INSERT INTO `item_weapon` VALUES (21255,'forefront_bowgun',26,0,67,0,0,1,1,432,7
 INSERT INTO `item_weapon` VALUES (21256,'illapa',26,0,242,0,0,1,1,432,135,0);
 INSERT INTO `item_weapon` VALUES (21257,'zoquittihuitz',26,0,67,0,0,1,1,432,90,0);
 INSERT INTO `item_weapon` VALUES (21258,'malayo_crossbow',26,0,0,0,0,1,1,288,45,0);
-INSERT INTO `item_weapon` VALUES (21259,'malayo_crossbow_+1',26,0,0,0,0,2,1,280,46,0);
+INSERT INTO `item_weapon` VALUES (21259,'malayo_crossbow_+1',26,0,0,0,0,1,1,280,46,0);
 INSERT INTO `item_weapon` VALUES (21260,'annihilator',26,1,242,0,0,1,1,582,105,0);
 INSERT INTO `item_weapon` VALUES (21261,'annihilator',26,1,242,0,0,1,1,582,105,0);
 INSERT INTO `item_weapon` VALUES (21262,'death_penalty',26,1,242,0,0,1,1,480,83,0);
@@ -4459,9 +4459,9 @@ INSERT INTO `item_weapon` VALUES (21426,'achaq_grip',0,0,0,0,0,1,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (21427,'bloodrain_strap',0,0,0,0,0,1,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (21428,'tzacab_grip',0,0,0,0,0,1,1,999,1,0);
 INSERT INTO `item_weapon` VALUES (21429,'mephitis_grip',0,0,0,0,0,1,1,999,1,0);
-INSERT INTO `item_weapon` VALUES (21430,'hesperiidae',1,0,0,0,0,1,1,999,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21431,'coiste_bodhar',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21432,'epitaph',1,0,0,0,0,1,1,999,1,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21430,'hesperiidae',0,0,0,0,0,0,1,999,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21431,'coiste_bodhar',0,0,0,0,0,0,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21432,'epitaph',0,0,0,0,0,0,1,999,1,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21433,'neo_animator',0,10,0,0,0,0,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (21438,'poisonous_broth',0,100,0,0,0,0,1,0,8776,0);
 INSERT INTO `item_weapon` VALUES (21439,'venomous_broth',0,101,0,0,0,0,1,0,8777,0);
@@ -4605,8 +4605,8 @@ INSERT INTO `item_weapon` VALUES (21606,'enriching_sword',3,0,242,242,188,2,1,24
 INSERT INTO `item_weapon` VALUES (21607,'enr._sword_+1',3,0,242,242,188,2,1,233,157,0);
 INSERT INTO `item_weapon` VALUES (21608,'onion_sword_ii',3,0,0,0,0,2,1,240,1,0);          -- DMG:1 Delay:240
 INSERT INTO `item_weapon` VALUES (21609,'save_the_queen_ii',3,0,0,0,0,2,1,264,1,0);       -- DMG:1 Delay:264
-INSERT INTO `item_weapon` VALUES (21610,'hepatizon_rapier',3,0,242,242,201,2,1,224,146,0); -- DMG:146 Delay:224
-INSERT INTO `item_weapon` VALUES (21611,'hep._rapier_+1',3,0,242,242,201,2,1,218,147,0);  -- DMG:147 Delay:218
+INSERT INTO `item_weapon` VALUES (21610,'hepatizon_rapier',3,0,242,242,201,1,1,224,146,0); -- DMG:146 Delay:224
+INSERT INTO `item_weapon` VALUES (21611,'hep._rapier_+1',3,0,242,242,201,1,1,218,147,0);  -- DMG:147 Delay:218
 INSERT INTO `item_weapon` VALUES (21612,'raetic_blade',3,0,242,242,215,2,1,236,157,0);    -- DMG:157 Delay:236
 INSERT INTO `item_weapon` VALUES (21613,'raetic_blade_+1',3,0,242,242,215,2,1,230,158,0); -- DMG:158 Delay:230
 INSERT INTO `item_weapon` VALUES (21614,'hepatizon_sapara',3,0,242,242,188,2,1,236,154,0); -- DMG:154 Delay:236
@@ -4633,19 +4633,19 @@ INSERT INTO `item_weapon` VALUES (21636,'nihility',3,0,0,0,0,2,1,240,1,0);      
 INSERT INTO `item_weapon` VALUES (21637,'sakpatas_sword',3,0,248,248,248,2,1,240,160,0); -- DMG:160 Delay:240
 INSERT INTO `item_weapon` VALUES (21638,'extinction',3,0,0,0,0,2,1,240,1,0); -- DMG:1 Delay:240
 INSERT INTO `item_weapon` VALUES (21640,'onion_sword_iii',3,0,269,269,269,2,1,240,165,0);
-INSERT INTO `item_weapon` VALUES (21641,'save_the_queen_iii',3,0,0,0,0,1,1,264,182,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21642,'prime_sword',3,0,0,0,0,1,1,233,156,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21643,'caliburnus',3,0,0,0,0,1,1,233,156,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21644,'caliburnus',3,0,0,0,0,1,1,233,165,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21645,'caliburnus',3,0,0,0,0,1,1,233,172,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21646,'caliburnus',3,0,0,0,0,1,1,233,181,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21641,'save_the_queen_iii',3,0,0,0,0,2,1,264,182,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21642,'prime_sword',3,0,0,0,0,2,1,233,156,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21643,'caliburnus',3,0,0,0,0,2,1,233,156,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21644,'caliburnus',3,0,0,0,0,2,1,233,165,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21645,'caliburnus',3,0,0,0,0,2,1,233,172,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21646,'caliburnus',3,0,0,0,0,2,1,233,181,0);         -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21647,'dathaba_hanger',3,0,0,0,0,2,1,225,150,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21648,'dathaba_sword',4,0,0,0,0,2,1,456,304,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21649,'helheim',4,0,0,0,0,1,1,431,336,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21650,'prime_blade',4,0,0,0,0,1,1,431,288,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21651,'helheim',4,0,0,0,0,1,1,431,288,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21652,'helheim',4,0,0,0,0,1,1,431,306,0);            -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21653,'helheim',4,0,0,0,0,1,1,431,318,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21649,'helheim',4,0,0,0,0,2,1,431,336,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21650,'prime_blade',4,0,0,0,0,2,1,431,288,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21651,'helheim',4,0,0,0,0,2,1,431,288,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21652,'helheim',4,0,0,0,0,2,1,431,306,0);            -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21653,'helheim',4,0,0,0,0,2,1,431,318,0);            -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21654,'arasy_claymore',4,0,242,242,188,2,1,489,251,0);
 INSERT INTO `item_weapon` VALUES (21655,'arasy_claymore_+1',4,0,242,242,188,2,1,475,252,0);
 INSERT INTO `item_weapon` VALUES (21656,'dyrnwyn',4,0,228,228,228,2,1,480,313,0);
@@ -4656,7 +4656,7 @@ INSERT INTO `item_weapon` VALUES (21660,'bery._sword_+1',4,0,242,242,118,2,1,431
 INSERT INTO `item_weapon` VALUES (21661,'rune_algol',4,0,0,0,0,2,1,489,80,0);             -- DMG:80 Delay:489
 INSERT INTO `item_weapon` VALUES (21662,'raetic_algol',4,0,242,242,215,2,1,489,326,0);    -- DMG:326 Delay:489
 INSERT INTO `item_weapon` VALUES (21663,'raetic_algol_+1',4,0,242,242,215,2,1,474,327,0); -- DMG:327 Delay:474
-INSERT INTO `item_weapon` VALUES (21664,'zantetsuken_x',4,0,0,0,0,1,1,456,323,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21664,'zantetsuken_x',4,0,0,0,0,2,1,456,323,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21665,'voluspa_blade',4,0,215,215,215,2,1,480,260,0);
 INSERT INTO `item_weapon` VALUES (21666,'ethereal_great_sword',4,0,0,0,0,2,1,480,1,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21667,'futhark_claymore',4,0,242,242,228,2,1,494,330,0); -- DMG:330 Delay:494
@@ -4667,10 +4667,10 @@ INSERT INTO `item_weapon` VALUES (21671,'ajja_claymore',4,0,223,223,223,2,1,480,
 INSERT INTO `item_weapon` VALUES (21672,'eletta_claymore',4,0,231,231,231,2,1,480,293,0);  -- DMG:293 Delay:480
 INSERT INTO `item_weapon` VALUES (21673,'kaja_claymore',4,0,242,242,242,2,1,480,313,0);    -- DMG:313 Delay:480
 INSERT INTO `item_weapon` VALUES (21674,'nandaka',4,0,250,250,250,2,1,480,333,0);          -- DMG:333 Delay:480
-INSERT INTO `item_weapon` VALUES (21675,'agwus_claymore',4,0,0,0,0,1,1,480,320,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21676,'brave_blade_iii',4,0,0,0,0,1,1,480,331,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21675,'agwus_claymore',4,0,0,0,0,2,1,480,320,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21676,'brave_blade_iii',4,0,0,0,0,2,1,480,331,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21677,'brave_blade_iii',4,0,0,0,0,2,1,480,366,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21680,'goujian',4,0,0,0,0,1,1,480,1,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21680,'goujian',4,0,0,0,0,2,1,480,1,0);                  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21681,'ophidian_sword',4,0,0,0,0,2,1,480,1,0);           -- DMG:1 Delay:480
 INSERT INTO `item_weapon` VALUES (21682,'lament',4,0,0,0,0,2,1,430,1,0);                   -- DMG:1 Delay:430
 INSERT INTO `item_weapon` VALUES (21683,'ragnarok',4,0,269,269,242,2,1,431,304,0);
@@ -4711,14 +4711,14 @@ INSERT INTO `item_weapon` VALUES (21719,'ajja_axe',5,0,223,223,223,2,1,288,168,0
 INSERT INTO `item_weapon` VALUES (21720,'eletta_axe',5,0,231,231,231,2,1,288,176,0);  -- DMG:176 Delay:288
 INSERT INTO `item_weapon` VALUES (21721,'kaja_axe',5,0,242,242,242,2,1,288,188,0);    -- DMG:188 Delay:288
 INSERT INTO `item_weapon` VALUES (21722,'dolichenus',5,0,250,250,250,2,1,288,200,0);  -- DMG:200 Delay:288
-INSERT INTO `item_weapon` VALUES (21723,'ikengas_axe',5,0,0,0,0,1,1,288,192,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21724,'agwus_axe',5,0,0,0,0,1,1,288,192,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21723,'ikengas_axe',5,0,0,0,0,2,1,288,192,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21724,'agwus_axe',5,0,0,0,0,2,1,288,192,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21725,'malefic_axe',5,0,269,269,269,2,1,340,234,0);
-INSERT INTO `item_weapon` VALUES (21726,'prime_pickaxe',5,0,0,0,0,1,1,280,187,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21727,'spalirisos',5,0,0,0,0,1,1,280,187,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21728,'spalirisos',5,0,0,0,0,1,1,280,198,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21729,'spalirisos',5,0,0,0,0,1,1,280,207,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21730,'spalirisos',5,0,0,0,0,1,1,280,218,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21726,'prime_pickaxe',5,0,0,0,0,2,1,280,187,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21727,'spalirisos',5,0,0,0,0,2,1,280,187,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21728,'spalirisos',5,0,0,0,0,2,1,280,198,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21729,'spalirisos',5,0,0,0,0,2,1,280,207,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21730,'spalirisos',5,0,0,0,0,2,1,280,218,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21731,'dathaba_axe',5,0,0,0,0,2,1,276,184,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21732,'demonic_axe',5,0,0,0,0,2,1,340,259,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21741,'demonic_axe',5,0,0,0,0,2,1,288,1,0);   -- DMG:1 Delay:288
@@ -4760,14 +4760,14 @@ INSERT INTO `item_weapon` VALUES (21776,'ajja_chopper',6,0,223,223,223,2,1,508,2
 INSERT INTO `item_weapon` VALUES (21777,'eletta_chopper',6,0,231,231,231,2,1,508,317,0); -- DMG:317 Delay:508
 INSERT INTO `item_weapon` VALUES (21778,'kaja_chopper',6,0,242,242,242,2,1,508,338,0);   -- DMG:338 Delay:508
 INSERT INTO `item_weapon` VALUES (21779,'lycurgos',6,0,250,250,250,2,1,508,359,0);       -- DMG:359 Delay:508
-INSERT INTO `item_weapon` VALUES (21780,'bunzis_chopper',6,0,0,0,0,1,1,504,336,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21781,'prime_great_axe',6,0,0,0,0,1,1,488,326,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21782,'laphria',6,0,0,0,0,1,1,488,326,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21783,'laphria',6,0,0,0,0,1,1,488,346,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21784,'laphria',6,0,0,0,0,1,1,488,361,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21785,'laphria',6,0,0,0,0,1,1,488,380,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21786,'poison_axe',6,0,0,0,0,1,1,504,1,0);             -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21787,'poison_axe_+1',6,0,0,0,0,1,1,489,1,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21780,'bunzis_chopper',6,0,0,0,0,2,1,504,336,0);         -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21781,'prime_great_axe',6,0,0,0,0,2,1,488,326,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21782,'laphria',6,0,0,0,0,2,1,488,326,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21783,'laphria',6,0,0,0,0,2,1,488,346,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21784,'laphria',6,0,0,0,0,2,1,488,361,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21785,'laphria',6,0,0,0,0,2,1,488,380,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21786,'poison_axe',6,0,0,0,0,2,1,504,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21787,'poison_axe_+1',6,0,0,0,0,2,1,489,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21788,'dathaba_voulge',6,0,0,0,0,2,1,504,336,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21789,'drastic_axe',6,0,0,0,0,2,1,504,385,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21804,'obschine',7,0,242,242,188,2,1,501,295,0);
@@ -4795,27 +4795,27 @@ INSERT INTO `item_weapon` VALUES (21827,'ajja_scythe',7,0,223,223,223,2,1,528,30
 INSERT INTO `item_weapon` VALUES (21828,'eletta_scythe',7,0,231,231,231,2,1,528,322,0);  -- DMG:322 Delay:528
 INSERT INTO `item_weapon` VALUES (21829,'kaja_scythe',7,0,242,242,242,2,1,528,344,0);    -- DMG:344 Delay:528
 INSERT INTO `item_weapon` VALUES (21830,'drepanum',7,0,250,250,250,2,1,528,366,0);       -- DMG:366 Delay:528
-INSERT INTO `item_weapon` VALUES (21831,'ligeia_scythe',7,0,0,0,0,1,1,528,300,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21831,'ligeia_scythe',7,0,0,0,0,2,1,528,300,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21832,'agwus_scythe',7,0,248,248,248,2,1,528,352,0);   -- DMG:352 Delay:528
-INSERT INTO `item_weapon` VALUES (21833,'prime_scythe',7,0,0,0,0,1,1,513,343,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21834,'foenaria',7,0,0,0,0,1,1,513,343,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21835,'foenaria',7,0,0,0,0,1,1,513,364,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21836,'foenaria',7,0,0,0,0,1,1,513,379,0);               -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21837,'foenaria',7,0,0,0,0,1,1,513,400,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21833,'prime_scythe',7,0,0,0,0,2,1,513,343,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21834,'foenaria',7,0,0,0,0,2,1,513,343,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21835,'foenaria',7,0,0,0,0,2,1,513,364,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21836,'foenaria',7,0,0,0,0,2,1,513,379,0);               -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21837,'foenaria',7,0,0,0,0,2,1,513,400,0);               -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21838,'ethereal_scythe',7,0,0,0,0,2,1,480,1,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21840,'mavens_scythe',7,0,0,0,0,2,1,480,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21841,'dathaba_sickle',7,0,0,0,0,2,1,501,334,0);       -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21842,'final_sickle',7,0,0,0,0,2,1,528,403,0);         -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21854,'reienkyo',8,0,242,242,188,2,1,480,282,0);       -- DMG:282 Delay:480
-INSERT INTO `item_weapon` VALUES (21855,'lembing',8,0,242,242,188,2,1,492,313,0);        -- DMG:313 Delay:492
+INSERT INTO `item_weapon` VALUES (21854,'reienkyo',8,0,242,242,188,1,1,480,282,0);       -- DMG:282 Delay:480
+INSERT INTO `item_weapon` VALUES (21855,'lembing',8,0,242,242,188,1,1,492,313,0);        -- DMG:313 Delay:492
 INSERT INTO `item_weapon` VALUES (21856,'geirrothr',8,0,0,0,0,1,1,492,348,0);              -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21857,'gungnir',8,0,269,269,228,2,1,492,347,0);        -- DMG:347 Delay:492
-INSERT INTO `item_weapon` VALUES (21858,'ryunohige',8,0,269,269,228,2,1,492,307,0);      -- DMG:307 Delay:492
-INSERT INTO `item_weapon` VALUES (21859,'rhongomiant',8,0,269,269,228,2,1,492,347,0);    -- DMG:347 Delay:492
-INSERT INTO `item_weapon` VALUES (21860,'aern_spear',8,0,0,0,0,2,1,396,1,0);             -- DMG:1 Delay:396
-INSERT INTO `item_weapon` VALUES (21861,'aern_spear_ii',8,0,0,0,0,2,1,396,1,0);          -- DMG:1 Delay:396
-INSERT INTO `item_weapon` VALUES (21862,'mizukage_naginata',8,0,0,0,0,2,1,480,1,0);      -- DMG:1 Delay:480
-INSERT INTO `item_weapon` VALUES (21863,'tzee_xicus_blade',8,0,0,0,0,2,1,480,1,0);       -- DMG:1 Delay:480
+INSERT INTO `item_weapon` VALUES (21857,'gungnir',8,0,269,269,228,1,1,492,347,0);        -- DMG:347 Delay:492
+INSERT INTO `item_weapon` VALUES (21858,'ryunohige',8,0,269,269,228,1,1,492,307,0);      -- DMG:307 Delay:492
+INSERT INTO `item_weapon` VALUES (21859,'rhongomiant',8,0,269,269,228,1,1,492,347,0);    -- DMG:347 Delay:492
+INSERT INTO `item_weapon` VALUES (21860,'aern_spear',8,0,0,0,0,1,1,396,1,0);             -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21861,'aern_spear_ii',8,0,0,0,0,1,1,396,1,0);          -- DMG:1 Delay:396
+INSERT INTO `item_weapon` VALUES (21862,'mizukage_naginata',8,0,0,0,0,1,1,480,1,0);      -- DMG:1 Delay:480
+INSERT INTO `item_weapon` VALUES (21863,'tzee_xicus_blade',8,0,0,0,0,1,1,480,1,0);       -- DMG:1 Delay:480
 INSERT INTO `item_weapon` VALUES (21864,'voluspa_lance',8,0,215,215,215,1,1,492,266,0);
 INSERT INTO `item_weapon` VALUES (21865,'arasy_lance',8,0,242,242,188,1,1,492,252,0);       -- DMG:252 Delay:492
 INSERT INTO `item_weapon` VALUES (21866,'arasy_lance_+1',8,0,242,242,188,1,1,478,253,0);    -- MG:253 Delay:478
@@ -4863,14 +4863,14 @@ INSERT INTO `item_weapon` VALUES (21921,'kaja_katana',9,0,242,242,242,2,1,227,14
 INSERT INTO `item_weapon` VALUES (21922,'gokotai',9,0,250,250,250,2,1,227,157,0);       -- DMG:157 Delay:227
 INSERT INTO `item_weapon` VALUES (21923,'debahocho',9,0,0,0,0,2,1,227,1,0);             -- DMG:1 Delay:227
 INSERT INTO `item_weapon` VALUES (21924,'debahocho_+1',9,0,0,0,0,2,1,222,2,0);          -- DMG:2 Delay:222
-INSERT INTO `item_weapon` VALUES (21925,'kunimitsu',9,0,0,0,0,1,1,227,151,0);             -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21926,'tsuru',9,0,0,0,0,1,1,190,131,0);                 -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21927,'yagyu_darkblade',9,0,0,0,0,1,1,227,156,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21928,'genshitanto',9,0,0,0,0,1,1,210,140,0);           -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21929,'dokoku',9,0,0,0,0,1,1,210,140,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21930,'dokoku',9,0,0,0,0,1,1,210,149,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21931,'dokoku',9,0,0,0,0,1,1,210,155,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21932,'dokoku',9,0,0,0,0,1,1,210,163,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21925,'kunimitsu',9,0,0,0,0,2,1,227,151,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21926,'tsuru',9,0,0,0,0,2,1,190,131,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21927,'yagyu_darkblade',9,0,0,0,0,2,1,227,156,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21928,'genshitanto',9,0,0,0,0,2,1,210,140,0);           -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21929,'dokoku',9,0,0,0,0,2,1,210,140,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21930,'dokoku',9,0,0,0,0,2,1,210,149,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21931,'dokoku',9,0,0,0,0,2,1,210,155,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21932,'dokoku',9,0,0,0,0,2,1,210,163,0);                -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21933,'yagyu_shortblade',9,0,0,0,0,2,1,227,1,0);      -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21934,'yagyu_shortblade_+1',9,0,0,0,0,2,1,222,2,0);   -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21935,'dathaba_blade',9,0,0,0,0,2,1,190,126,0);       -- TODO: Not implemented
@@ -4899,15 +4899,15 @@ INSERT INTO `item_weapon` VALUES (21974,'kaja_tachi',10,0,242,242,242,2,1,450,30
 INSERT INTO `item_weapon` VALUES (21975,'hachimonji',10,0,250,250,250,2,1,450,318,0);     -- DMG:318 Delay:450
 INSERT INTO `item_weapon` VALUES (21976,'voluspa_tachi',10,0,215,215,215,2,1,450,243,0);
 INSERT INTO `item_weapon` VALUES (21977,'mutsunokami',10,0,0,0,0,2,1,450,1,0);            -- DMG:1 Delay:450
-INSERT INTO `item_weapon` VALUES (21978,'mutsunokami_+1',10,0,0,0,0,1,1,437,2,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21979,'gekkei',10,0,0,0,0,1,1,450,300,0);                  -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21980,'zanmato_+2',10,0,0,0,0,1,1,464,320,0);              -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21981,'mutsu-no-kami_yoshiyuki',10,0,0,0,0,1,1,450,310,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21982,'genshito',10,0,0,0,0,1,1,437,292,0);                -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21983,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,292,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21984,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,310,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21985,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,323,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21986,'kusanagi-no-tsurugi',10,0,0,0,0,1,1,437,340,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21978,'mutsunokami_+1',10,0,0,0,0,2,1,437,2,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21979,'gekkei',10,0,0,0,0,2,1,450,300,0);                  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21980,'zanmato_+2',10,0,0,0,0,2,1,464,320,0);              -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21981,'mutsu-no-kami_yoshiyuki',10,0,0,0,0,2,1,450,310,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21982,'genshito',10,0,0,0,0,2,1,437,292,0);                -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21983,'kusanagi-no-tsurugi',10,0,0,0,0,2,1,437,292,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21984,'kusanagi-no-tsurugi',10,0,0,0,0,2,1,437,310,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21985,'kusanagi-no-tsurugi',10,0,0,0,0,2,1,437,323,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21986,'kusanagi-no-tsurugi',10,0,0,0,0,2,1,437,340,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21990,'dathaba_tachi',10,0,0,0,0,2,1,420,280,0);        -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21991,'wizards_rod',11,0,0,0,0,3,1,216,165,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21992,'dathaba_wand',11,0,0,0,0,3,1,216,144,0);         -- TODO: Not implemented
@@ -4916,11 +4916,11 @@ INSERT INTO `item_weapon` VALUES (21994,'erudites_staff_+1',12,0,0,0,0,3,1,399,2
 INSERT INTO `item_weapon` VALUES (21995,'mavens_staff',12,0,0,0,0,3,1,288,1,0);           -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21996,'magicians_rod',11,0,0,0,0,3,1,216,1,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (21997,'magicians_rod_+1',11,0,0,0,0,3,1,210,2,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21998,'lorg_mor',11,0,0,0,0,1,1,308,240,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (21999,'prime_maul',11,0,0,0,0,1,1,308,206,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22000,'lorg_mor',11,0,0,0,0,1,1,308,206,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22001,'lorg_mor',11,0,0,0,0,1,1,308,218,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22002,'lorg_mor',11,0,0,0,0,1,1,308,227,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21998,'lorg_mor',11,0,0,0,0,3,1,308,240,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (21999,'prime_maul',11,0,0,0,0,3,1,308,206,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22000,'lorg_mor',11,0,0,0,0,3,1,308,206,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22001,'lorg_mor',11,0,0,0,0,3,1,308,218,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22002,'lorg_mor',11,0,0,0,0,3,1,308,227,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22003,'arthros_scepter',11,0,0,0,0,3,1,288,1,0);  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22004,'soulflayers_wand',11,0,0,0,0,3,1,264,1,0); -- DMG:1 Delay:264
 INSERT INTO `item_weapon` VALUES (22005,'burrowers_wand',11,0,0,0,0,3,1,264,1,0);   -- DMG:1 Delay:264
@@ -4942,7 +4942,7 @@ INSERT INTO `item_weapon` VALUES (22028,'ajja_rod',11,0,223,223,223,3,1,288,168,
 INSERT INTO `item_weapon` VALUES (22029,'eletta_rod',11,0,231,231,231,3,1,288,176,0);        -- DMG:176 Delay:288
 INSERT INTO `item_weapon` VALUES (22030,'kaja_rod',11,0,242,242,242,3,1,288,188,0);          -- DMG:188 Delay:288
 INSERT INTO `item_weapon` VALUES (22031,'maxentius',11,0,250,250,250,3,1,288,200,0);         -- DMG:200 Delay:288
-INSERT INTO `item_weapon` VALUES (22032,'thunder_hammer',11,0,0,0,0,1,1,216,1,0);             -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22032,'thunder_hammer',11,0,0,0,0,3,1,216,1,0);             -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22033,'clerics_wand',11,0,228,228,242,3,1,288,192,0);      -- DMG:192 Delay:288
 INSERT INTO `item_weapon` VALUES (22034,'piety_wand',11,0,242,242,255,3,1,280,193,0);        -- DMG:193 Delay:280
 INSERT INTO `item_weapon` VALUES (22035,'asclepius',11,0,255,255,269,3,1,280,194,0);         -- DMG:194 Delay:280
@@ -4951,18 +4951,18 @@ INSERT INTO `item_weapon` VALUES (22037,'sifang_wand',11,0,242,242,255,3,1,280,1
 INSERT INTO `item_weapon` VALUES (22038,'bhima',11,0,255,255,269,3,1,280,194,0);             -- DMG:194 Delay:280
 INSERT INTO `item_weapon` VALUES (22039,'floral_hagoita',11,0,0,0,0,3,1,264,2,0);            -- DMG:2 Delay:264
 INSERT INTO `item_weapon` VALUES (22040,'daybreak',11,0,228,228,242,3,1,216,150,0);
-INSERT INTO `item_weapon` VALUES (22041,'bunzis_rod',11,0,0,0,0,1,1,216,144,0);                 -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22041,'bunzis_rod',11,0,0,0,0,3,1,216,144,0);                 -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22042,'wizards_rod',11,0,250,250,250,3,1,216,149,0);
-INSERT INTO `item_weapon` VALUES (22043,'apkallu_scepter',11,0,0,0,0,1,1,216,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22044,'tengu_war_fan',11,0,0,0,0,1,1,216,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22045,'feline_hagoita',11,0,0,0,0,1,1,264,2,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22046,'feline_hagoita_+1',11,0,0,0,0,1,1,257,3,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22047,'korrigan_mallet',11,0,0,0,0,1,1,288,1,0);   -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22048,'adenium_mallet',11,0,0,0,0,1,1,288,1,0);    -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22049,'citrullus_mallet',11,0,0,0,0,1,1,288,1,0);  -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22050,'chac-chacs',11,0,0,0,0,1,1,288,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22051,'lycopodium_mallet',11,0,0,0,0,1,1,288,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22052,'summer_uchiwa',11,0,0,0,0,1,1,216,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22043,'apkallu_scepter',11,0,0,0,0,3,1,216,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22044,'tengu_war_fan',11,0,0,0,0,3,1,216,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22045,'feline_hagoita',11,0,0,0,0,3,1,264,2,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22046,'feline_hagoita_+1',11,0,0,0,0,3,1,257,3,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22047,'korrigan_mallet',11,0,0,0,0,3,1,288,1,0);   -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22048,'adenium_mallet',11,0,0,0,0,3,1,288,1,0);    -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22049,'citrullus_mallet',11,0,0,0,0,3,1,288,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22050,'chac-chacs',11,0,0,0,0,3,1,288,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22051,'lycopodium_mallet',11,0,0,0,0,3,1,288,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22052,'summer_uchiwa',11,0,0,0,0,3,1,216,1,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22053,'ethereal_club',11,0,0,0,0,3,1,288,1,0);    -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22054,'grioavolr',12,0,242,242,228,3,1,366,202,0);
 INSERT INTO `item_weapon` VALUES (22055,'oranyan',12,0,242,242,228,3,1,366,230,0);
@@ -4980,7 +4980,7 @@ INSERT INTO `item_weapon` VALUES (22067,'levin',12,0,0,0,0,3,1,366,1,0);        
 INSERT INTO `item_weapon` VALUES (22068,'savage._pole',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22069,'hapy_staff',12,0,0,0,0,3,1,366,1,0);    -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22070,'ranine_staff',12,0,0,0,0,3,1,366,1,0);  -- DMG:1 Delay:366
-INSERT INTO `item_weapon` VALUES (22071,'profane_staff',12,0,0,0,0,1,1,366,1,0);  -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22071,'profane_staff',12,0,0,0,0,3,1,366,1,0);  -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22072,'lamia_staff',12,0,0,0,0,3,1,366,1,0);   -- DMG:1 Delay:366
 INSERT INTO `item_weapon` VALUES (22074,'arasy_staff',12,0,242,242,228,3,1,366,188,0);
 INSERT INTO `item_weapon` VALUES (22075,'arasy_staff_+1',12,0,242,242,228,3,1,356,189,0);
@@ -5010,11 +5010,11 @@ INSERT INTO `item_weapon` VALUES (22098,'pedagogy_staff',12,0,242,242,255,3,1,39
 INSERT INTO `item_weapon` VALUES (22099,'musa',12,0,255,255,269,3,1,399,276,0);           -- DMG:276 Delay:399
 INSERT INTO `item_weapon` VALUES (22100,'mpacas_staff',12,0,242,242,255,3,1,402,268,0); -- DMG:268 Delay:402
 INSERT INTO `item_weapon` VALUES (22101,'pandits_staff',12,0,269,269,269,3,1,412,284,0);
-INSERT INTO `item_weapon` VALUES (22102,'prime_staff',12,0,0,0,0,1,1,390,261,0);       -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22103,'opashoro',12,0,0,0,0,1,1,390,261,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22104,'opashoro',12,0,0,0,0,1,1,390,276,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22105,'opashoro',12,0,0,0,0,1,1,390,288,0);          -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22106,'opashoro',12,0,0,0,0,1,1,390,304,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22102,'prime_staff',12,0,0,0,0,3,1,390,261,0);       -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22103,'opashoro',12,0,0,0,0,3,1,390,261,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22104,'opashoro',12,0,0,0,0,3,1,390,276,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22105,'opashoro',12,0,0,0,0,3,1,390,288,0);          -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22106,'opashoro',12,0,0,0,0,3,1,390,304,0);          -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22107,'ullr',25,0,250,0,0,1,1,360,178,0);         -- DMG:178 Delay:360
 INSERT INTO `item_weapon` VALUES (22108,'tokko_bow',25,0,215,0,0,1,1,360,136,0);    -- DMG:136 Delay:360
 INSERT INTO `item_weapon` VALUES (22109,'ajja_bow',25,0,223,0,0,1,1,360,147,0);     -- DMG:147 Delay:360
@@ -5145,7 +5145,7 @@ INSERT INTO `item_weapon` VALUES (22288,'mandragora_pouch',0,0,0,0,0,0,0,0,0,0);
 INSERT INTO `item_weapon` VALUES (22289,'voluspa_arrow',25,0,0,0,0,1,1,90,105,0);
 INSERT INTO `item_weapon` VALUES (22290,'voluspa_bolt',26,0,0,0,0,1,1,192,132,0);
 INSERT INTO `item_weapon` VALUES (22291,'voluspa_bullet',26,0,0,0,0,1,1,240,270,0);
-INSERT INTO `item_weapon` VALUES (22292,'date_shuriken',27,0,0,0,0,1,1,192,125,0);
+INSERT INTO `item_weapon` VALUES (22292,'date_shuriken',27,3,0,0,0,1,1,192,125,0);
 INSERT INTO `item_weapon` VALUES (22293,'hauksbok_arrow',25,0,0,0,0,1,1,90,110,0);
 INSERT INTO `item_weapon` VALUES (22294,'hauksbok_bolt',26,0,0,0,0,1,1,192,156,0);
 INSERT INTO `item_weapon` VALUES (22295,'hauksbok_bullet',26,0,0,0,0,1,1,240,300,0);
@@ -5154,13 +5154,13 @@ INSERT INTO `item_weapon` VALUES (22297,'aurgelmir_orb',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22298,'aurgelmir_orb_+1',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22299,'per._lucky_egg',0,0,0,0,0,1,1,999,0,0);
 INSERT INTO `item_weapon` VALUES (22300,'crepuscular_pebble',0,0,0,0,0,0,0,0,0,0);
-INSERT INTO `item_weapon` VALUES (22301,'sroda_tathlum',1,0,0,0,0,1,1,999,1,0);     -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22302,'oshashas_treatise',1,0,0,0,0,1,1,999,1,0); -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22303,'prime_horn',1,0,0,0,0,1,1,240,1,0);        -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22304,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22305,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22306,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
-INSERT INTO `item_weapon` VALUES (22307,'loughnashade',1,0,0,0,0,1,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22301,'sroda_tathlum',0,0,0,0,0,0,1,999,1,0);     -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22302,'oshashas_treatise',0,0,0,0,0,0,1,999,1,0); -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22303,'prime_horn',42,0,0,0,0,0,1,240,1,0);        -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22304,'loughnashade',42,0,0,0,0,0,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22305,'loughnashade',42,0,0,0,0,0,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22306,'loughnashade',42,0,0,0,0,0,1,240,1,0);      -- TODO: Not implemented
+INSERT INTO `item_weapon` VALUES (22307,'loughnashade',42,0,0,0,0,0,1,240,1,0);      -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22308,'bayeux_bullet',26,0,0,0,0,1,1,240,315,0);     -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22309,'bayeux_arrow',25,0,0,0,0,1,1,90,116,0);      -- TODO: Not implemented
 INSERT INTO `item_weapon` VALUES (22310,'hoxne_ampulla',0,0,0,0,0,0,1,999,0,0);     -- TODO: Not implemented


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Review by commit

### 7e75c5e7a3b97cc2f2b9c2e63ce9709074f51b34
- Updates usable items with proper activation time and target flags
- Adds a handful of charged weapons/equipment that were missing entries

Done with a script. Checked a handful of implemented items like Signet staves, Soultrapper.

Target flags changes in an easier to review format

| ID | Name | Before | After |
|---|---|---|---|
| 4206 | `bottle_of_catholicon` | `29` (Self+Enemy+Alliance+Player) | `75` (Self+Party+Alliance+NPC) |
| 4208 | `bottle_of_catholicon_+1` | `29` (Self+Enemy+Alliance+Player) | `75` (Self+Party+Alliance+NPC) |
| 5895 | `odorless_fungus` | `1` (Self) | `4` (Enemy) |
| 5896 | `clump_of_absorbent_moss` | `1` (Self) | `4` (Enemy) |
| 5897 | `redolent_root` | `1` (Self) | `4` (Enemy) |
| 5898 | `shadescale_skull` | `1` (Self) | `4` (Enemy) |
| 5899 | `shadescale_femur` | `1` (Self) | `4` (Enemy) |
| 5900 | `shadescale_talon` | `1` (Self) | `4` (Enemy) |
| 5901 | `shadescale_heart` | `1` (Self) | `4` (Enemy) |
| 5902 | `vial_of_cagebeast_blood` | `1` (Self) | `4` (Enemy) |
| 5903 | `vial_of_sea_monk_venom` | `1` (Self) | `4` (Enemy) |
| 5904 | `perforated_wing` | `1` (Self) | `4` (Enemy) |
| 5905 | `undying_moiety` | `1` (Self) | `4` (Enemy) |
| 6002 | `trailblazing_pickaxe` | `1` (Self) | `68` (Enemy+NPC) |
| 6003 | `trailblazing_pickaxe_+1` | `1` (Self) | `68` (Enemy+NPC) |
| 6004 | `trailblazing_hatchet` | `1` (Self) | `68` (Enemy+NPC) |
| 6005 | `trailblazing_hatchet_+1` | `1` (Self) | `68` (Enemy+NPC) |
| 6006 | `trailblazing_sickle` | `1` (Self) | `68` (Enemy+NPC) |
| 6007 | `trailblazing_sickle_+1` | `1` (Self) | `68` (Enemy+NPC) |
| 11788 | `jesters_hat` | `1` (Self) | `3` (Self+Party) |
| 12408 | `absorbing_shield` | `20` (Enemy+Player) | `4` (Enemy) |
| 13182 | `oscar_scarf` | `20` (Enemy+Player) | `4` (Enemy) |
| 15175 | `revilers_helm` | `20` (Enemy+Player) | `4` (Enemy) |
| 15326 | `gargoyle_boots` | `0x101` (Self) | `1` (Self) |
| 15834 | `blind_ring` | `20` (Enemy+Player) | `4` (Enemy) |
| 16153 | `reikyo_hairpin` | `20` (Enemy+Player) | `4` (Enemy) |
| 16954 | `pealing_nagan` | `20` (Enemy+Player) | `4` (Enemy) |
| 17468 | `raise_rod` | `9` (Self+Alliance) | `107` (Self+Party+Alliance+Corpse+NPC) |
| 17469 | `raise_ii_rod` | `9` (Self+Alliance) | `107` (Self+Party+Alliance+Corpse+NPC) |
| 17470 | `pealing_buzdygan` | `20` (Enemy+Player) | `4` (Enemy) |
| 17583 | `kingdom_signet_staff` | `29` (Self+Enemy+Alliance+Player) | `75` (Self+Party+Alliance+NPC) |
| 17584 | `republic_signet_staff` | `29` (Self+Enemy+Alliance+Player) | `75` (Self+Party+Alliance+NPC) |
| 17585 | `federation_signet_staff` | `29` (Self+Enemy+Alliance+Player) | `75` (Self+Party+Alliance+NPC) |
| 17596 | `steel-splitter` | `20` (Enemy+Player) | `4` (Enemy) |
| 17625 | `ponderous_gully` | `20` (Enemy+Player) | `4` (Enemy) |
| 17703 | `pealing_anelace` | `20` (Enemy+Player) | `4` (Enemy) |
| 17949 | `furnace_tabarzin` | `20` (Enemy+Player) | `4` (Enemy) |
| 18060 | `blizzard_scythe` | `20` (Enemy+Player) | `4` (Enemy) |
| 18095 | `dispel_couse` | `20` (Enemy+Player) | `4` (Enemy) |
| 18107 | `ponderous_lance` | `20` (Enemy+Player) | `4` (Enemy) |
| 18225 | `blizzard_toporok` | `20` (Enemy+Player) | `4` (Enemy) |
| 18361 | `ponderous_manoples` | `20` (Enemy+Player) | `4` (Enemy) |
| 18399 | `charm_wand` | `4` (Enemy) | `2` (Party) |
| 18400 | `charm_wand_+1` | `4` (Enemy) | `2` (Party) |
| 18401 | `moogle_rod` | `4` (Enemy) | `2` (Party) |
| 18415 | `tojaku` | `20` (Enemy+Player) | `4` (Enemy) |
| 18679 | `soulgauger_sgr-1` | `20` (Enemy+Player) | `4` (Enemy) |
| 18721 | `soultrapper` | `20` (Enemy+Player) | `4` (Enemy) |
| 18724 | `soultrapper_2000` | `20` (Enemy+Player) | `4` (Enemy) |
| 18842 | `nomad_moogle_rod` | `4` (Enemy) | `2` (Party) |
| 18844 | `miracle_wand` | `4` (Enemy) | `2` (Party) |
| 18845 | `miracle_wand_+1` | `4` (Enemy) | `2` (Party) |
| 19204 | `fiendtrapper` | `20` (Enemy+Player) | `4` (Enemy) |

### 144bc22d80f7af3446c012c2e064ac1e98fc5b9f
Updates equipment entries with the proper:
- Level/SuLvl/iLvl
- Job mask
- Slot
- Shield Size

Noteworthy, beyond the formerly unimplemented items:
- Wizard's rod loses BLU job
- Sroda Tathlum: All Jobs -> BLM/RDM/SCH/GEO
- Thrus Earring: WAR/PLD/DRK/BST/SAM/DRG
- Srora earring: All Jobs -> BST/DRG/SMN/PUP
- Crepuscular Ring Lv1 -> 99
- Sroda Ring: All Jobs -> All but WHM/BLM/RDM/SCH/GEO
- Seabirds Ring: Lv99 -> Lv30
- Confectioner/Patissieres Ring: Lv99 -> Lv1
- Gene Ring loses RUN
- Gerdr Belt: All jobs -> All but WHM/BLM/RNG/SMN/PUP/SCH/GEO
- Bunch of items were on the wrong slots entirely

### 370ef5efcafacefaa399bde04c60bf433ba5b45f
Updates weapon entries with proper:
- Skill type
- Damage
- Delay

Not much to talk about, everything was marked as not implemented except Wizard's Rod getting a better delay.

### ea0859a360f40f53f5e494bede1fe7556fa33b08
Updates damage type on a handful of weapons.

This part was done by hand after matching skill types to default damage type and then working through the exclusions.

Noteworthy:
- Arrows get piercing damage to align on the rest (but this is cosmetic, the code doesnt care for it)
- Vampirism and other Degen/Fleurets: Slashing -> Piercing
- Camatlatia, Coalition Blade: Piercing -> Slashing
- Malayo Crossbow +1: Slashing -> Piercing
- Bunch of polearms: Slashing -> Piercing
- Date Shuriken gets the appropriate subSkill matching other shurikens


<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
