### PR TITLE
[Quest] Chocobos Wounds And Chocobo on the Loose Fixes

### DIFF
--- a/scripts/quests/jeuno/Chocobo_on_the_Loose.lua
+++ b/scripts/quests/jeuno/Chocobo_on_the_Loose.lua
@@ -17,7 +17,29 @@ quest.reward =
 
 quest.sections =
 {
-    -- NOTE: This quest is flagged by Chocobo's Wounds
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and player:getMainLvl() >= 20 and xi.settings.main.ENABLE_TOAU == 1
+        end,
+
+        [xi.zone.UPPER_JEUNO] =
+        {
+            ['Brutus'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:progressEvent(10093)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [10093] = function(player, csid, option, npc)
+                    quest:begin(player)
+                end,
+            },
+        },
+    },
+
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED
@@ -28,7 +50,7 @@ quest.sections =
             ['Chocobo_Tracks'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 1 then
+                    if quest:getVar(player, 'Prog') == 0 then
                         return quest:progressEvent(209)
                     end
                 end,
@@ -37,7 +59,7 @@ quest.sections =
             onEventFinish =
             {
                 [209] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 2)
+                    quest:setVar(player, 'Prog', 1)
                 end,
             },
         },
@@ -49,9 +71,9 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local questProgress = quest:getVar(player, 'Prog')
 
-                    if questProgress == 3 then
+                    if questProgress == 2 then
                         return quest:progressEvent(821)
-                    elseif questProgress == 4 then
+                    elseif questProgress == 3 then
                         return quest:progressEvent(822)
                     end
                 end,
@@ -60,7 +82,7 @@ quest.sections =
             onEventFinish =
             {
                 [821] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 4)
+                    quest:setVar(player, 'Prog', 3)
                 end,
             },
         },
@@ -73,17 +95,15 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if questProgress == 0 then
-                        return quest:progressEvent(10093)
+                        return quest:event(10094):oncePerZone()
                     elseif questProgress == 1 then
-                        return quest:progressEvent(10094):oncePerZone()
-                    elseif questProgress == 2 then
                         return quest:progressEvent(10095)
+                    elseif questProgress == 2 then
+                        return quest:event(10099)
                     elseif questProgress == 3 then
-                        return quest:progressEvent(10099)
-                    elseif questProgress == 4 then
                         return quest:progressEvent(10100)
                     elseif
-                        questProgress == 5 and
+                        questProgress == 4 and
                         not quest:getMustZone(player) and
                         quest:getVar(player, 'Timer') <= VanadielUniqueDay()
                     then
@@ -94,18 +114,14 @@ quest.sections =
 
             onEventFinish =
             {
-                [10093] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 1)
-                end,
-
                 [10095] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 3)
+                    quest:setVar(player, 'Prog', 2)
                 end,
 
                 [10100] = function(player, csid, option, npc)
-                    quest:setMustZone(player)
-                    quest:setVar(player, 'Prog', 5)
+                    quest:setVar(player, 'Prog', 4)
                     quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
+                    quest:setMustZone(player)
                 end,
 
                 [10109] = function(player, csid, option, npc)

--- a/scripts/quests/jeuno/Chocobos_Wounds.lua
+++ b/scripts/quests/jeuno/Chocobos_Wounds.lua
@@ -12,27 +12,10 @@ local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.CHOCOBOS_WOUNDS)
 
 quest.reward =
 {
-    fame = 30,
+    fame     = 30,
     fameArea = xi.fameArea.JEUNO,
-    keyItem = xi.ki.CHOCOBO_LICENSE,
-    title = xi.title.CHOCOBO_TRAINER,
-}
-
--- The following tables are based on the stage variable for feeding
--- the chocobo.
-local oskerFeedTriggers =
-{
-    103, 51, 52, 59, 46, 55,
-}
-
-local chocoboFeedTriggers =
-{
-    103, 51, 52, 61, 46, 55,
-}
-
-local chocoboFeedTrades =
-{
-    57, 58, 59, 60, 63, 64,
+    keyItem  = xi.ki.CHOCOBO_LICENSE,
+    title    = xi.title.CHOCOBO_TRAINER,
 }
 
 quest.sections =
@@ -57,27 +40,15 @@ quest.sections =
                 end,
             },
 
-            -- TODO: Need to verify these aren't a default action that gets replaced.
-            ['Chocobo'] =
-            {
-                onTrigger = quest:progressEvent(62),
-                onTrade   = quest:progressEvent(62),
-            },
-
-            ['Osker'] = quest:progressEvent(62),
-
             onEventFinish =
             {
                 [71] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:begin(player)
                         quest:setVar(player, 'Prog', 1)
-                        if xi.settings.main.ENABLE_TOAU == 1 then
-                            -- This quest is automatically flagged during this interaction.
-                            player:addQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.CHOCOBO_ON_THE_LOOSE)
-                        end
+
+                    -- Dialogue changes if the player fails to choose the correct option.
                     else
-                        -- Dialogue changes if the player fails to choose the correct option.
                         quest:setVar(player, 'Declined', 1)
                     end
                 end,
@@ -110,9 +81,9 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if questProgress == 1 then
-                        return quest:progressEvent(65)
+                        return quest:event(65)
                     elseif questProgress == 2 then
-                        return quest:progressEvent(66)
+                        return quest:event(66)
                     else
                         return quest:event(102)
                     end
