### PR TITLE
[core][lua][sql] Movalpolis Patrols and Guards

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -102,4 +102,6 @@ xi.mobMod =
     H2H_SINGLE_SWING       = 91, -- Mob will have only one swing per attack even as MNK with H2H skill
     AOE_HIT_ALL            = 92, -- Mob AoE can hit any player regardless of enmity
     RANGED_ATTACK_RANGE    = 93, -- Max range for ranged auto attacks. Mob will move closer if target is beyond this range.
+    FOLLOW_LEASH_RANGE     = 94, -- Distance the leader can walk before their followers start moving. Applied to followers.
+    FOLLOW_STOP_RANGE      = 95, -- Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
 }

--- a/scripts/globals/follow.lua
+++ b/scripts/globals/follow.lua
@@ -14,6 +14,9 @@ end
 -- @param follower the mob that will be doing the following.
 -- @param leader the target entity to follow.
 -----------------------------------
+---@param follower CBaseEntity
+---@param leader CBaseEntity
+---@return boolean|nil
 xi.follow.follow = function(follower, leader)
     if
         not leader:isSpawned() or
@@ -34,6 +37,7 @@ xi.follow.follow = function(follower, leader)
     follower:setLocalVar('leaderID', leaderID)
 end
 
+---@param leader CBaseEntity
 xi.follow.clearFollowers = function(leader)
     local followers = xi.follow.getFollowers(leader)
     if not followers then
@@ -45,6 +49,44 @@ xi.follow.clearFollowers = function(leader)
     end
 end
 
+---@param leader CBaseEntity
+---@param followers table<integer, integer> -- [leaderID] = followerCount
+xi.follow.spawnFollowers = function(leader, followers)
+    local followerCount = followers[leader:getID()] or 0
+
+    if followerCount > 0 then
+        for i = 1, followerCount do
+            local followerID     = leader:getID() + i
+            local followerEntity = GetMobByID(followerID)
+
+            if
+                followerEntity and
+                not followerEntity:isSpawned()
+            then
+                SpawnMob(followerID)
+            end
+        end
+    end
+end
+
+---@param leader CBaseEntity
+xi.follow.despawnFollowers = function(leader)
+    local followerEntity = xi.follow.getFollowers(leader)
+
+    if followerEntity then
+        for _, follower in ipairs(followerEntity) do
+            if
+                follower and
+                follower:isSpawned() and
+                not follower:isEngaged()
+            then
+                DespawnMob(follower:getID())
+            end
+        end
+    end
+end
+
+---@param follower CBaseEntity
 xi.follow.stopFollowing = function(follower)
     if follower:getLocalVar('leaderID') == 0 then
         return
@@ -55,6 +97,8 @@ xi.follow.stopFollowing = function(follower)
     follower:setLocalVar('leaderID', 0)
 end
 
+---@param leader CBaseEntity
+---@return CBaseEntity[]|nil
 xi.follow.getFollowers = function(leader)
     local leaderMod = leader:getMobMod(xi.mobMod.LEADER)
     if leaderMod <= 0 then
@@ -70,6 +114,8 @@ xi.follow.getFollowers = function(leader)
     return followers
 end
 
+---@param follower CBaseEntity
+---@return CBaseEntity|nil
 xi.follow.getLeader = function(follower)
     local leaderMod = follower:getMobMod(xi.mobMod.LEADER)
     if leaderMod >= 0 then
@@ -79,6 +125,9 @@ xi.follow.getLeader = function(follower)
     return GetMobByID(follower:getID() - leaderMod)
 end
 
+---@param mob CBaseEntity
+---@param leaders table<integer, integer> -- [leaderID] = followerCount
+---@param maxDistance integer
 xi.follow.assignLeaderMod = function(mob, leaders, maxDistance)
     local mobID = mob:getID()
     local followerCount = leaders[mobID]
@@ -93,5 +142,15 @@ xi.follow.assignLeaderMod = function(mob, leaders, maxDistance)
             mob:setMobMod(xi.mobMod.LEADER, -distanceFromLeader)
             return
         end
+    end
+end
+
+---@param mob CBaseEntity
+---@param followRange number
+---@param stopRange number
+xi.follow.setFollowRange = function(mob, followRange, stopRange)
+    if mob:getMobMod(xi.mobMod.LEADER) < 0 then -- Is a follower
+        mob:setMobMod(xi.mobMod.FOLLOW_LEASH_RANGE, followRange)
+        mob:setMobMod(xi.mobMod.FOLLOW_STOP_RANGE, stopRange)
     end
 end

