### PR TITLE
[core, sql] Flag certain items to skip treasure pool rare check and recycle bin

### DIFF
--- a/src/map/packets/c2s/0x028_item_dump.cpp
+++ b/src/map/packets/c2s/0x028_item_dump.cpp
@@ -116,9 +116,9 @@ void GP_CLI_COMMAND_ITEM_DUMP::process(MapSession* PSession, CCharEntity* PChar)
         }
     }
 
-    // Linkshells (other than Linkpearls and Pearlsacks) cannot be stored in the Recycle Bin.
     // Retail accurate: Any item dropped from a container other than inventory skips the recycle bin.
-    if (!settings::get<bool>("map.ENABLE_ITEM_RECYCLE_BIN") || PItem->getID() == ITEMID::LINKSHELL || Category != CONTAINER_ID::LOC_INVENTORY)
+    // Items with the NoRecycle flag bypass the recycle bin entirely (e.g. linkshells).
+    if (!settings::get<bool>("map.ENABLE_ITEM_RECYCLE_BIN") || Category != CONTAINER_ID::LOC_INVENTORY || PItem->hasFlag(ItemFlag::NoRecycle))
     {
         charutils::DropItem(PChar, Category, ItemIndex, ItemNum, PItem->getID());
         return;

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -175,8 +175,10 @@ uint8 CTreasurePool::addItem(uint16 ItemID, CBaseEntity* PEntity)
         return m_count; // no change
     }
 
-    // Check if everyone in the treasure pool already has this tiem
-    if (PNewItem->hasFlag(ItemFlag::Rare))
+    // Check if everyone in the treasure pool already has this item
+    // Some items do not honor this check and will be added to the party pool regardless
+    const bool skipRareCheck = m_TreasurePoolType != TreasurePoolType::Solo && PNewItem->hasFlag(ItemFlag::NoRareCheck);
+    if (PNewItem->hasFlag(ItemFlag::Rare) && !skipRareCheck)
     {
         bool doesNotHaveRareItem = false;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Add NoRareCheck to chest and coffer keys
- Modify treasure pool logic to allow items flagged as such to be added to the treasure pool even if everyone already owns one.
  - This does not apply to solo treasure pools
- Add NoRecycle to Linkshell
- Modify item drop packet to check for it and skip recycle bin if enabled

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
In a party, give both players a Garlaige Chest key and then kill mobs in Garlaige until one is added to the pool.
With the key in pool, have P2 leave zone and chest key should be lost automatically on next tick.

<!-- Clear and detailed steps to test your changes here -->
