### PR TITLE
Prevent client lockup during Brygid The Stylist Returns

### DIFF
--- a/scripts/quests/bastok/Brygid_the_Stylist_Returns.lua
+++ b/scripts/quests/bastok/Brygid_the_Stylist_Returns.lua
@@ -188,7 +188,8 @@ quest.sections =
             onEventFinish =
             {
                 [382] = function(player, csid, option, npc)
-                    if option ~= 99 then
+                    -- Limit the response value to the valid range to prevent client lock-up when this value is re-processed
+                    if optionToItems[option] then
                         quest:setVar(player, 'Option', option)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The onEventFinish handler for event 382 was guarding against an assumed cancel value of `99`, however in practice the client returns `0x40000000` (1073741824) when a dialog is cancelled by the user. This meant the guard was ineffective and an invalid option could be written to the player's quest vars, leading to a client side lockup on the next player interaction when the CS would be fed an abnormally large option value.

The fix replaces the magic number check with a table lookup against optionToItems, any option value not present in the table is silently ignored, regardless of what the client sends.

## Steps to test these changes

1. Start the Brygid The Stylist Returns quest
1. Cancel the Body Selection Dialog without making a selection
1. Verify quest state is preserved and no invalid option is saved
1. Complete the quest normally and verify it still works end to end
