### PR TITLE
Engine: Add runtime navmesh generation

### DIFF
--- a/scripts/commands/rebuildnavmesh.lua
+++ b/scripts/commands/rebuildnavmesh.lua
@@ -1,0 +1,146 @@
+-----------------------------------
+-- func: rebuildnavmesh
+-- desc: Rebuild the navmesh for the current zone with configurable parameters
+-----------------------------------
+---@type TCommand
+local commandObj = {}
+
+commandObj.cmdprops =
+{
+    permission = 5,
+    parameters = ''
+}
+
+local config =
+{
+    -- Horizontal voxel resolution. Smaller = more accurate but slower to build (more memory too?)
+    --
+    -- Docs:
+    -- The xz-plane cell size to use for fields. [Limit: > 0] [Units: wu]
+    cellSize = 0.5,
+
+    -- Vertical voxel resolution. Smaller = more accurate height detection, around drops and slope edges.
+    --
+    -- Docs:
+    -- The y-axis cell size to use for fields. [Limit: > 0] [Units: wu]
+    cellHeight = 0.4,
+
+    -- Slopes steeper than this angle (in degrees) are marked as unwalkable.
+    --
+    -- Docs:
+    -- The maximum slope that is considered walkable. [Limits: 0 <= value < 90] [Units: Degrees]
+    walkableSlopeAngle = 46.0,
+
+    -- Minimum clearance above the floor for an area to be walkable (in wu).
+    -- Areas with ceilings lower than this are excluded (doorframes, overhangs).
+    --
+    -- Docs:
+    -- Minimum floor to 'ceiling' height that will still allow the floor area to
+    -- be considered walkable. [Limit: >= 3] [Units: vx]
+    agentHeight = 2.0,
+
+    -- How far the walkable area is shrunk inward from walls and edges (in wu).
+    -- Higher values keep agents further from drops and obstacles, but narrow
+    -- paths (doorways, bridges) may disappear.
+    --
+    -- Docs:
+    -- The distance to erode/shrink the walkable area of the heightfield away from
+    -- obstructions. [Limit: >=0] [Units: vx]
+    agentRadius = 0.5,
+
+    -- Maximum step height the agent can climb (in wu). Ledges taller than
+    -- this become unwalkable barriers.
+    --
+    -- Docs:
+    -- Maximum ledge height that is considered to still be traversable. [Limit: >=0] [Units: vx]
+    agentMaxClimb = 0.6,
+
+    -- Maximum length of a single contour edge (in wu). Long edges are split
+    -- at this length. 0 = no limit (edges can be any length).
+    --
+    -- Docs:
+    -- The maximum allowed length for contour edges along the border of the mesh. [Limit: >=0] [Units: vx]
+    -- Setting maxEdgeLen to zero will disable the edge length feature.
+    maxEdgeLen = 0.0,
+
+    -- How aggressively contour corners are simplified. Higher values collapse
+    -- more vertices, producing blunter corners that stay further from edges.
+    -- Lower values follow the voxelized boundary more precisely.
+    --
+    -- Docs:
+    -- The maximum distance a simplified contour's border edges should deviate
+    -- the original raw contour. [Limit: >=0] [Units: vx]
+    maxSimplificationError = 1.3,
+
+    -- Isolated walkable patches smaller than this (in voxels squared) are
+    -- removed. Eliminates tiny floating islands of navmesh.
+    --
+    -- Docs:
+    -- The minimum number of cells allowed to form isolated island areas. [Limit: >=0] [Units: vx]
+    minRegionArea = 8,
+
+    -- Small regions below this size (in voxels squared) are merged into
+    -- adjacent larger regions instead of being removed.
+    --
+    -- Docs:
+    -- Any regions with a span count smaller than this value will, if possible,
+    -- be merged with larger regions. [Limit: >=0] [Units: vx]
+    mergeRegionArea = 20,
+
+    -- Maximum vertices per navmesh polygon. 6 = polygons (detailed),
+    -- 3 = triangles only (simpler, chunkier paths).
+    --
+    -- Docs:
+    -- The maximum number of vertices allowed for polygons generated during the
+    -- contour to polygon conversion process. [Limit: >= 3]
+    maxVertsPerPoly = 6,
+
+    -- How densely the detail mesh samples height data. Higher = more height
+    -- samples, smoother surface. 0 = no detail mesh.
+    --
+    -- Docs:
+    -- Sets the sampling distance to use when generating the detail mesh.
+    -- (For height detail only.) [Limits: 0 or >= 0.9] [Units: wu]
+    detailSampleDist = 6.0,
+
+    -- Maximum allowed height error in the detail mesh. Higher values allow
+    -- the detail surface to deviate more from the true height.
+    --
+    -- Docs:
+    -- The maximum distance the detail mesh surface should deviate from heightfield
+    -- data. (For height detail only.) [Limit: >=0] [Units: wu]
+    detailSampleMaxError = 1.0,
+
+    -- Size of each navmesh tile in voxels. (Memory/speed tradeoffs?)
+    -- Larger tiles = fewer tiles but more work per tile.
+    -- World size per tile = tileSize * cellSize (64 * 0.5 = 32 wu).
+    --
+    -- Docs:
+    -- The width/height size of tile's on the xz-plane. [Limit: >= 0] [Units: vx]
+    tileSize = 64,
+
+    -- Remove walkable spans that have small gaps above them (low ceilings
+    -- created by overhanging geometry).
+    filterLowHangingObstacles = true,
+
+    -- Remove walkable spans at ledge edges where the drop exceeds agentMaxClimb.
+    filterLedgeSpans = true,
+
+    -- Remove walkable spans where the ceiling is lower than agentHeight.
+    filterWalkableLowHeightSpans = true,
+}
+
+commandObj.onTrigger = function(player)
+    local zone = player:getZone()
+    if not zone then
+        return
+    end
+
+    local str = fmt('Rebuilding Navmesh for {}', zone:getName())
+    print(str)
+    player:printToPlayer(str)
+
+    zone:rebuildNavmesh(config)
+end
+
+return commandObj

--- a/scripts/specs/core/CZone.lua
+++ b/scripts/specs/core/CZone.lua
@@ -96,6 +96,11 @@ end
 function CZone:reloadNavmesh()
 end
 
