### PR TITLE
[lua] [sql] Scythe Mobskills

### DIFF
--- a/scripts/actions/mobskills/catastrophe.lua
+++ b/scripts/actions/mobskills/catastrophe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Catastrophe
 -- Family: Humanoid Scythe Weaponskill
--- Description: Deals damage to a target. Additional Effect: HP Drain
+-- Description: Converts damage dealt into own HP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -12,10 +12,13 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
+    local targetHP = target:getHP()
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 2.5, 2.5, 2.5 }
+    params.fTP            = { 2.75, 2.75, 2.75 }
+    -- params.agi_wSC     = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC     = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -23,7 +26,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
-        skill:setMsg(xi.mobskills.mobDrainMove(mob, target, xi.mobskills.drainType.HP, info.damage))
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        if not target:isUndead() then
+            local drain = math.floor(info.damage * math.random(30, 70) / 100)
+
+            mob:addHP(utils.clamp(drain, 0, targetHP))
+        end
     end
 
     return info.damage

--- a/scripts/actions/mobskills/cross_reaper.lua
+++ b/scripts/actions/mobskills/cross_reaper.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Cross Reaper
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Delivers a twofold attack. Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -14,12 +14,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
+    params.numHits        = 2
+    params.fTP            = { 2.0, 2.25, 2.5 }
     -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.mnd_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_2
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/dark_harvest.lua
+++ b/scripts/actions/mobskills/dark_harvest.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Dark Harvest
+-- Family: Humanoid Scythe Weaponskill
+-- Description: Deals darkness elemental damage. Damage varies with TP.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage       = mob:getMainLvl() + 2
+    params.fTP              = { 1.0, 2.0, 2.5 }
+    -- params.str_wSC       = 0.2 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC       = 0.2 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.MAGICAL
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.dStatMultiplier  = 1
+    params.dStatAttackerMod = xi.mod.INT
+    params.dStatDefenderMod = xi.mod.INT
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/entropy.lua
+++ b/scripts/actions/mobskills/entropy.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Entropy
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Delivers a fourfold attack that converts damage dealt into own MP. Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -14,17 +14,18 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
-    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.numHits        = 4
+    params.fTP            = { 0.75, 1.25, 2.0 }
+    -- params.int_wSC     = 0.85 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_4
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+        mob:addMP(math.floor(info.damage * 0.2))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/guillotine.lua
+++ b/scripts/actions/mobskills/guillotine.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Guillotine
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers a four-hit attack. Additional Effect: Silence
+-- Description: Delivers a fourfold attack that silences target. Duration of silence varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,7 +15,9 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 4
-    params.fTP            = { 0.8, 0.8, 0.8 } -- TODO: Capture fTPs
+    params.fTP            = { 0.875, 0.875, 0.875 }
+    -- params.str_wSC     = 0.25 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.mnd_wSC     = 0.25 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_4
@@ -25,7 +27,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, (skill:getTP() * 30 / 1000) + 30)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, math.floor(30 + 3 * skill:getTP() / 100))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/infernal_scythe.lua
+++ b/scripts/actions/mobskills/infernal_scythe.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Infernal Scythe
+-- Family: Humanoid Scythe Weaponskill
+-- Description: Deals darkness elemental damage. Additional effect: Lowers target's attack. Duration of effect varies with TP.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage       = mob:getMainLvl() + 2
+    params.fTP              = { 3.5, 3.5, 3.5 }
+    -- params.str_wSC       = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC       = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.MAGICAL
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, math.floor(18 * skill:getTP() / 100))
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/insurgency.lua
+++ b/scripts/actions/mobskills/insurgency.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Insurgency
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Delivers a fourfold attack. Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -14,12 +14,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
-    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.numHits        = 4
+    params.fTP            = { 0.5, 0.75, 1.0 }
+    -- params.str_wSC     = 0.2 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC     = 0.2 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
-    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_4
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/nightmare_scythe.lua
+++ b/scripts/actions/mobskills/nightmare_scythe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Nightmare Scythe
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Blinds enemy. Duration of blindness varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -17,6 +17,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.mnd_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -25,6 +26,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 20, 0, math.floor(6 * skill:getTP() / 100))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/origin.lua
+++ b/scripts/actions/mobskills/origin.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- Spinning Scythe
+-- Origin
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Absorbs HP and MP. Damage varies with TP.
+-- TODO: Range like Catastrophe? Is HP/MP Drain 1:1? BG Wiki claims it is clamped by current HP/MP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -12,11 +13,14 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
+    local targetHP = target:getHP()
+    local targetMP = target:getMP()
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
-    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 3.0, 6.0, 9.0 }
+    -- params.str_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
@@ -25,6 +29,17 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        if not target:isUndead() then
+            mob:addHP(utils.clamp(info.damage, 0, targetHP))
+        end
+
+        if targetMP > 0 then
+            local mpDrain = utils.clamp(info.damage, 0, targetMP)
+
+            target:delMP(mpDrain)
+            mob:addMP(mpDrain)
+        end
     end
 
     return info.damage

