### PR TITLE
[core] Introduce ItemState; encapsulate PC equipment

### DIFF
--- a/scripts/tests/systems/items/equip.lua
+++ b/scripts/tests/systems/items/equip.lua
@@ -1,0 +1,109 @@
+describe('Equipment', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.WAR,
+                level = 75,
+                zone  = xi.zone.SOUTHERN_SAN_DORIA,
+            })
+    end)
+
+    it('equips a weapon to main hand', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+
+        local weapon = player:getEquippedItem(xi.slot.MAIN)
+        assert(weapon)
+        assert(weapon:getID() == xi.item.BRONZE_SWORD)
+    end)
+
+    it('unequip empties the slot', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN))
+
+        player:unequipItem(xi.slot.MAIN)
+
+        assert(player:getEquippedItem(xi.slot.MAIN) == nil)
+    end)
+
+    it('swapping weapons replaces the previous one', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.BRONZE_AXE)
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.BRONZE_SWORD)
+
+        player:equipItem(xi.item.BRONZE_AXE, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.BRONZE_AXE)
+    end)
+
+    it('cannot equip an item you do not own', function()
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN) == nil)
+    end)
+
+    it('cannot put a sword on your feet', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.FEET)
+        assert(player:getEquippedItem(xi.slot.FEET) == nil)
+    end)
+
+    it('two-handed weapon clears the sub slot', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.LAUAN_SHIELD)
+        player:addItem(xi.item.GREATSWORD)
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.LAUAN_SHIELD, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB))
+
+        player:equipItem(xi.item.GREATSWORD, nil, xi.slot.MAIN)
+
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.GREATSWORD)
+        assert(player:getEquippedItem(xi.slot.SUB) == nil)
+    end)
+
+    it('equipping the same item again is a no-op', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        local first = player:getEquippedItem(xi.slot.MAIN)
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+
+        assert(player:getEquippedItem(xi.slot.MAIN) == first)
+    end)
+
+    it('changing job unequips gear that does not match', function()
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN))
+
+        player:changeJob(xi.job.BLM)
+
+        assert(player:getEquippedItem(xi.slot.MAIN) == nil)
+    end)
+
+    it('all visible armor slots accept their piece', function()
+        local pieces =
+        {
+            { id = xi.item.BRONZE_CAP,      slot = xi.slot.HEAD },
+            { id = xi.item.BRONZE_HARNESS,  slot = xi.slot.BODY },
+            { id = xi.item.BRONZE_MITTENS,  slot = xi.slot.HANDS },
+            { id = xi.item.BRONZE_SUBLIGAR, slot = xi.slot.LEGS },
+            { id = xi.item.BRONZE_LEGGINGS, slot = xi.slot.FEET },
+        }
+
+        for _, piece in ipairs(pieces) do
+            player:addItem(piece.id)
+            player:equipItem(piece.id, nil, piece.slot)
+            local equipped = player:getEquippedItem(piece.slot)
+            assert(equipped, string.format('slot %d empty', piece.slot))
+            assert(equipped:getID() == piece.id,
+                string.format('slot %d has wrong item: %d', piece.slot, equipped:getID()))
+        end
+    end)
+end)

--- a/src/map/ai/controllers/player_controller.cpp
+++ b/src/map/ai/controllers/player_controller.cpp
@@ -224,7 +224,7 @@ bool CPlayerController::WeaponSkill(uint16 targid, uint16 wsid)
             auto* ammo   = dynamic_cast<CItemWeapon*>(PChar->m_Weapons[SLOT_AMMO]);
 
             // before allowing ranged weapon skill...
