### PR TITLE
[core] [lua] abyssea cruor reward system

### DIFF
--- a/scripts/effects/visitant.lua
+++ b/scripts/effects/visitant.lua
@@ -1,10 +1,40 @@
 -----------------------------------
 -- xi.effect.VISITANT
 -----------------------------------
+require('scripts/globals/abyssea')
 ---@type TEffect
 local effectObject = {}
 
 local remainingTimeLimits = { 300, 240, 180, 120, 60, 30, 10, 5, 4, 3, 2, 1 }
+
+local function getGoldenExpBonusPct(player)
+    local cap = 200
+    local lightTable = xi.abyssea.getLightsTable(player)
+    local golden = math.min(lightTable[xi.abyssea.lightType.GOLDEN] or 0, cap)
+    local ebon = math.min(lightTable[xi.abyssea.lightType.EBON] or 0, cap)
+
+    local goldenBonus = (golden / cap) * 50
+    local ebonFactor = 1 + (ebon / cap)
+
+    return math.floor(goldenBonus * ebonFactor)
+end
+
+local function updateGoldenExpBonus(player)
+    local applied = player:getLocalVar('abysseaGoldenExpBonusApplied')
+    local newBonus = getGoldenExpBonusPct(player)
+
+    if applied ~= newBonus then
+        if applied > 0 then
+            player:delMod(xi.mod.EXP_BONUS, applied)
+        end
+
+        if newBonus > 0 then
+            player:addMod(xi.mod.EXP_BONUS, newBonus)
+        end
+
+        player:setLocalVar('abysseaGoldenExpBonusApplied', newBonus)
+    end
+end
 
 -- NOTE: Update the last
 local reportTimeRemaining
@@ -74,6 +104,7 @@ effectObject.onEffectGain = function(target, effect)
     effect:addEffectFlag(xi.effectFlag.HIDE_TIMER)
 
     target:setLocalVar('lastTimeUpdate', effect:getTimeRemaining() / 1000 + 1)
+    updateGoldenExpBonus(target)
 end
 
 effectObject.onEffectTick = function(target, effect)
@@ -86,6 +117,8 @@ effectObject.onEffectTick = function(target, effect)
     if target:getLocalVar('tetherTimer') == 11 then
         xi.abyssea.searingWardTimer(target)
     end
+
+    updateGoldenExpBonus(target)
 
     -- Handle Time Remaining Messages. This will no longer be called if the time
     -- remaining is less that 30s, as then we move to timers set on the player to
@@ -119,9 +152,20 @@ effectObject.onEffectLose = function(target, effect)
         target:setCharVar('abysseaTimeStored', timeRemaining)
     end
 
+    local appliedGoldenExpBonus = target:getLocalVar('abysseaGoldenExpBonusApplied')
+    if appliedGoldenExpBonus > 0 then
+        target:delMod(xi.mod.EXP_BONUS, appliedGoldenExpBonus)
+        target:setLocalVar('abysseaGoldenExpBonusApplied', 0)
+    end
+
     -- Reset Abyssea Lights
     target:setCharVar('abysseaLights1', 0)
     target:setCharVar('abysseaLights2', 0)
+
+    -- Reset Cruor reverse-chain progress when visitant status is lost.
+    target:setCharVar('AbysseaCruorChainCount', 0)
+    target:setCharVar('AbysseaCruorLastIdentity', 0)
+    target:setCharVar('AbysseaCruorLastKillTime', 0)
 end
 
 return effectObject

--- a/scripts/globals/abyssea.lua
+++ b/scripts/globals/abyssea.lua
@@ -1056,7 +1056,7 @@ local function setLightsFromTable(player, lightTable)
         if k <= 4 then
             lightMaskFirst = lightMaskFirst + bit.lshift(lightTable[k], (k - 1) * 8)
         else
-            lightMaskSecond = lightMaskSecond + bit.lshift(lightTable[k], (k - 1) * 8)
+            lightMaskSecond = lightMaskSecond + bit.lshift(lightTable[k], (k - 5) * 8)
         end
     end
 
