### PR TITLE
[Module][Quest] Home Point Era Menu

### DIFF
--- a/modules/soa/lua/npc_adjustments.lua
+++ b/modules/soa/lua/npc_adjustments.lua
@@ -1,0 +1,60 @@
+-----------------------------------
+-- Module: NPC  Adjustments (Seekers of Adoulin Era)
+-- Desc: Custom Home point Menu Options for Pre-SoA Era
+-- Source: https://www.bg-wiki.com/ffxi/Home_Point
+-----------------------------------
+require('modules/module_utils')
+require('scripts/globals/interaction/interaction_global')
+-----------------------------------
+local m = Module:new('homepoint_era_menu')
+
+local function showHomepointCustomMenu(player, npc)
+    local triggerTarget = npc
+
+    local menu =
+    {
+        title   = 'What will you do?',
+
+        options =
+        {
+            {
+                'Set this as your home point.',
+                function(playerArg)
+                    if triggerTarget and playerArg:checkDistance(triggerTarget) <= 6 then
+                        triggerTarget:entityAnimationPacket(xi.animationString.EFFECT_HOME_POINT, player)
+                        playerArg:setHomePoint()
+                    end
+
+                    if zones[playerArg:getZoneID()].text.HOMEPOINT_SET then
+                        playerArg:messageSpecial(zones[playerArg:getZoneID()].text.HOMEPOINT_SET)
+                    else
+                        print(string.format('ERROR: missing ID.text.HOMEPOINT_SET in zone %s.', playerArg:getZoneName()))
+                    end
+                end,
+            },
+            {
+                'On second thought, never mind.',
+                function(playerArg)
+                end,
+            },
+        },
+
+        onCancelled = function(playerArg)
+            playerArg:setFreezeFlag(false)
+        end,
+
+        onEnd = function(playerArg)
+            playerArg:setFreezeFlag(false)
+        end,
+    }
+
+    player:setFreezeFlag(true)
+    player:customMenu(menu)
+end
+
+m:addOverride('xi.homepoint.onTrigger', function(player, csid, index)
+    local npc = player:getCursorTarget()
+    showHomepointCustomMenu(player, npc)
+end)
+
+return m

--- a/scripts/enum/animation_string.lua
+++ b/scripts/enum/animation_string.lua
@@ -103,6 +103,7 @@ xi.animationString =
     EFFECT_SWEATING           = 'hitl',
     EFFECT_SILENCE            = 'sils',
     EFFECT_RAISE_PLAYER       = 'stnd',
+    EFFECT_HOME_POINT         = 'bind', -- Home Point Set animation, only used in a module
 
     -- Status
     STATUS_VISIBLE            = 'deru',


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Replaces the Home Point menu with a customized menu to emulate era accuracy.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
1. Enable the module
2. Target and trigger any homepoint
3. Observe the custom menu with options
- Title: What will you do?
- Set this as your home point.
- On second thought, never mind.
4. Observe the home point animation when choosing to set home point.
5. Receive the "Home Point Set!" message