### PR TITLE
[cpp] [lua] adds entity:getMasterThreatMob

### DIFF
--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2843,6 +2843,12 @@ end
 function CBaseEntity:getNotorietyList()
 end
 
+---@nodiscard
+---@param rangeOverride number? Optional, Defaults to 22
+---@return CBaseEntity?
+function CBaseEntity:getMasterThreatMob(rangeOverride)
+end
+
 ---@param PEntity CBaseEntity
 ---@return nil
 function CBaseEntity:clearEnmityForEntity(PEntity)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -13547,6 +13547,99 @@ sol::table CLuaBaseEntity::getNotorietyList()
 }
 
 /************************************************************************
+ *  Function: getMasterThreatMob(rangeOverride)
+ *  Purpose : Returns a mob in the master's notoriety list that threatens
+ *            the master's owner, preferring non-master-target mobs first.
+ *  Example : local target = entity:getMasterThreatMob(22)
+ *  Notes   : Intended for trust combat scripts that need efficient target
+ *            selection without Lua-side entity/enmity table iteration.
+ ************************************************************************/
+
+auto CLuaBaseEntity::getMasterThreatMob(const sol::object& rangeOverride) -> CBaseEntity*
+{
+    auto* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
+    if (!PBattleEntity)
+    {
+        ShowWarning("Attempting to get master threat target for invalid entity type (%s).", m_PBaseEntity->getName());
+        return nullptr;
+    }
+
+    auto* PMaster = PBattleEntity->PMaster;
+
+    if (!PMaster)
+    {
+        return nullptr;
+    }
+
+    const auto maxDistance = rangeOverride.is<float>() ? rangeOverride.as<float>() : 22.0f;
+    auto*      PMastersTarget{ PMaster->GetEntity(PMaster->GetBattleTargetID()) };
+
+    auto isMasterTopEnmityOnMob = [PMaster](CMobEntity* PMob) -> bool
+    {
+        if (!PMob)
+        {
+            return false;
+        }
+
+        auto* enmityList = PMob->PEnmityContainer->GetEnmityList();
+        if (!enmityList)
+        {
+            return false;
+        }
+
+        CBattleEntity* PTopEntity = nullptr;
+        int32          topHate    = std::numeric_limits<int32>::min();
+
+        for (const auto& [_, enmityObject] : *enmityList)
+        {
+            if (!enmityObject.active || !enmityObject.PEnmityOwner || !enmityObject.PEnmityOwner->isAlive())
+            {
+                continue;
+            }
+
+            const auto totalHate = enmityObject.CE + enmityObject.VE;
+            if (totalHate > topHate)
+            {
+                topHate    = totalHate;
+                PTopEntity = enmityObject.PEnmityOwner;
+            }
+        }
+
+        return PTopEntity && PTopEntity->id == PMaster->id;
+    };
+
+    CMobEntity* threateningTarget = nullptr;
+
+    for (auto* entity : *PMaster->PNotorietyContainer)
+    {
+        auto* PMob = dynamic_cast<CMobEntity*>(entity);
+        if (!PMob || !PMob->isAlive() || distance(PMaster->loc.p, PMob->loc.p) > maxDistance)
+        {
+            continue;
+        }
+
+        auto* PTarget            = PMob->GetEntity(PMob->GetBattleTargetID());
+        bool  isTargetingMaster  = PTarget && PTarget->id == PMaster->id;
+        bool  masterHasTopEnmity = isMasterTopEnmityOnMob(PMob);
+
+        if (isTargetingMaster || masterHasTopEnmity)
+        {
+            if (!PMastersTarget || PMob->id != PMastersTarget->id)
+            {
+                return PMob;
+            }
+
+            if (!threateningTarget)
+            {
+                threateningTarget = PMob;
+            }
+        }
+    }
+
+    return threateningTarget;
+}
+
+/************************************************************************
  *  Function: clearEnmityForEntity(...)
  *  Purpose :
  *  Example : mob:clearEnmityForEntity(player)
@@ -20213,6 +20306,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("hasClaim", CLuaBaseEntity::hasClaim);
     SOL_REGISTER("hasEnmity", CLuaBaseEntity::hasEnmity);
     SOL_REGISTER("getNotorietyList", CLuaBaseEntity::getNotorietyList);
+    SOL_REGISTER("getMasterThreatMob", CLuaBaseEntity::getMasterThreatMob);
     SOL_REGISTER("clearEnmityForEntity", CLuaBaseEntity::clearEnmityForEntity);
 
     // Status Effects

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -675,6 +675,7 @@ public:
     bool  hasClaim(CLuaBaseEntity* PTarget);
     bool  hasEnmity();
     auto  getNotorietyList() -> sol::table;
+    auto  getMasterThreatMob(const sol::object& rangeOverride) -> CBaseEntity*;
     void  clearEnmityForEntity(CLuaBaseEntity* PEntity);
 
     // Status Effects


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds function for entities, inspired by trusts, to get the notoriety list of their master on mobs within a specified range

- Range defaults to 22.0 (float) but overrides may be specified

- Specifically performs a check to determine whether master is the top of any nearby mobs' notoriety list and returns that target

## Steps to test these changes

I have tested this code in combination with a reworked version of scripts/actions/spells/trusts/valaineral.lua to validate the behavior functions as intended.  Everything functioned as expected in my testing.

You can add this to a trust's combat listener to periodically print the results every 5-10 ticks as a test.
