### PR TITLE
Fix Blu physical spell miss message

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -361,8 +361,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     finaldmg = math.floor(finaldmg * xi.combat.damage.calculateDamageAdjustment(target, true, false, false, false))
 
-    if finaldmg <= 0 then
-        spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
+    if hitslanded == 0 then
+        spell:setMsg(xi.msg.basic.MAGIC_FAIL)
     end
 
     return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget)

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2295,10 +2295,13 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
     action.recast     = state.GetRecast();
     action.spellgroup = PSpell->getSpellGroup();
 
-    MsgBasic msg = MsgBasic::None;
+    MsgBasic msg                 = MsgBasic::None;
+    MsgBasic initialSpellMessage = PSpell->getMessage();
 
     for (auto* PTarget : PAI->TargetFind->m_targets)
     {
+        PSpell->setMessage(initialSpellMessage);
+
         action_target_t& actionTarget = action.addTarget(PTarget->id);
         action_result_t& actionResult = actionTarget.addResult();
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request changes Blu Physical Spell miss messages from ` <caster>'s <spell> has no effect on <target>` to  `<caster> casts <spell> on <target>, but the spell fails to take effect` - which is the accurate retail message.  It now uses the criteria of a hit landing to make the decision, not 0 or less damage being done.

Additionally, while testing this fix with AoE spells I found that if multiple targets were hit by a spell, the message sent to the client would be incorrect if one of the earlier targets in the list evaded or was immune.

**Example 1:** Hitting 3 mobs with Battle Dance - and the first mob (mob1) evading would result in the client being informed that all 3 mobs evaded (spell fails to take effect), even though mob2 and mob3 did not evade and took damage.

**Example 1:** Hitting 3 mobs with Blood Saber - and the second mob (mob2) is Undead would result in the client being informed that Blood Saber had no effect on mob2 & mob3, even though mob3 was not Undead and had life drained.

**RCA:** When we iterate though a list of targets in battelentity.cpp we do so using a single CSpell object which is created when the instance of the CMagicState is created.  When underlying spell scripts (both spell and global processing scripts like bluemagic) make modifciations to the CSpell object - it persists through out the CMagicState for all subsequent targets and interactions until CMagicState is completed and cleaned up.  Therefore, modifying the Spell's message can carry forth through future targets if every spell interaction does not set the spell message based on its outcome.  This is not seen in most applications as the spell processing will be able to default to a generic message - e.g., for enfeebling, most processing will apply a resist message **or** MAGIC_ENFEEB_IS.  For Blu Physical Spells, such an approach is viable as there are only two messages - Fail & Dmg.  However for cases like Blu Drains there is variance between HP and MP messaging.  Hence I have gone with a more generic and higher placed solution - capturing the base message at the start of processing and re-setting to the base message during target iteration.

**Alternative approch considered:**  I also considered extending CSpell to expose getSpellMessage, add getDefaultSpellMessage, and add storage for the DefaultSpellMessage - this would give the lua layer more control and flexiblity in how to solve issues like this but would also add fair bit of bloat that is not required _so far as I see based on the existing use cases_.

## Steps to test these changes

1. Cast single target Blu Spells (Sprout Smack) against the following:
- Mob with Shadows - Expect to see a shadow removed per cast
- Mob with Stoneskin - Expect to see 0 damage.
- Mob with High Evasion/PD - Expect to see the new message format w/ "fails to take effect".
- Mob with none of the above - Expect to see a hit and damage.

2. Cast an AOE Physical Spell (Battle Dance) on a group of 2+ mobs.
- the mob you are targeting should be given PD or very high evasion `!setmod eva 1000`
- the other mobs should be of a lower level and have lower evasion `!setmod eva 0`
- Mamook works nicely as the bugards and mamool are T+ to a 75 and the colibri are dc/ep
- `!stun` works well to get mobs lined up and stay in a consistent testing order
- Note that ONLY the high level/high evasion mob reports "fails to take effect" consistently.
- Check mob HP before and after casts to verify that they do not lose hp despite being reported as an evade.

3. Cast an AoE Drain Blu Spell (Blood Saber) on multiple mobs - with only 1 being undead.
- Drain spell have "no effect" on the undead.
- Target a Skeleton surrounded by other non-undead.
- Garliage works well with low level skeletons and bats near the entrance
- Note that ONLY the undead return "has no effect" - especially when the skeleton is listed first (should be as the primary target).

4.  Regression
- Cast multiple other type of Aga spells that have mutiple state - blu or not blu.
- Sleepgas, Sheep Song, Aga Damage spells vs a mob which is immune or absrobs.
- Sch AoE Drain & Aspir