@@ -1126,7 +1126,9 @@ xi.abyssea.addPlayerLights = function(player, light, amount)
 end
 
 xi.abyssea.getLightValue = function(player, light)
-    return bit.band(bit.rshift(player:getCharVar('abysseaLights'), (light - 1) * 2), 0xFF)
+    local lightTable = xi.abyssea.getLightsTable(player)
+
+    return lightTable[light] or 0
 end
 
 xi.abyssea.canEnterAbyssea = function(player)

--- a/scripts/globals/abyssea/cruor.lua
+++ b/scripts/globals/abyssea/cruor.lua
@@ -1,0 +1,155 @@
+-----------------------------------
+-- Abyssea Cruor Rewards
+-----------------------------------
+require('scripts/globals/abyssea')
+xi = xi or {}
+xi.abyssea = xi.abyssea or {}
+xi.abyssea.cruor = xi.abyssea.cruor or {}
+
+local function getConfig(name, default)
+    local value = xi.settings.main[name]
+    if value == nil then
+        return default
+    end
+
+    return value
+end
+
+local function getLightBonus(player)
+    local silverCap      = getConfig('ABYSSEA_CRUOR_SILVER_CAP', 200)
+    local ebonCap        = getConfig('ABYSSEA_CRUOR_EBON_CAP', 200)
+    local silver         = math.min(xi.abyssea.getLightValue(player, xi.abyssea.lightType.SILVERY) or 0, silverCap)
+    local ebon           = math.min(xi.abyssea.getLightValue(player, xi.abyssea.lightType.EBON) or 0, ebonCap)
+
+    local silverMaxBonus = getConfig('ABYSSEA_CRUOR_SILVER_MAX_BONUS', 0.6)
+    local ebonAmplifier  = getConfig('ABYSSEA_CRUOR_EBON_SILVER_AMPLIFIER', 1.0)
+
+    local silverRatio    = silver / silverCap
+    local ebonRatio      = ebon / ebonCap
+
+    return 1 + silverRatio * silverMaxBonus * (1 + ebonRatio * ebonAmplifier)
+end
+
+local function getIdentity(mob)
+    local identityMode = getConfig('ABYSSEA_CRUOR_CHAIN_IDENTITY_MODE', 'pool')
+
+    if identityMode == 'name' then
+        return mob:getName()
+    end
+
+    return mob:getPool()
+end
+
+local function getFamilyModifier(mob)
+    local modifier = 1.0
+
+    -- Ephemeral mobs are documented by community resources as high Cruor/EXP outliers.
+    if string.find(mob:getName(), 'Ephemeral_', 1, true) then
+        modifier = modifier * getConfig('ABYSSEA_CRUOR_EPHEMERAL_MULTIPLIER', 3.0)
+    end
+
+    return modifier
+end
+
+local function getBaseCruor(mob)
+    if mob:isNM() then
+        local size            = mob:getModelSize() or 0
+        local smallThreshold  = getConfig('ABYSSEA_CRUOR_NM_SMALL_SIZE', 4)
+        local mediumThreshold = getConfig('ABYSSEA_CRUOR_NM_MEDIUM_SIZE', 7)
+
+        if size <= smallThreshold then
+            return getConfig('ABYSSEA_CRUOR_NM_BASE_T1', 50)
+        elseif size <= mediumThreshold then
+            return getConfig('ABYSSEA_CRUOR_NM_BASE_T2', 65)
+        end
+
+        return getConfig('ABYSSEA_CRUOR_NM_BASE_T3', 80)
+    end
+
+    local levelStep = getConfig('ABYSSEA_CRUOR_LEVEL_STEP', 0)
+    local minBase   = getConfig('ABYSSEA_CRUOR_KILL_BASE_MIN', 10)
+    local maxBase   = getConfig('ABYSSEA_CRUOR_KILL_BASE_MAX', 20)
+
+    if maxBase < minBase then
+        maxBase = minBase
+    end
+
+    local randomizedBase = math.random(minBase, maxBase)
+
+    return math.max(1, math.floor((randomizedBase + mob:getMainLvl() * levelStep) * getFamilyModifier(mob)))
+end
+
+local function getEligibleMembers(killer)
+    local members = {}
+
+    for _, member in pairs(killer:getAlliance()) do
+        local visitantEffect = member:getStatusEffect(xi.effect.VISITANT)
+        if
+            member:isPC() and
+            member:getZoneID() == killer:getZoneID() and
+            visitantEffect and
+            visitantEffect:getIcon() == xi.effect.VISITANT
+        then
+            table.insert(members, member)
+        end
+    end
+
+    return members
+end
+
+local function getKiller(player)
+    if player and not player:isPC() and player:getAllegiance() == 1 then
+        local master = player:getMaster()
+        if master then
+            return master
+        end
+    end
+
+    return player
+end
+
+xi.abyssea.cruor.onMobDefeat = function(killer, mob)
+    killer = getKiller(killer)
+    if not killer or not killer:isPC() then
+        return
+    end
+
+    local timeout    = getConfig('ABYSSEA_CRUOR_CHAIN_TIMEOUT_SEC', 0)
+    local chainStep  = getConfig('ABYSSEA_CRUOR_CHAIN_STEP', 9)
+    local chainCap   = getConfig('ABYSSEA_CRUOR_CHAIN_CAP', 180)
+    local reaperStep = getConfig('ABYSSEA_CRUOR_REAPER_BONUS_STEP', 0.2)
+
+    local now = GetSystemTime()
+    local identity = tostring(getIdentity(mob))
+
+    for _, member in pairs(getEligibleMembers(killer)) do
+        local lastIdentity = tostring(member:getCharVar('AbysseaCruorLastIdentity'))
+        local lastKillTime = member:getCharVar('AbysseaCruorLastKillTime')
+        local chainCount   = member:getCharVar('AbysseaCruorChainCount')
+
+        if timeout > 0 and lastKillTime > 0 and now - lastKillTime > timeout then
+            chainCount = 0
+        end
+
+        if lastIdentity == identity then
+            chainCount = 0
+        else
+            chainCount = chainCount + 1
+        end
+
+        local baseCruor   = getBaseCruor(mob)
+        local chainBonus  = math.min(chainCount * chainStep, chainCap)
+        local reaperBonus = 1 + xi.abyssea.getAbyssiteTotal(member, xi.abyssea.abyssiteType.THE_REAPER) * reaperStep
+        local lightBonus  = getLightBonus(member)
+        local cruorReward = math.floor((baseCruor + chainBonus) * reaperBonus * lightBonus)
+
+        member:addCurrency('cruor', cruorReward)
+        member:messageSpecial(zones[member:getZoneID()].text.CRUOR_OBTAINED, cruorReward)
+
+        member:setCharVar('AbysseaCruorChainCount', chainCount)
+        member:setCharVar('AbysseaCruorLastIdentity', identity)
+        member:setCharVar('AbysseaCruorLastKillTime', now)
+    end
+end
+
+return xi.abyssea.cruor