@@ -122,71 +93,123 @@ quest.sections =
             ['Chocobo'] =
             {
                 onTrade = function(player, npc, trade)
-                    local prog = quest:getVar(player, 'Prog')
-                    if npcUtil.tradeHasExactly(trade, xi.item.BUNCH_OF_GYSAHL_GREENS) then
-                        return quest:progressEvent(76)
-                    elseif
-                        (prog <= 2 and trade:getItemQty(xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) > 0) or
-                        npcUtil.tradeHasExactly(trade, xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS)
-                    then
-                        if quest:getVar(player, 'Timer') <= GetSystemTime() then
-                            return quest:progressEvent(chocoboFeedTrades[quest:getVar(player, 'Prog')])
-                        else
-                            return quest:progressEvent(73)
-                        end
+                    if trade:getItemQty(xi.item.BUNCH_OF_GYSAHL_GREENS) > 0 then
+                        return quest:event(76)
                     end
+
+                    if trade:getItemQty(xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) == 0 then
+                        return quest:noAction()
+                    end
+
+                    if quest:getVar(player, 'Timer') > GetSystemTime() then
+                        return quest:event(73)
+                    end
+
+                    local questProgress = quest:getVar(player, 'Prog')
+                    switch(questProgress): caseof
+                    {
+                        [1] = function()
+                            return quest:progressEvent(57)
+                        end,
+
+                        [2] = function()
+                            return quest:progressEvent(58)
+                        end,
+
+                        [3] = function()
+                            return quest:progressEvent(99)
+                        end,
+
+                        [4] = function()
+                            return quest:progressEvent(59)
+                        end,
+
+                        [5] = function()
+                            return quest:progressEvent(60)
+                        end,
+
+                        [6] = function()
+                            return quest:progressEvent(64)
+                        end,
+                    }
                 end,
 
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(chocoboFeedTriggers[quest:getVar(player, 'Prog')])
+                    if quest:getVar(player, 'Prog') <= 3 then
+                        return quest:event(62)
+                    else
+                        return quest:event(63)
+                    end
                 end,
             },
 
             ['Osker'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(oskerFeedTriggers[quest:getVar(player, 'Prog')])
+                    local questProgress = quest:getVar(player, 'Prog')
+                    switch(questProgress): caseof
+                    {
+                        [1] = function()
+                            return quest:event(103)
+                        end,
+
+                        [2] = function()
+                            return quest:event(51)
+                        end,
+
+                        [3] = function()
+                            return quest:event(52)
+                        end,
+
+                        [4] = function()
+                            return quest:event(49)
+                        end,
+
+                        [5] = function()
+                            return quest:event(46)
+                        end,
+
+                        [6] = function()
+                            return quest:event(47)
+                        end,
+                    }
                 end,
             },
 
             onEventFinish =
             {
                 [57] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
                     quest:setVar(player, 'Prog', 2)
+                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
                 end,
 
                 [58] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
                     quest:setVar(player, 'Prog', 3)
+                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
                 end,
 
                 [59] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    quest:setVar(player, 'Prog', 5)
                     quest:setVar(player, 'Timer', GetSystemTime() + 45)
-                    quest:setVar(player, 'Prog', 4)
-
-                    -- TODO: This needs retail verification to confirm no zoning
-                    -- event has occurred
-                    player:startEvent(99)
+                    player:confirmTrade()
                 end,
 
                 [60] = function(player, csid, option, npc)
-                    player:confirmTrade()
-                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
-                    quest:setVar(player, 'Prog', 5)
-                end,
-
-                [63] = function(player, csid, option, npc)
-                    player:confirmTrade()
-                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
                     quest:setVar(player, 'Prog', 6)
+                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
+                    player:confirmTrade()
                 end,
 
                 [64] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
                     end
+                end,
+
+                [99] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 4)
+                    quest:setVar(player, 'Timer', GetSystemTime() + 45)
+                    player:confirmTrade()
                 end,
             },
         },
@@ -200,9 +223,9 @@ quest.sections =
 
         [xi.zone.UPPER_JEUNO] =
         {
-            ['Brutus']  = quest:event(22), -- Always used except for importantOnce() for Chocobo on the Loose (10094)
-            ['Chocobo'] = quest:event(55),
-            ['Osker']   = quest:event(55),
+            ['Brutus' ] = quest:event(22), -- Always used except for importantOnce() for Chocobo on the Loose (10094)
+            ['Chocobo'] = quest:event(61),
+            ['Osker'  ] = quest:event(53),
         },
     },
 }

--- a/scripts/quests/jeuno/Chocobos_Wounds.lua
+++ b/scripts/quests/jeuno/Chocobos_Wounds.lua
@@ -122,9 +122,13 @@ quest.sections =
             ['Chocobo'] =
             {
                 onTrade = function(player, npc, trade)
+                    local prog = quest:getVar(player, 'Prog')
                     if npcUtil.tradeHasExactly(trade, xi.item.BUNCH_OF_GYSAHL_GREENS) then
                         return quest:progressEvent(76)
-                    elseif npcUtil.tradeHasExactly(trade, xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) then
+                    elseif
+                        (prog <= 2 and trade:getItemQty(xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS) > 0) or
+                        npcUtil.tradeHasExactly(trade, xi.item.CLUMP_OF_GAUSEBIT_WILDGRASS)
+                    then
                         if quest:getVar(player, 'Timer') <= GetSystemTime() then
                             return quest:progressEvent(chocoboFeedTrades[quest:getVar(player, 'Prog')])
                         else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Changes the Chocobo's onTrade function to properly handle non-consuming events.
- The events that don't complete the trade and destroy the item were setting the Gausbit Wildgrass in a reserved state making the item unable to be interacted with until the player zoned or logged out.

## Steps to test these changes

1. Use GM commands
!setplayerlevel 20
!zone Upper Jeuno
!gotoname Brutus
!additem clump_of_gausebit_wildgrass x 4
2. Talk to Brutus and start the quest
3. Trade the grass to Brutus every minute to confirm the item remains intractable and is only consumed on the correct quest stages.
