### PR TITLE
[cpp] Fix NM hp in mob groups not working

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -712,36 +712,43 @@ void CalculateMobStats(CMobEntity* PMob, bool recover)
 
     if (recover == true)
     {
-        // HP Calculations
-        mJobGrade = grade::GetJobGrade(mJob, 0);
-        sJobGrade = grade::GetJobGrade(sJob, 0);
-
-        // 1. Retrieve HP scaling values from job grades
-        // Index 0: Base HP
-        // Index 1: Job scaling
-        // Index 2: Modifier scale
-        uint8 BaseHP     = grade::GetMobHPScale(mJobGrade, 0);
-        uint8 JobScale   = grade::GetMobHPScale(mJobGrade, 1);
-        uint8 ScaleXHP   = grade::GetMobHPScale(mJobGrade, 2);
-        uint8 sjJobScale = grade::GetMobHPScale(sJobGrade, 1);
-        uint8 sjScaleXHP = grade::GetMobHPScale(sJobGrade, 2);
-
-        // 2. Calculate base HP from main job
-        uint32 baseMobHP = CalculateBaseMobHP(mLvl, BaseHP, JobScale, ScaleXHP);
-
-        // 3. Calculate subjob HP contribution scaled by level range
-        uint32 sjHP = CalculateSubjobHP(mLvl, sjJobScale, sjScaleXHP);
-
-        // 4. Final mob HP before traits/family modifiers
-        uint32 mobHP = baseMobHP + sjHP;
-
-        // 5. Apply pet multiplier (pets are 30% of base mob HP)
-        if (PMob->PMaster != nullptr)
+        if (PMob->HPmodifier == 0)
         {
-            mobHP = (uint32)(mobHP * 0.30f);
-        }
+            // HP Calculations
+            mJobGrade = grade::GetJobGrade(mJob, 0);
+            sJobGrade = grade::GetJobGrade(sJob, 0);
 
-        PMob->health.maxhp = (int16)(mobHP);
+            // 1. Retrieve HP scaling values from job grades
+            // Index 0: Base HP
+            // Index 1: Job scaling
+            // Index 2: Modifier scale
+            uint8 BaseHP     = grade::GetMobHPScale(mJobGrade, 0);
+            uint8 JobScale   = grade::GetMobHPScale(mJobGrade, 1);
+            uint8 ScaleXHP   = grade::GetMobHPScale(mJobGrade, 2);
+            uint8 sjJobScale = grade::GetMobHPScale(sJobGrade, 1);
+            uint8 sjScaleXHP = grade::GetMobHPScale(sJobGrade, 2);
+
+            // 2. Calculate base HP from main job
+            uint32 baseMobHP = CalculateBaseMobHP(mLvl, BaseHP, JobScale, ScaleXHP);
+
+            // 3. Calculate subjob HP contribution scaled by level range
+            uint32 sjHP = CalculateSubjobHP(mLvl, sjJobScale, sjScaleXHP);
+
+            // 4. Final mob HP before traits/family modifiers
+            uint32 mobHP = baseMobHP + sjHP;
+
+            // 5. Apply pet multiplier (pets are 30% of base mob HP)
+            if (PMob->PMaster != nullptr)
+            {
+                mobHP = (uint32)(mobHP * 0.30f);
+            }
+
+            PMob->health.maxhp = (int16)(mobHP);
+        }
+        else
+        {
+            PMob->health.maxhp = PMob->HPmodifier;
+        }
 
         // Apply NM/Mob HP multiplier from settings
         if (isNM)
@@ -1732,6 +1739,7 @@ auto InstantiateAlly(uint32 groupid, uint16 zoneID, CInstance* instance) -> CMob
         PMob->m_SpawnType   = rset->get<SPAWNTYPE>("spawntype");
         PMob->m_DropID      = rset->get<uint32>("dropid");
 
+        PMob->HPmodifier = rset->get<uint32>("HP");
         PMob->MPmodifier = rset->get<uint32>("MP");
 
         PMob->m_minLevel = rset->get<uint8>("minLevel");
@@ -1904,6 +1912,7 @@ auto InstantiateDynamicMob(uint32 groupid, uint16 groupZoneId, uint16 targetZone
         PMob->m_SpawnType   = rset->get<SPAWNTYPE>("spawntype");
         PMob->m_DropID      = rset->get<uint32>("dropid");
 
+        PMob->HPmodifier = rset->get<uint32>("HP");
         PMob->MPmodifier = rset->get<uint32>("MP");
 
         uint16 sqlModelID[10];


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I broke NM HP by accident when I removed the HPModifer == 0 call. I did not know that was hooked up to the same one that was being unused in the mobutils cpp in the sql call outs.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
NM
!spawnmob 16896131
!gotoid 16896131
See Boroka have 9000 HP

Normal Mob
!gotoid 17273010
See it have around 1800-1900 HP depending on its level (normal mob)
<img width="811" height="694" alt="image" src="https://github.com/user-attachments/assets/415f6d43-35fa-470e-99bc-e8ac96fd3280" />

<!-- Clear and detailed steps to test your changes here -->
