### PR TITLE
[quest] Unbridled Passion bugfix

### DIFF
--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -59,7 +59,10 @@ zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 4 then
+    if
+        csid == 4 or
+        csid == 5
+    then
         player:setCharVar('unbridledPassion', 4)
     elseif csid == 13 then
         player:setCharVar('Dynamis_Status', utils.mask.setBit(player:getCharVar('Dynamis_Status'), 0, true))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds in the secondary CS on zoning into Xarcabard to also trigger the var progression for the quest Unbridled Passion.

## Steps to test these changes

Zone into to Xarc with quest 2 74 and unbridledPassion var 3 and teleport into Xarc via the crystal teleport spell and see that you appropriately progress.
