### PR TITLE
[lua][module] Adds blocks for certain door related KIs

### DIFF
--- a/modules/abyssea/lua/fang_key_timer.lua
+++ b/modules/abyssea/lua/fang_key_timer.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Lamian Fang Key Timer Module
+-- Reverts timer to conquest tally instead of once per vanadiel day.
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('lamian_fang_key_tally_timer')
+
+m:addOverride('xi.zones.Caedarva_Mire.npcs.qm8.onTrigger', function(player, npc)
+    local ID = zones[xi.zone.CAEDARVA_MIRE]
+
+    if player:getCharVar('[TIMER]Lamian_Fang_Key') == 0 then
+        if npcUtil.giveItem(player, xi.item.LAMIAN_FANG_KEY) then
+            player:setCharVar('[TIMER]Lamian_Fang_Key', 1, NextConquestTally()) -- Can obtain key once per conquest tally
+        end
+    else
+        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+    end
+end)
+
+return m

--- a/modules/soa/lua/disable_magicked_astrolabe.lua
+++ b/modules/soa/lua/disable_magicked_astrolabe.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Disable Magicked Astrolabe (Solo Eldieme Necropolis Access)
+-- Source: https://forum.square-enix.com/ffxi/threads/40059
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('disable_magicked_astrolabe')
+
+m:addOverride('xi.zones.Windurst_Waters.npcs.Churano-Shurano.onTrigger', function(player, npc)
+    player:startEvent(280)
+end)
+
+m:addOverride('xi.zones.Windurst_Waters.npcs.Churano-Shurano.onEventUpdate', function(player, csid, option, npc)
+end)
+
+m:addOverride('xi.zones.Windurst_Waters.npcs.Churano-Shurano.onEventFinish', function(player, csid, option, npc)
+end)
+
+return m

--- a/modules/soa/lua/quest_adjustments.lua
+++ b/modules/soa/lua/quest_adjustments.lua
@@ -6,13 +6,13 @@ require('modules/module_utils')
 require('scripts/globals/interaction/interaction_global')
 -----------------------------------
 local m = Module:new('chocobos_wounds_era_wait')
------------------------------------
--- Reverts "Chocobo's Wounds" Feeding Timers To 1 Game Day
--- Source: https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-%28JST%29-Version-Update
------------------------------------
 m:addOverride('xi.server.onServerStart', function()
     super()
 
+    -----------------------------------
+    -- Reverts "Chocobo's Wounds" Feeding Timers To 1 Game Day
+    -- Source: https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-%28JST%29-Version-Update
+    -----------------------------------
     xi.module.modifyInteractionEntry('scripts/quests/jeuno/Chocobos_Wounds', function(quest)
         -- Override trade function timer with VanadielUniqueDay instead of GetSystemTime +45
         quest.sections[2][xi.zone.UPPER_JEUNO]['Chocobo'].onTrade = function(player, npc, trade)
@@ -76,7 +76,14 @@ m:addOverride('xi.server.onServerStart', function()
             player:confirmTrade()
         end
     end)
+
+    -----------------------------------
+    -- A Hard Day's Knight: Removes the ability to obtain the Temple Knight Key
+    -- Source: https://forum.square-enix.com/ffxi/threads/40059
+    -----------------------------------
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/A_Hard_Days_Knight', function(quest)
+        table.remove(quest.sections, 3)
+    end)
 end)
 
--- The final event [64] does not need to set a new timer as the quest is already complete at that point
 return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes post quest completion logic to award Temple Knight Key from A Hard Day's Knight
- Reverts Lamia Fang Key timer to conquest wait
- Removed ability to purchase Magicked Astrolabe

## Steps to test these changes

- Talk to Churano Shurano, see that she does not offer the ability to purchase astrolabe
- `!completequest 4 64` and try to trade sealion and coral crest key to Quelveuiat, see no reaction
- See that the char var set on picking up lamia fang key has an expiry set to the next conquest point tally