### PR TITLE
[sql] Minuet / Titanis Earring Latents

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -1235,6 +1235,12 @@ INSERT INTO `item_latents` VALUES (14757,68,1,64,60); -- Evasion +1 during Garri
 INSERT INTO `item_latents` VALUES (14757,68,1,64,70); -- Evasion +1 during Garrison, level 70+ (6 Eva)
 INSERT INTO `item_latents` VALUES (14757,68,1,64,75); -- Evasion +1 during Garrison, level 75+ (7 Eva)
 
+-- Minuet Earring
+INSERT INTO `item_latents` VALUES (14764,25,3,13,198); -- While effected by Minuet : Accuracy +3
+
+-- Titanis Earring
+INSERT INTO `item_latents` VALUES (14765,27,4,13,197); -- While effected by Minne : Enmity +4
+
 -- Vampire Earring
 INSERT INTO `item_latents` VALUES (14783,8,4,26,1);      -- STR+4 during Nighttime
 INSERT INTO `item_latents` VALUES (14783,10,4,26,1);     -- VIT+4 during Nighttime


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds two items to item_latents.sql

* Minuet Earring (+3 Accuracy while effected by Minuet)

<img width="464" height="220" alt="image" src="https://github.com/user-attachments/assets/8badbc32-62c6-44c8-a5e9-da92af23790e" />

* Titanis Earring (+4 Enmity while effected by Minne)

<img width="449" height="159" alt="image" src="https://github.com/user-attachments/assets/88713dda-47fa-4782-a059-8b07263bea24" />

## Steps to test these changes

Equip Minuet Earring
/checkparam name
cast Minuet
See +3 Acc

Equip TItanis Earring
!getmod Enmity
Cast Minne
See +4 Enmity

