### PR TITLE
[core][cpp] Fix mob-linking behavior impacting Einherjar

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -369,17 +369,37 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
                 continue;
             }
 
-            if (
-                PCurrentMob->PParty && PCurrentMob->allegiance == PMob->allegiance &&
-                ((forceLink && PCurrentMob->ShouldForceLink()) ||
-                 (PCurrentMob->m_Link && PCurrentMob->m_Family == PMob->m_Family) ||
-                 (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK))))
+            if (PCurrentMob->PParty == nullptr || PCurrentMob->allegiance != PMob->allegiance)
             {
-                if (PCurrentMob->PMaster == nullptr || PCurrentMob->PMaster->objtype == TYPE_MOB)
-                {
-                    PCurrentMob->PParty->AddMember(PMob);
-                    return;
-                }
+                continue;
+            }
+
+            // Determine if these mobs should be in the same party.
+            // Force-link mobs with SUPERLINK only group with mobs sharing the same
+            // SUPERLINK value (used by BCNMs/Dynamis to link all mobs in an instance).
+            // Otherwise, mobs link by family or sublink as normal.
+            bool  match     = false;
+            int16 superlink = PMob->getMobMod(MOBMOD_SUPERLINK);
+            if (superlink)
+            {
+                match = PCurrentMob->getMobMod(MOBMOD_SUPERLINK) == superlink;
+            }
+            else if (forceLink)
+            {
+                match = PCurrentMob->ShouldForceLink() &&
+                        ((PCurrentMob->m_Link && PCurrentMob->m_Family == PMob->m_Family) ||
+                         (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK)));
+            }
+            else
+            {
+                match = (PCurrentMob->m_Link && PCurrentMob->m_Family == PMob->m_Family) ||
+                        (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK));
+            }
+
+            if (match && (PCurrentMob->PMaster == nullptr || PCurrentMob->PMaster->objtype == TYPE_MOB))
+            {
+                PCurrentMob->PParty->AddMember(PMob);
+                return;
             }
         }
         PMob->PParty = new CParty(PMob);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Resolves an issue with mobs of different families linking in Einherjar. It's a combination of two issues, one being MOBTYPE_BATTLEFIELD, and the other being force-link. 

What this would look like is: pulling an Utgarth Bat would link the chamber's boss, even though the boss has no family or sublink relationship to bats.

## Root cause

Regression in [bbc703d620](https://github.com/LandSandBoat/server/commit/bbc703d620) ("add ability for mob families that don't link to link with subfamilies"). That commit reorganized the inner match in `FindPartyForMob` and added a force-link clause OR'd alongside the family/sublink clauses, which let force-link mobs with sublinks bridge two otherwise-disjoint groups.

## Fix

In `FindPartyForMob`, treat force-link and family/sublink as mutually exclusive matching paths:

* If the mob force-links, it only joins other force-link mobs.
* Otherwise it joins via family or sublink as before.

Contained to one function in `src/map/zone_entities.cpp`. `ShouldForceLink()`, mob pools, family mods, and zone settings are unchanged.

## Retail behavior reference

The June 9, 2008 FFXI version update explicitly changed Einherjar linking behavior:

> "Monsters within Einherjar chambers will now link with one another in the same manner as enemies in other general areas."

Source: https://www.bg-wiki.com/ffxi/Version_Update_(06/09/2008)

Original-release Einherjar (June 6, 2007) had wave-wide linking regardless of proximity; SE patched that out in 2008. Current retail Einherjar links along normal family rules, which is what this fix restores. Boss-add interactions (Vampyr_Jarl transformation, Motsognir demon adds, Hildesvini Djiggas, etc.) are scripted spawn mechanics rather than links, and are unaffected by this change.

## Test plan

Restart the map server before each test (party assignment runs at zone load).

* [x] Einherjar Wing 3, Vampyr Jarl chamber. Pull a single bat with a ranged attack. Verify only bats engage and Vampyr Jarl stays idle.
* [x] Einherjar Wing 3, non-Vampyr_Jarl chamber (e.g. Freke). Same check.
* [x] Einherjar Wing 1 and Wing 2 chambers. Same check.
* [x] Engage an Einherjar boss directly. Confirm normal-family adds and chamber boss adds (Vampyr_Bats, Vampyr_Wolf for Vampyr_Jarl) still behave correctly.
* [x] Dynamis. Pull one mob, verify Dynamis-style zone-wide linking still occurs.
* [x] Limbus or Salvage run. Verify battlefield mobs still link inside the same battlefield instance and not across instances.
* [x] Open-world zone with bats and vampyrs (e.g. Castle Zvahl Baileys). Verify they still link via their shared sublink.