+---@param config table
+---@return nil
+function CZone:rebuildNavmesh(config)
+end
+
 ---@nodiscard
 ---@param position table
 ---@return boolean

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -118,6 +118,9 @@ set(SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/monstrosity.h
     ${CMAKE_CURRENT_SOURCE_DIR}/navmesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/navmesh.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/navmesh_builder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/navmesh_builder.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/navmesh_config.h
     ${CMAKE_CURRENT_SOURCE_DIR}/zone_mesh.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/zone_mesh.h
     ${CMAKE_CURRENT_SOURCE_DIR}/ximesh.h

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -209,10 +209,32 @@ uint32 CLuaZone::getUptime()
 
 void CLuaZone::reloadNavmesh()
 {
-    if (m_pLuaZone->m_navMesh)
-    {
-        m_pLuaZone->m_navMesh->reload();
-    }
+    m_pLuaZone->RebuildNavMesh();
+}
+
+void CLuaZone::rebuildNavmesh(const sol::table& table)
+{
+    NavMeshConfig config;
+
+    config.cellSize                     = table.get_or("cellSize", config.cellSize);
+    config.cellHeight                   = table.get_or("cellHeight", config.cellHeight);
+    config.walkableSlopeAngle           = table.get_or("walkableSlopeAngle", config.walkableSlopeAngle);
+    config.agentHeight                  = table.get_or("agentHeight", config.agentHeight);
+    config.agentRadius                  = table.get_or("agentRadius", config.agentRadius);
+    config.agentMaxClimb                = table.get_or("agentMaxClimb", config.agentMaxClimb);
+    config.maxEdgeLen                   = table.get_or("maxEdgeLen", config.maxEdgeLen);
+    config.maxSimplificationError       = table.get_or("maxSimplificationError", config.maxSimplificationError);
+    config.minRegionArea                = table.get_or("minRegionArea", config.minRegionArea);
+    config.mergeRegionArea              = table.get_or("mergeRegionArea", config.mergeRegionArea);
+    config.maxVertsPerPoly              = table.get_or("maxVertsPerPoly", config.maxVertsPerPoly);
+    config.detailSampleDist             = table.get_or("detailSampleDist", config.detailSampleDist);
+    config.detailSampleMaxError         = table.get_or("detailSampleMaxError", config.detailSampleMaxError);
+    config.tileSize                     = table.get_or("tileSize", config.tileSize);
+    config.filterLowHangingObstacles    = table.get_or("filterLowHangingObstacles", config.filterLowHangingObstacles);
+    config.filterLedgeSpans             = table.get_or("filterLedgeSpans", config.filterLedgeSpans);
+    config.filterWalkableLowHeightSpans = table.get_or("filterWalkableLowHeightSpans", config.filterWalkableLowHeightSpans);
+
+    m_pLuaZone->RebuildNavMesh(config);
 }
 
 bool CLuaZone::isNavigablePoint(const sol::table& point)
@@ -386,6 +408,7 @@ void CLuaZone::Register()
     SOL_REGISTER("getWeather", CLuaZone::getWeather);
     SOL_REGISTER("getUptime", CLuaZone::getUptime);
     SOL_REGISTER("reloadNavmesh", CLuaZone::reloadNavmesh);
+    SOL_REGISTER("rebuildNavmesh", CLuaZone::rebuildNavmesh);
     SOL_REGISTER("isNavigablePoint", CLuaZone::isNavigablePoint);
     SOL_REGISTER("getTerrainType", CLuaZone::getTerrainType);
     SOL_REGISTER("getFloorId", CLuaZone::getFloorId);

--- a/src/map/lua/lua_zone.h
+++ b/src/map/lua/lua_zone.h
@@ -63,6 +63,7 @@ public:
     auto        getWeather() const -> Weather;
     uint32      getUptime();
     void        reloadNavmesh();
+    void        rebuildNavmesh(const sol::table& table);
     bool        isNavigablePoint(const sol::table& position);
     auto        getTerrainType(const sol::table& position) -> TerrainType;
     auto        getFloorId(const sol::table& position) -> uint8;

--- a/src/map/map_application.cpp
+++ b/src/map/map_application.cpp
@@ -51,6 +51,11 @@ auto appConfig() -> ApplicationConfig
             .description = "Load zones on demand. For development only.",
             .type        = ArgumentType::Flag,
         },
+        ArgumentDefinition{
+            .name        = "--rebuild-navmeshes",
+            .description = "Force rebuild all navmeshes from ximesh on startup.",
+            .type        = ArgumentType::Flag,
+        },
     };
 
     return ApplicationConfig{
@@ -77,9 +82,10 @@ MapApplication::MapApplication(const int argc, char** argv)
         port = std::stoi(*maybePort);
     }
 
-    engineConfig_.lazyZones = args().get<bool>("--lazy");
-    engineConfig_.inCI      = Application::isRunningInCI();
-    engineConfig_.ipp       = IPP(ip, port);
+    engineConfig_.ipp              = IPP(ip, port);
+    engineConfig_.inCI             = Application::isRunningInCI();
+    engineConfig_.lazyZones        = args().get<bool>("--lazy");
+    engineConfig_.rebuildNavmeshes = args().get<bool>("--rebuild-navmeshes");
 }
 
 MapApplication::~MapApplication()

--- a/src/map/map_config.h
+++ b/src/map/map_config.h
@@ -30,6 +30,7 @@ struct MapConfig final
     bool isTestServer{ false };      // Disables watchdog and certain recurring tasks when ticks are externally managed.
     bool lazyZones{ false };         // Load zones when first accessed
     bool controlledWeather{ false }; // Disables automated weather
+    bool rebuildNavmeshes{ false };  // Force rebuild all navmeshes from ximesh on startup
 };
 
 static_assert(std::is_standard_layout_v<MapConfig>, "MapConfig must be standard-layout");

--- a/src/map/navmesh.cpp
+++ b/src/map/navmesh.cpp
@@ -21,7 +21,6 @@
 
 #include "navmesh.h"
 
-#include <DetourCommon.h>
 #include <DetourNavMesh.h>
 #include <DetourNavMeshQuery.h>
 
@@ -29,7 +28,6 @@
 #include "common/xirand.h"
 
 #include <fstream>
-#include <iostream>
 #include <set>
 #include <vector>
 
@@ -243,16 +241,84 @@ bool CNavMesh::load(const std::string& filename)
     return true;
 }
 
-void CNavMesh::reload()
-{
-    this->unload();
-    this->load(this->m_filename);
-}
-
 void CNavMesh::unload()
 {
     dtFreeNavMesh(m_navMesh);
     m_navMesh = nullptr;
+}
+
+bool CNavMesh::installNavMesh(dtNavMesh* newNavMesh)
+{
+    if (!newNavMesh)
+    {
+        return false;
+    }
+
+    unload();
+
+    m_navMesh = newNavMesh;
+
+    const auto status = m_navMeshQuery.init(m_navMesh, MAX_NAV_POLYS);
+    if (dtStatusFailed(status))
+    {
+        ShowErrorFmt("CNavMesh::installNavMesh: Could not init navMeshQuery ({})", m_zoneID);
+        unload();
+        return false;
+    }
+
+    return true;
+}
+
+bool CNavMesh::save(const std::string& path) const
+{
+    if (!m_navMesh || path.empty())
+    {
+        return false;
+    }
+
+    std::ofstream file(path, std::ios::binary);
+    if (!file.good())
+    {
+        ShowErrorFmt("CNavMesh::save: Could not open file for writing ({})", path);
+        return false;
+    }
+
+    const auto* nav = m_navMesh;
+
+    auto header    = NavMeshSetHeader{};
+    header.magic   = NAVMESHSET_MAGIC;
+    header.version = NAVMESHSET_VERSION;
+    header.params  = *nav->getParams();
+
+    for (auto i = 0; i < nav->getMaxTiles(); ++i)
+    {
+        const auto* tile = nav->getTile(i);
+        if (tile && tile->header && tile->dataSize > 0)
+        {
+            header.numTiles++;
+        }
+    }
+
+    file.write(reinterpret_cast<const char*>(&header), sizeof(header));
+
+    for (auto i = 0; i < nav->getMaxTiles(); ++i)
+    {
+        const auto* tile = nav->getTile(i);
+        if (!tile || !tile->header || tile->dataSize <= 0)
+        {
+            continue;
+        }
+
+        const auto tileHeader = NavMeshTileHeader{
+            .tileRef  = nav->getTileRef(tile),
+            .dataSize = tile->dataSize,
+        };
+
+        file.write(reinterpret_cast<const char*>(&tileHeader), sizeof(tileHeader));
+        file.write(reinterpret_cast<const char*>(tile->data), tile->dataSize);
+    }
+
+    return true;
 }
 
 auto CNavMesh::findPath(const position_t& start, const position_t& end) -> std::vector<pathpoint_t>
