### PR TITLE
[Mob] BLU LB Raubahn out of combat self buff adjustment

### DIFF
--- a/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
+++ b/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
@@ -19,6 +19,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
+    mob:setMobMod(xi.mobMod.ROAM_COOL, 8)
     mob:setMod(xi.mod.DMGMAGIC, -1250) -- Observed at 99 and the skillchain damage in under level 71 vods
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     xi.mix.jobSpecial.config(mob, {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR reduces the roam time so Raubahn's self buffing averages out to be about the same as retail.

## Steps to test these changes

Enter the Beast Within and watch Raubahn buff himself multiple times.
