### PR TITLE
[core] Remove some NM only mods (no proof exists)

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1029,7 +1029,7 @@ void CalculateMobStats(CMobEntity* PMob, bool recover)
 
     if (PMob->m_Type & MOBTYPE_NOTORIOUS)
     {
-        SetupNMMob(PMob);
+        PMob->setMobMod(MOBMOD_NO_DESPAWN, 1);
     }
 
     if (zoneType & ZONE_TYPE::INSTANCED)
@@ -1353,33 +1353,6 @@ void SetupEventMob(CMobEntity* PMob)
     PMob->m_maxRoamDistance = 0.5f; // always go back to spawn
 
     PMob->setMobMod(MOBMOD_NO_DESPAWN, 1);
-}
-
-void SetupNMMob(CMobEntity* PMob)
-{
-    JOBTYPE mJob = PMob->GetMJob();
-    uint8   mLvl = PMob->GetMLevel();
-
-    PMob->setMobMod(MOBMOD_NO_DESPAWN, 1);
-
-    // NMs cure earlier
-    PMob->defaultMobMod(MOBMOD_HP_HEAL_CHANCE, 50);
-    PMob->defaultMobMod(MOBMOD_HEAL_CHANCE, 40);
-
-    // give a gil bonus if accurate value was not set
-    if (PMob->getMobMod(MOBMOD_GIL_MAX) == 0)
-    {
-        PMob->defaultMobMod(MOBMOD_GIL_BONUS, 100);
-    }
-
-    if (mLvl >= 25)
-    {
-        if (mJob == JOB_WHM)
-        {
-            // whm nms have stronger regen effect
-            PMob->addModifier(Mod::REGEN, mLvl / 4);
-        }
-    }
 }
 
 void SetupDungeonInstanceMob(CMobEntity* PMob)

--- a/src/map/utils/mobutils.h
+++ b/src/map/utils/mobutils.h
@@ -58,7 +58,6 @@ void SetupRoaming(CMobEntity* PMob);
 void SetupDynamisMob(CMobEntity* PMob);
 void SetupBattlefieldMob(CMobEntity* PMob);
 void SetupEventMob(CMobEntity* PMob);
-void SetupNMMob(CMobEntity* PMob);
 void SetupDungeonInstanceMob(CMobEntity* PMob);
 void SetupPetSkills(CMobEntity* PMob);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes fake regen mod on NM setup
these will be added per NM anyway if they are custom. WHMs will normally get Regen as well from traits.

## Steps to test these changes

N/A