@@ -634,6 +700,61 @@ void CNavMesh::snapToValidPosition(position_t& position)
         position.y = snearest[1];
         position.z = snearest[2];
     }
+}
+
+[[nodiscard]] auto CNavMesh::detourStatusString(const uint32 status) -> std::string
+{
+    std::string outStr;
+
+    // High level status.
+    if (status & DT_FAILURE)
+    {
+        outStr += "DT_FAILURE: Operation failed. ";
+    }
+    if (status & DT_SUCCESS)
+    {
+        outStr += "DT_SUCCESS: Operation succeeded. ";
+    }
+    if (status & DT_IN_PROGRESS)
+    {
+        outStr += "DT_IN_PROGRESS: Operation still in progress. ";
+    }
+
+    // Detail information for status.
+    if (status & DT_WRONG_MAGIC)
+    {
+        outStr += "DT_WRONG_MAGIC: Input data is not recognized. ";
+    }
+    if (status & DT_WRONG_VERSION)
+    {
+        outStr += "DT_WRONG_VERSION: Input data is in wrong version. ";
+    }
+    if (status & DT_OUT_OF_MEMORY)
+    {
+        outStr += "DT_OUT_OF_MEMORY: Operation ran out of memory. ";
+    }
+    if (status & DT_INVALID_PARAM)
+    {
+        outStr += "DT_INVALID_PARAM: An input parameter was invalid. ";
+    }
+    if (status & DT_BUFFER_TOO_SMALL)
+    {
+        outStr += "DT_BUFFER_TOO_SMALL: Result buffer for the query was too small to store all results. ";
+    }
+    if (status & DT_OUT_OF_NODES)
+    {
+        outStr += "DT_OUT_OF_NODES: Query ran out of nodes during search. ";
+    }
+    if (status & DT_PARTIAL_RESULT)
+    {
+        outStr += "DT_PARTIAL_RESULT: Query did not reach the end location, returning best guess. ";
+    }
+    if (status & DT_ALREADY_OCCUPIED)
+    {
+        outStr += "DT_ALREADY_OCCUPIED: A tile has already been assigned to the given x, y coordinate. ";
+    }
+
+    return outStr;
 }
 
 bool CNavMesh::onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter)

--- a/src/map/navmesh.h
+++ b/src/map/navmesh.h
@@ -46,7 +46,8 @@ public:
     ~CNavMesh();
 
     bool load(const std::string& path);
-    void reload();
+    bool installNavMesh(dtNavMesh* newNavMesh);
+    bool save(const std::string& path) const;
     void unload();
 
     auto findPath(const position_t& start, const position_t& end) -> std::vector<pathpoint_t>;
@@ -69,60 +70,7 @@ public:
     // Like validPosition(), but will also set the given position to the valid position that it finds.
     void snapToValidPosition(position_t& position);
 
-    [[nodiscard]] static auto detourStatusString(const uint32 status) -> std::string
-    {
-        std::string outStr;
-
-        // High level status.
-        if (status & DT_FAILURE)
-        {
-            outStr += "DT_FAILURE: Operation failed. ";
-        }
-        if (status & DT_SUCCESS)
-        {
-            outStr += "DT_SUCCESS: Operation succeeded. ";
-        }
-        if (status & DT_IN_PROGRESS)
-        {
-            outStr += "DT_IN_PROGRESS: Operation still in progress. ";
-        }
-
-        // Detail information for status.
-        if (status & DT_WRONG_MAGIC)
-        {
-            outStr += "DT_WRONG_MAGIC: Input data is not recognized. ";
-        }
-        if (status & DT_WRONG_VERSION)
-        {
-            outStr += "DT_WRONG_VERSION: Input data is in wrong version. ";
-        }
-        if (status & DT_OUT_OF_MEMORY)
-        {
-            outStr += "DT_OUT_OF_MEMORY: Operation ran out of memory. ";
-        }
-        if (status & DT_INVALID_PARAM)
-        {
-            outStr += "DT_INVALID_PARAM: An input parameter was invalid. ";
-        }
-        if (status & DT_BUFFER_TOO_SMALL)
-        {
-            outStr += "DT_BUFFER_TOO_SMALL: Result buffer for the query was too small to store all results. ";
-        }
-        if (status & DT_OUT_OF_NODES)
-        {
-            outStr += "DT_OUT_OF_NODES: Query ran out of nodes during search. ";
-        }
-        if (status & DT_PARTIAL_RESULT)
-        {
-            outStr += "DT_PARTIAL_RESULT: Query did not reach the end location, returning best guess. ";
-        }
-        if (status & DT_ALREADY_OCCUPIED)
-        {
-            outStr += "DT_ALREADY_OCCUPIED: A tile has already been assigned to the given x, y coordinate. ";
-        }
-
-        return outStr;
-    }
+    [[nodiscard]] static auto detourStatusString(const uint32 status) -> std::string;
 
 private:
     bool onSameFloor(const position_t& start, float* spos, const position_t& end, float* epos, dtQueryFilter& filter);