--- a/scripts/zones/Newton_Movalpolos/IDs.lua
+++ b/scripts/zones/Newton_Movalpolos/IDs.lua
@@ -32,6 +32,10 @@ zones[xi.zone.NEWTON_MOVALPOLOS] =
         MIMIC                 = GetFirstID('Mimic'),
         BUGBEAR_MATMAN        = GetFirstID('Bugbear_Matman'),
         GOBLIN_COLLECTOR      = GetFirstID('Goblin_Collector'),
+        GOBLIN_SWORDSMAN      = GetTableOfIDs('Goblin_Swordsman'),
+        MOBLIN_AIDMAN         = GetTableOfIDs('Moblin_Aidman'),
+        MOBLIN_ENGINEMAN      = GetTableOfIDs('Moblin_Engineman'),
+        MOBLIN_TOPSMAN        = GetTableOfIDs('Moblin_Topsman'),
     },
     npc =
     {

--- a/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Watchman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Bugbear_Watchman.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Newton Movalpolos
+--   Mob: Bugbear Watchman
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    -- These mobs are guards and do not roam randomly.
+    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 0)
+    mob:setMobMod(xi.mobMod.ROAM_RESET_FACING, 1)
+    mob:setRoamFlags(xi.roamFlag.SCRIPTED)
+end
+
+entity.onMobRoam = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- If not at spawn position, path back to it
+    if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+        mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
+    end
+end
+
+return entity

--- a/scripts/zones/Newton_Movalpolos/mobs/Goblin_Swordsman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Goblin_Swordsman.lua
@@ -8,11 +8,28 @@ local ID = zones[xi.zone.NEWTON_MOVALPOLOS]
 ---@type TMobEntity
 local entity = {}
 
+local followers =
+{
+    [ID.mob.GOBLIN_SWORDSMAN[1]] = 2,
+    [ID.mob.GOBLIN_SWORDSMAN[2]] = 2,
+    [ID.mob.GOBLIN_SWORDSMAN[3]] = 2,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, followers, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.spawnFollowers(mob, followers)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.SWASHSTOX_BEADBLINKER[1], 15, 10800)
+
+    xi.follow.despawnFollowers(mob)
 end
 
 return entity

--- a/scripts/zones/Newton_Movalpolos/mobs/Moblin_Aidman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Moblin_Aidman.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Newton Movalpolos
+--  Mob: Moblin Aidman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.NEWTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_AIDMAN[4]]  = -1,
+    [ID.mob.MOBLIN_AIDMAN[6]]  = -1,
+    [ID.mob.MOBLIN_AIDMAN[10]] = -1,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 1)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 2, 2)
+end
+
+return entity

--- a/scripts/zones/Newton_Movalpolos/mobs/Moblin_Engineman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Moblin_Engineman.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Newton Movalpolos
+--  Mob: Moblin Engineman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.NEWTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_ENGINEMAN[4]] = -2,
+    [ID.mob.MOBLIN_ENGINEMAN[5]] = -2,
+    [ID.mob.MOBLIN_ENGINEMAN[6]] = -2,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 3, 3)
+end
+
+return entity

--- a/scripts/zones/Newton_Movalpolos/mobs/Moblin_Topsman.lua
+++ b/scripts/zones/Newton_Movalpolos/mobs/Moblin_Topsman.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Area: Newton Movalpolos
+--  Mob: Moblin Topsman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.NEWTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_TOPSMAN[4]] = -2,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 3, 3)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/IDs.lua
+++ b/scripts/zones/Oldton_Movalpolos/IDs.lua
@@ -32,9 +32,17 @@ zones[xi.zone.OLDTON_MOVALPOLOS] =
     },
     mob =
     {
-        BUGALLUG          = GetFirstID('Bugallug'),
-        BUGBEAR_STRONGMAN = GetTableOfIDs('Bugbear_Strongman'),
-        GOBLIN_WOLFMAN    = GetFirstID('Goblin_Wolfman'),
+        BUGALLUG           = GetFirstID('Bugallug'),
+        BUGBEAR_BONDMAN    = GetTableOfIDs('Bugbear_Bondman'),
+        BUGBEAR_SERVINGMAN = GetTableOfIDs('Bugbear_Servingman'),
+        BUGBEAR_STRONGMAN  = GetTableOfIDs('Bugbear_Strongman'),
+        GOBLIN_FREELANCE   = GetTableOfIDs('Goblin_Freelance'),
+        GOBLIN_WOLFMAN     = GetFirstID('Goblin_Wolfman'),
+        GOBLIN_HAMMERMAN   = GetTableOfIDs('Goblin_Hammerman'),
+        MOBLIN_CHAPMAN     = GetTableOfIDs('Moblin_Chapman'),
+        MOBLIN_COALMAN     = GetTableOfIDs('Moblin_Coalman'),
+        MOBLIN_GASMAN      = GetTableOfIDs('Moblin_Gasman'),
+        MOBLIN_PIKEMAN     = GetTableOfIDs('Moblin_Pikeman'),
     },
     npc =
     {

--- a/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Bondman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Bondman.lua
@@ -8,7 +8,42 @@ local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobDeath = function(mob, player, optParams)
+entity.onMobInitialize = function(mob)
+    -- These act as guards and do not roam normally.
+    local mobId = mob:getID()
+    if
+        mobId == ID.mob.BUGBEAR_BONDMAN[1] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[2] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[8] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[9] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[10] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[11]
+    then
+        mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 0)
+        mob:setMobMod(xi.mobMod.ROAM_RESET_FACING, 1)
+        mob:setRoamFlags(xi.roamFlag.SCRIPTED)
+    end
+end
+
+entity.onMobRoam = function(mob)
+    local mobId    = mob:getID()
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- These act as guards and do not roam normally.
+    if
+        mobId == ID.mob.BUGBEAR_BONDMAN[1] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[2] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[8] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[9] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[10] or
+        mobId == ID.mob.BUGBEAR_BONDMAN[11]
+    then
+        -- If not at spawn position, path back to it
+        if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+            mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
+        end
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Muscleman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Muscleman.lua
@@ -8,6 +8,7 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     -- Very fast TP gain or auto-TP/Regain. Can and will use Earthshock every 5-6 seconds regardless of TP fed.
     mob:addMod(xi.mod.REGAIN, 400)