--- a/scripts/globals/abyssea/lights.lua
+++ b/scripts/globals/abyssea/lights.lua
@@ -2,6 +2,7 @@
 -- Abyssea Lights Global
 -----------------------------------
 require('scripts/globals/abyssea')
+require('scripts/globals/abyssea/cruor')
 -----------------------------------
 xi = xi or {}
 xi.abyssea = xi.abyssea or {}
@@ -523,6 +524,12 @@ local lightTypes =
     [xi.abyssea.deathType.WS_MAGICAL]  = { light = xi.abyssea.lightType.AMBER, lightType = 'amber' }, -- Amber
 }
 
+local function isCruorKillRewardsEnabled()
+    local value = xi.settings.main.ABYSSEA_ENABLE_CRUOR_KILL_REWARDS
+
+    return value == true or value == 1
+end
+
 xi.abyssea.RemoveDeathListeners = function(mob)
     mob:removeListener('ABYSSEA_PHYSICAL_DEATH_CHECK')
     mob:removeListener('ABYSSEA_MAGIC_DEATH_CHECK')
@@ -569,6 +576,10 @@ xi.abyssea.AddDeathListeners = function(mob)
         local deathType = mobArg:getDeathType()
         if deathType == xi.abyssea.deathType.NONE then
             deathType = xi.abyssea.deathType.PHYSICAL