--- a/src/map/navmesh_builder.cpp
+++ b/src/map/navmesh_builder.cpp
@@ -1,0 +1,637 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "navmesh_builder.h"
+
+#include "zone_mesh.h"
+
+#include "common/logging.h"
+#include "common/timer.h"
+
+#include <DetourNavMesh.h>
+#include <DetourNavMeshBuilder.h>
+#include <Recast.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <unordered_set>
+
+namespace
+{
+
+// Recast/Detour constants (not tunable)
+constexpr uint16 SAMPLE_POLYFLAGS_WALK  = 0x0001; // RecastDemo/Include/Sample.h
+constexpr int    TILE_BORDER_PADDING    = 3;      // Extra cells beyond walkableRadius for tile stitching (Sample_TileMesh.cpp)
+constexpr float  MIN_DETAIL_SAMPLE_DIST = 0.9f;   // Recast clamps non-zero detailSampleDist to >= 0.9
+constexpr int    DT_MAX_TILE_BITS       = 14;     // dtNavMesh max bits for tile indexing
+constexpr int    DT_TOTAL_REF_BITS      = 22;     // dtNavMesh total bits for tile + poly refs
+
+// FFXI dat format constant (not tunable)
+constexpr float XIMESH_CELL_SIZE = 4.0f; // Each ximesh grid cell covers 4x4 world units
+
+constexpr std::size_t TILE_BATCH_SIZE = 32;
+
+auto transform(const std::array<float, 9>& rot, const std::array<float, 3>& trans, const float* vertex) -> std::array<float, 3>
+{
+    return {
+        rot[0] * vertex[0] + rot[3] * vertex[1] + rot[6] * vertex[2] + trans[0],
+        rot[1] * vertex[0] + rot[4] * vertex[1] + rot[7] * vertex[2] + trans[1],
+        rot[2] * vertex[0] + rot[5] * vertex[1] + rot[8] * vertex[2] + trans[2],
+    };
+}
+
+} // namespace
+
+NavMeshBuilder::NavMeshBuilder(const CZoneMesh& zoneMesh)
+: zoneMesh_(&zoneMesh)
+, gridWidth_(zoneMesh.gridWidth())
+, gridHeight_(zoneMesh.gridHeight())
+{
+    const auto& blocks     = zoneMesh.blocks();
+    const auto& placements = zoneMesh.placements();
+    const auto& entries    = zoneMesh.entries();
+    const auto& cells      = zoneMesh.cells();
+    const auto  cellCount  = static_cast<uint32>(gridWidth_) * gridHeight_;
+
+    for (uint32 cellIndex = 0; cellIndex < cellCount; ++cellIndex)
+    {
+        const auto& cell = cells[cellIndex];
+        for (uint16 ref = 0; ref < cell.count; ++ref)
+        {
+            const auto& [blockIdx, placementIdx] = entries[cell.offset + ref];
+            const auto& block                    = blocks[blockIdx];
+            const auto& place                    = placements[placementIdx];
+
+            const auto key = (static_cast<uint32>(blockIdx) << 16) | placementIdx;
+            if (preTransformed_.contains(key))
+            {
+                continue;
+            }
+
+            const auto& rot = place.rotation;
+            const auto  det = rot[0] * (rot[4] * rot[8] - rot[5] * rot[7]) -
+                             rot[3] * (rot[1] * rot[8] - rot[2] * rot[7]) +
+                             rot[6] * (rot[1] * rot[5] - rot[2] * rot[4]);
+
+            auto ptb = PreTransformedBlock{
+                .worldVerts  = std::vector<float>(block.vertices.size()),
+                .flipWinding = det > 0.0f,
+            };
+
+            for (std::size_t v = 0; v < block.vertices.size(); v += 3)
+            {
+                const auto world = transform(place.rotation, place.translation, &block.vertices[v]);
+
+                ptb.worldVerts[v]     = world[0];
+                ptb.worldVerts[v + 1] = world[1];
+                ptb.worldVerts[v + 2] = world[2];
+
+                for (int axis = 0; axis < 3; ++axis)
+                {
+                    worldBmin_[axis] = std::min(worldBmin_[axis], world[axis]);
+                    worldBmax_[axis] = std::max(worldBmax_[axis], world[axis]);
+                }
+            }
+
+            preTransformed_.emplace(key, std::move(ptb));
+        }
+    }
+}
+
+auto NavMeshBuilder::worldToCell(const float x, const float z) const -> CellCoord
+{
+    return {
+        .cx = static_cast<int>(std::floor(x / XIMESH_CELL_SIZE)) + gridWidth_ / 2,
+        .cz = static_cast<int>(std::floor(z / XIMESH_CELL_SIZE)) + gridHeight_ / 2,
+    };
+}
+
+void NavMeshBuilder::getWorldBounds(float* bmin, float* bmax) const
+{
+    bmin[0] = worldBmin_[0];
+    bmin[1] = worldBmin_[1];
+    bmin[2] = worldBmin_[2];
+    bmax[0] = worldBmax_[0];
+    bmax[1] = worldBmax_[1];
+    bmax[2] = worldBmax_[2];
+}
+
+void NavMeshBuilder::gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out) const
+{
+    out.verts.clear();
+    out.indices.clear();
+    out.areas.clear();
+
+    const auto& blocks  = zoneMesh_->blocks();
+    const auto& entries = zoneMesh_->entries();
+    const auto& cells   = zoneMesh_->cells();
+
+    const auto [cxMin, czMin] = worldToCell(bmin[0], bmin[2]);
+    const auto [cxMax, czMax] = worldToCell(bmax[0], bmax[2]);
+
+    const auto xStart = std::max(0, cxMin);
+    const auto xEnd   = std::min(static_cast<int>(gridWidth_) - 1, cxMax);
+    const auto zStart = std::max(0, czMin);
+    const auto zEnd   = std::min(static_cast<int>(gridHeight_) - 1, czMax);
+
+    std::unordered_set<uint32> visited;
+
+    for (int cz = zStart; cz <= zEnd; ++cz)
+    {
+        for (int cx = xStart; cx <= xEnd; ++cx)
+        {
+            const auto& cell = cells[static_cast<uint32>(cz) * gridWidth_ + cx];
+            for (uint16 ref = 0; ref < cell.count; ++ref)
+            {
+                const auto& entry = entries[cell.offset + ref];
+                const auto  key   = (static_cast<uint32>(entry.blockIdx) << 16) | entry.placementIdx;
+
+                if (!visited.emplace(key).second)
+                {
+                    continue;
+                }
+
+                const auto it = preTransformed_.find(key);
+                if (it == preTransformed_.end())
+                {
+                    continue;
+                }
+
+                const auto& ptb   = it->second;
+                const auto& block = blocks[entry.blockIdx];
+
+                const auto vertexBase = static_cast<int>(out.verts.size() / 3);
+
+                out.verts.insert(out.verts.end(), ptb.worldVerts.begin(), ptb.worldVerts.end());
+
+                for (std::size_t tri = 0; tri < block.metas.size(); ++tri)
+                {
+                    const auto i0 = vertexBase + block.indices[tri * 3 + 0];
+                    const auto i1 = vertexBase + block.indices[tri * 3 + 1];
+                    const auto i2 = vertexBase + block.indices[tri * 3 + 2];
+
+                    if (ptb.flipWinding)
+                    {
+                        out.indices.push_back(i2);
+                        out.indices.push_back(i1);
+                        out.indices.push_back(i0);
+                    }
+                    else
+                    {
+                        out.indices.push_back(i0);
+                        out.indices.push_back(i1);
+                        out.indices.push_back(i2);
+                    }
+
+                    out.areas.push_back(block.metas[tri].barrier ? RC_NULL_AREA : RC_WALKABLE_AREA);
+                }
+            }
+        }
+    }
+}
+
+// Full Recast tile pipeline: RecastDemo/Source/Sample_TileMesh.cpp:794-830.
+auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, const NavMeshConfig& config, const float tileWorldSize) const -> TileResult
+{
+    //
+    // Tile AABB in Detour space
+    //
+
+    const float tileBmin[3] = { cfg.bmin[0] + tx * tileWorldSize, cfg.bmin[1], cfg.bmin[2] + ty * tileWorldSize };
+    const float tileBmax[3] = { cfg.bmin[0] + (tx + 1) * tileWorldSize, cfg.bmax[1], cfg.bmin[2] + (ty + 1) * tileWorldSize };
+
+    //
+    // Expand for border overlap so adjacent tiles connect
+    //
+
+    const float expandedBmin[3] = { tileBmin[0] - cfg.borderSize * cfg.cs, tileBmin[1], tileBmin[2] - cfg.borderSize * cfg.cs };
+    const float expandedBmax[3] = { tileBmax[0] + cfg.borderSize * cfg.cs, tileBmax[1], tileBmax[2] + cfg.borderSize * cfg.cs };
+
+    //
+    // Gather geometry (reverse Y/Z negation back to world space for the gather)
+    //
+
+    const float gatherBmin[3] = { expandedBmin[0], -expandedBmax[1], -expandedBmax[2] };
+    const float gatherBmax[3] = { expandedBmax[0], -expandedBmin[1], -expandedBmin[2] };
+
+    GatheredMesh tileMesh;
+    gatherTrianglesInAABB(gatherBmin, gatherBmax, tileMesh);
+    if (tileMesh.verts.empty())
+    {
+        return {};
+    }
+
+    //
+    // Transform gathered verts to Detour coordinate space (negate Y and Z)
+    //
+
+    for (std::size_t i = 0; i < tileMesh.verts.size(); i += 3)
+    {
+        tileMesh.verts[i + 1] = -tileMesh.verts[i + 1];
+        tileMesh.verts[i + 2] = -tileMesh.verts[i + 2];
+    }
+
+    const auto numVerts = static_cast<int>(tileMesh.verts.size() / 3);
+    const auto numTris  = static_cast<int>(tileMesh.indices.size() / 3);
+
+    //
+    // Per-tile rcConfig with expanded bounds
+    //
+
+    rcConfig tileCfg = cfg;
+    tileCfg.width    = tileCfg.tileSize + tileCfg.borderSize * 2;
+    tileCfg.height   = tileCfg.tileSize + tileCfg.borderSize * 2;
+    rcVcopy(tileCfg.bmin, expandedBmin);
+    rcVcopy(tileCfg.bmax, expandedBmax);
+
+    //
+    // Heightfield
+    //
+
+    rcContext ctx(false);
+
+    rcHeightfield* solid = rcAllocHeightfield();
+    if (!solid || !rcCreateHeightfield(&ctx, *solid, tileCfg.width, tileCfg.height, tileCfg.bmin, tileCfg.bmax, tileCfg.cs, tileCfg.ch))
+    {
+        rcFreeHeightField(solid);
+        return {};
+    }
+
+    //
+    // Walkable triangles + rasterize
+    //
+
+    std::vector<unsigned char> triAreas(numTris, 0);
+    rcMarkWalkableTriangles(&ctx, tileCfg.walkableSlopeAngle, tileMesh.verts.data(), numVerts, tileMesh.indices.data(), numTris, triAreas.data());
+
+    for (int i = 0; i < numTris; ++i)
+    {
+        if (tileMesh.areas[i] == RC_NULL_AREA)
+        {
+            triAreas[i] = RC_NULL_AREA;
+        }
+    }
+
+    if (!rcRasterizeTriangles(&ctx, tileMesh.verts.data(), numVerts, tileMesh.indices.data(), triAreas.data(), numTris, *solid, tileCfg.walkableClimb))
+    {
+        rcFreeHeightField(solid);
+        return {};
+    }
+
+    //
+    // Filters
+    //
+
+    if (config.filterLowHangingObstacles)
+    {
+        rcFilterLowHangingWalkableObstacles(&ctx, tileCfg.walkableClimb, *solid);
+    }
+
+    if (config.filterLedgeSpans)
+    {
+        rcFilterLedgeSpans(&ctx, tileCfg.walkableHeight, tileCfg.walkableClimb, *solid);
+    }
+
+    if (config.filterWalkableLowHeightSpans)
+    {
+        rcFilterWalkableLowHeightSpans(&ctx, tileCfg.walkableHeight, *solid);
+    }
+
+    //
+    // Compact heightfield + erosion
+    //
+
+    rcCompactHeightfield* chf = rcAllocCompactHeightfield();
+    if (!chf || !rcBuildCompactHeightfield(&ctx, tileCfg.walkableHeight, tileCfg.walkableClimb, *solid, *chf))
+    {
+        rcFreeHeightField(solid);
+        rcFreeCompactHeightfield(chf);
+        return {};
+    }
+    rcFreeHeightField(solid);
+
+    if (!rcErodeWalkableArea(&ctx, tileCfg.walkableRadius, *chf))
+    {
+        rcFreeCompactHeightfield(chf);
+        return {};
+    }
+
+    //
+    // Regions
+    //
+
+    if (!rcBuildDistanceField(&ctx, *chf) ||
+        !rcBuildRegions(&ctx, *chf, tileCfg.borderSize, tileCfg.minRegionArea, tileCfg.mergeRegionArea))
+    {
+        rcFreeCompactHeightfield(chf);
+        return {};
+    }
+
+    //
+    // Contours
+    //
+
+    rcContourSet* cset = rcAllocContourSet();
+    if (!cset || !rcBuildContours(&ctx, *chf, tileCfg.maxSimplificationError, tileCfg.maxEdgeLen, *cset))
+    {
+        rcFreeCompactHeightfield(chf);
+        rcFreeContourSet(cset);
+        return {};
+    }
+
+    if (cset->nconts == 0)
+    {
+        rcFreeCompactHeightfield(chf);
+        rcFreeContourSet(cset);
+        return {};
+    }
+
+    //
+    // Poly mesh
+    //
+
+    rcPolyMesh* pmesh = rcAllocPolyMesh();
+    if (!pmesh || !rcBuildPolyMesh(&ctx, *cset, tileCfg.maxVertsPerPoly, *pmesh))
+    {
+        rcFreeCompactHeightfield(chf);
+        rcFreeContourSet(cset);
+        rcFreePolyMesh(pmesh);
+        return {};
+    }
+
+    //
+    // Detail mesh
+    //
+
+    rcPolyMeshDetail* dmesh = rcAllocPolyMeshDetail();
+    if (!dmesh || !rcBuildPolyMeshDetail(&ctx, *pmesh, *chf, tileCfg.detailSampleDist, tileCfg.detailSampleMaxError, *dmesh))
+    {
+        rcFreeCompactHeightfield(chf);
+        rcFreeContourSet(cset);
+        rcFreePolyMesh(pmesh);
+        rcFreePolyMeshDetail(dmesh);
+        return {};
+    }
+
+    rcFreeCompactHeightfield(chf);
+    rcFreeContourSet(cset);
+
+    //
+    // Poly flags
+    //
+
+    for (int i = 0; i < pmesh->npolys; ++i)
+    {
+        if (pmesh->areas[i] == RC_WALKABLE_AREA)
+        {
+            pmesh->flags[i] = SAMPLE_POLYFLAGS_WALK;
+        }
+    }
+
+    //
+    // Build Detour tile data
+    //
+
+    auto params = dtNavMeshCreateParams{
+        .verts            = pmesh->verts,
+        .vertCount        = pmesh->nverts,
+        .polys            = pmesh->polys,
+        .polyFlags        = pmesh->flags,
+        .polyAreas        = pmesh->areas,
+        .polyCount        = pmesh->npolys,
+        .nvp              = pmesh->nvp,
+        .detailMeshes     = dmesh->meshes,
+        .detailVerts      = dmesh->verts,
+        .detailVertsCount = dmesh->nverts,
+        .detailTris       = dmesh->tris,
+        .detailTriCount   = dmesh->ntris,
+        .offMeshConVerts  = nullptr,
+        .offMeshConRad    = nullptr,
+        .offMeshConFlags  = nullptr,
+        .offMeshConAreas  = nullptr,
+        .offMeshConDir    = nullptr,
+        .offMeshConUserID = nullptr,
+        .offMeshConCount  = 0,
+        .userId           = 0,
+        .tileX            = tx,
+        .tileY            = ty,
+        .tileLayer        = 0,
+        .bmin             = {}, // set via rcVcopy below
+        .bmax             = {}, // set via rcVcopy below
+        .walkableHeight   = config.agentHeight,
+        .walkableRadius   = config.agentRadius,
+        .walkableClimb    = config.agentMaxClimb,
+        .cs               = tileCfg.cs,
+        .ch               = tileCfg.ch,
+        .buildBvTree      = true,
+    };
+    rcVcopy(params.bmin, pmesh->bmin);
+    rcVcopy(params.bmax, pmesh->bmax);
+
+    unsigned char* navData     = nullptr;
+    int            navDataSize = 0;
+    if (!dtCreateNavMeshData(&params, &navData, &navDataSize))
+    {
+        rcFreePolyMesh(pmesh);
+        rcFreePolyMeshDetail(dmesh);
+        return {};
+    }
+
+    rcFreePolyMesh(pmesh);
+    rcFreePolyMeshDetail(dmesh);
+
+    return {
+        .tx       = tx,
+        .ty       = ty,
+        .data     = navData,
+        .dataSize = navDataSize,
+    };
+}
+
+auto NavMeshBuilder::buildAsync(Scheduler& scheduler, const std::string& zoneName, const uint16 zoneID, const NavMeshConfig& config) -> Task<dtNavMesh*>
+{
+    //
+    // World bounds to Detour coordinate space (negate Y and Z, swap min/max)
+    //
+
+    float worldBmin[3];
+    float worldBmax[3];
+    getWorldBounds(worldBmin, worldBmax);
+
+    const float detourBmin[3] = { worldBmin[0], -worldBmax[1], -worldBmax[2] };
+    const float detourBmax[3] = { worldBmax[0], -worldBmin[1], -worldBmin[2] };
+
+    const auto startTime = timer::now();
+
+    //
+    // rcConfig
+    // Standard Recast boilerplate. See: RecastDemo/Source/Sample_TileMesh.cpp
+    //
+
+    const auto cs             = config.cellSize;
+    const auto ch             = config.cellHeight;
+    const auto walkableHeight = static_cast<int>(std::ceil(config.agentHeight / ch));
+    const auto walkableClimb  = static_cast<int>(std::floor(config.agentMaxClimb / ch));
+    const auto walkableRadius = static_cast<int>(std::ceil(config.agentRadius / cs));
+
+    const auto cfg = rcConfig{
+        .width                  = 0,
+        .height                 = 0,
+        .tileSize               = config.tileSize,
+        .borderSize             = walkableRadius + TILE_BORDER_PADDING,
+        .cs                     = cs,
+        .ch                     = ch,
+        .bmin                   = { detourBmin[0], detourBmin[1], detourBmin[2] },
+        .bmax                   = { detourBmax[0], detourBmax[1], detourBmax[2] },
+        .walkableSlopeAngle     = config.walkableSlopeAngle,
+        .walkableHeight         = walkableHeight,
+        .walkableClimb          = walkableClimb,
+        .walkableRadius         = walkableRadius,
+        .maxEdgeLen             = config.maxEdgeLen > 0.0f ? static_cast<int>(config.maxEdgeLen / cs) : 0,
+        .maxSimplificationError = config.maxSimplificationError,
+        .minRegionArea          = config.minRegionArea,
+        .mergeRegionArea        = config.mergeRegionArea,
+        .maxVertsPerPoly        = config.maxVertsPerPoly,
+        .detailSampleDist       = config.detailSampleDist < MIN_DETAIL_SAMPLE_DIST ? 0.0f : cs * config.detailSampleDist,
+        .detailSampleMaxError   = ch * config.detailSampleMaxError,
+    };
+
+    //
+    // Tile grid
+    //
+
+    int gridW = 0;
+    int gridH = 0;
+    rcCalcGridSize(cfg.bmin, cfg.bmax, cfg.cs, &gridW, &gridH);
+
+    const auto tileWorldSize = cfg.tileSize * cfg.cs;
+    const auto tw            = (gridW + cfg.tileSize - 1) / cfg.tileSize;
+    const auto th            = (gridH + cfg.tileSize - 1) / cfg.tileSize;
+
+    //
+    // Tile coordinates
+    //
+
+    std::vector<TileCoord> tileCoords;
+    tileCoords.reserve(static_cast<std::size_t>(tw) * th);
+    for (int ty = 0; ty < th; ++ty)
+    {
+        for (int tx = 0; tx < tw; ++tx)
+        {
+            tileCoords.push_back({ .tx = tx, .ty = ty });
+        }
+    }
+
+    //
+    // Init dtNavMesh
+    //
+
+    auto tileBits = 0;
+    for (auto v = tw * th; v > 0; v >>= 1)
+    {
+        tileBits++;
+    }
+    tileBits = std::min(tileBits, DT_MAX_TILE_BITS);
+
+    const auto polyBits = DT_TOTAL_REF_BITS - tileBits;
+
+    auto navParams = dtNavMeshParams{
+        .orig       = {},
+        .tileWidth  = tileWorldSize,
+        .tileHeight = tileWorldSize,
+        .maxTiles   = 1 << tileBits,
+        .maxPolys   = 1 << polyBits,
+    };
+    rcVcopy(navParams.orig, cfg.bmin);
+
+    auto* navMesh = dtAllocNavMesh();
+    if (!navMesh)
+    {
+        ShowErrorFmt("NavMeshBuilder::build: Could not allocate dtNavMesh ({})", zoneID);
+        co_return nullptr;
+    }
+
+    auto status = navMesh->init(&navParams);
+    if (dtStatusFailed(status))
+    {
+        ShowErrorFmt("NavMeshBuilder::build: Could not init dtNavMesh ({})", zoneID);
+        dtFreeNavMesh(navMesh);
+        co_return nullptr;
+    }
+
+    //
+    // Parallel tile builds in batches
+    //
+
+    std::vector<TileResult> results(tileCoords.size());
+    for (std::size_t batch = 0; batch < tileCoords.size(); batch += TILE_BATCH_SIZE)
+    {
+        const auto batchEnd = std::min(batch + TILE_BATCH_SIZE, tileCoords.size());
+
+        co_await Scheduler::TaskGroup(
+            batchEnd - batch,
+            [&, batch, batchEnd](auto& add)
+            {
+                for (std::size_t i = batch; i < batchEnd; ++i)
+                {
+                    const auto& tile = tileCoords[i];
+                    add(scheduler.spawnOnWorkerThread(
+                        [this, i, tile, &cfg, &config, tileWorldSize, &results]()
+                        {
+                            results[i] = buildTile(tile.tx, tile.ty, cfg, config, tileWorldSize);
+                        }));
+                }
+            });
+    }
+
+    //
+    // Add tiles to navmesh (addTile is not thread-safe)
+    //
+
+    auto tilesBuilt = 0;
+    for (const auto& result : results)
+    {
+        if (result.data)
+        {
+            status = navMesh->addTile(result.data, result.dataSize, DT_TILE_FREE_DATA, 0, nullptr);
+            if (dtStatusFailed(status))
+            {
+                dtFree(result.data);
+                continue;
+            }
+            tilesBuilt++;
+        }
+    }
+
+    if (tilesBuilt == 0)
+    {
+        ShowErrorFmt("NavMeshBuilder::build: No tiles built ({})", zoneID);
+        dtFreeNavMesh(navMesh);
+        co_return nullptr;
+    }
+
+    const auto endTime    = timer::now();
+    const auto durationMs = timer::count_milliseconds(endTime - startTime);
+
+    ShowInfoFmt("Built {} nav tiles in {}x{} grid for {} ({}) in {}ms", tilesBuilt, tw, th, zoneName, zoneID, durationMs);
+    co_return navMesh;
+}

