### PR TITLE
[magic] Change default spell list entry to a buff

### DIFF
--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -34,7 +34,7 @@ LOCK TABLES `mob_spell_lists` WRITE;
 /*!40000 ALTER TABLE `mob_spell_lists` DISABLE KEYS */;
 
 -- DEFAULT (1) Used for mobs with their cast logic defined in lua.
-INSERT INTO `mob_spell_lists` VALUES ('DEFAULT',1,368,0,255);  -- Foe Requiem (0 ~ 255) -- Placeholder entry.
+INSERT INTO `mob_spell_lists` VALUES ('DEFAULT',1,389,0,255);  -- Knight's Minne (0 ~ 255) -- Placeholder entry. Needs to be a buff.
 
 -- Beastmen_BLM (2)
 INSERT INTO `mob_spell_lists` VALUES ('Beastmen_BLM',2,144,13,22);  -- fire (13~22)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As title sais. Change needed to allow mobs to choose spells via onMobSpellChoose() lua function while roaming.

## Steps to test these changes
None. Thris has already tested them.