### PR TITLE
[Fix] Add player and trial table check to magian onMobDeath function

### DIFF
--- a/scripts/globals/magian.lua
+++ b/scripts/globals/magian.lua
@@ -1007,6 +1007,14 @@ end
 xi.magian.onMobDeath = function(mob, player, optParams, trialTable)
     local relevantTrials = {}
 
+    if not player then
+        return
+    end
+
+    if not trialTable then
+        return
+    end
+
     for equipSlot = xi.slot.MAIN, xi.slot.FEET do
         local itemObj = player:getEquippedItem(equipSlot)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Does exactly that. Fixes this:
```
[04/30/26 18:22:01:381][map][error] luautils::onMobDeath: ./scripts/globals/magian.lua:1011: attempt to index local 'player' (a nil value)                                           |
stack traceback:                                                                                                                                                                     |
        ./scripts/globals/magian.lua:1011: in function 'onMobDeath'
        scripts/zones/Ranguemont_Pass/mobs/Hyakume.lua:57: in function <scripts/zones/Ranguemont_Pass/mobs/Hyakume.lua:55> (OnMobDeath:3551)
```

## Steps to test these changes
None.