-            if (PItem == nullptr || !weapon || !weapon->isRanged() || !ammo || !ammo->isRanged() || PChar->equip[SLOT_AMMO] == 0)
+            if (PItem == nullptr || !weapon || !weapon->isRanged() || !ammo || !ammo->isRanged() || !PChar->getEquip(SLOT_AMMO))
             {
                 PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, 0, MsgBasic::NoRangedWeapon);
                 return false;

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -435,8 +435,9 @@ void CAttackRound::ProcFollowUpAttacks()
 
                         if (PAmmo && PAmmo->getID() == virtueStone && PAmmo->getQuantity() > 0)
                         {
-                            uint8 loc  = PChar->equipLoc[SLOT_AMMO];
-                            uint8 slot = PChar->equip[SLOT_AMMO];
+                            auto  eloc = PChar->equipLocation(SLOT_AMMO);
+                            uint8 loc  = eloc ? static_cast<uint8>(eloc->Container) : 0;
+                            uint8 slot = eloc ? eloc->Slot : 0;
 
                             if (AddFollowUpAttack(direction))
                             {

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include "enums/item_lockflg.h"
+#include "items/item_access.h"
 #include "packets/basic.h"
 #include "packets/char_status.h"
 #include "packets/char_sync.h"
@@ -151,8 +152,6 @@ CCharEntity::CCharEntity()
     m_RecycleBin = std::make_unique<CItemContainer>(LOC_RECYCLEBIN);
 
     keys = {};
-    std::memset(&equip, 0, sizeof(equip));
-    std::memset(&equipLoc, 0, sizeof(equipLoc));
 
     m_SpellList.reset();
     std::memset(&m_LearnedAbilities, 0, sizeof(m_LearnedAbilities));
@@ -936,16 +935,74 @@ timer::duration CCharEntity::GetPlayTime(bool needUpdate)
 
 auto CCharEntity::getEquip(const SLOTTYPE slot) const -> CItemEquipment*
 {
-    const uint8     loc  = equip[slot];
-    const uint8     est  = equipLoc[slot];
-    CItemEquipment* item = nullptr;
-
-    if (loc != 0)
+    if (slot >= EquipSlotCount)
     {
-        item = static_cast<CItemEquipment*>(getStorage(est)->GetItem(loc));
+        ShowWarningFmt("getEquip: slot {} out of range", slot);
+        return nullptr;
     }
 
-    return item;
+    return static_cast<CItemEquipment*>(equipped_[slot]);
+}
+
+auto CCharEntity::equipLocation(const uint8 equipSlot) const -> std::optional<ItemLocation>
+{
+    if (equipSlot >= EquipSlotCount)
+    {
+        ShowWarningFmt("equipLocation: slot {} out of range", equipSlot);
+        return std::nullopt;
+    }
+
+    if (!equipped_[equipSlot])
+    {
+        return std::nullopt;
+    }
+
+    return ItemLocation{
+        static_cast<CONTAINER_ID>(equipped_[equipSlot]->getLocationID()),
+        equipped_[equipSlot]->getSlotID(),
+    };
+}
+
+auto CCharEntity::bindEquip(const uint8 equipSlot, CItem* item) -> bool
+{
+    if (equipSlot >= EquipSlotCount)
+    {
+        ShowWarningFmt("bindEquip: slot {} out of range", equipSlot);
+        return false;
+    }
+
+    if (!item)
+    {
+        ShowWarningFmt("bindEquip: null item for slot {}", equipSlot);
+        return false;
+    }
+
+    if (!xi::items::mark(item, ItemState::Equipped))
+    {
+        return false;
+    }
+
+    clearEquip(equipSlot);
+    equipped_[equipSlot] = item;
+    return true;
+}
+
+void CCharEntity::clearEquip(const uint8 equipSlot)
+{
+    if (equipSlot >= EquipSlotCount)
+    {
+        return;
+    }
+
+    if (auto* item = equipped_[equipSlot]; item != nullptr)
+    {
+        if (!xi::items::mark(item, ItemState::Free))
+        {
+            return;
+        }
+
+        equipped_[equipSlot] = nullptr;
+    }
 }
 
 void CCharEntity::ReloadPartyInc()

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -34,9 +34,11 @@
 #include "common/mmo.h"
 #include "common/xi.h"
 
+#include <array>
 #include <bitset>
 #include <deque>
 #include <map>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -276,6 +278,14 @@ class CItemUsable;
 typedef std::map<uint32, CBaseEntity*> SpawnIDList_t;
 typedef std::vector<EntityID_t>        BazaarList_t;
 
+struct ItemLocation
+{
+    CONTAINER_ID Container{};
+    uint8        Slot{};
+};
+
+constexpr uint8 EquipSlotCount = 18;
+
 class CCharEntity : public CBattleEntity
 {
 public:
@@ -317,12 +327,14 @@ public:
     expChain_t      expChain{};
     search_t        search{};              // Data and comment displayed in the search box
     bazaar_t        bazaar{};              // All the data you need to run bazaar
-    uint16          m_EquipFlag{};         // Current events handled by the equipment (later it will be packed into a structure, along with equip[])
+    uint16          m_EquipFlag{};         // Current events handled by the equipment
     uint16          m_EquipBlock{};        // Locked equipment slots
     uint16          m_StatsDebilitation{}; // Debilitation arrows
-    uint8           equip[18]{};           // SlotID where equipment is
-    uint8           equipLoc[18]{};        // ContainerID where equipment is
     uint16          styleItems[16]{};      // Item IDs for items that are style locked.
+
+    auto bindEquip(uint8 equipSlot, CItem* item) -> bool;
+    void clearEquip(uint8 equipSlot);
+    auto equipLocation(uint8 equipSlot) const -> std::optional<ItemLocation>;
 
     uint8            m_ZonesVisitedList[38]{}; // List of zones visited by the character
     xi::bitset<1024> m_SpellList{};            // List of learned spells
@@ -681,6 +693,8 @@ protected:
     void TrackArrowUsageForScavenge(CItemWeapon* PAmmo);
 
 private:
+    std::array<CItem*, EquipSlotCount> equipped_{};
+
     // Lazily initialized AMAN data
     Maybe<CAMANContainer> m_AMAN;
     GMCallContainer       gmCallContainer_;

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -12,6 +12,7 @@ set(ENUMS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_type.h
     ${CMAKE_CURRENT_SOURCE_DIR}/emote.h
     ${CMAKE_CURRENT_SOURCE_DIR}/four_cc.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/item_state.h
     ${CMAKE_CURRENT_SOURCE_DIR}/item_types.h
     ${CMAKE_CURRENT_SOURCE_DIR}/item_lockflg.h
     ${CMAKE_CURRENT_SOURCE_DIR}/key_items.h

--- a/src/map/enums/item_state.h
+++ b/src/map/enums/item_state.h
@@ -1,0 +1,33 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+enum class ItemState : uint8
+{
+    Free            = 0,
+    Equipped        = 1, // Item is currently equipped
+    Bazaar          = 2, // Item is currently being sold in Bazaar
+    PlacedFurniture = 3, // Item has been placed in the Mog House
+    InTransaction   = 4, // Item is being used as part of a transaction subsystem
+};

--- a/src/map/items/CMakeLists.txt
+++ b/src/map/items/CMakeLists.txt
@@ -88,5 +88,6 @@ set(ITEM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/item_weapon.h
     ${CMAKE_CURRENT_SOURCE_DIR}/item.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/item.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/item_access.h
     PARENT_SCOPE
 )

--- a/src/map/items/item.cpp
+++ b/src/map/items/item.cpp
@@ -427,7 +427,7 @@ auto CItem::state() const -> ItemState
     return state_;
 }
 
-auto CItem::setState(ItemState newState, xi::Badge<xi::items::detail::ItemAccess>) -> void
+void CItem::setState(const ItemState newState, xi::Badge<xi::items::detail::ItemAccess>)
 {
     state_ = newState;
 }

--- a/src/map/items/item.cpp
+++ b/src/map/items/item.cpp
@@ -421,3 +421,18 @@ bool CItem::isMannequin() const
 {
     return m_id >= 256 && m_id <= 263;
 }
+
+auto CItem::state() const -> ItemState
+{
+    return state_;
+}
+
+auto CItem::setState(ItemState newState, xi::Badge<xi::items::detail::ItemAccess>) -> void
+{
+    state_ = newState;
+}
+
+auto CItem::isBusy() const -> bool
+{
+    return state_ != ItemState::Free;
+}

--- a/src/map/items/item.h
+++ b/src/map/items/item.h
@@ -121,7 +121,7 @@ public:
     bool isMannequin() const;
 
     auto state() const -> ItemState;
-    auto setState(ItemState newState, xi::Badge<xi::items::detail::ItemAccess>) -> void;
+    void setState(ItemState newState, xi::Badge<xi::items::detail::ItemAccess>);
     auto isBusy() const -> bool;
 
     static constexpr uint32_t extra_size = 0x18;

--- a/src/map/items/item.h
+++ b/src/map/items/item.h
@@ -24,8 +24,15 @@
 
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
+#include "common/types/badge.h"
 
 #include "map/enums/item_flag.h"
+#include "map/enums/item_state.h"
+
+namespace xi::items::detail
+{
+struct ItemAccess;
+} // namespace xi::items::detail
 
 // The main type of item m_type
 enum ITEM_TYPE
@@ -113,6 +120,10 @@ public:
 
     bool isMannequin() const;
 
+    auto state() const -> ItemState;
+    auto setState(ItemState newState, xi::Badge<xi::items::detail::ItemAccess>) -> void;
+    auto isBusy() const -> bool;
+
     static constexpr uint32_t extra_size = 0x18;
     uint8                     m_extra[extra_size]{};
 
@@ -155,6 +166,8 @@ private:
     std::string m_name;
     std::string m_send;
     std::string m_recv;
+
+    ItemState state_{ ItemState::Free };
 };
 
 #endif

--- a/src/map/items/item_access.h
+++ b/src/map/items/item_access.h
@@ -24,8 +24,8 @@
 #include "common/logging.h"
 #include "common/types/badge.h"
 
-#include "map/items/item.h"
 #include "map/enums/item_state.h"
+#include "map/items/item.h"
 
 #include <magic_enum/magic_enum.hpp>
 
@@ -33,7 +33,7 @@ namespace xi::items::detail
 {
 struct ItemAccess
 {
-    static auto mark(CItem* item, const ItemState target) -> bool
+    [[nodiscard]] static auto mark(CItem* item, const ItemState target) -> bool
     {
         if (item == nullptr)
         {
@@ -77,7 +77,7 @@ struct ItemAccess
 
 namespace xi::items
 {
-inline auto mark(CItem* item, const ItemState target) -> bool
+[[nodiscard]] inline auto mark(CItem* item, const ItemState target) -> bool
 {
     return detail::ItemAccess::mark(item, target);
 }

--- a/src/map/items/item_access.h
+++ b/src/map/items/item_access.h
@@ -1,0 +1,84 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/logging.h"
+#include "common/types/badge.h"
+
+#include "map/items/item.h"
+#include "map/enums/item_state.h"
+
+#include <magic_enum/magic_enum.hpp>
+
+namespace xi::items::detail
+{
+struct ItemAccess
+{
+    static auto mark(CItem* item, const ItemState target) -> bool
+    {
+        if (item == nullptr)
+        {
+            ShowErrorFmt("ItemAccess::mark: null item, target={}", magic_enum::enum_name(target));
+            return false;
+        }
+
+        // InTransaction transitions go through the tx commit/rollback path.
+        // Refuse on either side of the transition.
+        if (target == ItemState::InTransaction || item->state() == ItemState::InTransaction)
+        {
+            ShowErrorFmt("ItemAccess::mark: illegal tx transition for item {} (current={}, target={}) — use tx commit/rollback path",
+                         item->getID(),
+                         magic_enum::enum_name(item->state()),
+                         magic_enum::enum_name(target));
+            return false;
+        }
+
+        // Releasing back to Free is always allowed.
+        if (target == ItemState::Free)
+        {
+            item->setState(ItemState::Free, xi::Badge<ItemAccess>{});
+            return true;
+        }
+
+        // Acquiring a role: item must currently be Free.
+        if (item->isBusy())
+        {
+            ShowErrorFmt("ItemAccess::mark: item {} not Free, cannot acquire role (current={}, target={})",
+                         item->getID(),
+                         magic_enum::enum_name(item->state()),
+                         magic_enum::enum_name(target));
+            return false;
+        }
+
+        item->setState(target, xi::Badge<ItemAccess>{});
+        return true;
+    }
+};
+} // namespace xi::items::detail
+
+namespace xi::items
+{
+inline auto mark(CItem* item, const ItemState target) -> bool
+{
+    return detail::ItemAccess::mark(item, target);
+}
+} // namespace xi::items

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -1128,11 +1128,11 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
             break;
         case LATENT::MP_UNDER_VISIBLE_GEAR:
             // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getEquip(SLOT_HEAD));
+            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getEquip(SLOT_BODY));
+            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getEquip(SLOT_HANDS));
+            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getEquip(SLOT_LEGS));
+            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getEquip(SLOT_FEET));
 
             // int32 visibleMp = 0;
             // visibleMp += (head ? head->getModifier(Mod::MP) : 0);
@@ -1154,11 +1154,11 @@ bool CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
             break;
         case LATENT::HP_OVER_VISIBLE_GEAR:
             // TODO: figure out if this is actually right
-            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HEAD]));
-            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_BODY]));
-            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_HANDS]));
-            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_LEGS]));
-            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getStorage(LOC_INVENTORY)->GetItem(m_POwner->equip[SLOT_FEET]));
+            // CItemEquipment* head = (CItemEquipment*)(m_POwner->getEquip(SLOT_HEAD));
+            // CItemEquipment* body = (CItemEquipment*)(m_POwner->getEquip(SLOT_BODY));
+            // CItemEquipment* hands = (CItemEquipment*)(m_POwner->getEquip(SLOT_HANDS));
+            // CItemEquipment* legs = (CItemEquipment*)(m_POwner->getEquip(SLOT_LEGS));
+            // CItemEquipment* feet = (CItemEquipment*)(m_POwner->getEquip(SLOT_FEET));
 
             // int32 visibleHp = 0;
             // visibleHp += (head ? head->getModifier(Mod::HP) : 0);