+        end
+
+        if isCruorKillRewardsEnabled() then
+            xi.abyssea.cruor.onMobDefeat(player, mobArg)
         end
 
         xi.abyssea.DropLights(player, mobArg:getName(), deathType, mobArg)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -109,6 +109,29 @@ xi.settings.main =
     -- recomended amount 0 - 100, some lights will cap at 255 while others are less, these are capped automatically
     ABYSSEA_BONUSLIGHT_AMOUNT = 0,
 
+    -- Abyssea cruor kill rewards enable toggle (true/1 = enabled or false/0 = disabled)
+    ABYSSEA_ENABLE_CRUOR_KILL_REWARDS = 1, -- Enable or disable cruor rewards in Abyssea zones
+    -- Base cruor implementation: reward = floor((base + chainBonus) * (silver effect * (ebon bonus)) * reaperBonus)
+    ABYSSEA_CRUOR_KILL_BASE_MIN         = 10,        -- Minimum of randomized base cruor reward
+    ABYSSEA_CRUOR_KILL_BASE_MAX         = 20,        -- Maximum of randomized base cruor reward
+    ABYSSEA_CRUOR_LEVEL_STEP            = 0,         -- Set > 0 only if your server wants explicit level-based scaling for cruor rewards
+    ABYSSEA_CRUOR_CHAIN_STEP            = 9,         -- This is the bonus earned each time a mob of a different family from the last is defeated
+    ABYSSEA_CRUOR_CHAIN_CAP             = 180,       -- This is the maximum chain bonus value
+    ABYSSEA_CRUOR_CHAIN_TIMEOUT_SEC     = 0,         -- 0 disables timeout; reverse-chain persists until same family/name kill or visitant loss (retail-like)
+    ABYSSEA_CRUOR_CHAIN_IDENTITY_MODE   = 'pool',    -- accepts pool|name for identifying valid targets to maintain the chain, default pool (retail-like)
+    ABYSSEA_CRUOR_REAPER_BONUS_STEP     = 0.1,       -- Multiplier at the end of the calculation; eg. 0.2 = 120% and 0.15 = 115%.  Default (0.1)
+    ABYSSEA_CRUOR_EPHEMERAL_MULTIPLIER  = 3.0,       -- Ephemeral mob cruor multiplier, multiplies the result of the randomized base before chain, lights, and atma bonuses
+
+    ABYSSEA_CRUOR_SILVER_CAP            = 200,       -- Maximum silver light; determines how rapidly you can reach the cap and effectiveness per light
+    ABYSSEA_CRUOR_EBON_CAP              = 200,       -- Maximum ebon light; determines how rapidly you can reach the cap and effectiveness per light
+    ABYSSEA_CRUOR_SILVER_MAX_BONUS      = 0.6,       -- Maximum bonus multiplier to base+chain cruor; 0.6 = 1.6 multiplier (160%)
+    ABYSSEA_CRUOR_EBON_SILVER_AMPLIFIER = 1.0,       -- Maximum bonus multiplier to silver light multiplier; 1.0 doubles silver effectiveness at cap (0.6 -> 1.2)
+    ABYSSEA_CRUOR_NM_BASE_T1            = 50,        -- Cruor base reward for T1 NM sizes (default 0-4, set by ABYSSEA_CRUOR_NM_SMALL_SIZE)
+    ABYSSEA_CRUOR_NM_BASE_T2            = 65,        -- Cruor base reward for T2 NM sizes (default 5-7, set by ABYSSEA_CRUOR_NM_MEDIUM_SIZE)
+    ABYSSEA_CRUOR_NM_BASE_T3            = 80,        -- Cruor base reward for T3 NM sizes (default 8+, will always be everything larger than ABYSSEA_CRUOR_NM_MEDIUM_SIZE)
+    ABYSSEA_CRUOR_NM_SMALL_SIZE         = 4,         -- Determines maximum small size threshold for NM rewards
+    ABYSSEA_CRUOR_NM_MEDIUM_SIZE        = 7,         -- Determines maximum medium size threshold for NM rewards
+
     -- CHARACTER CONFIG
     INITIAL_LEVEL_CAP              = 50, -- The initial level cap for new players.  There seems to be a hardcap of 255.
     MAX_LEVEL                      = 99, -- Level max of the server, lowers the attainable cap by disabling Limit Break quests.

