### PR TITLE
[cpp] fixes ranged job abilities

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -2101,13 +2101,13 @@ void CCharEntity::OnRangedAttack(CRangeState& state, action_t& action)
             hitCount = PAmmo->getQuantity();
         }
     }
-    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBLE_SHOT) && xirand::GetRandomNumber(100) < (40 + this->getMod(Mod::DOUBLE_SHOT_RATE)))
-    {
-        hitCount = 2;
-    }
-    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_TRIPLE_SHOT) && xirand::GetRandomNumber(100) < (40 + this->getMod(Mod::TRIPLE_SHOT_RATE)))
+    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_TRIPLE_SHOT) && xirand::GetRandomNumber(100) < this->getMod(Mod::TRIPLE_SHOT_RATE))
     {
         hitCount = 3;
+    }
+    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBLE_SHOT) && xirand::GetRandomNumber(100) < this->getMod(Mod::DOUBLE_SHOT_RATE))
+    {
+        hitCount = 2;
     }
 
     // loop for barrage hits, if a miss occurs, the loop will end

--- a/src/map/entities/trustentity.cpp
+++ b/src/map/entities/trustentity.cpp
@@ -168,13 +168,19 @@ void CTrustEntity::OnRangedAttack(CRangeState& state, action_t& action)
     bool  hitOccured   = false; // track if player hit mob at all
     bool  isBarrage    = StatusEffectContainer->HasStatusEffect(EFFECT_BARRAGE, 0);
 
-    /*
-    // if barrage is detected, getBarrageShotCount also checks for ammo count
-    if (!ammoThrowing && !rangedThrowing && isBarrage)
+    // Barrage does not stack with Double/Triple Shot.
+    if (isBarrage)
     {
         hitCount += battleutils::getBarrageShotCount(this);
     }
-    */
+    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_TRIPLE_SHOT) && xirand::GetRandomNumber(100) < this->getMod(Mod::TRIPLE_SHOT_RATE))
+    {
+        hitCount = 3;
+    }
+    else if (this->StatusEffectContainer->HasStatusEffect(EFFECT_DOUBLE_SHOT) && xirand::GetRandomNumber(100) < this->getMod(Mod::DOUBLE_SHOT_RATE))
+    {
+        hitCount = 2;
+    }
 
     // loop for barrage hits, if a miss occurs, the loop will end
     // TODO: do trusts need barrage racc & ratt bonus mods?


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes shadow bug for double and triple shot (+40% activation rate over what's shown on mod::double_shot_rate and mod::triple_shot_rate

- Existing bug is due to base power applied both in src/map/entities/charentity.cpp:2104 ("40 +") and scripts/globals/job_utils/ranger.lua:294 (power = 40) for double shot and scripts/actions/abilities/triple_shot.lua:16 for triple shot (power = 40); both cases result in mod power of 40, but activation rate of 80 due to charentity calculation.

- Adds barrage logic for trusts, which scales with player level, and prevents overlap of barrage/double shot/triple shot

## Steps to test these changes

Activate double shot or triple shot, fire at targets and compare results for damage and TP (easiest indicator)
Your base activation rate should be approximately 40%, if every shot hit.  Typically observed at 30-40% due to racc and rng.

For testing the Trust Barrage effects, summon Semih Lafihna after level 50.  She will use it effectively.

Sources:
https://www.bg-wiki.com/ffxi/Barrage
*established around 2012
https://www.bg-wiki.com/ffxi/Double_Shot
https://www.bg-wiki.com/ffxi/Triple_Shot