### PR TITLE
[lua] Fix hybridDamage mobskill function

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -1790,22 +1790,22 @@ xi.mobskills.calculatePetMagicAccuracyBonus = function(mob, target, actionElemen
 end
 
 xi.mobskills.handleHybridDamage = function(mob, target, physicalDamage, element)
-    local magicDamage = math.floor(physicalDamage * 2)
+    local magicDamage = math.floor(physicalDamage)
 
     -- Multipliers.
     local nullifyDamage         = xi.spells.damage.calculateNullification(target, element, true, false)
-    local absorbDamage          = xi.spells.damage.calculateAbsorption(target, element.hybridSkillElement, true)
+    local absorbDamage          = xi.spells.damage.calculateAbsorption(target, element, true)
     local sdt                   = 1
     local resist                = 1
     local magicDamageAdjustment = 1
-    local dayAndWeather         = xi.spells.damage.calculateDayAndWeather(mob, element.hybridSkillElement, false)
-    local magicBonusDiff        = xi.spells.damage.calculateMagicBonusDiff(mob, target, 0, 0, element.hybridSkillElement, 0)
-    local petAccBonus           = xi.mobskills.calculatePetMagicAccuracyBonus(mob, target, element.hybridSkillElement)
+    local dayAndWeather         = xi.spells.damage.calculateDayAndWeather(mob, element, false)
+    local magicBonusDiff        = xi.spells.damage.calculateMagicBonusDiff(mob, target, 0, 0, element, 0)
+    local petAccBonus           = xi.mobskills.calculatePetMagicAccuracyBonus(mob, target, element)
     -- Note: Elemental absorb mechanics such as Liement are calculated BEFORE resist/damage adjustments (such as shell/magic bursts).
 
     if absorbDamage > 0 then
-        sdt                   = xi.combat.damage.magicalElementSDT(target, element.hybridSkillElement)
-        resist                = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, element.hybridSkillElement, xi.mod.INT, 0, petAccBonus)
+        sdt                   = xi.combat.damage.magicalElementSDT(target, element)
+        resist                = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, element, xi.mod.INT, 0, petAccBonus)
         magicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
     end
 
@@ -1817,8 +1817,9 @@ xi.mobskills.handleHybridDamage = function(mob, target, physicalDamage, element)
     magicDamage = math.floor(magicDamage * magicDamageAdjustment)
     magicDamage = math.floor(magicDamage * absorbDamage)
     magicDamage = math.floor(magicDamage * nullifyDamage)
-    magicDamage = utils.handleOneForAll(target, magicDamage)
+    magicDamage = math.floor(magicDamage * 0.5)
 
+    magicDamage = utils.handleOneForAll(target, magicDamage)
     magicDamage = utils.handleStoneskin(target, magicDamage)
 
     return magicDamage


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Overlooked this since I didn't have it hooked up to anything at the time of testing.

Fixes handleHybridDamage() function used for future hybrid bloodpacts/mobskills.

## Steps to test these changes

1. Pick any physical mobskill script. Add the following:
-- params.hybridSkill = true
-- params.hybridSkillElement = xi.element.FIRE
-- params.hybridAttackType = xi.attackType.MAGICAL
-- params.hybridDamageType = xi.damageType.FIRE

2. execute that script on yourself using `!exec target:useMobAbility(skillID, player)` on a mob
3. Test Absorb or Nullification on yourself `!setmod FIRE_ABSORB 100` or `!setmod FIRE_NULL`
4. See that NULL mod reduces to 0 and Absorb reduces damage of the skill (You usually won't be able to get it to do more damage than the primary physical damage and actually see the healing message)

