### PR TITLE
[core] Add some startup sanity checks for NMs

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -680,6 +680,48 @@ auto LoadMOBList(Scheduler& scheduler, const std::vector<uint16>& zoneIds) -> Ta
             PZone->ForEachMob(
                 [&PZone](CMobEntity* PMob)
                 {
+                    // Check if mob is spawnable via lottery
+                    if (PMob->m_SpawnType == SPAWNTYPE_LOTTERY)
+                    {
+                        auto zone = PMob->loc.zone->getName();
+                        auto name = PMob->getName();
+
+                        auto phList = lua["xi"]["zones"][zone]["mobs"][name]["phList"];
+                        if (phList.valid())
+                        {
+                            auto table      = phList.get<sol::table>();
+                            bool hasEntries = false;
+                            bool mobInList  = false;
+
+                            for (auto& [phObj, nmObj] : table)
+                            {
+                                [[maybe_unused]] uint32 phID = phObj.as<uint32>(); // TODO: check if the PH is spawnable?
+                                uint32                  nmID = nmObj.as<uint32>();
+
+                                if (nmID == PMob->id)
+                                {
+                                    mobInList = true;
+                                }
+
+                                hasEntries = true;
+                            }
+
+                            if (!hasEntries)
+                            {
+                                ShowErrorFmt("Lottery spawn NM '{}' in zone '{}' has a blank phList", name, zone);
+                            }
+
+                            if (!mobInList)
+                            {
+                                ShowErrorFmt("Lottery spawn NM '{}' ID ({}) in zone '{}' has a phList that doesn't contain itself as a spawnable NM", name, PMob->id, zone);
+                            }
+                        }
+                        else
+                        {
+                            ShowErrorFmt("Lottery spawn NM '{}' in zone '{}' is missing a phList and may not be spawnable", name, zone);
+                        }
+                    }
+
                     // Skip mobs already registered via setRespawnTime in onMobInitialize - let SpawnHandler handle them
                     if (PZone->spawnHandler().isRegistered(PMob))
                     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR will inform us of some badly hooked up NMs at startup

This is how I found [Peg Powler](https://github.com/LandSandBoat/server/pull/9885) was missing a PH. I (and others if they want to) will go through this list and fix things in different PRs to reduce the count.

It seems this a mix of misclassified spawntypes, unimplemented NMs and/or unimplemented copies of NMs.

Currently, this PR will only check if the NMs are spawnable. I might have another PR that checks if the phList mobs are not spawnable in any way as well but I think that is less likely.

## Steps to test these changes

CI passes

