### PR TITLE
[trust, lua, sql] Rughadjeen and Trion & gambit TP trigger logic

### DIFF
--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -16,8 +16,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if mob:isTrust() then
         local effectDuration = 60
         skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, effectDuration))
-        mob:addStatusEffect(xi.effect.PALISADE, {power = 30, duration = effectDuration, origin = mob})
-        mob:addStatusEffect(xi.effect.STONESKIN, {power = utils.clamp(math.floor(mob:getMaxHP() / 10), 10, 200) , duration = effectDuration, origin = mob})
+        mob:addStatusEffect(xi.effect.PALISADE, { power = 30, duration = effectDuration, origin = mob })
+        mob:addStatusEffect(xi.effect.STONESKIN, { power = utils.clamp(math.floor(mob:getMaxHP() / 10), 10, 200) , duration = effectDuration, origin = mob })
         effect = xi.effect.DEFENSE_BOOST
         mob:setTP(0)
     else

--- a/scripts/actions/mobskills/royal_savior.lua
+++ b/scripts/actions/mobskills/royal_savior.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Royal Savior
--- Grants effect of Protect
+-- [Hero's Combat BCNM] Grants effect of Protect
+-- [Trust] Grants defence boost, palisade effect and stoneskin
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -10,9 +11,21 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 175, 0, 300))
+    local effect = xi.effect.NONE
 
-    return xi.effect.PROTECT
+    if mob:isTrust() then
+        local effectDuration = 60
+        skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, effectDuration))
+        mob:addStatusEffect(xi.effect.PALISADE, {power = 30, duration = effectDuration, origin = mob})
+        mob:addStatusEffect(xi.effect.STONESKIN, {power = utils.clamp(math.floor(mob:getMaxHP() / 10), 10, 200) , duration = effectDuration, origin = mob})
+        effect = xi.effect.DEFENSE_BOOST
+        mob:setTP(0)
+    else
+        skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, 175, 0, 300))
+        effect = xi.effect.PROTECT
+    end
+
+    return effect
 end
 
 return mobskillObject

--- a/scripts/actions/spells/trust/rughadjeen.lua
+++ b/scripts/actions/spells/trust/rughadjeen.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Trust: Rughadjeen
 -- Possesses Fast Cast, Cure Potency Received +30%, Damage Taken -5%.
--- He wields the Algol and so has an enfire effect (TODO) and a 3% triple attack rate.
+-- He wields the Algol and so has an enfire effect and a 3% triple attack rate.
 -- Uses Holy Circle if the enemy is Undead.
 -- Will only cast Cure I - IV when a party member is below 75% (yellow) HP or asleep.
 -- Tries to use weapon skills at 1000 TP, but it is lower priority.
@@ -27,34 +27,74 @@ spellObject.onMobSpawn = function(mob)
         [xi.magic.spell.MIHLI_ALIAPOH] = xi.trust.messageOffset.TEAMWORK_5
     })
 
-    -- TODO: Load/Apply MODs from mob_pool_mods instead
+    mob:addMod(xi.mod.HPP, 20)
+    mob:addMod(xi.mod.MPP, 20)
     mob:addMod(xi.mod.FASTCAST, 30)
     mob:addMod(xi.mod.CURE_POTENCY_RCVD, 30)
     mob:addMod(xi.mod.DMG, -500)
     mob:addMod(xi.mod.TRIPLE_ATTACK, 3)
-    -- TODO: Add en-fire effect from Algol
 
-    mob:addGambit(ai.t.SELF, { ai.c.NOT_STATUS, xi.effect.SENTINEL }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.SENTINEL })
+    -- Algol Additional Effect: Fire DMG, procs around 33%, dmg seems to be around 30 at lvl 99 from testing.
+    local potency =  utils.clamp(math.floor(mob:getMainLvl() * 0.26), 3, 30)
+    mob:addMod(xi.mod.ENSPELL, xi.element.FIRE)
+    mob:addMod(xi.mod.ENSPELL_DMG, potency)
+    mob:addMod(xi.mod.ENSPELL_CHANCE, 33)
 
