### PR TITLE
[lua] Fixes bad arguments in 3 mobskills, converts Jailer of Hope AE

### DIFF
--- a/scripts/actions/mobskills/aerial_collision.lua
+++ b/scripts/actions/mobskills/aerial_collision.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         -- -38% ~ -50% defense. Decays every 2 ticks by 10% -> 6% -> 6% -> 4% -> 4% -> 4% and then wears off. Lower durations just end without decaying fully.
         local power = 50 - math.min(10, 5 * math.floor((skill:getTP() - 1000) / 1000))
 
-        xi.mobskills.mobStatusEffectMove(mob, target, skill, xi.effect.DEFENSE_DOWN, power, 0, math.random(45, 75))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, power, 0, math.random(45, 75))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/envoutement.lua
+++ b/scripts/actions/mobskills/envoutement.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, skill, xi.effect.CURSE_I, 25, 0, 180)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.CURSE_I, 25, 0, 180)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/grim_reaper.lua
+++ b/scripts/actions/mobskills/grim_reaper.lua
@@ -30,7 +30,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, skill, xi.effect.DOOM, 10, 3, 45)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DOOM, 10, 3, 45)
     end
 
     return info.damage

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
@@ -100,7 +100,15 @@ entity.onMobWeaponSkill = function(mob, target, skill, action)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.STUN, { chance = 65, duration = math.random(4, 8) })
+    local pTable =
+    {
+        chance   = 65,
+        effectId = xi.effect.STUN,
+        element  = xi.element.THUNDER,
+        duration = math.random(4, 8),
+    }
+
+    return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Removes invalid argument skill from 3 status effect mobskills
* Converts Jailer of Hope Stun AE to new AE framework

## Steps to test these changes

Pop Jailer of Hope
See no errors in log when using Aerial Collision / having AE proc
