### PR TITLE
[core, lua] Execute *_TAKE listeners on all targets. Lower cleave stagger chance in Dynamis

### DIFF
--- a/scripts/mixins/dynamis_dreamland.lua
+++ b/scripts/mixins/dynamis_dreamland.lua
@@ -43,8 +43,11 @@ g_mixins.dynamis_dreamland = function(dynamisDreamlandMob)
         [4] = { single = 250, hundred = 50 },
     }
 
-    dynamisDreamlandMob:addListener('MAGIC_TAKE', 'DYNAMIS_MAGIC_PROC_CHECK', function(target, caster, spell)
-        if math.random(1, 100) > 8 then
+    dynamisDreamlandMob:addListener('MAGIC_TAKE', 'DYNAMIS_MAGIC_PROC_CHECK', function(target, caster, spell, action)
+        local isPrimary = action and target:getID() == action:getPrimaryTargetID()
+        local chance = isPrimary and 8 or 1 -- Lowered chance if not primary target. 1% is likely not the right number, submit captures.
+
+        if math.random(1, 100) > chance then
             return
         end
 
@@ -65,7 +68,10 @@ g_mixins.dynamis_dreamland = function(dynamisDreamlandMob)
     end)
 
     dynamisDreamlandMob:addListener('WEAPONSKILL_TAKE', 'DYNAMIS_WS_PROC_CHECK', function(user, target, skill, tp, action)
-        if math.random(1, 100) > 25 then
+        local isPrimary = action and target:getID() == action:getPrimaryTargetID()
+        local chance = isPrimary and 25 or 2 -- Lowered chance if not primary target. 2% is likely not the right number, submit captures.
+
+        if math.random(1, 100) > chance then
             return
         end
 
@@ -86,7 +92,10 @@ g_mixins.dynamis_dreamland = function(dynamisDreamlandMob)
     end)
 
     dynamisDreamlandMob:addListener('ABILITY_TAKE', 'DYNAMIS_ABILITY_PROC_CHECK', function(user, target, skill, action)
-        if math.random(1, 100) > 20 then
+        local isPrimary = action and target:getID() == action:getPrimaryTargetID()
+        local chance = isPrimary and 20 or 2 -- Lowered chance if not primary target. 2% is likely not the right number, submit captures.
+
+        if math.random(1, 100) > chance then
             return
         end
 

--- a/scripts/tests/systems/listeners.lua
+++ b/scripts/tests/systems/listeners.lua
@@ -1,0 +1,50 @@
+describe('AoE Listeners', function()
+    ---@type CClientEntityPair
+    local player
+
+    ---@type CTestEntity
+    local mob1
+
+    ---@type CTestEntity
+    local mob2
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            zone  = xi.zone.WEST_RONFAURE,
+            job   = xi.job.BLM,
+            level = 99,
+        })
+
+        mob1 = player.entities:moveTo('Wild_Rabbit')
+        mob2 = player.entities:moveTo('Wild_Sheep')
+
+        local pos = player:getPos()
+        mob1:setPos(pos.x, pos.y, pos.z)
+        mob2:setPos(pos.x, pos.y, pos.z)
+    end)
+
+    it('fires MAGIC_TAKE on all targets of an AoE spell', function()
+        local mob1Hit = false
+        local mob2Hit = false
+
+        mob1:addListener('MAGIC_TAKE', 'TEST_MAGIC_TAKE_1', function()
+            mob1Hit = true
+        end)
+
+        mob2:addListener('MAGIC_TAKE', 'TEST_MAGIC_TAKE_2', function()
+            mob2Hit = true
+        end)
+
+        player:addSpell(xi.magic.spell.FIRAGA)
+        player.actions:useSpell(mob1, xi.magic.spell.FIRAGA)
+        xi.test.world:tickEntity(player)
+        xi.test.world:skipTime(10)
+
+        assert(mob1Hit, 'MAGIC_TAKE should fire on primary target')
+        assert(mob2Hit, 'MAGIC_TAKE should fire on AoE subtarget')
+
+        mob1:removeListener('TEST_MAGIC_TAKE_1')
+        mob2:removeListener('TEST_MAGIC_TAKE_2')
+    end)
+end)

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -37,6 +37,7 @@
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
+#include "utils/zoneutils.h"
 
 namespace
 {
@@ -209,9 +210,13 @@ bool CAbilityState::Update(timer::time_point tick)
             {
                 m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
             }
-            if (auto* target = GetTarget())
+            for (auto& actionTarget : action.targets)
             {
-                target->PAI->EventHandler.triggerListener("ABILITY_TAKE", m_PEntity, target, m_PAbility.get(), &action);
+                auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
+                if (PActionTarget)
+                {
+                    PActionTarget->PAI->EventHandler.triggerListener("ABILITY_TAKE", m_PEntity, PActionTarget, m_PAbility.get(), &action);
+                }
             }
         }
 

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -38,6 +38,7 @@
 #include "spell.h"
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
+#include "utils/zoneutils.h"
 
 CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid, uint8 flags)
 : CState(PEntity, targid)
@@ -260,7 +261,14 @@ bool CMagicState::Update(timer::time_point tick)
         {
             m_PEntity->OnCastFinished(*this, action);
             m_PEntity->PAI->EventHandler.triggerListener("MAGIC_USE", m_PEntity, PTarget, m_PSpell.get(), &action);
-            PTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", PTarget, m_PEntity, m_PSpell.get(), &action);
+            for (auto& actionTarget : action.targets)
+            {
+                auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
+                if (PActionTarget)
+                {
+                    PActionTarget->PAI->EventHandler.triggerListener("MAGIC_TAKE", PActionTarget, m_PEntity, m_PSpell.get(), &action);
+                }
+            }
         }
 
         // Zero messageID so spells dont emit messages

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -29,6 +29,7 @@
 #include "roe.h"
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
+#include "utils/zoneutils.h"
 #include "weapon_skill.h"
 
 CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid)
@@ -158,7 +159,14 @@ bool CWeaponSkillState::Update(timer::time_point tick)
                 uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
                 m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", m_PEntity, PTarget, m_PSkill.get(), m_spent, &action, weaponskillDamage);
-                PTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", m_PEntity, PTarget, m_PSkill.get(), m_spent, &action);
+                for (auto& actionTarget : action.targets)
+                {
+                    auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
+                    if (PActionTarget)
+                    {
+                        PActionTarget->PAI->EventHandler.triggerListener("WEAPONSKILL_TAKE", m_PEntity, PActionTarget, m_PSkill.get(), m_spent, &action);
+                    }
+                }
 
                 if (m_PEntity->objtype == TYPE_PC)
                 {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closing a gap I've been aware of for a while: _TAKE listeners only execute for main targets presently. 
This PR makes it so the listener is executed for all targets.

This enables cleave procs in Dynamis so I'm lowering the rate for subtargets from Magic 8%/JA 20%/WS 25% to 1%/2%/2%. 
I've tried digging exact numbers but all that floats around is "significantly reduced" and I'm not willing to go capture 1000 procs myself right this minute.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
