### PR TITLE
[core] equip sync: remove stale references from items being deleted

### DIFF
--- a/src/map/inventory_sync_state.cpp
+++ b/src/map/inventory_sync_state.cpp
@@ -54,6 +54,15 @@ void InventorySyncState::queueEquipChange(CONTAINER_ID container, uint8 containe
     dirtyContainers_.insert(equipping ? container : static_cast<CONTAINER_ID>(item->getLocationID()));
 }
 
+void InventorySyncState::removeEquipChange(const CItem* item)
+{
+    std::erase_if(pendingEquipChanges_,
+                  [&](const equip_change_t& x)
+                  {
+                      return x.item == item;
+                  });
+}
+
 void InventorySyncState::clearEquipChanges()
 {
     pendingEquipChanges_.clear();

--- a/src/map/inventory_sync_state.h
+++ b/src/map/inventory_sync_state.h
@@ -53,6 +53,7 @@ public:
 
     // Equipment change queue
     void queueEquipChange(CONTAINER_ID container, uint8 containerSlotId, SLOTTYPE equipSlot, CItem* item, Equipping equipping);
+    void removeEquipChange(const CItem* item);
     void clearEquipChanges();
     auto hasPendingEquipChanges() const -> bool;
     auto pendingEquipChanges() const -> const std::vector<equip_change_t>&;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -47,6 +47,7 @@
 #include "packets/s2c/0x020_item_attr.h"
 #include "packets/s2c/0x026_item_subcontainer.h"
 #include "packets/s2c/0x02d_battle_message2.h"
+#include "packets/s2c/0x04f_equip_clear.h"
 #include "packets/s2c/0x050_equip_list.h"
 #include "packets/s2c/0x051_grap_list.h"
 #include "packets/s2c/0x055_scenarioitem.h"
@@ -1989,6 +1990,9 @@ uint32 UpdateItem(CCharEntity* PChar, uint8 LocationID, uint8 slotID, int32 quan
             }
         }
         luautils::OnItemDrop(PChar, PItem);
+
+        // Remove soon to be stale PItem pointer from sync state
+        PChar->inventorySyncState().removeEquipChange(PItem);
     }
     return ItemID;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When ammo items are consumed they can leave a stale ref in the item sync state, so remove them in that case.

## Steps to test these changes

in ASAN build: Use something like a jug or ammo with 1 qty left, consume it immediately on equip (i.e. shadowbind or something in a macro) and don't get ASAN freaking out on you
