### PR TITLE
[lua] Add rank requirement to signet staves

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -784,7 +784,7 @@ local overseerInvNation =
         [32898] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.RESERVE_CAPTAINS_MACE,          place = 2 },
         [32899] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.RESERVE_CAPTAINS_LANCE,         place = 1 },
         [32912] = { rank = 10, cp = 56000, lvl =  1, item = xi.item.KINGDOM_AKETON,                 place = 1 },
-        [32932] = {            cp =  5000, lvl =  1, item = xi.item.KINGDOM_SIGNET_STAFF           },
+        [32932] = { rank = 10, cp =  5000, lvl =  1, item = xi.item.KINGDOM_SIGNET_STAFF           },
         [32940] = { rank = 10, cp = 10000, lvl =  1, item = xi.item.IMPERIAL_CHAIR_SET             },
     },
 
@@ -842,7 +842,7 @@ local overseerInvNation =
         [32898] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.SENIOR_GOLD_MUSKETEERS_AXE,       place = 2 },
         [32899] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.SENIOR_GOLD_MUSKETEERS_SCIMITAR,  place = 1 },
         [32912] = { rank = 10, cp = 56000, lvl =  1, item = xi.item.REPUBLIC_AKETON,                  place = 1 },
-        [32932] = {            cp =  5000, lvl =  1, item = xi.item.REPUBLIC_SIGNET_STAFF            },
+        [32932] = { rank = 10, cp =  5000, lvl =  1, item = xi.item.REPUBLIC_SIGNET_STAFF            },
         [32940] = { rank = 10, cp = 10000, lvl =  1, item = xi.item.DECORATIVE_CHAIR_SET             },
     },
 
@@ -904,7 +904,7 @@ local overseerInvNation =
         [32898] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.MASTER_CASTERS_BAGHNAKHS,     place = 2 },
         [32899] = { rank =  9, cp = 48000, lvl = 71, item = xi.item.MASTER_CASTERS_KNIFE,         place = 1 },
         [32912] = { rank = 10, cp = 56000, lvl =  1, item = xi.item.FEDERATION_AKETON,            place = 1 },
-        [32932] = {            cp =  5000, lvl =  1, item = xi.item.FEDERATION_SIGNET_STAFF      },
+        [32932] = { rank = 10, cp =  5000, lvl =  1, item = xi.item.FEDERATION_SIGNET_STAFF      },
         [32940] = { rank = 10, cp = 10000, lvl =  1, item = xi.item.ORNATE_STOOL_SET             },
     },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add rank to signet staves, preventing them from being purchasable by working around the client side hiding when the player isn't rank 10. It's a bit suspect to me that signet staves are the only items here that don't have a rank associated with them, so apologies if there's a good reason that it's not set for these I just don't know about.

## Steps to test these changes

I've been doing direct memory injection to navigate menus, so steps to recreate are a bit messy. Doing a quick packet replay attack would probably be easier, but for simplicity here's a screenshot of before/after making the change. Please let me know if more would be useful. I found this on accident, trying to move the cursor to the memory address of the chariot band and purchasing on a rank 1 character and instead hitting the hidden signet staff, hah.

Before change:
<img width="756" height="56" alt="Screenshot_20260504_150241" src="https://github.com/user-attachments/assets/81e9acbc-33dd-4dc7-8254-a65a10413026" />

After change:
<img width="994" height="79" alt="Screenshot_20260504_150318" src="https://github.com/user-attachments/assets/c03de6e7-1a0a-4a34-96bf-08c5c268d757" />