--- a/src/map/navmesh_builder.h
+++ b/src/map/navmesh_builder.h
@@ -1,0 +1,94 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+#include "common/scheduler.h"
+#include "navmesh_config.h"
+
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+struct rcConfig;
+
+class CZoneMesh;
+class dtNavMesh;
+
+constexpr auto FloatMax    = std::numeric_limits<float>::max();
+constexpr auto FloatLowest = std::numeric_limits<float>::lowest();
+
+struct GatheredMesh
+{
+    std::vector<float>         verts;
+    std::vector<int>           indices;
+    std::vector<unsigned char> areas;
+};
+
+struct TileCoord
+{
+    int tx{};
+    int ty{};
+};
+
+struct CellCoord
+{
+    int cx{};
+    int cz{};
+};
+
+struct TileResult
+{
+    int            tx{};
+    int            ty{};
+    unsigned char* data{};
+    int            dataSize{};
+};
+
+class NavMeshBuilder
+{
+public:
+    explicit NavMeshBuilder(const CZoneMesh& zoneMesh);
+
+    void getWorldBounds(float* bmin, float* bmax) const;
+    void gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out) const;
+    auto buildAsync(Scheduler& scheduler, const std::string& zoneName, uint16 zoneID, const NavMeshConfig& config) -> Task<dtNavMesh*>;
+
+private:
+    auto buildTile(int tx, int ty, const rcConfig& cfg, const NavMeshConfig& config, float tileWorldSize) const -> TileResult;
+    auto worldToCell(float x, float z) const -> CellCoord;
+
+    struct PreTransformedBlock
+    {
+        std::vector<float> worldVerts;
+        bool               flipWinding{};
+    };
+
+    const CZoneMesh* zoneMesh_{};
+    uint16           gridWidth_{};
+    uint16           gridHeight_{};
+    float            worldBmin_[3]{ FloatMax, FloatMax, FloatMax };
+    float            worldBmax_[3]{ FloatLowest, FloatLowest, FloatLowest };
+
+    std::unordered_map<uint32, PreTransformedBlock> preTransformed_;
+};

