### PR TITLE
Fixes augment 1152: DEF +10

### DIFF
--- a/sql/augments.sql
+++ b/sql/augments.sql
@@ -1424,7 +1424,7 @@ INSERT INTO `augments` VALUES (1150,0,0,0,0,0);
 INSERT INTO `augments` VALUES (1151,0,0,0,0,0);
 -- End unused block
 
-INSERT INTO `augments` VALUES (1152,0,1,10,0,0); -- DEF +10
+INSERT INTO `augments` VALUES (1152,10,1,1,0,0); -- DEF +10 (increases by 10)
 INSERT INTO `augments` VALUES (1153,0,68,3,0,0); -- Evasion +3
 INSERT INTO `augments` VALUES (1154,0,31,3,0,0); -- Mag. Evasion +3
 INSERT INTO `augments` VALUES (1155,200,161,-1,0,0); -- Physical Damage Taken -2%


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes augment 1152 to match the in-client dat (+10 per step).

Modifies multiplier from 0 to 10, and reduces value from 10 to 1.  Results in +10 steps tested and verified.

## Steps to test these changes

Use !additem 26496 1 1152 1

Equip the shield and notice you receive +21 defense (augment +20, 1 base)

<img width="148" height="49" alt="image" src="https://github.com/user-attachments/assets/b922d13f-84c8-41f4-b878-0d5a29a6a5b1" />
