### PR TITLE
[lua] Give Peg Powler a PH, upgrade spawn rate

### DIFF
--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Flying_Manta.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Flying_Manta.lua
@@ -14,7 +14,7 @@ end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.LORD_OF_ONZOZO, 4, 57600) -- 16 hour minimum
-    xi.mob.phOnDespawn(mob, ID.mob.PEG_POWLER, 4, 7200) -- 2 hour minimum
+    xi.mob.phOnDespawn(mob, ID.mob.PEG_POWLER, 10, 7200) -- 2 hour minimum
 end
 
 return entity

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Peg_Powler.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Peg_Powler.lua
@@ -2,6 +2,8 @@
 -- Area: Labyrinth of Onzozo
 --   NM: Peg Powler
 -----------------------------------
+local ID = zones[xi.zone.LABYRINTH_OF_ONZOZO]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -57,6 +59,11 @@ entity.spawnPoints =
     { x = -113.402, y =  5.154, z =  16.410 },
     { x =  -62.300, y =  5.386, z =  76.543 },
     { x =  -61.656, y =  5.255, z =  58.971 }
+}
+
+entity.phList =
+{
+    [ID.mob.PEG_POWLER - 1] = ID.mob.PEG_POWLER, -- 106.015 -13.864 5 (retail approx area)
 }
 
 entity.onMobInitialize = function(mob)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

see title. the PH is ID-1, verified on retail.
I upgraded the rate to half the actual rate I observed with only killing that one PH. 4% is for sure far too low.

## Steps to test these changes

Kill that ID and see Peg Powler pop eventually