--- a/src/map/navmesh_config.h
+++ b/src/map/navmesh_config.h
@@ -1,0 +1,44 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+struct NavMeshConfig
+{
+    float cellSize{ 0.5f };               // Previous xiNavmeshes value: 0.4
+    float cellHeight{ 0.4f };             // Previous xiNavmeshes value: 0.2
+    float walkableSlopeAngle{ 46.0f };    // Previous xiNavmeshes value: 46.0
+    float agentHeight{ 2.0f };            // Previous xiNavmeshes value: 1.8
+    float agentRadius{ 0.5f };            // Previous xiNavmeshes value: 0.3
+    float agentMaxClimb{ 0.6f };          // Previous xiNavmeshes value: 0.6
+    float maxEdgeLen{ 0.0f };             // Previous xiNavmeshes value: 12.0
+    float maxSimplificationError{ 1.3f }; // Previous xiNavmeshes value: 1.3
+    int   minRegionArea{ 8 };             // Previous xiNavmeshes value: 8
+    int   mergeRegionArea{ 20 };          // Previous xiNavmeshes value: 20
+    int   maxVertsPerPoly{ 6 };           // Previous xiNavmeshes value: 6
+    float detailSampleDist{ 6.0f };       // Previous xiNavmeshes value: 6.0
+    float detailSampleMaxError{ 1.0f };   // Previous xiNavmeshes value: 1.0
+    int   tileSize{ 64 };                 // Previous xiNavmeshes value: 256
+
+    bool filterLowHangingObstacles{ true };
+    bool filterLedgeSpans{ true };
+    bool filterWalkableLowHeightSpans{ true };
+};

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -756,8 +756,6 @@ auto CreateZone(Scheduler& scheduler, MapConfig config, uint16 ZoneID) -> CZone*
 
 auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>& zoneIds) -> Task<void>
 {
-    TracyZoneScoped;
-
     std::vector<uint16> zonesIdsToLoad;
 
     for (const auto zoneId : zoneIds)
@@ -788,18 +786,13 @@ auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>
         g_PZoneList[0] = CreateZone(scheduler, config, 0);
     }
 