-    mob:addGambit(ai.t.TARGET, { ai.c.NOT_STATUS, xi.effect.FLASH }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLASH })
+    local lastSynergyBonus = 0
+    -- Dynamic modifier that checks party member list on tick to apply
+    mob:addListener('COMBAT_TICK', 'RUGHADJEEN_CTICK', function(mobArg)
+        local synergyMembers =
+        {
+            xi.magic.spell.MIHLI_ALIAPOH,
+            xi.magic.spell.GADALAR,
+            xi.magic.spell.ZAZARG,
+            xi.magic.spell.NAJELITH
+        }
 
-    mob:addGambit(ai.t.SELF, { ai.c.NOT_STATUS, xi.effect.DIVINE_EMBLEM }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.DIVINE_EMBLEM })
+        local synergyCount = 0
+        local party = mobArg:getMaster():getPartyWithTrusts()
 
-    mob:addGambit(ai.t.TARGET, { ai.c.NOT_SC_AVAILABLE, 0 }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.HOLY })
+        for _, member in pairs(party) do
+            if member:getObjType() == xi.objType.TRUST then
+                local trustId = member:getTrustID()
+                for _, sId in ipairs(synergyMembers) do
+                    if trustId == sId then
+                        synergyCount = synergyCount + 1
+                        break
+                    end
+                end
+            end
+        end
 
-    mob:addGambit(ai.t.PARTY, { ai.c.STATUS, xi.effect.SLEEP_I }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE })
-    mob:addGambit(ai.t.PARTY, { ai.c.STATUS, xi.effect.SLEEP_II }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE })
+        -- Determine what the bonus should be
+        -- When any other serpent generals are in the party, Rughadjeen has Damage Taken -29% while in combat with a foe.
+        local targetBonus = (synergyCount >= 1) and -2900 or 0
+        -- Only update if the state has changed
+        if targetBonus ~= lastSynergyBonus then
+            -- Subtract exactly what we added last time
+            mobArg:delMod(xi.mod.DMG, lastSynergyBonus)
+            -- Add the new bonus
+            mobArg:addMod(xi.mod.DMG, targetBonus)
+            -- Update lastSynergyBonus
+            lastSynergyBonus = targetBonus
+        end
+    end)
 
-    mob:addGambit(ai.t.PARTY, { ai.c.HPP_LT, 75 }, { ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE })
+    mob:addGambit(ai.t.SELF,       { ai.c.NOT_STATUS,       xi.effect.SENTINEL      }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.SENTINEL             })
+    mob:addGambit(ai.t.TARGET,     { ai.c.NOT_STATUS,       xi.effect.FLASH         }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLASH       })
+    mob:addGambit(ai.t.SELF,       { ai.c.NOT_STATUS,       xi.effect.DIVINE_EMBLEM }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.DIVINE_EMBLEM        })
+    mob:addGambit(ai.t.TARGET,     { ai.c.NOT_SC_AVAILABLE, 0                       }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.HOLY        })
+    mob:addGambit(ai.t.PARTY,      { ai.c.STATUS,           xi.effect.SLEEP_I       }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE        })
+    mob:addGambit(ai.t.PARTY,      { ai.c.STATUS,           xi.effect.SLEEP_II      }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.CURE        })
+    mob:addGambit(ai.t.PARTY,      { ai.c.HPP_LT,           75                      }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.CURE  })
+    mob:addGambit(ai.t.TARGET,     { ai.c.IS_ECOSYSTEM,     xi.ecosystem.UNDEAD     }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.HOLY_CIRCLE          })
+    mob:addGambit(ai.t.SELF,       { ai.c.MPP_LT,           50                      }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.CHIVALRY             })
+    mob:addGambit(ai.t.PARTY_DEAD, { ai.c.MPP_GTE,          200                     }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.RAISE })
 
