### PR TITLE
[lua, sql][module] Remove OOE HELM items

### DIFF
--- a/modules/abyssea/lua/helm_adjustments.lua
+++ b/modules/abyssea/lua/helm_adjustments.lua
@@ -1,0 +1,59 @@
+-----------------------------------
+-- Module: HELM Adjustments (Abyssea Era)
+-- Desc: Removes items that were added to existing zone HELM rewards during the Abyssea era
+-- Source:
+--  Aquilaria Log: https://www.bg-wiki.com/ffxi/September_2010_Version_Update_Changes#Usable_Items
+--  Butterpear and Kapor Log: https://www.bg-wiki.com/ffxi/September_2011_Version_Update_Changes#Wings_of_the_Goddess_Quests
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('abyssea_helm_adjustments')
+
+local removals =
+{
+    [xi.helmType.LOGGING] =
+    {
+        [xi.zone.YHOATOR_JUNGLE] =
+        {
+            xi.item.BUTTERPEAR,
+            xi.item.AQUILARIA_LOG,
+            xi.item.KAPOR_LOG,
+        },
+
+        [xi.zone.YUHTUNGA_JUNGLE] =
+        {
+            xi.item.AQUILARIA_LOG,
+        },
+    },
+}
+
+local removeItems = function(drops, itemsToRemove)
+    local removeSet = {}
+    for _, itemId in ipairs(itemsToRemove) do
+        removeSet[itemId] = true
+    end
+
+    local filtered = {}
+    for _, entry in ipairs(drops) do
+        if not removeSet[entry[2]] then
+            filtered[#filtered + 1] = entry
+        end
+    end
+
+    return filtered
+end
+
+-- Apply removals to xi.helm.dataTable.
+for helmType, zones in pairs(removals) do
+    local helmData = xi.helm.dataTable[helmType]
+    if helmData then
+        for zoneId, itemsToRemove in pairs(zones) do
+            local zoneData = helmData.zone[zoneId]
+            if zoneData and zoneData.drops then
+                zoneData.drops = removeItems(zoneData.drops, itemsToRemove)
+            end
+        end
+    end
+end
+
+return m

--- a/modules/wotg/lua/helm_adjustments.lua
+++ b/modules/wotg/lua/helm_adjustments.lua
@@ -1,0 +1,67 @@
+-----------------------------------
+-- Module: HELM Adjustments (Wings of the Goddess Era)
+-- Desc: Removes items that were added to existing zone HELM rewards during the WotG era
+-- Source:
+--  Eastern Ginger Root: https://www.bg-wiki.com/ffxi/June_2008_Version_Update_Changes#Other_Usable_Items
+--  Dyer's Woad: https://www.bg-wiki.com/ffxi/September_2008_Version_Update_Changes#Other_Usable_Items
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('wotg_helm_adjustments')
+
+local removals =
+{
+    [xi.helmType.HARVESTING] =
+    {
+        [xi.zone.BHAFLAU_THICKETS] =
+        {
+            xi.item.EASTERN_GINGER_ROOT,
+        },
+
+        [xi.zone.GIDDEUS] =
+        {
+            xi.item.SPRIG_OF_DYERS_WOAD,
+        },
+
+        [xi.zone.WAJAOM_WOODLANDS] =
+        {
+            xi.item.EASTERN_GINGER_ROOT,
+        },
+
+        [xi.zone.WEST_SARUTABARUTA] =
+        {
+            xi.item.SPRIG_OF_DYERS_WOAD,
+        },
+    },
+}
+
+local removeItems = function(drops, itemsToRemove)
+    local removeSet = {}
+    for _, itemId in ipairs(itemsToRemove) do
+        removeSet[itemId] = true
+    end
+
+    local filtered = {}
+    for _, entry in ipairs(drops) do
+        if not removeSet[entry[2]] then
+            filtered[#filtered + 1] = entry
+        end
+    end
+
+    return filtered
+end
+
+-- Apply removals to xi.helm.dataTable.
+for helmType, zones in pairs(removals) do
+    local helmData = xi.helm.dataTable[helmType]
+    if helmData then
+        for zoneId, itemsToRemove in pairs(zones) do
+            local zoneData = helmData.zone[zoneId]
+            if zoneData and zoneData.drops then
+                zoneData.drops = removeItems(zoneData.drops, itemsToRemove)
+            end
+        end
+    end
+end
+
+return m

--- a/modules/wotg/sql/mob_droplist_removal.sql
+++ b/modules/wotg/sql/mob_droplist_removal.sql
@@ -2,23 +2,21 @@
 -- Mob drop list item removal module
 -- This module removes or dds items for the ToAU era
 -----------------------------------
--- Source: http://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
------------------------------------
-
--- Define rate variables
-SET @COMMON = 150;   -- Common, 15%
 
 -- ACP/AMK/ASA Items
-DELETE FROM mob_droplist WHERE itemId = 2741; -- Seedspall Luna (Uncommon, 10%) ACP
-DELETE FROM mob_droplist WHERE itemId = 2758; -- Quadav Backscale (Rare, 5%) AMK 
-DELETE FROM mob_droplist WHERE itemId = 2778; -- Inferior Cocoon (Uncommon, 10%) ASA item
-DELETE FROM mob_droplist WHERE itemId = 2776; -- Pumice Stone (Uncommon, 10%) ASA item
-DELETE FROM mob_droplist WHERE itemId = 2757; -- Orcish Armor Plate (Rare, 5%) AMK item
-DELETE FROM mob_droplist WHERE itemId = 2759; -- Block Of Yagudo Caulk (Rare, 5%) AMK item
-DELETE FROM mob_droplist WHERE itemId = 2742; -- Seedspall Astrum
-DELETE FROM mob_droplist WHERE itemId = 2740; -- Seedspall Lux (Uncommon, 10%) ACP Item
+-- Added in their respective mini-expansions
+DELETE FROM mob_droplist WHERE itemId = 2757; -- Orcish Armor Plate AMK item
+DELETE FROM mob_droplist WHERE itemId = 2758; -- Quadav Backscale AMK item
+DELETE FROM mob_droplist WHERE itemId = 2759; -- Block Of Yagudo Caulk AMK item
+DELETE FROM mob_droplist WHERE itemId = 2740; -- Seedspall Lux ACP Item
+DELETE FROM mob_droplist WHERE itemId = 2741; -- Seedspall Luna ACP item
+DELETE FROM mob_droplist WHERE itemId = 2742; -- Seedspall Astrum ACP Item
+DELETE FROM mob_droplist WHERE itemId = 2776; -- Pumice Stone ASA item
+DELETE FROM mob_droplist WHERE itemId = 2777; -- Magicked Blood ASA item
+DELETE FROM mob_droplist WHERE itemId = 2778; -- Inferior Cocoon ASA item
 
 -- WOTG
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/08/2009)
 DELETE FROM mob_droplist WHERE itemId = 4702; -- Scroll of Sacrifice
 DELETE FROM mob_droplist WHERE itemId = 4703; -- Scroll Of Esuna WOTG
 DELETE FROM mob_droplist WHERE itemId = 4726; -- Scroll Of Enthunder II WOTG


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds two new modules to remove specific OOE items from their respective zones.
- Relocates the mob droplist module into the correct era folder and reworks the logic slightly to include a missing item.

## Steps to test these changes

- Load the module
- Try logging in a listed zone
- See that you no longer receive the item listed