### PR TITLE
[core] Skip sub slot if main is h2h with /lockstyleset #

### DIFF
--- a/src/map/packets/c2s/0x053_lockstyle.cpp
+++ b/src/map/packets/c2s/0x053_lockstyle.cpp
@@ -49,6 +49,8 @@ auto GP_CLI_COMMAND_LOCKSTYLE::validate(MapSession* PSession, const CCharEntity*
 
 void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    bool hasH2HInMainSlot = false;
+
     switch (static_cast<GP_CLI_COMMAND_LOCKSTYLE_MODE>(this->Mode))
     {
         case GP_CLI_COMMAND_LOCKSTYLE_MODE::Disable:
@@ -100,6 +102,17 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                 }
 
                 PChar->styleItems[item.EquipKind] = itemId;
+
+                if (i == SLOT_MAIN)
+                {
+                    if (const CItemWeapon* PItemWeapon = dynamic_cast<const CItemWeapon*>(PItem); PItemWeapon)
+                    {
+                        if (PItemWeapon->isHandToHand())
+                        {
+                            hasH2HInMainSlot = true;
+                        }
+                    }
+                }
             }
 
             // Check if we need to remove conflicting slots. Essentially, packet injection shenanigan detector.
@@ -126,8 +139,15 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
 
                 switch (i)
                 {
-                    case SLOT_MAIN:
                     case SLOT_SUB:
+                        // Don't update the style of sub if main already assigned one (from being a h2h weapon)
+                        if (hasH2HInMainSlot)
+                        {
+                            continue;
+                        }
+                        charutils::UpdateWeaponStyle(PChar, i, PItem);
+                        break;
+                    case SLOT_MAIN:
                     case SLOT_RANGED:
                     case SLOT_AMMO:
                         charutils::UpdateWeaponStyle(PChar, i, PItem);
@@ -138,6 +158,8 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                     case SLOT_LEGS:
                     case SLOT_FEET:
                         charutils::UpdateArmorStyle(PChar, i);
+                        break;
+                    default:
                         break;
                 }
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

/lockstyleset was not properly setting the sub model due to `UpdateWeaponStyle` being called on every slot, even if SLOT_SUB was _technically_ already set from SLOT_MAIN being h2h inside `UpdateWeaponStyle`.

## Steps to test these changes

Set a h2h weapon in a lockstyleset, use /lockstyleset # and see it work properly (and persist on zone)