-    mob:addGambit(ai.t.TARGET, { ai.c.IS_ECOSYSTEM, xi.ecosystem.UNDEAD }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.HOLY_CIRCLE })
-
-    mob:addGambit(ai.t.SELF, { ai.c.MPP_LT, 50 }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.CHIVALRY })
-
-    -- TODO: Add Trust Synergy for Serpent Generals
+    mob:setTrustTPSkillSettings(ai.tp.ASAP, ai.s.RANDOM, 1000)
 
     mob:addListener('WEAPONSKILL_USE', 'RUGHADJEEN_WEAPONSKILL_USE', function(mobArg, target, skill, tp, action, damage)
-        if skill:getID() == 3237 then -- Victory Beacon
+        if skill:getID() == xi.mobSkill.VICTORY_BEACON_TRUST then -- Victory Beacon
         -- Do not despair! The Goddess of Victory fights by our side!
             if math.random(1, 100) <= 33 then
                 xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)

--- a/scripts/actions/spells/trust/trion.lua
+++ b/scripts/actions/spells/trust/trion.lua
@@ -19,11 +19,28 @@ spellObject.onMobSpawn = function(mob)
         [xi.magic.spell.HALVER] = xi.trust.messageOffset.TEAMWORK_3,
     })
 
-    mob:addGambit(ai.t.SELF, { ai.c.NOT_HAS_TOP_ENMITY, 0 }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE })
+    mob:setMobMod(xi.mobMod.CAN_SHIELD_BLOCK, 1)
+    mob:setMobMod(xi.mobMod.CAN_PARRY, 3)
 
-    mob:addGambit(ai.t.TARGET, { ai.c.NOT_STATUS, xi.effect.FLASH }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLASH })
+    mob:addMod(xi.mod.HPP, 10)
+    mob:addMod(xi.mod.MPP, 10)
+    mob:addMod(xi.mod.FASTCAST, 30)
+    mob:addMod(xi.mod.DMG, -1000)
+    mob:addMod(xi.mod.ENMITY, 25)
 
-    mob:addGambit(ai.t.PARTY, { ai.c.HPP_LT, 75 }, { ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE })
+    mob:addGambit(ai.t.SELF,   { ai.c.NOT_HAS_TOP_ENMITY, 0                  }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.PROVOKE                  })
+    mob:addGambit(ai.t.TARGET, { ai.c.NOT_STATUS,         xi.effect.FLASH    }, { ai.r.MA, ai.s.SPECIFIC, xi.magic.spell.FLASH           })
+    mob:addGambit(ai.t.SELF,   { ai.c.NOT_STATUS,         xi.effect.SENTINEL }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.SENTINEL                 })
+    mob:addGambit(ai.t.PARTY,  { ai.c.HPP_LT,             75                 }, { ai.r.MA, ai.s.HIGHEST,  xi.magic.spellFamily.CURE      })
+
+    mob:setTrustTPSkillSettings(ai.tp.RANDOM, ai.s.RANDOM, 1500)
+
+    mob:addListener('WEAPONSKILL_USE', 'TRION_WEAPONSKILL_USE', function(mobArg, target, skill, tp, action, damage)
+        if skill:getID() == xi.mobSkill.ROYAL_SAVIOR_TRUST then -- Royal Savior
+            -- O great kings of the noble line of d'Oraguille, shield me from harm!
+            xi.trust.message(mobArg, xi.trust.messageOffset.SPECIAL_MOVE_1)
+        end
+    end)
 end
 
 spellObject.onMobDespawn = function(mob)

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -1038,7 +1038,12 @@ xi.mobSkill =
 
     ARROGANCE_INCARNATE_1         = 3178,
 
+    ROYAL_BASH_TRUST              = 3193, -- Trion Trust
+    ROYAL_SAVIOR_TRUST            = 3194, -- Trion Trust
+
     LIGHT_BLADE_2                 = 3214,
