### PR TITLE
[lua][module] Set gravity to apply evasion penalty

### DIFF
--- a/modules/soa/lua/magic_adjustments.lua
+++ b/modules/soa/lua/magic_adjustments.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Module: Magic Adjustments (Seekers of Adoulin era)
+-- Desc: Reverts adjustments to spells and their effects that were made during the SoA era
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('soa_magic_adjustments')
+
+-- Gravity: Revert weight to apply an evasion down penalty
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+m:addOverride('xi.effects.weight.onEffectGain', function(target, effect)
+    super(target, effect)
+
+    effect:addMod(xi.mod.EVA, -10)
+end)
+
+return m

--- a/scripts/effects/weight.lua
+++ b/scripts/effects/weight.lua
@@ -5,7 +5,7 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MOVE_SPEED_WEIGHT_PENALTY, effect:getPower())
+    effect:addMod(xi.mod.MOVE_SPEED_WEIGHT_PENALTY, effect:getPower())
 
     -- Immunobreak reset.
     target:setMod(xi.mod.GRAVITY_IMMUNOBREAK, 0)
@@ -15,7 +15,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MOVE_SPEED_WEIGHT_PENALTY, effect:getPower())
 end
 
 return effectObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reverts the weight effect to also lower the target's evasion in the SoA module.

## Source

- https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
- https://wiki.ffo.jp/html/678.html for the evasion reduction value