--- a/src/map/linkshell.cpp
+++ b/src/map/linkshell.cpp
@@ -283,8 +283,7 @@ void CLinkshell::RemoveMemberByName(const std::string& MemberName, uint8 request
                 linkshell::DelOnlineMember(PMember, PItemLinkshell);
 
                 PItemLinkshell->setSubType(ITEM_UNLOCKED);
-
-                PMember->equip[slot] = 0;
+                PMember->clearEquip(slot);
                 if (slot == SLOT_LINK1)
                 {
                     PMember->updatemask |= UPDATE_HP;

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -4404,7 +4404,8 @@ bool CLuaBaseEntity::delContainerItems(const sol::object& containerID)
     // ensure we unequip equipped items before deletion
     for (uint8 equipmentSlot = 0; equipmentSlot <= 15; equipmentSlot++)
     {
-        if (PChar->equipLoc[equipmentSlot] == location)
+        auto eloc = PChar->equipLocation(equipmentSlot);
+        if (eloc && static_cast<uint8>(eloc->Container) == location)
         {
             // UnequipItem doesn't consider SLOT_MAIN removing SLOT_SUB, so we say to Equip nothing in this equipment slot
             // this is the same thing that equipset_set packet does to remove a slot
@@ -4860,8 +4861,13 @@ bool CLuaBaseEntity::addLinkpearl(const std::string& lsname, bool equip)
         auto* PInserted = static_cast<CItemLinkshell*>(PChar->getStorage(LOC_INVENTORY)->GetItem(slotID));
         linkshell::AddOnlineMember(PChar, PInserted, 2);
         PInserted->setSubType(ITEM_LOCKED);
-        PChar->equip[SLOT_LINK2]    = PInserted->getSlotID();
-        PChar->equipLoc[SLOT_LINK2] = LOC_INVENTORY;
+        if (!PChar->bindEquip(SLOT_LINK2, PInserted))
+        {
+            linkshell::DelOnlineMember(PChar, PInserted);
+            PInserted->setSubType(ITEM_UNLOCKED);
+            return false;
+        }
+
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(PInserted, ItemLockFlg::Linkshell);
         charutils::SaveCharEquip(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_GROUP_COMLINK>(PChar, PInserted->GetLSID());

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -457,7 +457,7 @@ int32 MapNetworking::parse(uint8* buff, size_t* buffsize, MapSession* PSession)
     {
         for (uint8 equipSlotID = 0; equipSlotID < 16; ++equipSlotID)
         {
-            if (PChar->equip[equipSlotID] != 0)
+            if (PChar->getEquip(static_cast<SLOTTYPE>(equipSlotID)))
             {
                 PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
             }

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -133,9 +133,10 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
         PChar->pushPacket<GP_SERV_COMMAND_LOGIN>(PChar, PChar->currentEvent);
         for (uint8 i = 0; i < 16; ++i)
         {
-            if (PChar->equip[i] != 0)
+            auto eloc = PChar->equipLocation(i);
+            if (eloc)
             {
-                PChar->pushPacket<GP_SERV_COMMAND_EQUIP_LIST>(PChar->equip[i], static_cast<SLOTTYPE>(i), static_cast<CONTAINER_ID>(PChar->equipLoc[i]));
+                PChar->pushPacket<GP_SERV_COMMAND_EQUIP_LIST>(*eloc, static_cast<SLOTTYPE>(i));
             }
         }
         PChar->status = STATUS_TYPE::NORMAL;

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -156,7 +156,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
     {
         for (uint8 equipSlotID = 0; equipSlotID < 16; ++equipSlotID)
         {
-            if (PChar->equip[equipSlotID] != 0)
+            if (PChar->getEquip(static_cast<SLOTTYPE>(equipSlotID)))
             {
                 PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
             }

--- a/src/map/packets/c2s/0x037_item_use.cpp
+++ b/src/map/packets/c2s/0x037_item_use.cpp
@@ -81,7 +81,8 @@ void GP_CLI_COMMAND_ITEM_USE::process(MapSession* PSession, CCharEntity* PChar) 
     {
         for (uint8 slot = 0; slot < 18; ++slot)
         {
-            if (PChar->equipLoc[slot] == this->Category && PChar->equip[slot] == this->PropertyItemIndex)
+            auto eloc = PChar->equipLocation(slot);
+            if (eloc && static_cast<uint8>(eloc->Container) == this->Category && eloc->Slot == this->PropertyItemIndex)
             {
                 return true;
             }

--- a/src/map/packets/c2s/0x0c4_group_comlink_active.cpp
+++ b/src/map/packets/c2s/0x0c4_group_comlink_active.cpp
@@ -142,8 +142,13 @@ const auto equipLinkshell = [](CCharEntity* PChar, CItemLinkshell* PItemLinkshel
     // Now equip the new linkshell
     linkshell::AddOnlineMember(PChar, PItemLinkshell, data.LinkshellId);
     PItemLinkshell->setSubType(ITEM_LOCKED);
-    PChar->equip[SLOT_BACK + data.LinkshellId]    = data.ItemIndex;
-    PChar->equipLoc[SLOT_BACK + data.LinkshellId] = data.Category;
+    if (!PChar->bindEquip(SLOT_BACK + data.LinkshellId, PItemLinkshell))
+    {
+        linkshell::DelOnlineMember(PChar, PItemLinkshell);
+        PItemLinkshell->setSubType(ITEM_UNLOCKED);
+        return;
+    }
+
     if (data.LinkshellId == 1)
     {
         PChar->updatemask |= UPDATE_HP;
@@ -161,8 +166,7 @@ const auto unequipLinkshell = [](CCharEntity* PChar, CItemLinkshell* PItemLinksh
 {
     linkshell::DelOnlineMember(PChar, PItemLinkshell);
     PItemLinkshell->setSubType(ITEM_UNLOCKED);
-    PChar->equip[SLOT_BACK + data.LinkshellId]    = 0;
-    PChar->equipLoc[SLOT_BACK + data.LinkshellId] = 0;
+    PChar->clearEquip(SLOT_BACK + data.LinkshellId);
     if (data.LinkshellId == 1)
     {
         PChar->updatemask |= UPDATE_HP;

--- a/src/map/packets/s2c/0x020_item_attr.cpp
+++ b/src/map/packets/s2c/0x020_item_attr.cpp
@@ -22,6 +22,7 @@
 #include "0x020_item_attr.h"
 
 #include "common/vana_time.h"
+#include "entities/charentity.h"
 #include "enums/item_lockflg.h"
 #include "items/item_linkshell.h"
 #include "utils/itemutils.h"
@@ -117,4 +118,9 @@ GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAIN
     {
         std::memcpy(packet.Attr, staleItem->m_extra, sizeof(staleItem->m_extra));
     }
+}
+
+GP_SERV_COMMAND_ITEM_ATTR::GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const ItemLocation& loc, CItem* staleItem)
+: GP_SERV_COMMAND_ITEM_ATTR(PItem, loc.Container, loc.Slot, staleItem)
+{
 }

--- a/src/map/packets/s2c/0x020_item_attr.h
+++ b/src/map/packets/s2c/0x020_item_attr.h
@@ -26,6 +26,7 @@
 enum class ItemLockFlg : uint8_t;
 enum CONTAINER_ID : uint8;
 class CItem;
+struct ItemLocation;
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x0020
 // This packet is sent by the server to populate an items full information.
@@ -47,4 +48,5 @@ public:
     // It then sends a "set old slot to empty" and when it does so, it leaks the old extdata
     // We emulate this here with a non-null `staleItem` pointer to the old item
     GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const CONTAINER_ID locationId, const uint8_t slotId, CItem* staleItem = nullptr);
+    GP_SERV_COMMAND_ITEM_ATTR(CItem* PItem, const ItemLocation& loc, CItem* staleItem = nullptr);
 };

--- a/src/map/packets/s2c/0x050_equip_list.cpp
+++ b/src/map/packets/s2c/0x050_equip_list.cpp
@@ -21,6 +21,8 @@
 
 #include "0x050_equip_list.h"
 
+#include "entities/charentity.h"
+
 GP_SERV_COMMAND_EQUIP_LIST::GP_SERV_COMMAND_EQUIP_LIST(const uint8 slotId, const SLOTTYPE equipSlot, const CONTAINER_ID containerId)
 {
     auto& packet = this->data();
@@ -28,4 +30,13 @@ GP_SERV_COMMAND_EQUIP_LIST::GP_SERV_COMMAND_EQUIP_LIST(const uint8 slotId, const
     packet.PropertyItemIndex = slotId;
     packet.EquipKind         = equipSlot;
     packet.Category          = containerId;
+}
+
+GP_SERV_COMMAND_EQUIP_LIST::GP_SERV_COMMAND_EQUIP_LIST(const ItemLocation& loc, const SLOTTYPE equipSlot)
+{
+    auto& packet = this->data();
+
+    packet.PropertyItemIndex = loc.Slot;
+    packet.EquipKind         = equipSlot;
+    packet.Category          = loc.Container;
 }

--- a/src/map/packets/s2c/0x050_equip_list.h
+++ b/src/map/packets/s2c/0x050_equip_list.h
@@ -25,6 +25,7 @@
 
 enum SLOTTYPE : uint8;
 enum CONTAINER_ID : uint8;
+struct ItemLocation;
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x0050
 // This packet is sent by the server when a piece of equipment is equipped or unequipped by the player.
@@ -40,4 +41,5 @@ public:
     };
 
     GP_SERV_COMMAND_EQUIP_LIST(uint8_t slotId, SLOTTYPE equipSlot, CONTAINER_ID containerId);
+    GP_SERV_COMMAND_EQUIP_LIST(const ItemLocation& loc, SLOTTYPE equipSlot);
 };

--- a/src/map/packets/s2c/0x05a_motionmes.cpp
+++ b/src/map/packets/s2c/0x05a_motionmes.cpp
@@ -42,7 +42,7 @@ GP_SERV_COMMAND_MOTIONMES::GP_SERV_COMMAND_MOTIONMES(const CCharEntity* PChar, c
     }
     else if (emoteId == Emote::Hurray)
     {
-        const auto* PWeapon = PChar->getStorage(PChar->equipLoc[SLOT_MAIN])->GetItem(PChar->equip[SLOT_MAIN]);
+        const auto* PWeapon = PChar->getEquip(SLOT_MAIN);
         if (PWeapon && PWeapon->getID() != 65535)
         {
             packet.Param = PWeapon->getID();
@@ -51,7 +51,7 @@ GP_SERV_COMMAND_MOTIONMES::GP_SERV_COMMAND_MOTIONMES(const CCharEntity* PChar, c
     else if (emoteId == Emote::Aim)
     {
         packet.Param               = 65535;
-        const CItemWeapon* PWeapon = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_RANGED])->GetItem(PChar->equip[SLOT_RANGED]));
+        const CItemWeapon* PWeapon = static_cast<CItemWeapon*>(PChar->getEquip(SLOT_RANGED));
         if (PWeapon && PWeapon->getID() != 65535)
         {
             if (PWeapon->getSkillType() == SKILL_THROWING)
@@ -60,7 +60,7 @@ GP_SERV_COMMAND_MOTIONMES::GP_SERV_COMMAND_MOTIONMES(const CCharEntity* PChar, c
             }
             else if (PWeapon->getSkillType() == SKILL_MARKSMANSHIP || PWeapon->getSkillType() == SKILL_ARCHERY)
             {
-                const CItemWeapon* PAmmo = static_cast<CItemWeapon*>(PChar->getStorage(PChar->equipLoc[SLOT_AMMO])->GetItem(PChar->equip[SLOT_AMMO]));
+                const CItemWeapon* PAmmo = static_cast<CItemWeapon*>(PChar->getEquip(SLOT_AMMO));
                 if (PAmmo && PAmmo->getID() != 65535)
                 {
                     packet.Param = PWeapon->getID();

--- a/src/map/packets/s2c/0x0e0_group_comlink.cpp
+++ b/src/map/packets/s2c/0x0e0_group_comlink.cpp
@@ -30,12 +30,20 @@ GP_SERV_COMMAND_GROUP_COMLINK::GP_SERV_COMMAND_GROUP_COMLINK(const CCharEntity* 
     packet.LinkshellNum = linkshellNumber;
     if (linkshellNumber == 1)
     {
-        packet.ItemIndex = PChar->equip[SLOT_LINK1];
-        packet.Category  = PChar->equipLoc[SLOT_LINK1];
+        auto eloc = PChar->equipLocation(SLOT_LINK1);
+        if (eloc)
+        {
+            packet.ItemIndex = eloc->Slot;
+            packet.Category  = static_cast<uint8>(eloc->Container);
+        }
     }
     else
     {
-        packet.ItemIndex = PChar->equip[SLOT_LINK2];
-        packet.Category  = PChar->equipLoc[SLOT_LINK2];
+        auto eloc = PChar->equipLocation(SLOT_LINK2);
+        if (eloc)
+        {
+            packet.ItemIndex = eloc->Slot;
+            packet.Category  = static_cast<uint8>(eloc->Container);
+        }
     }
 }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -6216,8 +6216,9 @@ bool RemoveAmmo(CCharEntity* PChar, int quantity)
     {
         if ((PItem->getQuantity() - quantity) < 1)
         {
-            uint8 slot = PChar->equip[SLOT_AMMO];
-            uint8 loc  = PChar->equipLoc[SLOT_AMMO];
+            auto  eloc = PChar->equipLocation(SLOT_AMMO);
+            uint8 slot = eloc ? eloc->Slot : 0;
+            uint8 loc  = eloc ? static_cast<uint8>(eloc->Container) : 0;
             charutils::UnequipItem(PChar, SLOT_AMMO);
             PChar->RequestPersist(CHAR_PERSIST::EQUIP);
             charutils::UpdateItem(PChar, loc, slot, -quantity);
@@ -6226,7 +6227,8 @@ bool RemoveAmmo(CCharEntity* PChar, int quantity)
         }
         else
         {
-            charutils::UpdateItem(PChar, PChar->equipLoc[SLOT_AMMO], PChar->equip[SLOT_AMMO], -quantity);
+            auto ammoLoc = PChar->equipLocation(SLOT_AMMO);
+            charutils::UpdateItem(PChar, static_cast<uint8>(ammoLoc->Container), ammoLoc->Slot, -quantity);
             PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);
             return false;
         }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1189,8 +1189,11 @@ void LoadEquip(CCharEntity* PChar)
                 if ((PItem != nullptr) && PItem->isType(ITEM_LINKSHELL))
                 {
                     PItem->setSubType(ITEM_LOCKED);
-                    PChar->equip[equipSlotId]    = inventoryLoc.first;
-                    PChar->equipLoc[equipSlotId] = inventoryLoc.second;
+                    if (!PChar->bindEquip(equipSlotId, PItem))
+                    {
+                        continue;
+                    }
+
                     if (equipSlotId == SLOT_LINK1)
                     {
                         PLinkshell1 = (CItemLinkshell*)PItem;
@@ -1217,7 +1220,7 @@ void LoadEquip(CCharEntity* PChar)
                 uint8 SlotID     = PLinkshell1->getSlotID();
                 uint8 LocationID = PLinkshell1->getLocationID();
                 PLinkshell1->setSubType(ITEM_UNLOCKED);
-                PChar->equip[SLOT_LINK1] = 0;
+                PChar->clearEquip(SLOT_LINK1);
                 db::preparedStmt("DELETE char_equip FROM char_equip WHERE charid = ? AND slotid = ? AND containerid = ? LIMIT 1",
                                  PChar->id,
                                  SlotID,
@@ -1237,7 +1240,7 @@ void LoadEquip(CCharEntity* PChar)
                 uint8 SlotID     = PLinkshell2->getSlotID();
                 uint8 LocationID = PLinkshell2->getLocationID();
                 PLinkshell2->setSubType(ITEM_UNLOCKED);
-                PChar->equip[SLOT_LINK2] = 0;
+                PChar->clearEquip(SLOT_LINK2);
                 db::preparedStmt("DELETE char_equip FROM char_equip WHERE charid = ? AND slotid = ? AND containerid = ? LIMIT 1",
                                  PChar->id,
                                  SlotID,
@@ -1520,8 +1523,9 @@ void SendInventory(CCharEntity* PChar)
     if (PItem != nullptr)
     {
         PItem->setSubType(ITEM_LOCKED);
+        auto eloc1 = PChar->equipLocation(SLOT_LINK1);
 
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItem, static_cast<CONTAINER_ID>(PChar->equipLoc[SLOT_LINK1]), PChar->equip[SLOT_LINK1]);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItem, *eloc1);
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(PItem, ItemLockFlg::Linkshell);
         PChar->pushPacket<GP_SERV_COMMAND_GROUP_COMLINK>(PChar, 1);
     }
@@ -1530,8 +1534,9 @@ void SendInventory(CCharEntity* PChar)
     if (PItem != nullptr)
     {
         PItem->setSubType(ITEM_LOCKED);
+        auto eloc2 = PChar->equipLocation(SLOT_LINK2);
 
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItem, static_cast<CONTAINER_ID>(PChar->equipLoc[SLOT_LINK2]), PChar->equip[SLOT_LINK2]);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(PItem, *eloc2);
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(PItem, ItemLockFlg::Linkshell);
         PChar->pushPacket<GP_SERV_COMMAND_GROUP_COMLINK>(PChar, 2);
     }
@@ -2144,8 +2149,7 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
 
         // todo: issues as item 0 reference is being handled as a real equipment piece
         //      thought to be source of nin bug
-        PChar->equip[equipSlotID]    = 0;
-        PChar->equipLoc[equipSlotID] = 0;
+        PChar->clearEquip(equipSlotID);
 
         if (((CItemEquipment*)PItem)->getScriptType() & SCRIPT_EQUIP)
         {
@@ -2209,7 +2213,7 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
             break;
             case SLOT_AMMO:
             {
-                if (PChar->equip[SLOT_RANGED] == 0)
+                if (!PChar->getEquip(SLOT_RANGED))
                 {
                     PChar->look.ranged = 0;
                 }
@@ -2219,7 +2223,7 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
             break;
             case SLOT_RANGED:
             {
-                if (PChar->equip[SLOT_RANGED] == 0)
+                if (!PChar->getEquip(SLOT_RANGED))
                 {
                     PChar->look.ranged = 0;
                 }
@@ -2544,7 +2548,7 @@ bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 conta
                             UnequipItem(PChar, SLOT_RANGED, Recalculate::No);
                         }
                     }
-                    if (PChar->equip[SLOT_RANGED] == 0)
+                    if (!PChar->getEquip(SLOT_RANGED))
                     {
                         PChar->look.ranged = PItem->getModelId();
                     }
@@ -2580,8 +2584,10 @@ bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 conta
             break;
         }
 
-        PChar->equip[equipSlotID]    = slotID;
-        PChar->equipLoc[equipSlotID] = containerID;
+        if (!PChar->bindEquip(equipSlotID, PItem))
+        {
+            return false;
+        }
 
         // Changed visible equipment
         if (equipSlotID >= SLOT_HEAD && equipSlotID <= SLOT_FEET)
@@ -5827,14 +5833,15 @@ void SaveCharLinkshells(CCharEntity* PChar)
 {
     for (uint8 lsSlot = 16; lsSlot < 18; ++lsSlot)
     {
-        if (PChar->equip[lsSlot] == 0)
+        auto eloc = PChar->equipLocation(lsSlot);
+        if (!eloc)
         {
             sql->Query("DELETE FROM char_linkshells WHERE charid = %u AND lsslot = %u LIMIT 1", PChar->id, lsSlot);
         }
         else
         {
             const char* fmtQuery = "INSERT INTO char_linkshells SET charid = %u, lsslot = %u, location = %u, slot = %u ON DUPLICATE KEY UPDATE location = %u, slot = %u";
-            sql->Query(fmtQuery, PChar->id, lsSlot, PChar->equipLoc[lsSlot], PChar->equip[lsSlot], PChar->equipLoc[lsSlot], PChar->equip[lsSlot]);
+            sql->Query(fmtQuery, PChar->id, lsSlot, static_cast<uint8>(eloc->Container), eloc->Slot, static_cast<uint8>(eloc->Container), eloc->Slot);
         }
     }
 }
@@ -6084,7 +6091,8 @@ void SaveCharEquip(CCharEntity* PChar)
 
     for (uint8 i = 0; i < 18; ++i)
     {
-        if (PChar->equip[i] == 0)
+        auto eloc = PChar->equipLocation(i);
+        if (!eloc)
         {
             db::preparedStmt("DELETE FROM char_equip WHERE charid = ? AND equipslotid = ? LIMIT 1", PChar->id, i);
         }
@@ -6095,10 +6103,10 @@ void SaveCharEquip(CCharEntity* PChar)
                              "ON DUPLICATE KEY UPDATE slotid  = ?, containerid = ?",
                              PChar->id,
                              i,
-                             PChar->equip[i],
-                             PChar->equipLoc[i],
-                             PChar->equip[i],
-                             PChar->equipLoc[i]);
+                             eloc->Slot,
+                             static_cast<uint8>(eloc->Container),
+                             eloc->Slot,
+                             static_cast<uint8>(eloc->Container));
         }
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Introduce ItemState with setters/getters
- Encapsulate PC equipment array, with minor tweaks here and there to packets and how container/slots are represented
- Enforce routing through bindEquip which in turns goes through the new ItemState path
- ITEM_LOCKED still in place etc, this is pretty much no-op at this point
- Adds a handful of tests

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
