### PR TITLE
[lua] [sql] Axe Mobskills

### DIFF
--- a/scripts/actions/mobskills/avalanche_axe.lua
+++ b/scripts/actions/mobskills/avalanche_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Avalanche Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 1.5, 2.0, 2.5 }
+    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -25,8 +25,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/blitz.lua
+++ b/scripts/actions/mobskills/blitz.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Blitz
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Delivers a fivefold attack. Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -14,19 +14,18 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.numHits        = 5
+    params.fTP            = { 1.5, 7.0, 12.5 }
+    -- params.str_wSC     = 0.32 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.dex_wSC     = 0.32 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_5
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/bora_axe.lua
+++ b/scripts/actions/mobskills/bora_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Bora Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Binds target.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -13,20 +13,21 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
-    params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.baseDamage       = mob:getWeaponDmg()
+    params.numHits          = 1
+    params.fTP              = { 1.0, 1.0, 1.0 }
+    -- params.dex_wSC       = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.attackType       = xi.attackType.PHYSICAL
+    params.damageType       = xi.damageType.SLASHING
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.attackMultiplier = { 3.5, 3.5, 3.5 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, 20)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/calamity.lua
+++ b/scripts/actions/mobskills/calamity.lua
@@ -1,14 +1,12 @@
 -----------------------------------
 -- Calamity
--- Family: Humanoird Axe Weaponskill
--- Description: Delivers a single-hit attack.
+-- Family: Humanoid Axe Weaponskill
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    mob:messageBasic(xi.msg.basic.READIES_WS, 0, 685 + 256)
-
     return 0
 end
 
@@ -17,7 +15,9 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 3.0, 3.0, 3.0 } -- TODO: Capture fTPs
+    params.fTP            = { 1.0, 1.5, 4.0 }
+    -- params.str_wSC     = 0.32 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.vit_wSC     = 0.32 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1

--- a/scripts/actions/mobskills/cloudsplitter.lua
+++ b/scripts/actions/mobskills/cloudsplitter.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Cloudsplitter
+-- Family: Humanoid Axe Weaponskill
+-- Description: Deals lightning elemental damage. Damage varies with TP.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage       = mob:getMainLvl() + 2
+    params.fTP              = { 3.75, 5.0, 6.0 }
+    -- params.str_wSC       = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.mnd_wSC       = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.element          = xi.element.THUNDER
+    params.attackType       = xi.attackType.MAGICAL
+    params.damageType       = xi.damageType.THUNDER
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/decimation.lua
+++ b/scripts/actions/mobskills/decimation.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Decimation
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Delivers a threefold attack. Accuracy varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -13,20 +13,19 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
-    params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.baseDamage        = mob:getWeaponDmg()
+    params.numHits           = 3
+    params.fTP               = { 1.25, 1.25, 1.25 }
+    -- params.str_wSC        = 0.5 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.accuracyModifier  = { 0, 30, 60 }
+    params.attackType        = xi.attackType.PHYSICAL
+    params.damageType        = xi.damageType.SLASHING
+    params.shadowBehavior    = xi.mobskills.shadowBehavior.NUMSHADOWS_3
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/gale_axe.lua
+++ b/scripts/actions/mobskills/gale_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Gale Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Chokes target.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 1.0, 1.0, 1.0 }
+    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -26,7 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CHOKE, 5, 3, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/mistral_axe.lua
+++ b/scripts/actions/mobskills/mistral_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Mistral Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 2.5, 3.0, 3.5 }
+    -- params.str_wSC     = 0.5 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -25,8 +25,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/primal_rend.lua
+++ b/scripts/actions/mobskills/primal_rend.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Primal Rend
+-- Family: Humanoid Axe Weaponskill
+-- Description: Deals light elemental damage. Damage varies with TP.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage       = mob:getMainLvl() + 2
+    params.fTP              = { 4.0, 4.25, 4.75 }
+    -- params.chr_wSC       = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.element          = xi.element.LIGHT
+    params.attackType       = xi.attackType.MAGICAL
+    params.damageType       = xi.damageType.LIGHT
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.dStatMultiplier  = 1.5
+    params.dStatAttackerMod = xi.mod.CHR
+    params.dStatDefenderMod = xi.mod.INT
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/raging_axe.lua
+++ b/scripts/actions/mobskills/raging_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Raging Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Delivers a twofold attack. Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -13,20 +13,18 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
-    params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.baseDamage        = mob:getWeaponDmg()
+    params.numHits           = 2
+    params.fTP               = { 1.0, 1.5, 2.0 }
+    -- params.str_wSC        = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.attackType        = xi.attackType.PHYSICAL
+    params.damageType        = xi.damageType.SLASHING
+    params.shadowBehavior    = xi.mobskills.shadowBehavior.NUMSHADOWS_2
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/rampage.lua
+++ b/scripts/actions/mobskills/rampage.lua
@@ -1,27 +1,27 @@
 -----------------------------------
 -- Rampage
 -- Family: Humanoid Axe Weaponskill
