### PR TITLE
[lua] Toramorai Turmoil & Waking Dreams Reward Bugfix

### DIFF
--- a/scripts/quests/windurst/Toraimarai_Turmoil.lua
+++ b/scripts/quests/windurst/Toraimarai_Turmoil.lua
@@ -13,10 +13,10 @@ local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.TORAIMARAI_TU
 
 quest.reward =
 {
-    gil  = 4500,
-    fame = 100,
+    gil      = 4500,
+    fame     = 100,
     fameArea = xi.fameArea.WINDURST,
-    title = xi.title.CERTIFIED_RHINOSTERY_VENTURER,
+    title    = xi.title.CERTIFIED_RHINOSTERY_VENTURER,
 }
 
 quest.sections =
@@ -46,7 +46,7 @@ quest.sections =
     },
 
     {
-        --initial completion
+        -- Initial completion
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED
         end,
@@ -55,21 +55,18 @@ quest.sections =
         {
             ['Ohbiru-Dohbiru'] =
             {
-                onTrigger = quest:event(786, 4500, xi.keyItem.RHINOSTERY_CERTIFICATE, xi.item.STARMITE_SHELL), -- Reminder text.
-
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.item.STARMITE_SHELL, 3 } }) then
                         return quest:progressEvent(791)
                     end
                 end,
-            },
 
-            ['Leepe-Hoppe'] =
-            {
                 onTrigger = function(player, npc)
-                    return quest:event(790, 0, xi.ki.RHINOSTERY_CERTIFICATE)
+                    return quest:event(786, 4500, xi.keyItem.RHINOSTERY_CERTIFICATE, xi.item.STARMITE_SHELL) -- Reminder text.
                 end,
             },
+
+            ['Leepe-Hoppe'] = quest:event(790, 0, xi.ki.RHINOSTERY_CERTIFICATE),
 
             onEventFinish =
             {
@@ -83,24 +80,14 @@ quest.sections =
 
         [xi.zone.WINDURST_WALLS] =
         {
-            ['Polikal-Ramikal'] =
-            {
-                onTrigger = function(player, npc)
-                    return quest:event(391)
-                end,
-            },
+            ['Polikal-Ramikal'] = quest:event(391),
 
-            ['Yoran-Oran'] =
-            {
-                onTrigger = function(player, npc)
-                    return quest:event(392)
-                end,
-            },
+            ['Yoran-Oran'] = quest:event(392),
         },
     },
 
     {
-        --repeat completion
+        -- Repeat completion
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_COMPLETED
         end,
@@ -109,11 +96,20 @@ quest.sections =
         {
             ['Ohbiru-Dohbiru'] =
             {
-                onTrigger = quest:event(795, 4500, 0, xi.item.STARMITE_SHELL), -- repeat dialog
-
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.item.STARMITE_SHELL, 3 } }) then
+                    if
+                        quest:getVar(player, 'Prog') == 1 and
+                        npcUtil.tradeHasExactly(trade, { { xi.item.STARMITE_SHELL, 3 } })
+                    then
                         return quest:progressEvent(791)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:event(786, 4500, xi.keyItem.RHINOSTERY_CERTIFICATE, xi.item.STARMITE_SHELL) -- Reminder text.
+                    else
+                        return quest:event(795, 4500, 0, xi.item.STARMITE_SHELL) -- Repeat dialog.
                     end
                 end,
             },
@@ -121,12 +117,18 @@ quest.sections =
             onEventFinish =
             {
                 [791] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    if quest:getVar(player, 'Prog') == 1 then
+                        quest:setVar(player, 'Prog', 0)
+                        player:confirmTrade()
+                        player:addFame(xi.fameArea.WINDURST, 50)
+                        npcUtil.giveCurrency(player, 'gil', 4500)
+                    end
+                end,
 
-                    --From previous implementation, award 100 fame on first completion,
-                    -- and 50 fame for any subsequent trade.
-                    player:addFame(xi.fameArea.WINDURST, 50)
-                    npcUtil.giveCurrency(player, 'gil', 4500)
+                [795] = function(player, csid, option, npc)
+                    if option == 1 then
+                        quest:setVar(player, 'Prog', 1)
+                    end
                 end,
             },
         },

--- a/scripts/quests/windurst/Waking_Dreams.lua
+++ b/scripts/quests/windurst/Waking_Dreams.lua
@@ -106,6 +106,7 @@ quest.sections =
                     if quest:complete(player) then
                         player:delKeyItem(xi.ki.WHISPER_OF_DREAMS)
                         player:setCharVar('Darkness_Named_date', JstMidnight())
+                        quest:setMustZone(player)
                     end
                 end,
             },
@@ -115,7 +116,8 @@ quest.sections =
     -- Section 3: Quest completed (repeats)
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_COMPLETED
+            return status == xi.questStatus.QUEST_COMPLETED and
+                not quest:getMustZone(player)
         end,
 
         [xi.zone.WINDURST_WATERS] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The repeatable portion of these quests was not gated, so on first completion, the repeatable portion would also trigger, giving double rewards. 

<img width="815" height="124" alt="image" src="https://github.com/user-attachments/assets/b1cc5637-8d9b-41f7-a783-fe0b6f11370e" />

Changes Toramorai Turmoil repeatable section to be gated by picking up the quest again - as shown in a capture by Siknoz : https://youtu.be/YRTjN78jhPo?si=7hdOTbUYkA3gu_jJ&t=590

Changes Waking Dreams repeatable section to be gated by zoning. 

## Steps to test these changes

On a character that has never completed Waking Dreams :

!addquest 2 93
!addkeyitem 327
!setgil 0
!pos 13 -5 -157 238
Choose gil, see only 15,000 rewarded.

