### PR TITLE
[trust, lua, sql] Mnejing: gambits, scripts, sql and mob_skill.lua additions

### DIFF
--- a/scripts/actions/mobskills/chimera_ripper.lua
+++ b/scripts/actions/mobskills/chimera_ripper.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Chimera Ripper
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage     = mob:getWeaponDmg()
+    params.numHits        = 1
+    params.fTP            = { 6.0, 8.5, 11.0 }
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/disruptor.lua
+++ b/scripts/actions/mobskills/disruptor.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Disruptor
+-- Description: Dispels one effects from a target.
+-- Type: Enfeebling
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local dispel = target:dispelStatusEffect()
+
+    if dispel == xi.effect.NONE then
+        -- no effect
+        skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT) -- no effect
+    else
+        skill:setMsg(xi.msg.basic.SKILL_ERASE)
+    end
+
+    return dispel
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/flashbulb.lua
+++ b/scripts/actions/mobskills/flashbulb.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Flashbulb
+-- Family: Atomaton
+-- Description: Automaton will use Flash.
+-- Type: A light-based automaton attachment.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    if mob:isTrust() then
+        target:addEnmity(mob, 180, 1280)
+    end
+
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.FLASH, 0, 0, 15)) -- Handled in status effect
+
+    return xi.effect.FLASH
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/shield_subverter.lua
+++ b/scripts/actions/mobskills/shield_subverter.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- Shield Subverter
+-- Family: Automaton
+-- Description: Deals AoE Conal damage. Additional effect: Silence.
+-- Notes: Only available to the Mnejing Trust.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage     = mob:getWeaponDmg()
+    params.numHits        = 1
+    params.fTP            = { 1.0, 2.0, 3.0 }
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 15)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/string_clipper.lua
+++ b/scripts/actions/mobskills/string_clipper.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- String Clipper
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    local params = {}
+
+    params.baseDamage     = mob:getWeaponDmg()
+    params.numHits        = 2
+    params.fTP            = { 3.5, 3.5, 3.5 }
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_2
+
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
+
+    if xi.mobskills.processDamage(mob, target, skill, action, info) then
+        target:takeDamage(info.damage, mob, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return mobskillObject

--- a/scripts/actions/spells/trust/mnejing.lua
+++ b/scripts/actions/spells/trust/mnejing.lua
@@ -14,6 +14,44 @@ end
 
 spellObject.onMobSpawn = function(mob)
     xi.trust.message(mob, xi.trust.messageOffset.SPAWN)
+
+    mob:setMobMod(xi.mobMod.CAN_SHIELD_BLOCK, 1)
+    mob:setMobMod(xi.mobMod.CAN_PARRY, 3)
+    mob:setMod(xi.mod.SHIELD_MASTERY_TP, 40) -- Possesses Barrier Module (Increased Shield Mastery)
+    mob:setMod(xi.mod.SHIELDBLOCKRATE, 45) -- Possesses Barrier Module (Increased Block Chance, 45% base block rate from testing)
+    mob:addMod(xi.mod.DMG, -375) -- Passive -37.5% Damage Taken Reduction.
+
+    local lastSynergyBonus = 0
+
+    mob:addListener('COMBAT_TICK', 'MNEJING_CTICK', function(mobArg)
+        local targetBonus = 0
+        local party = mobArg:getMaster():getPartyWithTrusts()
+
+        for _, member in pairs(party) do
+            if member:getObjType() == xi.objType.TRUST then
+                if member:getTrustID() == xi.magic.spell.NASHMEIRA then
+                    targetBonus = 10
+                end
+            end
+        end
+
+        if targetBonus ~= lastSynergyBonus then
+            mobArg:delMod(xi.mod.DEF, lastSynergyBonus)
+            mobArg:delMod(xi.mod.ENMITY, lastSynergyBonus)
+            mobArg:addMod(xi.mod.DEF, targetBonus)
+            mobArg:addMod(xi.mod.ENMITY, targetBonus)
+
+            lastSynergyBonus = targetBonus
+        end
+    end)
+
+    mob:addGambit(ai.t.TARGET, { ai.c.ALWAYS,      0                        }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.PROVOKE_AUTOMATON     }, 30)
+    mob:addGambit(ai.t.TARGET, { ai.c.NOT_STATUS,  xi.effect.FLASH          }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.FLASHBULB_AUTOMATON   }, 45)
+    mob:addGambit(ai.t.TARGET, { ai.c.READYING_MS, 0                        }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.SHIELD_BASH_AUTOMATON }, 60)
+    mob:addGambit(ai.t.TARGET, { ai.c.READYING_WS, 0                        }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.SHIELD_BASH_AUTOMATON }, 60)
+    mob:addGambit(ai.t.TARGET, { ai.c.STATUS_FLAG, xi.effectFlag.DISPELABLE }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.DISRUPTOR_AUTOMATON   }, 15)
+
+    mob:setTrustTPSkillSettings(ai.tp.CLOSER_UNTIL_TP, ai.s.RANDOM, 1500)
 end
 
 spellObject.onMobDespawn = function(mob)

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -887,6 +887,10 @@ xi.mobSkill =
     WARP_IN_GESSHO                = 1939,
 
     SLAPSTICK                     = 1943,
+    SHIELD_BASH_AUTOMATON         = 1944, -- Used by the trust Mnejing but may also be used by mobs.
+    PROVOKE_AUTOMATON             = 1945, -- Used by the trust Mnejing but may also be used by mobs.
+    FLASHBULB_AUTOMATON           = 1947, -- Used by the trust Mnejing but may also be used by mobs.
+    DISRUPTOR_AUTOMATON           = 2747, -- Used by the trust Mnejing but may also be used by mobs.
 
     RANGED_ATTACK_15              = 1949,
 

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3490,7 +3490,9 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lehko_Habhoka',1037,3233); -- Lunar
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Nashmeira',1038,3243); -- Imperial Authority
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zazarg',1039,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ovjang',1040,0);
--- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Mnejing',1041,0);
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Mnejing',1041,1940); -- Chimera Ripper
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Mnejing',1041,1941); -- String Clipper
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Mnejing',1041,3245); -- Shield Subverter
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Sakura',1042,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Luzaf',1043,0);
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Najelith',1044,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds gambits and functionality to the trust Mnejing.
see https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Mnejing for details.
NOTE: damage may need adjusting, it seems a little low.

## Steps to test these changes
Call Mnejing and beat things.