--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -13,7 +13,7 @@ CREATE TABLE `char_unlocks` (
   `campaign_windy` int(10) unsigned NOT NULL DEFAULT 0,
   `homepoints` blob DEFAULT NULL,
   `survivals` blob DEFAULT NULL,
-  `traverser_start` TIMESTAMP DEFAULT 0,
+  `traverser_start` TIMESTAMP NULL DEFAULT NULL,
   `traverser_claimed` int(10) unsigned NOT NULL DEFAULT 0,
   `abyssea_conflux` blob DEFAULT NULL,
   `waypoints` blob DEFAULT NULL,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a fully configurable system for cruor drops in abyssea zones
- Adds base cruor drop range for standard mobs, ephemeral mob multiplier, and the varying cruor amounts based on NM model size
- Adds the differing species cruor chain mechanic
- Incorporates the effect of silver lights on cruor earning (0-60%)
- Incorporates the effect of ebon lights on silver lights (1.0 - 2.0)
- Incorporates the effect of the reaper abyssites for 10% bonus (configurable)
- Adds bonus exp effect of golden lights (0~50%)
- Incorporates the effect of ebon lights on golden lights (1.0 - 2.0)
- Resolves SQL table formatting bug for traverser start (bug #9893)

Bonus experience points from golden (and ebon effect on golden) lights are calculated as additive to the multiplier received from sources such as RoV key items.  At maximum combined effect, they add 1.0 to the calculation.  RoV KI's cap at 180% (base exp * 2.8); golden light cap (+0.5) and ebon light cap (gold effect * 2) results in (base exp * 3.8).  Thus, 195 base exp becomes 546 with RoV KIs, and 741 with capped gold and ebon lights.

Sources:
https://www.bg-wiki.com/ffxi/Abyssea_Lights
https://www.bluegartr.com/threads/104530-Abyssea-Lights?p=4691394&viewfull=1#post4691394
https://www.bg-wiki.com/ffxi/Category:Abyssea
https://www.bg-wiki.com/ffxi/Category:Abyssea_Atma
https://www.bg-wiki.com/ffxi/Category:Abyssea_Abyssite

## Steps to test these changes

Leave the default settings on - go to Abyssea, defeat mobs, receive cruor.
Alternate mob families between each kill to see the effect of the chain.
Use !addlights silver 100 {playername} and see a spike in cruor received
Repeat tests for extra silver and ebon lights
Use !addlights gold 100 {playername} and see a spike in exp received
Repeat tests for extra gold and ebon lights

Enjoy!

Final image below shows capped chain effect with capped lights (silver, gold, and ebon) without any reaper abyssites.:

<img width="204" height="79" alt="image" src="https://github.com/user-attachments/assets/6dbc7e53-bd26-43b8-9a44-5c2c0fc6a7d5" />

<img width="142" height="34" alt="image" src="https://github.com/user-attachments/assets/dc735ce3-5d6f-403f-bd24-3db1ac051af2" />

<img width="229" height="25" alt="image" src="https://github.com/user-attachments/assets/e93143dc-13df-48c8-870f-16067ee6b166" />

<img width="168" height="99" alt="image" src="https://github.com/user-attachments/assets/f8278bab-0f15-45c3-993f-bf03c5435920" />

<img width="146" height="34" alt="image" src="https://github.com/user-attachments/assets/641bb84d-ac4e-4963-8fc0-ef8c9747e78f" />
