### PR TITLE
[Mob] SMN AF2 Class Reunion Dryad roaming

### DIFF
--- a/scripts/zones/Cloister_of_Frost/mobs/Dryad.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Dryad.lua
@@ -11,4 +11,11 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 15)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setRoamFlags(xi.roamFlag.NONE)
+    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 5)
+    mob:setMobMod(xi.mobMod.DONT_ROAM_HOME, 1)
+    mob:setMobMod(xi.mobMod.ROAM_COOL, 5)
+end
+
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR correctly allows dryads in the SMN AF2 fight Class Reunion to roam in a small area.

https://youtu.be/FlZnNLwUPjg?t=102

## Steps to test these changes

Enter Class Reunion at the cloister of frost and behold retail accurate behavior.
