### PR TITLE
[lua] Charmed Pet/MNK Mob TP Returns

### DIFF
--- a/scripts/globals/combat/tp.lua
+++ b/scripts/globals/combat/tp.lua
@@ -17,8 +17,25 @@ xi.combat.tp = xi.combat.tp or {}
 --- @return integer
 xi.combat.tp.calculateTPReturn = function(gainee, delay)
     local tpReturn = 0
+    local isCharmedPCPet = false
 
-    if gainee and gainee:getObjType() ~= xi.objType.MOB then -- Pets and PCs have been observed to use this formula
+    -- Charmed pets controlled by the player are not caught by isPet() and are considered mobs still.
+    -- However once charmed, they convert to use the PC delay formula.
+    if
+        gainee:getObjType() == xi.objType.MOB and
+        gainee:getMaster() ~= nil and
+        gainee:getMaster():isPC() and
+        gainee:isCharmed()
+    then
+        isCharmedPCPet = true
+    end
+
+    if
+        gainee and
+        gainee:getObjType() ~= xi.objType.MOB or
+        isCharmedPCPet
+
+    then -- Pets and PCs have been observed to use this formula
         if delay > 900 then
             tpReturn = 173 + (delay - 900) * 28 / 360
         elseif delay > 720 then
@@ -57,7 +74,7 @@ xi.combat.tp.getModifiedDelayAndCanZanshin = function(actor, delay)
     if actor:isDualWielding() then -- NOTE: this 'isDualWielding' may trip on non-PCs even if they are 'using h2h'. If this is rectified in core in the future this should fall through correctly.
         modifiedDelay = (delay * (100 - actor:getMod(xi.mod.DUAL_WIELD)) / 100) / 2
     elseif actor:isUsingH2H() then
-        if actor:getObjType() == xi.objType.PC then            -- handle h2h with > 1 swing only on PC
+        if actor:getObjType() == xi.objType.PC then -- handle h2h with > 1 swing only on PC
             if
                 actor:getEquippedItem(xi.slot.SUB) ~= nil or   -- equipped shield = one swing
                 actor:getSkillRank(xi.skill.HAND_TO_HAND) == 0 -- zero h2h rank skill = one swing
@@ -67,6 +84,8 @@ xi.combat.tp.getModifiedDelayAndCanZanshin = function(actor, delay)
             else
                 modifiedDelay = math.max((delay - actor:getMod(xi.mod.MARTIAL_ARTS)) / 2, 48) -- min delay of 96 total so 96/2 per fist, https://www.bg-wiki.com/ffxi/Attack_Speed
             end
+        elseif actor:getObjType() == xi.objType.MOB then
+            modifiedDelay = math.max(delay / 2, 48) -- Mobs are not affected at all by Martial Arts.
         else
             -- TODO: handle the corner case where a PC-like entity is using h2h but is only hitting with one 'fist'. Perhaps they have a shield with no main weapon.
             -- elseif actor:getAutoAttackHits() > 1
@@ -139,7 +158,6 @@ xi.combat.tp.getSingleWeaponTPReturn = function(actor, slot)
     return math.floor(tpReturn * storeTPModifier)
 end
 
--- UNUSED.
 -- Returns a single ranged hit's TP return
 xi.combat.tp.getSingleRangedHitTPReturn = function(actor)
     if actor:hasStatusEffect(xi.effect.MEIKYO_SHISUI) then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Martial Arts was affecting TP gain for mobs that use H2H. From retail testing, their TP returns are not supposed to be affected by Martial Arts(Their delay is not affected by the trait and TP shouldn't as well).

Fixes an edge case for charmed BST pets. Player spawned pets already used the correct formula but charmed pets were still using the mob formula even after being charmed.

Since charmed mobs are currently considered mobs and not true pet entities, they were not swapping to the correct TP formula.

## Steps to test these changes

1. Aggro a mob and let it hit you, then charm it. Note its TP return (Mob TP return)

2. Release mob and find another of the same type.

3. Charm mob and have it hit something once. Note the TP return. It should be the player formula.