+    mob:addMod(xi.mod.STORETP, 50)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Servingman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Bugbear_Servingman.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--   Mob: Bugbear Servingman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.BUGBEAR_SERVINGMAN[5]] = -1,
+    [ID.mob.BUGBEAR_SERVINGMAN[6]] = -1,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 2)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Freelance.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Freelance.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Goblin Freelance
+-----------------------------------
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local followers =
+{
+    [ID.mob.GOBLIN_FREELANCE[1]] = 3,
+    [ID.mob.GOBLIN_FREELANCE[2]] = 3,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, followers, 3)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.spawnFollowers(mob, followers)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.follow.despawnFollowers(mob)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Hammerman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Goblin_Hammerman.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Goblin Hammerman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local followers =
+{
+    [ID.mob.GOBLIN_HAMMERMAN[3]] = 1,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, followers, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.spawnFollowers(mob, followers)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.follow.despawnFollowers(mob)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Chapman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Chapman.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Moblin Chapman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local followers =
+{
+    [ID.mob.MOBLIN_CHAPMAN[3]] = 1,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, followers, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.spawnFollowers(mob, followers)
+end
+
+entity.onMobDespawn = function(mob)
+    xi.follow.despawnFollowers(mob)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Coalman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Coalman.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Moblin Coalman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_COALMAN[2]] = -2,
+    [ID.mob.MOBLIN_COALMAN[3]] = -2,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 2)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 3, 3)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Gasman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Gasman.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Moblin Gasman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_GASMAN[2]] = -1,
+    [ID.mob.MOBLIN_GASMAN[3]] = -1,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 1)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 2, 2)
+end
+
+return entity