+    // Phase 1: Load zone meshes and LOS data (navmesh build depends on zone mesh)
     co_await Scheduler::TaskGroup(
-        zoneIds.size() * 3,
+        zonesIdsToLoad.size() * 2,
         [&](auto& add)
         {
             for (const auto zoneId : zonesIdsToLoad)
             {
-                add(scheduler.spawnOnWorkerThread(
-                    [zoneId]()
-                    {
-                        g_PZoneList[zoneId]->LoadNavMesh();
-                    }));
-
                 add(scheduler.spawnOnWorkerThread(
                     [zoneId]()
                     {
@@ -813,6 +806,13 @@ auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>
                     }));
             }
         });
+
+    // Phase 2: Load/build navmeshes (requires zone mesh; processed serially because
+    // each zone's build is a coroutine that dispatches tile work to workers)
+    for (const auto zoneId : zonesIdsToLoad)
+    {
+        co_await g_PZoneList[zoneId]->LoadNavMesh();
+    }
 
     // IDs attached to xi.zone[name] need to be populated before NPCs and Mobs are loaded
     for (const auto zoneId : zonesIdsToLoad)

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -49,6 +49,7 @@ constexpr std::uint16_t WeatherCycle = 2160;
 #include "map_engine.h"
 #include "monstrosity.h"
 #include "navmesh.h"
+#include "navmesh_builder.h"
 #include "party.h"
 #include "recast_container.h"
 #include "spawn_handler.h"
@@ -257,23 +258,23 @@ const QueryByNameResult_t& CZone::queryEntitiesByName(const std::string& pattern
     std::vector<CBaseEntity*> entities;
 
     // TODO: Make work for instances
-    // clang-format off
-    ForEachNpc([&](CNpcEntity* PNpc)
-    {
-        if (matches(PNpc->getName(), pattern))
+    ForEachNpc(
+        [&](CNpcEntity* PNpc)
         {
-            entities.emplace_back(PNpc);
-        }
-    });
+            if (matches(PNpc->getName(), pattern))
+            {
+                entities.emplace_back(PNpc);
+            }
+        });
 
-    ForEachMob([&](CMobEntity* PMob)
-    {
-        if (matches(PMob->getName(), pattern))
+    ForEachMob(
+        [&](CMobEntity* PMob)
         {
-            entities.emplace_back(PMob);
-        }
-     });
-    // clang-format on
+            if (matches(PMob->getName(), pattern))
+            {
+                entities.emplace_back(PMob);
+            }
+        });
 
     m_queryByNameResults[pattern] = std::move(entities);
     return m_queryByNameResults[pattern];
@@ -464,24 +465,59 @@ void CZone::LoadZoneSettings()
     }
 }
 
