### PR TITLE
[lua] Enable second Tom Tit Tat PH, disallow phList with multiple NMs from having two up at once

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -16,13 +16,13 @@ end
 -- placeholder / lottery NMs
 -----------------------------------
 
--- is a lottery NM already spawned or primed to pop?
-local function lotteryPrimed(phList, nmId)
+-- is a lottery NM in the table already spawned or primed to pop?
+local function lotteryPrimed(phList)
     local nm
 
     for k, v in pairs(phList) do
         nm = GetMobByID(v)
-        if v == nmId and nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+        if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
             return true
         end
     end
@@ -100,11 +100,12 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
         params.doNotEnablePhSpawn = true    Don't enable ph respawns after NM is killed (for chained ph systems like steelfleece)
     ]]
 
-    local phId = ph:getID()
-    local nmId = nil
-    local nm = nil
-    local phList = nil
+    local phId         = ph:getID()
+    local nmId         = nil
+    local nm           = nil
+    local phList       = nil
     local mobEntityObj = getMobLuaPathObject(GetMobByID(phNmId))
+
     if mobEntityObj then
         phList = mobEntityObj.phList
         nmId   = phList and phList[phId]
@@ -150,7 +151,7 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
 
     if
         GetSystemTime() <= pop or
-        lotteryPrimed(phList, nmId) or
+        lotteryPrimed(phList) or
         math.random(1, 1000) > chance
     then
         return false

--- a/scripts/zones/West_Sarutabaruta/IDs.lua
+++ b/scripts/zones/West_Sarutabaruta/IDs.lua
@@ -67,7 +67,7 @@ zones[xi.zone.WEST_SARUTABARUTA] =
     mob =
     {
         NUNYENUNC   = GetFirstID('Nunyenunc'),
-        TOM_TIT_TAT = GetFirstID('Tom_Tit_Tat'),
+        TOM_TIT_TAT = GetTableOfIDs('Tom_Tit_Tat'),
         VOIDWALKER  =
         {
             [xi.keyItem.CLEAR_ABYSSITE] =

--- a/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
@@ -13,7 +13,8 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.TOM_TIT_TAT, 10, math.random(3600, 7200)) -- 1 to 2 hours
+    -- Currently, this will look up both Tom Tit Tats to try to spawn them
+    xi.mob.phOnDespawn(mob, ID.mob.TOM_TIT_TAT[1], 10, math.random(3600, 7200)) -- 1 to 2 hours
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Tom_Tit_Tat.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Tom_Tit_Tat.lua
@@ -7,6 +7,7 @@ local ID = zones[xi.zone.WEST_SARUTABARUTA]
 ---@type TMobEntity
 local entity = {}
 
+-- TODO: Support East/West Tom Tit Tat
 entity.spawnPoints =
 {
     { x =   31.149, y = -20.045, z =  358.265 },
@@ -63,7 +64,8 @@ entity.spawnPoints =
 
 entity.phList =
 {
-    [ID.mob.TOM_TIT_TAT - 1] = ID.mob.TOM_TIT_TAT, -- Confirmed on retail
+    [ID.mob.TOM_TIT_TAT[1] - 1] = ID.mob.TOM_TIT_TAT[1], -- Confirmed on retail
+    [ID.mob.TOM_TIT_TAT[2] - 1] = ID.mob.TOM_TIT_TAT[2], -- Confirmed on retail
 }
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
See title:

Enables Tom Tit Tat's second spawn to work. However on retail they spawn in "east" and "west" portions individually which we don't currently support but that is a future problem.

Also, disallow spawning of the other NMs in the scripts PH list if one is spawned or primed to spawn.
This will prevent two Tom Tit Tat or Leaping Lizzy etc from being up at the same time.

## Steps to test these changes

Kill Tom Tit Tat/Leaping Lizzy PHs at 100% spawn rate after editing their luas, see only one of each NM spawn. Check the other one to spawn as well.
