### PR TITLE
[lua] Add default action in Grand Palace of Hu'Xzoi

### DIFF
--- a/scripts/zones/Grand_Palace_of_HuXzoi/DefaultActions.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/DefaultActions.lua
@@ -1,8 +1,9 @@
 local ID = zones[xi.zone.GRAND_PALACE_OF_HUXZOI]
 
 return {
-    ['_0y0'] = { event = 173 },
-    ['_iyb'] = { event = 56 },
-    ['_iyc'] = { event = 172 },
-    ['_iyq'] = { messageSpecial = ID.text.NOTHING_LEFT_TO_DO }
+    ['_0y0']             = { event = 173 },
+    ['_iyb']             = { event = 56 },
+    ['_iyc']             = { event = 172 },
+    ['_iyq']             = { messageSpecial = ID.text.NOTHING_LEFT_TO_DO },
+    ['qm_cancel_escort'] = { event = 171 },
 }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a default action to "qm_cancel_escort" to allow for one way transport.

## Steps to test these changes

`!gotoid 16916897`
Click Displacement. Accept transport.
Be amazed.

## Capture
<img width="620" height="85" alt="image" src="https://github.com/user-attachments/assets/96f41a01-6188-4b24-8559-09d4c0e3e0f7" />
Arrow for location.
<img width="166" height="153" alt="image" src="https://github.com/user-attachments/assets/22863504-817a-49c9-8ffc-7406cf1b54dd" />