--- a/scripts/actions/mobskills/quietus.lua
+++ b/scripts/actions/mobskills/quietus.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Quietus
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Delivers a triple damage attack that ignores target's defense. Amount ignored varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,8 +15,10 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
-    -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.fTP            = { 3.0, 3.0, 3.0 }
+    -- params.str_wSC     = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.mnd_wSC     = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.ignoreDefense  = { 0.1, 0.3, 0.5 }
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1

--- a/scripts/actions/mobskills/shadow_of_death.lua
+++ b/scripts/actions/mobskills/shadow_of_death.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- Shadow of Death
+-- Family: Humanoid Scythe Weaponskill
+-- Description: Deals darkness elemental damage. Damage varies with TP.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage       = mob:getMainLvl() + 2
+    params.fTP              = { 1.0, 2.5, 3.0 }
+    -- params.str_wSC       = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC       = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
+    params.element          = xi.element.DARK
+    params.attackType       = xi.attackType.MAGICAL
+    params.damageType       = xi.damageType.DARK
+    params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.dStatMultiplier  = 1
+    params.dStatAttackerMod = xi.mod.INT
+    params.dStatDefenderMod = xi.mod.INT
+
+    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/slice.lua
+++ b/scripts/actions/mobskills/slice.lua
@@ -1,7 +1,7 @@
 -----------------------------------
--- Spinning Scythe
+-- Slice
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers an area attack. TODO: Radius varies with TP.
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,7 +15,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 }
+    params.fTP            = { 1.5, 1.75, 2.0 }
     -- params.str_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING

--- a/scripts/actions/mobskills/spiral_hell.lua
+++ b/scripts/actions/mobskills/spiral_hell.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Spiral Hell
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers a single-hit attack
+-- Description: Damage varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,9 +15,11 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.25, 1.25, 1.25 } -- TODO: Capture fTPs
+    params.fTP            = { 1.375, 1.875, 3.625 }
+    -- params.str_wSC     = 0.5 -- TODO: Capture if mobskill weaponskills have wSC.
+    -- params.int_wSC     = 0.5 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
-    params.damageType     = xi.damageType.BLUNT
+    params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)

--- a/scripts/actions/mobskills/vorpal_scythe.lua
+++ b/scripts/actions/mobskills/vorpal_scythe.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Vorpal Scythe
 -- Family: Humanoid Scythe Weaponskill
