### PR TITLE
[cpp] Changes crystal drop rate for TOAU and COP

### DIFF
--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -1037,11 +1037,11 @@ void CMobEntity::DropItems(CCharEntity* PChar)
             }
         }
 
-        uint8 effect = 0; // Begin Adding Crystals
-
+        // Begin Adding Crystals
         if (m_Element > 0)
         {
-            REGION_TYPE regionID = PChar->loc.zone->GetRegionID();
+            REGION_TYPE regionID       = PChar->loc.zone->GetRegionID();
+            EFFECT      requiredEffect = EFFECT_NONE;
 
             switch (regionID)
             {
@@ -1051,7 +1051,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 case REGION_TYPE::HALVUNG:
                 case REGION_TYPE::ARRAPAGO:
                 case REGION_TYPE::ALZADAAL:
-                    effect = 2;
+                    requiredEffect = EFFECT_SANCTION;
                     break;
 
                 // Sigil Regions
@@ -1063,69 +1063,66 @@ void CMobEntity::DropItems(CCharEntity* PChar)
                 case REGION_TYPE::ARAGONEAU_FRONT:
                 case REGION_TYPE::FAUREGANDI_FRONT:
                 case REGION_TYPE::VALDEAUNIA_FRONT:
-                    effect = 3;
+                    requiredEffect = EFFECT_SIGIL;
                     break;
 
                 // Ionis Regions
                 case REGION_TYPE::ADOULIN_ISLANDS:
                 case REGION_TYPE::EAST_ULBUKA:
-                    effect = 4;
+                    requiredEffect = EFFECT_IONIS;
                     break;
 
                 // Signet Regions
                 default:
-                    effect = (regionID < REGION_TYPE::TAVNAZIA && conquest::GetRegionOwner(regionID) <= 2) ? 1 : 0;
+                    if (regionID < REGION_TYPE::TAVNAZIA && conquest::GetRegionOwner(regionID) <= 2)
+                    {
+                        requiredEffect = EFFECT_SIGNET;
+                    }
                     break;
             }
-        }
 
-        uint8 crystalRolls = 0;
-        // clang-format off
-        PChar->ForParty([this, &crystalRolls, &effect](CBattleEntity* PMember)
-        {
-            switch (effect)
+            if (requiredEffect == EFFECT_NONE)
             {
-                case 1:
-                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SIGNET) && PMember->getZone() == getZone() &&
-                        distance(PMember->loc.p, loc.p) < 100)
-                    {
-                        crystalRolls++;
-                    }
-                    break;
-                case 2:
-                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SANCTION) && PMember->getZone() == getZone() &&
-                        distance(PMember->loc.p, loc.p) < 100)
-                    {
-                        crystalRolls++;
-                    }
-                    break;
-                case 3:
-                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_SIGIL) && PMember->getZone() == getZone() &&
-                        distance(PMember->loc.p, loc.p) < 100)
-                    {
-                        crystalRolls++;
-                    }
-                    break;
-                case 4:
-                    if (PMember->StatusEffectContainer->HasStatusEffect(EFFECT_IONIS) && PMember->getZone() == getZone() &&
-                        distance(PMember->loc.p, loc.p) < 100)
-                    {
-                        crystalRolls++;
-                    }
-                    break;
-                default:
-                    break;
+                return;
             }
-        });
-        // clang-format on
 
-        // Is this really checked last? Would crystals actually kick out non-rare/ex items from the same mob dropping a large pool?
-        for (uint8 i = 0; i < crystalRolls; i++)
-        {
-            // TODO: implement nation aketon crystal bonus (per member?)
-            if (xirand::GetRandomNumber(100) < 20)
+            uint8 playersNearby = 0;
+            // clang-format off
+            PChar->ForParty([this, &playersNearby, requiredEffect](CBattleEntity* PMember)
             {
-                AddItemToPool(4095 + m_Element);
+                if (PMember->StatusEffectContainer->HasStatusEffect(requiredEffect) &&
+                    PMember->getZone() == getZone() &&
+                    distance(PMember->loc.p, loc.p) < 100)
+                {
+                    playersNearby++;
+                }
+            });
+            // clang-format on
+
+            if (playersNearby == 0)
+            {
+                return;
+            }
+
+            // Signet regions: 55% if solo, 45% if in a party
+            // Sanction regions: 30%
+            // Others leave at 20% - TODO: need more info on WOTG+
+            uint8 crystalRate = 20;
+            if (requiredEffect == EFFECT_SIGNET)
+            {
+                crystalRate = (playersNearby == 1) ? 55 : 45;
+            }
+            else if (requiredEffect == EFFECT_SANCTION)
+            {
+                crystalRate = 30;
+            }
+
+            for (uint8 i = 0; i < playersNearby; i++)
+            {
+                if (xirand::GetRandomNumber(100) < crystalRate)
+                {
+                    AddItemToPool(4095 + m_Element);
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Notes: All research credit goes to @KnowOne134 and the Eden team

Changes the crystal drop rates for TOAU and COP areas to the following:
Assuming signet/sanction/etc. are on in their appropriate area
- Signet regions: 55% if solo and 45% if in a party and part members are within 100 yards
- Sanction regions: 30% across the board

I left the other regions as the 20% that were in the database originally until more research is done for WOTG+
 
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Login with 2 characters and join the party
1) Kill any EP+ mob with both characters near each other
2) Assuming you have killed enough and procd both crystal drops it should look like this
<img width="1654" height="557" alt="image" src="https://github.com/user-attachments/assets/8e3981e5-23b9-4fad-a6a0-3db4bff8e0c7" />

3) Drop party and kill solo - see crystals still drop
<!-- Clear and detailed steps to test your changes here -->