+
+    VICTORY_BEACON_TRUST          = 3237, -- Rughadjeen Trust
 
     SHIBARAKU_TRUST               = 3257, -- Gessho Trust
     SHIKO_NO_MITATE_TRUST         = 3258, -- Gessho Trust

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3430,11 +3430,10 @@ INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,39); -- Spirits Within
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,40); -- Vorpal Blade
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Volker',1018,42); -- Savage Blade
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Ajido-Marujido',1019,0);
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,34);   -- Red Lotus Blade
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,35);   -- Flat Blade
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,42);   -- Savage Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,968);  -- Red Lotus Blade
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,970);  -- Savage Blade
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3193); -- Royal Bash
-INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3194); -- Royal Saviour
+INSERT INTO `mob_skill_lists` VALUES ('TRUST_Trion',1020,3194); -- Royal Savior
 -- INSERT INTO `mob_skill_lists` VALUES ('TRUST_Zeid',1021,0);
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3198); -- Grapeshot
 INSERT INTO `mob_skill_lists` VALUES ('TRUST_Lion',1022,3199); -- Pirate Pummel

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -3221,8 +3221,8 @@ INSERT INTO `mob_skills` VALUES (3189,1508,'king_cobra_clamp',1,0.0,7.0,2000,150
 -- INSERT INTO `mob_skills` VALUES (3190,2934,'red_lotus_blade',0,0.0,7.0,2000,1500,4,0,0,0,3,6,0);
 -- INSERT INTO `mob_skills` VALUES (3191,2935,'spirits_within',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3192,681,'vorpal_blade',0,0.0,7.0,2000,1500,4,0,0,0,4,8,0); -- Trion
-INSERT INTO `mob_skills` VALUES (3193,669,'royal_bash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3194,670,'royal_savior',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3193,669,'royal_bash',0,0.0,7.0,0,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3194,670,'royal_savior',0,0.0,7.0,1000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3195,671,'abyssal_drain',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0); -- Zeid
 INSERT INTO `mob_skills` VALUES (3196,672,'abyssal_strike',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3197,684,'ground_strike',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);

--- a/sql/mob_spell_lists.sql
+++ b/sql/mob_spell_lists.sql
@@ -3643,6 +3643,7 @@ INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,1,1,255);    -- cur
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,2,11,255);   -- cure_ii (11~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,3,21,255);   -- cure_iii (21~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,4,41,255);   -- cure_iv (41~255)
+INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,12,50,255);  -- raise (50~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,21,55,255);  -- holy (55~255)
 INSERT INTO `mob_spell_lists` VALUES ('TRUST_Rughadjeen',373,112,37,255); -- flash (37~255)
 

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -1364,17 +1364,37 @@ bool CGambitsContainer::TryTrustSkill()
                 return true;
                 break;
             }
+            case G_TP_TRIGGER::RANDOM:
+            {
+                bool result = false;
+                // clang-format off
+                if (tp_value <= 1000) // If the value provided by the script is missing or too low
+                {
+                    tp_value = 1000; // Apply the minimum TP Hold Threshold
+                }
+                if (POwner->health.tp >= tp_value && xirand::GetRandomNumber<uint16>(10000) < tp_value)
+                {
+                    result = true;
+                }
+                // clang-format on
+                return result;
+                break;
+            }
             case G_TP_TRIGGER::OPENER:
             {
                 bool result = false;
                 // clang-format off
-                    static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                static_cast<CCharEntity*>(POwner->PMaster)->ForPartyWithTrusts([&](CBattleEntity* PMember)
+                {
+                    if (tp_value <= 1000) // If the value provided by the script is missing or too low
                     {
-                        if (PMember->health.tp >= 1000 && PMember != POwner)
-                        {
-                            result = true;
-                        }
-                    });
+                        tp_value = 1000; // Apply the minimum TP Hold Threshold
+                    }
+                    if (PMember->health.tp >= tp_value && PMember != POwner)
+                    {
+                        result = true;
+                    }
+                });
                 // clang-format on
                 return result;
                 break;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Trust behavior for Rughadjeen and Trion, including new/updated gambits, mob skills as per:
https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Rughadjeen
https://www.bg-wiki.com/ffxi/BGWiki:Trusts#Trion
It also updates gambit trigger logic to support a random TP amount condition.

**Trust behavior updates**
- Added/updated Trust logic for:
- rughadjeen.lua
- trion.lua
- updated Royal Savior mob skill behavior

**Gambit system update**
- Updated gambits_container.cpp to add support for a RANDOM TP amount trigger.

**Notes:**
Nothing crazy just little tweeks.
As before, the dmg is a little lack luster but that is a later problem.

## Steps to test these changes

Call the respective trust and fight things, the behavior should be close to retail.
