### PR TITLE
[core] Use message to determine if spell had no effect

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2352,8 +2352,8 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 
             actionResult.param = damage;
 
-            // Handle EFFECT_NONE - spell failed to apply
-            if (damage == EFFECT_NONE)
+            // spell failed to apply
+            if (!PSpell->tookEffect())
             {
                 actionResult.resolution = ActionResolution::Miss;
                 actionResult.param      = 0;

--- a/src/map/enums/msg_basic.h
+++ b/src/map/enums/msg_basic.h
@@ -99,6 +99,7 @@ enum class MsgBasic : uint16_t
     SkillRecoversHP                 = 103, // The <player> uses .. <target> recovers .. HP.
     IsIntimidated                   = 106, // The <player> is intimidated by <target>'s presence.
     UsesAbilityTakesDamage          = 110, // <user> uses <ability>. <target> takes <amount> points of damage.
+    MagicFail                       = 114, // <caster> casts <spell> on <target>, but the spell fails to take effect
     UsesAbilityFortifiedUndead      = 131, // <user> uses <ability>. <target> is fortified against undead.
     SpikesEffectHPDrain             = 132, // <target>'s spikes drain <number> HP from the <attacker>.
     UsesAbilityFortifiedArcana      = 134, // <user> uses <ability>. <target> is fortified against arcana.
@@ -250,6 +251,7 @@ enum class MsgBasic : uint16_t
     PerfectCounterMiss              = 592, // <player> attempts to counter <target>'s attack, but misses.
     TreasureHunterUp                = 603, // Additional effect: Treasure Hunter effectiveness against <target> increases to ..
     CounterAbsorbedDmg              = 606, // The <target> absorbs <player>'s counter. The <target> recovers .. HP.
+    MagicCompleteResist             = 655, // <caster> casts <spell>. <target> completely resists the spell.
     SameEffectLuopan                = 660, // The same effect is already active on that luopan!
     LuopanAlreadyPlaced             = 661, // <player> has already placed a luopan. Unable to use ability.
     RequireLuopan                   = 662, // This action requires a luopan.

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -142,7 +142,7 @@ bool CSpell::isBuff() const
 
 bool CSpell::tookEffect() const
 {
-    return !(m_message == MsgBasic::MagicNoEffect || m_message == MsgBasic::MagicResistedTarget || m_message == MsgBasic::TargetNoEffect || m_message == MsgBasic::MagicResisted);
+    return !(m_message == MsgBasic::MagicNoEffect || m_message == MsgBasic::MagicResistedTarget || m_message == MsgBasic::TargetNoEffect || m_message == MsgBasic::MagicResisted || m_message == MsgBasic::MagicCompleteResist || m_message == MsgBasic::MagicFail);
 }
 
 bool CSpell::hasMPCost()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

See title

## Steps to test these changes

Check if spells/buffs take effect normally. xi_test passes.
