### PR TITLE
[lua] [sql] Add Barrage support to mobskill Ranged Attacks

### DIFF
--- a/scripts/actions/mobskills/barrage.lua
+++ b/scripts/actions/mobskills/barrage.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- Barrage
+-- Family : Humanoid Job Ability
+-- Description : Allows the next ranged attack to fire multiple shots at once.
+-- Number of shots fired is determined by the power of the effect.
+-- 4 shots at Lv. 30, 5 shots at Lv. 60, 6 shots at Lv. 75 and 7 shots at Lv. 90.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    action:setCategory(xi.action.category.JOBABILITY_FINISH)
+
+    local level = mob:getMainLvl()
+    local projectileCount
+    if level >= 90 then
+        projectileCount = 7
+    elseif level >= 75 then
+        projectileCount = 6
+    elseif level >= 60 then
+        projectileCount = 5
+    elseif level >= 30 then
+        projectileCount = 4
+    else
+        projectileCount = 3
+    end
+
+    mob:addStatusEffect(xi.effect.BARRAGE, { power = projectileCount, duration = 60, origin = mob })
+
+    skill:setMsg(xi.msg.basic.USES)
+
+    return xi.effect.BARRAGE
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/ranged_attack.lua
+++ b/scripts/actions/mobskills/ranged_attack.lua
@@ -32,6 +32,18 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     -- TODO: Fomor type mobs that should use the player style ranged attacks are currently use this script.
     --       Their ranged attacks can crit.
 
+    -- TODO: When Humanoid style ranged attacks are implemented, this should probably be moved to that script.
+    if mob:hasStatusEffect(xi.effect.BARRAGE) then
+        local barrage = mob:getStatusEffect(xi.effect.BARRAGE)
+
+        if barrage then
+            params.numHits         = barrage:getPower()
+            params.terminateOnMiss = true
+        end
+
+        mob:delStatusEffect(xi.effect.BARRAGE)
+    end
+
     local info = xi.mobskills.mobRangedMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -136,6 +136,7 @@ end
 --- @field skipParry           boolean
 --- @field skipGuard           boolean
 --- @field skipBlock           boolean
+--- @field terminateOnMiss     boolean
 --- @field primaryMessage      xi.msg.basic
 
 --- Table of default skill params shared by physical/ranged mobskills.
@@ -171,6 +172,7 @@ local function normalizePhysicalSkillParams(skillParams)
         skipParry             = false,
         skipGuard             = false,
         skipBlock             = false,
+        terminateOnMiss       = false,
         primaryMessage        = xi.msg.basic.DAMAGE,
     }
 
@@ -640,6 +642,7 @@ xi.mobskills.mobRangedMove = function(mob, target, skill, action, skillParams)
         local hitAbsorbed       = false
         local attackAnticipated = false
         local attackYaegasumi   = false
+        local attackMissed      = false
 
         ----------------------------------
         -- Handle Utsusemi and Blink
@@ -691,6 +694,7 @@ xi.mobskills.mobRangedMove = function(mob, target, skill, action, skillParams)
             else
                 hitInfo          = defaultHitInfo(hitNumber)
                 hitInfo.missType = 'Evaded / Missed'
+                attackMissed     = true
             end
         end
 
@@ -707,7 +711,8 @@ xi.mobskills.mobRangedMove = function(mob, target, skill, action, skillParams)
         if
             hitAbsorbed or
             attackAnticipated or
-            attackYaegasumi
+            attackYaegasumi or
+            (params.terminateOnMiss and attackMissed)
         then
             break
         end

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1462,7 +1462,7 @@ INSERT INTO `mob_skills` VALUES (1427,1054,'marionette_dice_14',0,0.0,15.0,2000,
 INSERT INTO `mob_skills` VALUES (1431,803,'shield_bash',0,0.0,7.0,2000,1500,4,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1432,1176,'weapon_bash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1433,1177,'sic',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1434,1178,'barrage',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1434,23,'barrage',0,0.0,7.0,2000,0,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1435,1179,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1436,1180,'meditate',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1437,1181,'jump',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Barrage support to mobskill ranged attacks. 

Works identical to player barrage, and will terminate all extra hits on miss.

## Steps to test these changes

!zone Phomiuna Aquaducts
!gotoname Fomor_Ranger 1
Fight them in standback
!exec target:useMobAbility(1434)
Check RA Damage
