### PR TITLE
[lua] utils.shadowAbsorb cleanup + mobskill numHits

### DIFF
--- a/scripts/actions/mobskills/cross_attack.lua
+++ b/scripts/actions/mobskills/cross_attack.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage       = mob:getWeaponDmg()
-    params.numHits          = 1
+    params.numHits          = 2
     params.fTP              = { 1.0, 1.0, 1.0 }
     params.attackType       = xi.attackType.PHYSICAL
     params.damageType       = xi.damageType.HTH

--- a/scripts/actions/mobskills/nimble_snap.lua
+++ b/scripts/actions/mobskills/nimble_snap.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
+    params.numHits        = 3
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING

--- a/scripts/actions/mobskills/savage_blade.lua
+++ b/scripts/actions/mobskills/savage_blade.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
+    params.numHits        = 2
     params.fTP            = { 2.0, 2.0, 2.0 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING

--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -129,46 +129,75 @@ end
 ---@param shadowsToRemove number
 ---@return boolean, number
 function utils.shadowAbsorb(target, shadowsToRemove)
-    local shadowType    = xi.mod.UTSUSEMI
-    local targetShadows = target:getMod(xi.mod.UTSUSEMI)
+    local utsusemiMod = target:getMod(xi.mod.UTSUSEMI)
+    local blinkMod    = target:getMod(xi.mod.BLINK)
 
-    if targetShadows == 0 then
-        if
-            target:getMod(xi.mod.BLINK) == 0 or
-            math.random(1, 100) > 80
-        then
-            return false, 0
-        end
-
-        shadowType    = xi.mod.BLINK
-        targetShadows = target:getMod(xi.mod.BLINK)
+    -- Early return: Target has no shadows.
+    if
+        utsusemiMod == 0 and
+        blinkMod == 0
+    then
+        return false, 0
     end
 
-    local actualConsumed   = math.min(targetShadows, shadowsToRemove)
-    local hadEnoughShadows = targetShadows >= shadowsToRemove
+    local targetShadows   = 0
+    local shadowsConsumed = 0
+    local absorbHit       = false
 
-    targetShadows = targetShadows - actualConsumed
+    -- Utsusemi takes precedence over blink.
+    if utsusemiMod > 0 then
+        shadowsConsumed = utils.clamp(shadowsToRemove, 0, utsusemiMod) -- How many shadows were consumed (Used for SHADOW_ABSORB messaging later).
+        targetShadows   = utsusemiMod - shadowsConsumed                -- How many shadows left after the attack.
+        absorbHit       = utsusemiMod >= shadowsToRemove               -- Check to see if the target had enough shadows to block the attack.
 
-    if shadowType == xi.mod.UTSUSEMI then
         local effect = target:getStatusEffect(xi.effect.COPY_IMAGE)
-
         if effect then
-            local icons = { xi.effect.COPY_IMAGE, xi.effect.COPY_IMAGE_2, xi.effect.COPY_IMAGE_3 }
-
-            if icons[targetShadows] then
-                effect:setIcon(icons[targetShadows])
+            if targetShadows == 0 then
+                target:delStatusEffect(xi.effect.COPY_IMAGE)
+            elseif targetShadows == 1 then
+                effect:setIcon(xi.effect.COPY_IMAGE)
+            elseif targetShadows == 2 then
+                effect:setIcon(xi.effect.COPY_IMAGE_2)
+            elseif targetShadows == 3 then
+                effect:setIcon(xi.effect.COPY_IMAGE_3)
+            else
+                effect:setIcon(xi.effect.COPY_IMAGE_4) -- 4 or more shadows active use the same "4+" icon.
             end
         end
+
+        target:setMod(xi.mod.UTSUSEMI, targetShadows)
+
+    -- Blink has a random chance of triggering when no utsusemi is present.
+    elseif blinkMod > 0 then
+        if math.random(1, 100) <= 20 then
+            absorbHit = false
+
+            return absorbHit, 0
+        end
+
+        shadowsConsumed = utils.clamp(shadowsToRemove, 0, blinkMod) -- How many shadows were consumed by the attack (Used for SHADOW_ABSORB messaging later)
+        targetShadows   = blinkMod - shadowsConsumed                -- How many shadows left over after the attack.
+        absorbHit       = blinkMod >= shadowsToRemove               -- Check to see if the target had enough shadows to fully block the attack.
+
+        if targetShadows == 0 then
+            target:delStatusEffect(xi.effect.BLINK)
+        end
+
+        target:setMod(xi.mod.BLINK, targetShadows)
+
+        -- Retail Testing Notes:
+        -- Tested with WHM spell Blink
+        -- 1 hit skills took 1 shadow.
+        -- TODO: When hit by a 2 hit skill, it was observed to consume 2 blink shadows, however the message returned was SKILL_MISS rather than SHADOW_ABSORB.
+        -- Did not block 3+ hit mob skills. (Player Weaponskills untested)
+        -- AOE skills delete Blink.
+
+        -- TODO: Test Zephyr Mantle proc rate.
+        -- TODO: Test player Weapon Skills on mob/players with Blink/Zephyr Mantle.
+        -- Note: JPWiki/FFXIPedia repeatedly mentions that Blink can block multi hit skills, but this was not observed in testing. Needs further testing.
     end
 
-    target:setMod(shadowType, targetShadows)
-
-    if targetShadows == 0 then
-        target:delStatusEffect(xi.effect.COPY_IMAGE)
-        target:delStatusEffect(xi.effect.BLINK)
-    end
-
-    return hadEnoughShadows, actualConsumed
+    return absorbHit, shadowsConsumed
 end
 
 -- Calculates Phalanx damage reduction.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Cleans up utils.shadowAbsorb. Supports shadows values above 4.

2. Corrects three mobskill where numHits was set to incorrect value. Went over all the skills again to make numHits was correct based on existing information/captures.

## Steps to test these changes
Test Utsusemi:

1. Cast Utsusemi: Ni on self.
2. `!exec target:useMobAbility(257, player)` This is a single target skill. Use it until you run out of shadows in 4 attempts.
3. Cast Utsusemi: Ni on self.
4. `!exec target:useMobAbility(363, player)` This is a conal multi hit that can take up to 4 shadows. Use until your shadows deplete.
5. Cast Utsusemi: Ni on self.
6. `!setmod utsusemi 6 <me>`  This gives you 6 shadows. Note: Icons only support up to 4 so it will say 4+ until you have 3 shadows.
7. Repeat earlier steps with mob skills. See that your shadow icons update once you get to less than 4 shadows.

Test Blink:

1. Cast Blink on self.
2. `!exec target:useMobAbility(257, player)` This is a single target skill. Use it until you run out of shadows.
3. Cast Blink on self again.
4. `!exec target:useMobAbility(460, player)` This is a single target 2 hit skill. It should eat both shadows if Blink procs.
5. Cast Blink on self again.
6. `!exec target:useMobAbility(590, player)` This is a single target 3 hit skill. It should eat both shadows and deal full damage through your blink.