--- Description: Delivers a five-hit attack. Chance of critical varies with TP.
+-- Description: Delivers a fivefold attack. Chance of critical hit varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    mob:messageBasic(xi.msg.basic.READIES_WS, 0, 684 + 256)
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 5
-    params.fTP            = { 1.5, 1.5, 1.5 } -- TODO: Capture fTPs
-    params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.BLUNT
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_5
-    params.canCrit        = true
-    params.criticalChance = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
+    params.baseDamage        = mob:getWeaponDmg()
+    params.numHits           = 5
+    params.fTP               = { 0.5, 0.5, 0.5 }
+    -- params.str_wSC        = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.canCrit           = true
+    params.criticalChance    = { 0.10, 0.30, 0.50 }
+    params.attackType        = xi.attackType.PHYSICAL
+    params.damageType        = xi.damageType.SLASHING
+    params.shadowBehavior    = xi.mobskills.shadowBehavior.NUMSHADOWS_5
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/ruinator.lua
+++ b/scripts/actions/mobskills/ruinator.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Ruinator
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Delivers a fourfold attack. Accuracy varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -13,20 +13,20 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
-    params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.baseDamage        = mob:getWeaponDmg()
+    params.numHits           = 4
+    params.fTP               = { 1.08, 1.08, 1.08 }
+    -- params.str_wSC        = 0.85 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.accuracyModifier  = { 0, 30, 60 }
+    params.attackMultiplier  = { 1.1, 1.1, 1.1 }
+    params.attackType        = xi.attackType.PHYSICAL
+    params.damageType        = xi.damageType.SLASHING
+    params.shadowBehavior    = xi.mobskills.shadowBehavior.NUMSHADOWS_4
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/smash_axe.lua
+++ b/scripts/actions/mobskills/smash_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Smash Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Stuns target.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 1.0, 1.0, 1.0 }
+    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -26,7 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 4)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/spinning_axe.lua
+++ b/scripts/actions/mobskills/spinning_axe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Onslaught
+-- Spinning Axe
 -- Family: Humanoid Axe Weaponskill