--- a/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Pikeman.lua
+++ b/scripts/zones/Oldton_Movalpolos/mobs/Moblin_Pikeman.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  Mob: Goblin Pikeman
+-----------------------------------
+mixins = { require('scripts/mixins/follow') }
+local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local leaders =
+{
+    [ID.mob.MOBLIN_PIKEMAN[3]] = -3,
+    [ID.mob.MOBLIN_PIKEMAN[4]] = -3,
+}
+
+entity.onMobInitialize = function(mob)
+    xi.follow.assignLeaderMod(mob, leaders, 3)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.follow.setFollowRange(mob, 4, 4)
+end
+
+return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -499,6 +499,11 @@ INSERT INTO `mob_groups` VALUES (40,1114,11,'Dread_Dealing_Dredodak',0,128,0,0,0
 INSERT INTO `mob_groups` VALUES (41,564,11,'Bugbear_Porterman',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (42,7321,11,'Goblins_Bat',0,128,0,0,0,0,NULL);
 
+-- Followers only respawn when their leader respawns.
+INSERT INTO `mob_groups` VALUES (43,565,11,'Bugbear_Servingman',0,128,377,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (44,2689,11,'Moblin_Coalman',0,128,1706,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (45,2694,11,'Moblin_Gasman',0,128,1706,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (46,2699,11,'Moblin_Pikeman',0,128,1706,0,0,0,NULL);
 -- ------------------------------------------------------------
 -- Newton_Movalpolos (Zone 12)
 -- ------------------------------------------------------------
@@ -541,6 +546,11 @@ INSERT INTO `mob_groups` VALUES (34,562,12,'Bugbear_Matman',0,128,375,11900,0,0,
 INSERT INTO `mob_groups` VALUES (36,6718,12,'Sword_Sorcerer_Solisoq',3600,0,3224,14000,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (37,2684,12,'Moblin_Aidman',0,128,1703,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (38,2692,12,'Moblin_Engineman',0,128,1708,0,0,0,NULL);
+
+-- Followers only respawn when their leader respawns.
+INSERT INTO `mob_groups` VALUES (39,2684,12,'Moblin_Aidman',0,128,1703,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (40,2692,12,'Moblin_Engineman',0,128,1708,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (41,2706,12,'Moblin_Topsman',0,128,1717,0,0,0,NULL);
 
 -- ------------------------------------------------------------
 -- Mine_Shaft_2716 (Zone 13)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1070,11 +1070,23 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
 
     if (PFollowTarget != nullptr && m_followType == FollowType::Roam)
     {
+        float followRoamDistance = 4.0f;
+
+        if (PMob->getMobMod(MOBMOD_FOLLOW_LEASH_RANGE) > 0)
+        {
+            followRoamDistance = PMob->getMobMod(MOBMOD_FOLLOW_LEASH_RANGE);
+        }
         // Only path to leader if they're moving
-        if (distance(PMob->loc.p, PFollowTarget->loc.p) > FollowRoamDistance &&
+        if (distance(PMob->loc.p, PFollowTarget->loc.p) > followRoamDistance &&
             PFollowTarget->PAI->PathFind->IsFollowingPath())
         {
-            PMob->PAI->PathFind->PathAround(PFollowTarget->loc.p, 2.0f, PATHFLAG_RUN | PATHFLAG_WALLHACK);
+            float followStopRange = 2.0f;
+
+            if (PMob->getMobMod(MOBMOD_FOLLOW_STOP_RANGE) > 0)
+            {
+                followStopRange = PMob->getMobMod(MOBMOD_FOLLOW_STOP_RANGE);
+            }
+            PMob->PAI->PathFind->PathAround(PFollowTarget->loc.p, followStopRange, PATHFLAG_RUN | PATHFLAG_WALLHACK);
         }
 
         if (!PMob->PAI->PathFind->IsFollowingPath())

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -122,6 +122,8 @@ enum MOBMODIFIER : int
     MOBMOD_H2H_SINGLE_SWING       = 91, // Mob will have only one swing per attack even as MNK with H2H skill
     MOBMOD_AOE_HIT_ALL            = 92, // Mob AoE can hit any player regardless of enmity
     MOBMOD_RANGED_ATTACK_RANGE    = 93, // Max range for ranged auto attacks. Mob will move closer if target is beyond this range.
+    MOBMOD_FOLLOW_LEASH_RANGE     = 94, // Distance the leader can walk before their followers start moving. Applied to followers.
+    MOBMOD_FOLLOW_STOP_RANGE      = 95, // Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
 };
 
 #endif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Implements Moblin patrols and Bugbear guard behavior.
2. Adds support for adjustable spacing between leaders and followers with FOLLOW_LEASH_RANGE and FOLLOW_STOP_RANGE mob mods.

### Bugbears
- Some bugbears stand guard the paths leading deeper into Movalpolis. They do not roam.
<img width="904" height="649" alt="image" src="https://github.com/user-attachments/assets/6a72b4c8-5ff2-4991-9d5d-3ff5ed16412b" />

### Moblin Patrols
- In Oldton, there are two types of patrols
-- The first is a Moblin leader and a Bugbear follower.
-- The second is a Goblin Freelance with 3 Moblin followers.

- In Newton there are only patrols.
-- In this case there is a Goblin Swordsman with 2 Moblin followers.

- The follower mobs do not superlink like BST pets but they will often link normally since they usually end up facing their leader after pathing.

- The followers do NOT respawn if killed until the leader respawns.

- When the leader dies, any followers not in combat despawn shortly after.

- When the leader respawns, all followers respawn with it.

https://www.youtube.com/watch?v=3vfUNX5EB7w

<img width="1189" height="675" alt="image" src="https://github.com/user-attachments/assets/ddcb6bfb-1a19-455c-a121-c1c9c8bb089d" />

I got the pathing/mob spacing as close as I could. It won't completely replicate retail do to path node vs our navmesh(The followers will sometimes path in weird directions before leashing back to their master on retail), but it does closely replicate their normal pathing.

## Steps to test these changes

Go into mob_spawn_points.sql and search for Goblin_Freelance and Goblin_Swordsman. These are the patrol leaders in their respective zones. Use !gotoid to teleport to them and see that they are functioning as expected.

The various bugbears that act as guards in Oldton should not move.

Use `!pos -224 8 22 11` to teleport to Oldton. There should be two bugbears here that are following a Goblin Hammerman and a Moblin Chapman.
