### PR TITLE
[Module] Quest "Chocobo's Wounds" - Era-Wait-Time

### DIFF
--- a/modules/soa/lua/quest_adjustments.lua
+++ b/modules/soa/lua/quest_adjustments.lua
@@ -1,0 +1,82 @@
+-----------------------------------
+-- Module: Quest Adjustments (Seekers of Adoulin Era)
+-- Desc: Reverts quest adjustments that were done in the SoA expansion
+-----------------------------------
+require('modules/module_utils')
+require('scripts/globals/interaction/interaction_global')
+-----------------------------------
+local m = Module:new('chocobos_wounds_era_wait')
+-----------------------------------
+-- Reverts "Chocobo's Wounds" Feeding Timers To 1 Game Day
+-- Source: https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-%28JST%29-Version-Update
+-----------------------------------
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Chocobos_Wounds', function(quest)
+        -- Override trade function timer with VanadielUniqueDay instead of GetSystemTime +45
+        quest.sections[2][xi.zone.UPPER_JEUNO]['Chocobo'].onTrade = function(player, npc, trade)
+            if trade:getItemQty(xi.item.BUNCH_OF_GYSAHL_GREENS) > 0 then
+                return quest:event(76)
+            end
+
+            if trade:getItemQty(xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) == 0 then
+                return quest:noAction()
+            end
+
+            if quest:getVar(player, 'Timer') >= VanadielUniqueDay() then
+                return quest:event(73)
+            end
+
+            local eventTable =
+            {
+                [1] = 57,
+                [2] = 58,
+                [3] = 99,
+                [4] = 59,
+                [5] = 60,
+                [6] = 64,
+            }
+
+            local questProgress = quest:getVar(player, 'Prog')
+            if questProgress <= 2 then
+                return quest:progressEvent(eventTable[questProgress])
+            end
+
+            if npcUtil.tradeHasExactly(trade, xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) then
+                return quest:progressEvent(eventTable[questProgress])
+            end
+        end
+
+        quest.sections[2][xi.zone.UPPER_JEUNO].onEventFinish[57] = function(player, csid, option, npc)
+            quest:setVar(player, 'Timer', VanadielUniqueDay())
+            quest:setVar(player, 'Prog', 2)
+        end
+
+        quest.sections[2][xi.zone.UPPER_JEUNO].onEventFinish[58] = function(player, csid, option, npc)
+            quest:setVar(player, 'Timer', VanadielUniqueDay())
+            quest:setVar(player, 'Prog', 3)
+        end
+
+        quest.sections[2][xi.zone.UPPER_JEUNO].onEventFinish[59] = function(player, csid, option, npc)
+            quest:setVar(player, 'Timer', VanadielUniqueDay())
+            quest:setVar(player, 'Prog', 5)
+            player:confirmTrade()
+        end
+
+        quest.sections[2][xi.zone.UPPER_JEUNO].onEventFinish[60] = function(player, csid, option, npc)
+            quest:setVar(player, 'Timer', VanadielUniqueDay())
+            quest:setVar(player, 'Prog', 6)
+            player:confirmTrade()
+        end
+
+        quest.sections[2][xi.zone.UPPER_JEUNO].onEventFinish[99] = function(player, csid, option, npc)
+            quest:setVar(player, 'Timer', VanadielUniqueDay())
+            quest:setVar(player, 'Prog', 4)
+            player:confirmTrade()
+        end
+    end)
+end)
+
+-- The final event [64] does not need to set a new timer as the quest is already complete at that point
+return m


### PR DESCRIPTION
[Module] Quest "Chocobo's Wounds" - Era Wait-Time

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
1. Modify the "Chocobo's Wounds" quest wait time between trades
from 1 minute to wait for a new unique Vanadiel day.
Proposal Co-Authored-By: Xaver-DaRed

- Makes the quest function like it did in Era prior to Feb. 2015 updates.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Run command in map.exe: gm "player" 4 (5 if you're going to use !addtime)
2. Run the following GM commands in FFXI client

!setplayerlevel 20
!zone Upper Jeuno
!gotoname Brutus
!additem CLUMP_OF_GAUSEBIT_WILDGRASS x4

3. Talk to brutus and start the quest
4. Attempt to trade CLUMP_OF_GAUSEBIT_WILDGRASS to Chocobo every new in game day
- 1st, 2nd, and "too soon" attempts return appropriate dialogue
- Cutscene shows on 3rd attempt
- 3rd, 4th, 5th, and 6th attempts return appropriate dialogue and remove 1 grass from player
5. Quest completed with a cutscene and player received chocobo license

<!-- Clear and detailed steps to test your changes here -->