--- Description: Lowers target's accuracy.
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.75, 2.75, 2.75 }
-    -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 2.0, 2.5, 3.0 }
+    -- params.str_wSC     = 0.35 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -25,8 +25,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 30, 0, 60)
     end
 
     return info.damage

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -73,7 +73,7 @@ INSERT INTO `mob_skills` VALUES (27,42,'mandalic_stab',0,0.0,7.0,2000,0,4,0,0,0,
 INSERT INTO `mob_skills` VALUES (28,43,'mordant_rime',0,0.0,7.0,2000,0,4,0,0,0,12,10,0);
 INSERT INTO `mob_skills` VALUES (29,44,'pyrrhic_kleos',0,0.0,7.0,2000,0,4,0,0,0,10,4,0);
 INSERT INTO `mob_skills` VALUES (30,45,'aeolian_edge',1,8.0,15.0,2000,0,4,0,0,0,4,6,8);
-INSERT INTO `mob_skills` VALUES (31,46,'rudras_storm',0,0.0,7.0,2000,0,4,0,0,0,14,10,0);
+INSERT INTO `mob_skills` VALUES (31,236,'rudras_storm',0,0.0,7.0,2000,0,4,0,0,0,14,10,0);
 INSERT INTO `mob_skills` VALUES (32,1,'fast_blade',0,0.0,7.0,2000,0,4,0,0,0,4,0,0);
 INSERT INTO `mob_skills` VALUES (33,2,'burning_blade',0,0.0,7.0,2000,0,4,0,0,0,3,0,0);
 INSERT INTO `mob_skills` VALUES (34,3,'red_lotus_blade',0,0.0,7.0,2000,0,4,0,0,0,3,6,0);
@@ -105,21 +105,21 @@ INSERT INTO `mob_skills` VALUES (59,117,'torcleaver',0,0.0,10.0,2000,0,4,0,0,0,1
 INSERT INTO `mob_skills` VALUES (60,118,'resolution',0,0.0,10.0,2000,0,4,0,0,0,12,4,0);
 INSERT INTO `mob_skills` VALUES (61,119,'dimidiation',0,0.0,10.0,2000,0,4,0,0,0,13,12,0);
 INSERT INTO `mob_skills` VALUES (62,115,'fimbulvetr',0,0.0,10.0,2000,0,4,0,0,0,10,8,6);
--- INSERT INTO `mob_skills` VALUES (64,??,'raging_axe'
--- INSERT INTO `mob_skills` VALUES (65,??,'smash_axe'
--- INSERT INTO `mob_skills` VALUES (66,??,'gale_axe'
--- INSERT INTO `mob_skills` VALUES (67,??,'avalanche_axe'
--- INSERT INTO `mob_skills` VALUES (68,??,'spinning_axe'
--- INSERT INTO `mob_skills` VALUES (69,??,'rampage'
--- INSERT INTO `mob_skills` VALUES (70,??,'calamity'
--- INSERT INTO `mob_skills` VALUES (71,??,'mistral_axe'
--- INSERT INTO `mob_skills` VALUES (72,??,'decimation'
--- INSERT INTO `mob_skills` VALUES (73,??,'onslaught'
--- INSERT INTO `mob_skills` VALUES (74,??,'primal_rend'
--- INSERT INTO `mob_skills` VALUES (75,??,'bora_axe'
--- INSERT INTO `mob_skills` VALUES (76,??,'cloudsplitter'
--- INSERT INTO `mob_skills` VALUES (77,??,'ruinator'
--- INSERT INTO `mob_skills` VALUES (78,??,'blitz'
+INSERT INTO `mob_skills` VALUES (64,46,'raging_axe',0,0.0,7.0,2000,0,4,0,0,0,6,8,0);
+INSERT INTO `mob_skills` VALUES (65,47,'smash_axe',0,0.0,7.0,2000,0,4,0,0,0,7,5,0);
+INSERT INTO `mob_skills` VALUES (66,48,'gale_axe',0,0.0,7.0,2000,0,4,0,0,0,6,0,0);
+INSERT INTO `mob_skills` VALUES (67,49,'avalanche_axe',0,0.0,7.0,2000,0,4,0,0,0,4,8,0);
+INSERT INTO `mob_skills` VALUES (68,50,'spinning_axe',0,0.0,7.0,2000,0,4,0,0,0,3,4,8);
+INSERT INTO `mob_skills` VALUES (69,51,'rampage',0,0.0,7.0,2000,0,4,0,0,0,4,0,0);
+INSERT INTO `mob_skills` VALUES (70,52,'calamity',0,0.0,7.0,2000,0,4,0,0,0,4,8,0);
+INSERT INTO `mob_skills` VALUES (71,53,'mistral_axe',0,0.0,15.0,2000,0,4,0,0,0,11,0,0);
+INSERT INTO `mob_skills` VALUES (72,54,'decimation',0,0.0,7.0,2000,0,4,0,0,0,11,5,0);
+INSERT INTO `mob_skills` VALUES (73,55,'onslaught',0,0.0,7.0,2000,0,4,0,0,0,14,9,0);
+INSERT INTO `mob_skills` VALUES (74,56,'primal_rend',0,0.0,7.0,2000,0,4,0,0,0,9,5,0);
+INSERT INTO `mob_skills` VALUES (75,57,'bora_axe',0,0.0,15.0,2000,0,4,0,0,0,4,6,0);
+INSERT INTO `mob_skills` VALUES (76,58,'cloudsplitter',0,0.0,7.0,2000,0,4,0,0,0,14,12,0);
+INSERT INTO `mob_skills` VALUES (77,59,'ruinator',0,0.0,7.0,2000,0,4,0,0,0,10,6,0);
+INSERT INTO `mob_skills` VALUES (78,55,'blitz',0,0.0,7.0,2000,0,4,0,0,0,12,8,3);
 INSERT INTO `mob_skills` VALUES (80,91,'shield_break',0,0.0,7.0,2000,0,4,0,0,0,8,0,0);
 INSERT INTO `mob_skills` VALUES (81,92,'iron_tempest',0,0.0,7.0,2000,0,4,0,0,0,4,0,0);
 INSERT INTO `mob_skills` VALUES (82,93,'sturmwind',0,0.0,7.0,2000,0,4,0,0,0,5,4,0);
@@ -253,7 +253,7 @@ INSERT INTO `mob_skills` VALUES (219,229,'numbing_shot',0,0.0,5.0,2000,0,4,0,0,0
 INSERT INTO `mob_skills` VALUES (220,235,'wildfire',0,0.0,15.0,2000,0,4,0,0,0,14,9,0);
 INSERT INTO `mob_skills` VALUES (221,241,'last_stand',0,0.0,15.0,2000,0,4,0,0,0,11,5,0);
 INSERT INTO `mob_skills` VALUES (222,226,'terminus',0,0.0,15.0,2000,0,4,0,0,0,11,7,5);
-INSERT INTO `mob_skills` VALUES (224,1,'exenterator',0,0.0,7.0,2000,0,4,0,0,0,12,4,0);
+INSERT INTO `mob_skills` VALUES (224,238,'exenterator',0,0.0,7.0,2000,0,4,0,0,0,12,4,0);
 INSERT INTO `mob_skills` VALUES (225,233,'chant_du_cygne',0,0.0,7.0,2000,0,4,0,0,0,13,10,0);
 INSERT INTO `mob_skills` VALUES (226,237,'requiescat',0,0.0,7.0,2000,0,4,0,0,0,9,4,0);
 INSERT INTO `mob_skills` VALUES (227,12,'knights_of_rotund',0,0.0,7.0,2000,0,4,0,0,0,11,0,0);


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Axe mobskills as pre-adoulin player weaponskills where applicable, also fixes a couple of missing animations I found

## Steps to test these changes

!exec target:useMobAbility(64-78) against any humanoid
