### PR TITLE
[lua] [module] Lamian Fang Key Conquest Timer

### DIFF
--- a/modules/wotg/lua/npc_adjustments.lua
+++ b/modules/wotg/lua/npc_adjustments.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Module: NPC  Adjustments (Wings of the Goddess Era)
+-- Desc: Adjust Lamian Fang Key timer to be once per conquest tally
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('lamian_fang_era')
+
+m:addOverride('xi.zones.Caedarva_Mire.npcs.qm8.onTrigger', function(player, npc)
+    local ID = zones[xi.zone.CAEDARVA_MIRE]
+
+    if player:getCharVar('[TIMER]Lamian_Fang_Key') == 0 then
+        if npcUtil.giveItem(player, xi.item.LAMIAN_FANG_KEY) then
+            player:setCharVar('[TIMER]Lamian_Fang_Key', 1, NextConquestTally()) -- Can obtain key once per conquest tally
+        end
+    else
+        player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+    end
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adjusts the timer on Lamian Fang Key QM from Vanadiel Unique Day to Conquest Tally

## Steps to test these changes

1. !Gotoname qm8 in Caedarva Mire
2. Trigger the QM and obtain the key
3. Try to obtain the key before conquest tally rolls over, get the message "nothing out of the ordinary"
4. !addtime >604800 or wait an entire week
5. Trigger the QM to obtain the key again

<!-- Clear and detailed steps to test your changes here -->
