### PR TITLE
[lua] Have core use lua functions for fSTR

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -323,7 +323,7 @@ xi.combat.physical.calculateRangedStatFactor = function(actor, target)
     end
 
     -- Players and Trusts
-    local weaponRank   = actor:getWeaponDmgRank()
+    local weaponRank   = actor:getRangedDmgRank()
     local statLowerCap = (7 + weaponRank * 2) * -2
     local statUpperCap = (14 + weaponRank * 2) * 2
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2777,105 +2777,24 @@ float GetDamageRatio(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool is
  *                                                                       *
  ************************************************************************/
 
-int32 GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID)
+auto GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID) -> int32
 {
-    int32 rank = 0;
-    int32 fstr = 0;
-    float dif  = (float)(PAttacker->STR() - PDefender->VIT());
-
-    // does mob FSTR2 for ranged attack apply here?
-    if (PAttacker->objtype == TYPE_MOB || PAttacker->objtype == TYPE_PET)
-    {
-        fstr = (PAttacker->STR() - PDefender->VIT() + 4) / 4;
-
-        // Level -1 mobs are coded as level 1, but they have an fSTR of 1 always
-        if (PAttacker->objtype == TYPE_MOB && PAttacker->GetMLevel() == 1)
-        {
-            return 1;
-        }
-
-        return std::clamp(fstr, -20, 24);
-    }
-
-    if (dif >= 12)
-    {
-        fstr = static_cast<int32>((dif + 4) / 2);
-    }
-    else if (dif >= 6)
-    {
-        fstr = static_cast<int32>((dif + 6) / 2);
-    }
-    else if (dif >= 1)
-    {
-        fstr = static_cast<int32>((dif + 7) / 2);
-    }
-    else if (dif >= -2)
-    {
-        fstr = static_cast<int32>((dif + 8) / 2);
-    }
-    else if (dif >= -7)
-    {
-        fstr = static_cast<int32>((dif + 9) / 2);
-    }
-    else if (dif >= -15)
-    {
-        fstr = static_cast<int32>((dif + 10) / 2);
-    }
-    else if (dif >= -21)
-    {
-        fstr = static_cast<int32>((dif + 12) / 2);
-    }
-    else
-    {
-        fstr = static_cast<int32>((dif + 13) / 2);
-    }
+    int32 fSTR = 0;
 
     if (SlotID == SLOT_RANGED || SlotID == SLOT_AMMO)
     {
-        rank = PAttacker->GetRangedWeaponRank();
-        // Different caps than melee weapons
-        if (fstr <= (-rank * 2))
-        {
-            return (-rank * 2);
-        }
-
-        if ((fstr > (-rank * 2)) && (fstr <= (2 * (rank + 8))))
-        {
-            return fstr;
-        }
-        else
-        {
-            return 2 * (rank + 8);
-        }
+        fSTR = luautils::callGlobal<int32>("xi.combat.physical.calculateRangedStatFactor", PAttacker, PDefender);
+    }
+    else if (SlotID == SLOT_MAIN || SlotID == SLOT_SUB)
+    {
+        fSTR = luautils::callGlobal<int32>("xi.combat.physical.calculateMeleeStatFactor", PAttacker, PDefender);
     }
     else
     {
-        fstr /= 2;
-
-        if (SlotID == SLOT_MAIN)
-        {
-            rank = PAttacker->GetMainWeaponRank();
-        }
-        else if (SlotID == SLOT_SUB)
-        {
-            rank = PAttacker->GetSubWeaponRank();
-        }
-
-        // Everything else
-        if (fstr <= (-rank))
-        {
-            return (-rank);
-        }
-
-        if ((fstr > (-rank)) && (fstr <= rank + 8))
-        {
-            return fstr;
-        }
-        else
-        {
-            return rank + 8;
-        }
+        ShowError("battleutils::GetFSTR() failed to run lua calls");
     }
+
+    return fSTR;
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -144,7 +144,7 @@ bool IsParalyzed(CBattleEntity* PAttacker);
 bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker);
 bool IsIntimidated(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 
-int32 GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID);
+auto  GetFSTR(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 SlotID) -> int32;
 uint8 GetHitRateEx(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber, int16 offsetAccuracy);
 uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 uint8 GetHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, uint8 attackNumber);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Has core use our existing lua functions for calculating FSTR and FSTR2 (Ranged Weapon formula).
2. Corrects our ranged lua function to use the weapon rank of the ranged or ammo slot instead of main hand slot.

## Steps to test these changes

1. Shoot stuff. See no crashes.
2. You may see increased or decreased ranged weaponskill/mobskill power at high STR differences due to weapon rank now using the correct slot.
