### PR TITLE
[lua] Fix Water Way to Go trade item not consumed on completion

### DIFF
--- a/scripts/quests/windurst/Water_Way_to_Go.lua
+++ b/scripts/quests/windurst/Water_Way_to_Go.lua
@@ -99,7 +99,7 @@ quest.sections =
 
                 [355] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:tradeComplete()
+                        player:confirmTrade()
                         -- Note: Message display for gil reward is handled by the event
                         player:addGil(900)
                         player:setLocalVar('Quest[2][17]mustZone', 1)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7926.

When the player trades the Canteen of Giddeus Water to Ohbiru-Dohbiru to complete _Water Way to Go_, the gil reward is granted but the canteen is not removed from inventory. The bug is in the handler for event 355 (the quest-completion cutscene): it called `player:tradeComplete()` instead of `player:confirmTrade()`, so the trade items were never consumed.

This PR replaces that single call. `confirmTrade()` matches the canonical pattern used by every other Windurst trade-completion quest:

- `scripts/quests/windurst/A_Smudge_on_Ones_Record.lua` (event `[417]`)
- `scripts/quests/windurst/Blast_from_the_Past.lua` (event `[224]`)
- `scripts/quests/windurst/All_At_Sea.lua` (event `[295]`)
- `scripts/quests/windurst/Curses_Foiled_Again_1.lua` (event `[173]`)

…and the working event `[55]` handler in this same file (the earlier trade where the Giddeus Spring fills the empty canteen).

## Steps to test these changes

On a character that has completed _Overnight Delivery_ and has Windurst fame ≥ 3:

1. `!addquest 2 16` (adds _Water Way to Go_ in QUEST_ACCEPTED state)
2. `!additem 4351` (Canteen of Giddeus Water)
3. Travel to Windurst Waters and trade the canteen to Ohbiru-Dohbiru
4. Watch the cutscene complete

Verify after the event:

- _Water Way to Go_ shows as completed in the quest log
- Player gained 900 gil
- **Canteen of Giddeus Water is no longer in inventory** (this was the bug)
