### PR TITLE
[lua] Implement high/low pdif rolls for melee

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -671,10 +671,18 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
 
     -- Apply level correction to UL/LL
     -- https://www.ffxiah.com/forum/topic/57989/post-2016-level-correction-testing/
-    pDifLowerCap = pDifLowerCap + levelDifFactor
-    pDifUpperCap = pDifUpperCap + levelDifFactor
+    -- Dice roll the 50/50 chance to select two different bounds. Mote has not yet implemented the spike by the time of this post so his ratio is not 50/50 rate.
+    -- His model at the time and implemented spike, so the (0.0, 0.5) bounds also looks different
+    -- https://www.bluegartr.com/threads/108161-pDif-and-damage?p=5007487&viewfull=1#post5007487
+    local upperMax   = math.random(0, 1) == 0 and 0.5 or 0
+    local upperBound = math.max(pDifUpperCap + levelDifFactor, upperMax)
+    local lowerbound = math.max(pDifLowerCap + levelDifFactor, 0)
 
-    pDif = math.random(pDifLowerCap * 1000, pDifUpperCap * 1000) / 1000
+    if upperBound == 0 then
+        return 0
+    end
+
+    pDif = math.random(lowerbound * 1000, upperBound * 1000) / 1000
 
     ----------------------------------------
     -- Step 4: Melee random factor.
@@ -820,6 +828,9 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     pDifLowerCap = pDifLowerCap + levelDifFactor
 
     pDif = math.random(pDifLowerCap * 1000, pDifUpperCap * 1000) / 1000
+
+    -- do not go negative, rolls below zero (proportionally) need to be rolled
+    pDif = math.max(pDif, 0)
 
     ----------------------------------------
     -- Step 4: Ranged critical factor. Bypasses caps.

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -518,6 +518,37 @@ xi.combat.physical.wRatioCapOthers = function(wRatio, pDifFinalCap)
     return pDifLowerCap, pDifUpperCap
 end
 
+---@param isPC boolean
+---@param wRatio number
+---@return number
+local function getSpikeRatio(isPC, wRatio)
+    if isPC then
+        -- https://www.bg-wiki.com/ffxi/PDIF#Average_Melee_pDIF(qRatio)
+        -- This is also known as "pDIF spike"
+        if wRatio > 0.5 and wRatio < 1.5 then -- 0.5 and 1.5 are 0% chance
+            local sRatio = (0.5 - math.abs(wRatio - 1)) * 1.2
+
+            return utils.clamp(sRatio, 0, 1 / 3) -- 1/3 (one-third), not 0.33
+        end
+    else
+        -- https://www.ffxiah.com/forum/topic/58479/monster-pdif-curves-and-other-info/#3751498
+        -- This is also known as "pDIF spike"
+        local sRatio = 0
+
+        if wRatio > 0.0 and wRatio < 0.75 then
+            sRatio = -5 / 9 + (10 / 9) * wRatio
+        elseif wRatio <= 1.3 then
+            sRatio = 0.3
+        else
+            sRatio = 5 / 3 - (270 / 256) * wRatio
+        end
+
+        return utils.clamp(sRatio, 0, 0.3)
+    end
+
+    return 0
+end
+
 -- WARNING: This function is used in src/utils/battleutils.cpp "GetDamageRatio" function.
 -- If you update this parameters, update them there aswell.
 ---@param actor CBaseEntity
@@ -614,16 +645,10 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     if actor:isPC() then
         pDifFinalCap = (xi.combat.physical.pDifWeaponCapTable[weaponType] + damageLimitPlus) * damageLimitPercent + (isCritical and 1 or 0)
 
-        -- https://www.bg-wiki.com/ffxi/PDIF#Average_Melee_pDIF(qRatio)
-        -- This is also known as "pDIF spike"
-        if wRatio > 0.5 and wRatio < 1.5 then -- 0.5 and 1.5 are 0% chance
-            local sRatio = (0.5 - math.abs(wRatio - 1)) * 1.2
+        local sRatio = getSpikeRatio(true, wRatio)
 
-            sRatio = utils.clamp(sRatio, 0, 1 / 3) -- 1/3 (one-third), not 0.33
-
-            if math.random(1, 10000) / 10000 <= sRatio then
-                return 1.0
-            end
+        if math.random(1, 10000) / 10000 <= sRatio then
+            return 1.0
         end
 
         pDifLowerCap, pDifUpperCap = xi.combat.physical.wRatioCapPC(wRatio, pDifFinalCap)
@@ -635,19 +660,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
         local critBonus = (applyLevelCorrection and isCritical) and 1 or 0
         pDifFinalCap    = (basePDIF + damageLimitPlus) * damageLimitPercent + critBonus
 
-        -- https://www.ffxiah.com/forum/topic/58479/monster-pdif-curves-and-other-info/#3751498
-        -- This is also known as "pDIF spike"
-        local sRatio = 0
-
-        if wRatio > 0.0 and wRatio < 0.75 then
-            sRatio = -5 / 9 + (10 / 9) * wRatio
-        elseif wRatio <= 1.3 then
-            sRatio = 0.3
-        else
-            sRatio = 5 / 3 - (270 / 256) * wRatio
-        end
-
-        sRatio = utils.clamp(sRatio, 0, 0.3)
+        local sRatio = getSpikeRatio(false, wRatio)
 
         if math.random(1, 10000) / 10000 <= sRatio then
             return 1.0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the 50/50 high/low pdif selector for super low pdif values based on source cited in the code and word from Jimmayus (and other math nerds)

Fixes #9783

## Steps to test these changes
Have ultra low pdif (1 attack vs 20k+ def mob), sometimes hit for non-zero with at ( weapon damage minus fstr) * .5 *1.05 and half of the time for zero


22 base damage weapon:
<img width="484" height="494" alt="image" src="https://github.com/user-attachments/assets/3dc48702-1b50-4a71-9cbe-99a89564ae3f" />