--- Description: Delivers a single-hit attack
+-- Description: Deals critical damage. Chance of critical hit varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,12 +15,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.0, 1.0, 1.0 } -- TODO: Capture fTPs
+    params.fTP            = { 1.0, 1.0, 1.0 }
+    -- params.str_wSC     = 0.35 -- TODO: Capture if mobskill weaponskills have wSC.
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     params.canCrit        = true
-    params.criticalChance = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
+    params.criticalChance = { 0.3, 0.6, 0.9 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -135,20 +135,21 @@ INSERT INTO `mob_skills` VALUES (91,102,'fell_cleave',2,4.0,7.0,2000,0,4,0,0,0,4
 INSERT INTO `mob_skills` VALUES (92,103,'ukkos_fury',0,0.0,7.0,2000,0,4,0,0,0,13,12,0);
 INSERT INTO `mob_skills` VALUES (93,104,'upheaval',0,0.0,7.0,2000,0,4,0,0,0,11,2,0);
 INSERT INTO `mob_skills` VALUES (94,100,'disaster',0,0.0,7.0,2000,0,4,0,0,0,9,4,1);
--- INSERT INTO `mob_skills` VALUES (96,??,'slice'
--- INSERT INTO `mob_skills` VALUES (97,??,'dark_harvest'
--- INSERT INTO `mob_skills` VALUES (98,??,'shadow_of_death'
--- INSERT INTO `mob_skills` VALUES (99,??,'nightmare_scythe'
--- INSERT INTO `mob_skills` VALUES (100,??,'spinning_scythe'
-INSERT INTO `mob_skills` VALUES (101,66,'vorpal_scythe',0,0.0,7.0,2000,900,4,0,0,0,1,4,0);
-INSERT INTO `mob_skills` VALUES (102,67,'guillotine',0,0.0,7.0,2000,900,4,0,0,0,7,0,0);
-INSERT INTO `mob_skills` VALUES (104,69,'spiral_hell',0,0.0,7.0,2000,900,4,0,0,0,10,4,0);
--- INSERT INTO `mob_skills` VALUES (105,??,'catastrophe'
--- INSERT INTO `mob_skills` VALUES (106,??,'insurgency'
--- INSERT INTO `mob_skills` VALUES (107,??,'infernal_scythe'
--- INSERT INTO `mob_skills` VALUES (108,??,'quietus'
--- INSERT INTO `mob_skills` VALUES (109,??,'entropy'
--- INSERT INTO `mob_skills` VALUES (110,??,'origin'
+INSERT INTO `mob_skills` VALUES (96,61,'slice',0,0.0,7.0,2000,0,4,0,0,0,4,0,0);
+INSERT INTO `mob_skills` VALUES (97,62,'dark_harvest',0,0.0,7.0,2000,0,4,0,0,0,5,0,0);
+INSERT INTO `mob_skills` VALUES (98,63,'shadow_of_death',0,0.0,7.0,2000,0,4,0,0,0,7,5,0);
+INSERT INTO `mob_skills` VALUES (99,64,'nightmare_scythe',0,0.0,7.0,2000,0,4,0,0,0,2,4,0);
+INSERT INTO `mob_skills` VALUES (100,65,'spinning_scythe',2,4.0,7.0,2000,0,4,0,0,0,5,4,0);
+INSERT INTO `mob_skills` VALUES (101,66,'vorpal_scythe',0,0.0,7.0,2000,0,4,0,0,0,1,4,0);
+INSERT INTO `mob_skills` VALUES (102,67,'guillotine',0,0.0,7.0,2000,0,4,0,0,0,7,0,0);
+INSERT INTO `mob_skills` VALUES (103,68,'cross_reaper',0,0.0,7.0,2000,0,4,0,0,0,10,0,0);
+INSERT INTO `mob_skills` VALUES (104,69,'spiral_hell',0,0.0,7.0,2000,0,4,0,0,0,10,4,0);
+INSERT INTO `mob_skills` VALUES (105,70,'catastrophe',0,0.0,7.0,2000,0,4,0,0,0,14,9,0);
+INSERT INTO `mob_skills` VALUES (106,71,'insurgency',0,0.0,7.0,2000,0,4,0,0,0,11,2,0);
+INSERT INTO `mob_skills` VALUES (107,72,'infernal_scythe',0,0.0,7.0,2000,0,4,0,0,0,2,5,0);
+INSERT INTO `mob_skills` VALUES (108,73,'quietus',0,0.0,7.0,2000,0,4,0,0,0,14,10,0);
+INSERT INTO `mob_skills` VALUES (109,74,'entropy',0,0.0,7.0,2000,0,4,0,0,0,9,5,0);
+INSERT INTO `mob_skills` VALUES (110,70,'origin',0,0.0,7.0,2000,0,4,0,0,0,11,7,5);
 -- INSERT INTO `mob_skills` VALUES (112,??,'double_thrust'
 -- INSERT INTO `mob_skills` VALUES (113,??,'thunder_thrust'
 INSERT INTO `mob_skills` VALUES (114,123,'raiden_thrust',0,0.0,7.0,2000,0,4,0,0,0,1,8,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Scythe mobskills as pre-adoulin weaponskills where applicable. Left some comments in Origin, that WS doesn't seem well researched yet. (Mainly does it have a drain range like Catastrophe?)

## Steps to test these changes

!exec target:useMobAbility(96-110)
