### PR TITLE
[lua] Update Dialogue to reference correct brother in The Competition

### DIFF
--- a/scripts/quests/sandoria/The_Competition.lua
+++ b/scripts/quests/sandoria/The_Competition.lua
@@ -87,7 +87,7 @@ quest.sections =
                     -- NPC cycles dialogue
                     if cycle == 0 then
                         player:setLocalVar('Cycle', 1)
-                        return quest:event(309, 0, 0, fishCount)
+                        return quest:event(309, 1, 0, fishCount)
                     elseif cycle == 1 then
                         player:setLocalVar('Cycle', 0)
                         return quest:event(310)
@@ -156,7 +156,7 @@ quest.sections =
                     -- NPC cycles dialogue
                     if cycle == 0 then
                         player:setLocalVar('Cycle', 1)
-                        return quest:event(309, 0, 0, fishCount)
+                        return quest:event(309, 1, 0, fishCount)
                     elseif cycle == 1 then
                         player:setLocalVar('Cycle', 0)
                         return quest:event(310)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a 1 to arg0 on event 309 to reference Joulet instead of Gallijaux which is 0.

## Steps to test these changes

Talk to Joulet to start the quest.
Talk to Ufanne.
