### PR TITLE
[lua] [sql] Implement Lamiabane

### DIFF
--- a/scripts/items/lamiabane.lua
+++ b/scripts/items/lamiabane.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- ID: 18693
+-- Item: Lamiabane
+-- Description : Adds 1/tick auto-refresh effect. Duration : 60 Minutes. Only able to be used in Mamook, Arrapago Reef, or Halvung. Effect lost upon zoning.
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, param, caster)
+    local zoneId = target:getZoneID()
+
+    if
+        zoneId == xi.zone.ARRAPAGO_REEF or
+        zoneId == xi.zone.HALVUNG or
+        zoneId == xi.zone.MAMOOK
+    then
+        return 0
+    else
+        return xi.msg.basic.CANT_BE_USED_IN_AREA
+    end
+end
+
+itemObject.onItemUse = function(target, user)
+    if target:hasEquipped(xi.item.LAMIABANE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 3600, origin = user, flag = xi.effectFlag.ON_ZONE, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.LAMIABANE })
+    end
+end
+
+itemObject.onEffectGain = function(target, effect)
+    effect:addMod(xi.mod.REFRESH, 1)
+end
+
+itemObject.onEffectLose = function(target, effect)
+end
+
+return itemObject

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2945,6 +2945,11 @@ INSERT INTO `item_latents` VALUES (18683,287,2,58,0);    -- DMG+2 in Assault
 INSERT INTO `item_latents` VALUES (18684,24,10,58,0);    -- Ranged Attack +10 in Assault
 INSERT INTO `item_latents` VALUES (18684,287,2,58,0);    -- DMG+2 in Assault
 
+-- Lamiabane
+INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 54); -- +2 Magic Attack Bonus in Arrapago Reef
+INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 62); -- +2 Magic Attack Bonus in Halvung
+INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 65); -- +2 Magic Attack Bonus in Mamook
+
 -- Snakeeye
 INSERT INTO `item_latents` VALUES (18708,8,5,13,3);    -- +5 STR while Poisoned
 INSERT INTO `item_latents` VALUES (18708,404,20,13,3); -- -20 HP/tick while Poisoned


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements Lamiabane - a ranged weapon that gives +2 MATT while in Arrapago Reef, Halvung or Mamook.
May be used in those zones to gain a 1 mp/tick enchantment that stacks with Refresh. Effect is lost upon zoning.

Behavior for this item captured by @ThrisStraizo 

## Steps to test these changes

!additem Lamiabane
!zone Halvung
Zone out - attempt to use
Zone in - use item - see refresh enchantment
Zone out - lose enchantment
