### PR TITLE
[core] Limit targetfinding vertical to 8/8.5y

### DIFF
--- a/scripts/tests/systems/combat/aoe_vertical.lua
+++ b/scripts/tests/systems/combat/aoe_vertical.lua
@@ -1,0 +1,126 @@
+describe('AoE Vertical Range', function()
+    describe('player-centered', function()
+        ---@type CClientEntityPair
+        local p1, p2
+
+        before_each(function()
+            local pConfig =
+            {
+                zone  = xi.zone.GM_HOME,
+                job   = xi.job.WHM,
+                level = 99,
+            }
+
+            p1 = xi.test.world:spawnPlayer(pConfig)
+            p2 = xi.test.world:spawnPlayer(pConfig)
+            p1.actions:inviteToParty(p2)
+            p2.actions:acceptPartyInvite()
+
+            p1:addSpell(xi.magic.spell.BARSTONRA)
+        end)
+
+        it('Barstonra hits party member at 7.999y above', function()
+            p2:setPos(p1:getXPos(), p1:getYPos() - 7.999, p1:getZPos())
+            p1.actions:useSpell(p1, xi.magic.spell.BARSTONRA)
+            xi.test.world:tickEntity(p1)
+            xi.test.world:skipTime(10)
+            p2.assert:hasEffect(xi.effect.BARSTONE)
+        end)
+
+        it('Barstonra misses party member at 8y above', function()
+            p2:setPos(p1:getXPos(), p1:getYPos() - 8.0, p1:getZPos())
+            p1.actions:useSpell(p1, xi.magic.spell.BARSTONRA)
+            xi.test.world:tickEntity(p1)
+            xi.test.world:skipTime(10)
+            p2.assert.no:hasEffect(xi.effect.BARSTONE)
+        end)
+    end)
+
+    describe('mob self-centered', function()
+        ---@type CClientEntityPair
+        local p1, p2
+
+        ---@type CTestEntity
+        local fafnir
+
+        before_each(function()
+            local pConfig =
+            {
+                zone  = xi.zone.DRAGONS_AERY,
+                job   = xi.job.DRG,
+                level = 1,
+            }
+
+            p1 = xi.test.world:spawnPlayer(pConfig)
+            p1:setUnkillable(true)
+
+            p2 = xi.test.world:spawnPlayer(pConfig)
+            p2:setUnkillable(true)
+
+            p1.actions:inviteToParty(p2)
+            p2.actions:acceptPartyInvite()
+
+            p1.entities:moveTo('Fafnir')
+            fafnir = p2.entities:moveTo('Fafnir')
+            fafnir:spawn()
+            fafnir.assert:isAlive()
+            fafnir:updateClaim(p1)
+        end)
+
+        it('Hurricane Wing hits at 8.499y above', function()
+            p1:setPos(fafnir:getXPos(), fafnir:getYPos() - 8.499, fafnir:getZPos())
+            fafnir:setTP(3000)
+            fafnir:useMobAbility(xi.mobSkill.HURRICANE_WING_1, p1)
+            xi.test.world:skipTime(5)
+            xi.test.world:skipTime(5)
+
+            assert(p1:getHPP() ~= 100, 'P1 was not hit by Hurricane Wing')
+        end)
+
+        it('Hurricane Wing misses at 8.5y above', function()
+            p1:setPos(fafnir:getXPos(), fafnir:getYPos() - 8.5, fafnir:getZPos())
+            fafnir:setTP(3000)
+            fafnir:useMobAbility(xi.mobSkill.HURRICANE_WING_1, p1)
+            xi.test.world:skipTime(5)
+            xi.test.world:skipTime(5)
+
+            assert(p1:getHPP() == 100, 'P1 was hit by Hurricane Wing')
+        end)
+
+        -- Spike Flail is centered on the targeted player, not the mob
+        it('Spike Flail hits party member at 7.999y above target', function()
+            local m = stub('xi.mobskills.mobPhysicalMove',
+                {
+                    damage     = 100,
+                    hitsLanded = 3,
+                    isCritical = false,
+                })
+
+            p2:setPos(p1:getXPos(), p1:getYPos() - 7.999, p1:getZPos())
+            fafnir:setTP(3000)
+            fafnir:useMobAbility(xi.mobSkill.SPIKE_FLAIL_1, p1)
+            xi.test.world:skipTime(5)
+            xi.test.world:skipTime(5)
+
+            m:called()
+            assert(p2:getHPP() ~= 100, 'P2 was not hit by Spike Flail')
+        end)
+
+        it('Spike Flail misses party member at 8y above target', function()
+            stub('xi.mobskills.mobPhysicalMove',
+                {
+                    damage     = 100,
+                    hitsLanded = 3,
+                    isCritical = false,
+                })
+
+            p2:setPos(p1:getXPos(), p1:getYPos() - 8.0, p1:getZPos())
+            fafnir:setTP(3000)
+            fafnir:useMobAbility(xi.mobSkill.SPIKE_FLAIL_1, p1)
+            xi.test.world:skipTime(5)
+            xi.test.world:skipTime(5)
+
+            assert(p2:getHPP() == 100, 'P2 was hit by Spike Flail')
+        end)
+    end)
+end)

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -530,6 +530,15 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
         }
     }
 
+    // check vertical range
+    // Retail caps at 8.5y for mob self-centered AoE, 8y for everything else.
+    const float yDelta = fabsf(PTarget->loc.p.y - m_PRadiusAround->y);
+    const float yCap   = m_selfCenteredAoE && m_PBattleEntity->objtype == TYPE_MOB ? 8.5f : 8.0f;
+    if (yDelta >= yCap)
+    {
+        return false;
+    }
+
     // this is first target, always add him first
     // Exception: for self-centered AoEs, all targets must pass radius validation
     // Conals always add the main target


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I had [documented it](https://sruonlsb.notion.site/FFXI-Range-Radius-testing-2b23768470138076bf5cfa5020e375bc#2bb376847013804ab306f430233feab3) when researching various distance mechanics. 
Retested today, still seems to hold true. 

8y cap on most actions except mob self-centered which is 8.5y.

Supposedly _some zones, possibly Dynamis_ have a different limit but I tested Dreamlands and it lined up with expectations.

## Steps to test these changes
- Cast a buff with P2 at 7.999 and 8.000
- !fafnir and have P2 test various vertical coords with Spike Flail (P1 centered, 8y) and Hurricane Wing (Fafnir centered, 8.5y)

<!-- Clear and detailed steps to test your changes here -->
