### PR TITLE
[core] Set EVA Rank fallback for mobs with no subjob.

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1279,6 +1279,11 @@ uint8 JobSkillRankToBaseEvaRank(JOBTYPE mjob, JOBTYPE sjob)
     uint8 mainEvasionSkillRank = battleutils::GetSkillRank(SKILL_EVASION, mjob);
     uint8 subEvasionSkillRank  = battleutils::GetSkillRank(SKILL_EVASION, sjob);
 
+    if (sjob == JOB_NON)
+    {
+        subEvasionSkillRank = mainEvasionSkillRank;
+    }
+
     switch (std::min(mainEvasionSkillRank, subEvasionSkillRank))
     {
         case 1:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes https://github.com/LandSandBoat/server/issues/8380

For mobs with no subjob, JobSkillRankToBaseEvaRank() couldn't find an appropriate skill rank for the subjob since subjob was "None/0". This caused an error to get thrown in map.

## Steps to test these changes

1. Give yourself GM
2. !zone to a burning circle with a maat fight. All Maats should have subjob 0 so any should do for this test.
3. Enter a Maat BCNM.
4. After cutscene and Maat is spawned, check map.exe log
5. Do not see the following error in map: `JobSkillRankToBaseEvaRank: rank not implemented. Job SKILL_EVASION rank is likely not valid or no longer exists (A- rank in particular.)`
