### PR TITLE
[core] [C++] Remove scripted roamflag from battlefield enemies

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1319,9 +1319,8 @@ void SetupBattlefieldMob(CMobEntity* PMob)
     }
 
     // do not roam around
-    PMob->m_roamFlags |= ROAMFLAG_SCRIPTED;
     PMob->setMobMod(MOBMOD_ROAM_RESET_FACING, 1);
-    PMob->m_maxRoamDistance = 0.5f;
+    PMob->m_maxRoamDistance = 0.0f;
     if ((PMob->m_bcnmID != 864) && (PMob->m_bcnmID != 704) && (PMob->m_bcnmID != 706))
     {
         // bcnmID 864 (desires of emptiness), 704 (darkness named), and 706 (waking dreams) don't superlink


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Enemies in battlefields have had a long standing bug of not behaving properly when it comes to pre-combat buffing. The reason is because when setting up battlefield mobs, code in mobutils.cpp was setting their default roam flag to scripted, which causes them not to roam. 

At this time, out of combat buffing is tied to roam ticks, when a mob roams, there is a 30% chance it will also cast a spell. However, setting roam distance to zero achieves the same thing, preventing mobs from inside the battlefield from moving around, while also preserving the ability for the game engine to perform roam checks on the mob, thus allowing it to buff in the battlefield as normal. 

I checked many battlefields and could discern no negative effects. Mobs still path back to their spawn point in battlefields after a wipe as they should and all other behavior seems to work as normal. 

## Steps to test these changes

Rebuild, run BCNMs. See that mobs don't move still, but now buff themselves occasionally (based of ROAM_COOL for now, monsters with lower ROAM_COOL will buff more) 
