### PR TITLE
[Fix] Impetus `setMod()` usage

### DIFF
--- a/scripts/effects/impetus.lua
+++ b/scripts/effects/impetus.lua
@@ -18,14 +18,14 @@ effectObject.onEffectGain = function(target, effect)
 
         -- Handle Attack & Critical Hit Rate bonuses
         effectArg:setPower(mainPower)
-        effectArg:setMod(xi.mod.ATT, 2 * mainPower)
-        effectArg:setMod(xi.mod.CRITHITRATE, mainPower)
+        effectArg:addMod(xi.mod.ATT, 2)
+        effectArg:addMod(xi.mod.CRITHITRATE, 1)
 
         -- Handle Critical Hit Damage & Accuracy bonuses
         local subPower = effectArg:getSubPower() -- Subpower tracks if user had effect augment, and what quality, when effect was applied.
         if subPower ~= 0 then
-            effectArg:setMod(xi.mod.ACC, 2 * mainPower)
-            effectArg:setMod(xi.mod.CRIT_DMG_INCREASE, math.floor(subPower / 2) * mainPower)
+            effectArg:addMod(xi.mod.ACC, 2)
+            effectArg:addMod(xi.mod.CRIT_DMG_INCREASE, math.floor(subPower / 2))
         end
     end)
 
@@ -35,12 +35,16 @@ effectObject.onEffectGain = function(target, effect)
             return
         end
 
+        local power = effectArg:getPower()
         effectArg:setPower(0)
+        effectArg:delMod(xi.mod.ATT, 2 * power)
+        effectArg:delMod(xi.mod.CRITHITRATE, power)
 
-        effectArg:setMod(xi.mod.ATT, 0)
-        effectArg:setMod(xi.mod.CRITHITRATE, 0)
-        effectArg:setMod(xi.mod.ACC, 0)
-        effectArg:setMod(xi.mod.CRIT_DMG_INCREASE, 0)
+        local subPower = effectArg:getSubPower() -- Subpower tracks if user had effect augment, and what quality, when effect was applied.
+        if subPower ~= 0 then
+            effectArg:delMod(xi.mod.ACC, 2 * power)
+            effectArg:delMod(xi.mod.CRIT_DMG_INCREASE, math.floor(subPower / 2) * power)
+        end
     end)
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes this
<img width="1097" height="42" alt="imagen" src="https://github.com/user-attachments/assets/19eb8332-dd7f-465d-a4c0-304615a39e88" />

## Steps to test these changes
Use impetus. melee and dont get this error in the log.