-void CZone::LoadNavMesh()
+auto CZone::LoadNavMesh() -> Task<void>
 {
-    TracyZoneScoped;
-
     if (m_navMesh == nullptr)
     {
         m_navMesh = std::make_unique<CNavMesh>(static_cast<uint16>(GetID()));
     }
 
-    char file[255];
-    std::memset(file, 0, sizeof(file));
-    snprintf(file, sizeof(file), "navmeshes/%s.nav", getName().c_str());
+    const auto file = fmt::format("navmeshes/{}.nav", getName());
 
-    if (!m_navMesh->load(file))
+    if (!config_.rebuildNavmeshes && m_navMesh->load(file))
     {
-        DebugNavmesh("CZone::LoadNavMesh: Cannot load navmesh file (%s)", file);
-        m_navMesh = nullptr;
+        co_return;
     }
+
+    if (zoneMesh_ && zoneMesh_->isLoaded())
+    {
+        NavMeshBuilder builder(*zoneMesh_);
+
+        auto* navMesh = co_await builder.buildAsync(scheduler_, getName(), static_cast<uint16>(GetID()), NavMeshConfig{});
+        if (navMesh && m_navMesh->installNavMesh(navMesh))
+        {
+            m_navMesh->save(file);
+            co_return;
+        }
+    }
+
+    DebugNavmesh("CZone::LoadNavMesh: No navmesh available for zone (%s)", getName().c_str());
+    m_navMesh = nullptr;
+}
+
+void CZone::RebuildNavMesh(const NavMeshConfig& config)
+{
+    if (!zoneMesh_ || !zoneMesh_->isLoaded())
+    {
+        ShowErrorFmt("CZone::RebuildNavMesh: No zone mesh loaded for ({})", getName());
+        return;
+    }
+
+    const auto  zoneName    = getName();
+    const auto  zoneID      = static_cast<uint16>(GetID());
+    const auto* zoneMeshPtr = zoneMesh_.get();
+
+    scheduler_.postToMainThread(
+        [this, zoneName, zoneID, config, zoneMeshPtr]() -> Task<void>
+        {
+            NavMeshBuilder builder(*zoneMeshPtr);
+
+            auto* newNavMesh = co_await builder.buildAsync(scheduler_, zoneName, zoneID, config);
+            if (m_navMesh && m_navMesh->installNavMesh(newNavMesh))
+            {
+                m_navMesh->save(fmt::format("navmeshes/{}.nav", zoneName));
+            }
+        });
 }
 
 auto CZone::zoneMesh() const -> Maybe<CZoneMesh*>

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -36,6 +36,7 @@
 #include "battlefield_handler.h"
 #include "campaign_handler.h"
 #include "map_config.h"
+#include "navmesh_config.h"
 #include "packets/basic.h"
 #include "spawn_slot.h"
 #include "trigger_area.h"
@@ -682,7 +683,8 @@ public:
 
     timer::time_point m_LoadedAt; // The time the zone was loaded
 
-    void LoadNavMesh();
+    auto LoadNavMesh() -> Task<void>;
+    void RebuildNavMesh(const NavMeshConfig& config = {});
     void LoadZoneMesh();
     void LoadZoneLos();
 

--- a/src/map/zone_mesh.cpp
+++ b/src/map/zone_mesh.cpp
@@ -34,6 +34,7 @@
 
 namespace
 {
+
 template <typename T>
 auto readAt(const std::span<const uint8> buf, const uint32 offset) -> T
 {
@@ -279,7 +280,7 @@ auto CZoneMesh::load(const std::string& filename) -> bool
         }
     }
 
-    // Step 4. Pre-compute Y bounds per placement
+    // Step 4. Pre-compute Y bounds per placement (used by query culling).
     for (uint32 cellIndex = 0; cellIndex < cellCount; ++cellIndex)
     {
         const auto& cell = cells_[cellIndex];
@@ -291,11 +292,10 @@ auto CZoneMesh::load(const std::string& filename) -> bool
 
             for (size_t v = 0; v < block.vertices.size(); v += 3)
             {
-                const auto  world = transform(place.rotation, place.translation, &block.vertices[v]);
-                const float wy    = world[1];
+                const auto world = transform(place.rotation, place.translation, &block.vertices[v]);
 
-                place.yMin = std::min(place.yMin, wy);
-                place.yMax = std::max(place.yMax, wy);
+                place.yMin = std::min(place.yMin, world[1]);
+                place.yMax = std::max(place.yMax, world[1]);
             }
         }
     }
@@ -316,6 +316,8 @@ auto CZoneMesh::worldToCell(const float x, const float z) const -> std::pair<int
 // Returns the triangle under (x, z) closest above y.
 auto CZoneMesh::query(const float x, const float y, const float z) const -> std::optional<CellHit>
 {
+    TracyZoneScoped;
+
     const auto [cx, cz]    = worldToCell(x, z);
     const std::array point = { x, 0.0f, z };
 
@@ -442,4 +444,39 @@ auto CZoneMesh::getFloorId(const float x, const float y, const float z) const ->
     }
 
     return 0;
+}
+
+auto CZoneMesh::isLoaded() const -> bool
+{
+    return loaded_;
+}
+
+auto CZoneMesh::blocks() const -> const std::vector<MeshBlock>&
+{
+    return blocks_;
+}
+
+auto CZoneMesh::placements() const -> const std::vector<MeshPlacement>&
+{
+    return placements_;
+}
+
+auto CZoneMesh::entries() const -> const std::vector<CellEntry>&
+{
+    return entries_;
+}
+
+auto CZoneMesh::cells() const -> const std::vector<CellSpan>&
+{
+    return cells_;
+}
+
+auto CZoneMesh::gridWidth() const -> uint16
+{
+    return header_.gridWidth;
+}
+
+auto CZoneMesh::gridHeight() const -> uint16
+{
+    return header_.gridHeight;
 }

--- a/src/map/zone_mesh.h
+++ b/src/map/zone_mesh.h
@@ -79,10 +79,14 @@ public:
     auto query(float x, float y, float z) const -> std::optional<CellHit>;
     auto getTerrainAt(float x, float y, float z) const -> TerrainType;
     auto getFloorId(float x, float y, float z) const -> uint8;
-    auto isLoaded() const -> bool
-    {
-        return loaded_;
-    }
+    auto isLoaded() const -> bool;
+
+    auto blocks() const -> const std::vector<MeshBlock>&;
+    auto placements() const -> const std::vector<MeshPlacement>&;
+    auto entries() const -> const std::vector<CellEntry>&;
+    auto cells() const -> const std::vector<CellSpan>&;
+    auto gridWidth() const -> uint16;
+    auto gridHeight() const -> uint16;
 
 private:
     auto worldToCell(float x, float z) const -> std::pair<int, int>;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Given that Ino has done _god's work_ with [ximeshes](https://github.com/InoUno/ximeshes) and [xi-visualizer](https://github.com/InoUno/xi-visualizer), sruon added [ximesh loading](https://github.com/LandSandBoat/server/blob/base/src/map/ximesh.h) to LSB, and the [RecastDemo](https://github.com/recastnavigation/recastnavigation/tree/main/RecastDemo) shows you how to generate nav data from 3D point/tri data... why don't we just make xi_map capable of generating it's own navmeshes?

By default, the system remains as it has always been: if the file is in `/navmeshes/`, use it. If it isn't there, it'll use the corresponding `ximeshes` entry and generate a new navmesh file using the defaults we used in the `xiNavmeshes` repo.

**The defaults are the same as before, so this doesn't FIX any foibles with navmeshes yet**

But, this opens up the doors to test and experiment and actually know what the different numbers do, and try to capture test cases and get things like Garlaige Citadel or the high walkways in Sky to behave better.

**THIS ALSO DOESN'T FIX PATHFINDING** - Both navmesh and pathfinding are borked, and both need to be working for a smooth experience. 

<img width="858" height="73" alt="image" src="https://github.com/user-attachments/assets/2d677272-e0eb-47aa-81e7-874818dfc14a" />

**Tracy**

I did a little experimenting of dropping `cellSize` and `cellHeight` down, and it does seem to give a 5% boost in performance, at the cost of doubling (or more) the size and memory footprint of the navmesh. Interesting stuff.