### PR TITLE
[lua] Fix Kumhau the Flashfrost Naakual cutscene exit position

### DIFF
--- a/scripts/missions/soa/3_6_1_Kumhau_the_Flashfrost_Naakual.lua
+++ b/scripts/missions/soa/3_6_1_Kumhau_the_Flashfrost_Naakual.lua
@@ -87,7 +87,7 @@ mission.sections =
             {
                 [27] = function(player, csid, option, npc)
                     mission:setVar(player, 'Status', 2)
-                    player:setPos(344.003, 40.676, -381.140, 12, xi.zone.KAMIHR_DRIFTS)
+                    player:setPos(-344.003, 40.676, -381.140, 12, xi.zone.KAMIHR_DRIFTS)
                 end,
             },
         },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #7234.

The X coordinate of the post-cutscene `setPos` call in SoA mission 3-6-1 (Kumhau, the Flashfrost Naakual) was missing its negative sign. After the cutscene at event 27 finishes, the player is teleported to `(344.003, 40.676, -381.140)` in Kamihr Drifts, which lands them out-of-bounds. The intended location is `(-344.003, 40.676, -381.140)`.

This PR adds the missing minus sign so the player lands at the intended spot.

## Steps to test these changes

In Kamihr Drifts (zone 267), with GM rights:

1. `!pos 344.003 40.676 -381.140 267` — observe player is teleported out-of-bounds (into sky/void area), reproducing the bug.
2. `!pos -344.003 40.676 -381.140 267` — observe player lands on solid, walkable terrain inside the zone, confirming the fix.

Verified locally — buggy coordinates land in a void, fixed coordinates land on solid Kamihr Drifts terrain.
