### PR TITLE
[core] Mobskills only trigger resonance on main target

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2847,18 +2847,22 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
             result.resolution = ActionResolution::Hit;
         }
 
-        if (result.resolution != ActionResolution::Miss && result.resolution != ActionResolution::Parry)
+        if (first)
         {
-            if (first && PTargetFound->health.hp > 0 && PSkill->getPrimarySkillchain() != 0)
+            bool isNegated = result.resolution == ActionResolution::Miss || result.resolution == ActionResolution::Parry;
+            if (!isNegated)
             {
-                const auto effect = battleutils::GetSkillChainEffect(PTargetFound, PSkill->getPrimarySkillchain(), PSkill->getSecondarySkillchain(), PSkill->getTertiarySkillchain());
-                if (effect != ActionProcSkillChain::None)
+                if (PTargetFound->health.hp > 0 && PSkill->getPrimarySkillchain() != 0)
                 {
-                    result.recordSkillchain(effect, battleutils::TakeSkillchainDamage(this, PTargetFound, result.param, nullptr));
+                    const auto effect = battleutils::GetSkillChainEffect(PTargetFound, PSkill->getPrimarySkillchain(), PSkill->getSecondarySkillchain(), PSkill->getTertiarySkillchain());
+                    if (effect != ActionProcSkillChain::None)
+                    {
+                        result.recordSkillchain(effect, battleutils::TakeSkillchainDamage(this, PTargetFound, result.param, nullptr));
+                    }
                 }
-
-                first = false;
             }
+
+            first = false;
         }
 
         if (PSkill->getValidTargets() & TARGET_ENEMY)

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1623,7 +1623,8 @@ void CCharEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& acti
                 // On retail, weaponskills will contain 0x08, 0x10 (HIT, ABILITY) on hit and may include the following:
                 // 0x01, 0x02, 0x04 (MISS, GUARDED, BLOCK)
                 // TODO: refactor this so lua returns the number of hits so we don't have to check the reaction bits.
-                if (actionResult.resolution != ActionResolution::Miss)
+                bool isNegated = actionResult.resolution == ActionResolution::Miss || actionResult.resolution == ActionResolution::Parry;
+                if (!isNegated)
                 {
                     int wspoints = settings::get<uint8>("map.WS_POINTS_BASE");
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Trust WS resonance was leaking to secondary targets if the initial target dodged the hit due to the way the conditionals were nested. 

Added a missing parry check on the player side while I was at it.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
- PC can skillchain
- No skillchain on parried WSs
- Trusts can skillchains

<!-- Clear and detailed steps to test your changes here -->
