### PR TITLE
Add HitDistortion and Knockback to Blu spells

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -40,6 +40,7 @@
 #include "ai/states/weaponskill_state.h"
 #include "attack.h"
 #include "attackround.h"
+#include "blue_spell.h"
 #include "items/item_weapon.h"
 #include "job_points.h"
 #include "lua/luautils.h"
@@ -2306,6 +2307,7 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 
     for (auto* PTarget : PAI->TargetFind->m_targets)
     {
+        // Reset the spell's message to prevent any state carryover between targets
         PSpell->setMessage(initialSpellMessage);
 
         action_target_t& actionTarget = action.addTarget(PTarget->id);
@@ -2361,7 +2363,7 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 
             actionResult.param = damage;
 
-            // spell failed to apply
+            // Handle spell failed to apply
             if (!PSpell->tookEffect())
             {
                 actionResult.resolution = ActionResolution::Miss;
@@ -2405,6 +2407,32 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
             msg != MsgBasic::ShadowAbsorb) // If message isn't the shadow loss message, because I had to move this outside of the above check for it.
         {
             luautils::OnMagicHit(this, PTarget, PSpell);
+
+            // Process Blu Spell based Actions
+            if (PSpell->getSpellGroup() == SPELLGROUP_BLUE && PSpell->getMessage() != MsgBasic::MagicFail)
+            {
+                if (auto* PBlueSpell = dynamic_cast<CBlueSpell*>(PSpell))
+                {
+                    // Physical Blue Spells trigger HitDistortion - using the existence of a Primary Skillchain element as a physical indicator
+                    if (PBlueSpell->getPrimarySkillchain() != 0)
+                    {
+                        // This will set the Hit Distortion field
+                        actionResult.recordDamage(attack_outcome_t{
+                            .atkType    = ATTACK_TYPE::PHYSICAL,
+                            .damage     = damage,
+                            .target     = PTarget,
+                            .isCritical = false, // ToDo: Get Critical status from spell processing
+                        });
+                    }
+
+                    // Some Physical Blue Spells present with a knockback effect - using knockback on linked Mob Skill to determine which
+                    CMobSkill* mobSkillForBlueSpell = battleutils::GetMobSkill(PBlueSpell->getMonsterSkillId());
+                    if (mobSkillForBlueSpell)
+                    {
+                        actionResult.knockback = mobSkillForBlueSpell->getKnockback();
+                    }
+                }
+            }
         }
 
         // The entity under consideration for RoE objective credit


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request adds HitDistortion (mob reaction) to all BLU Physical Spells and adds Knockback (animation only) to the BLU spells that have knockback.  Ensures that Physical Spells have not missed- so misses do not result in mobs flinching.

Room for improvement - this could be extracted to its own fcn, however there doesnt seem to be an existing home for this kind of functionality - I almost put it in battleUtils but that felt off.  Alternatively we could route the ActionResult through LuaUtils::OnSpellCast, through the individual Blu Spells, and into BlueMagic.lua where processing could handle updating the HitDistortion (in usePhysicalSpell) and Knockback.  ActionResult over Action as the processing is per target.  I'm open to updating for either pathway.

## Limitations

1. I have only captured and verified 75 Era spells as my Retail Blu is only 75.  As I level and learn more spells, I will continue to verify.
2. Despite the `0x028` packet now directly matching retail captuues aside from expected variances (Target, Damage, Spell Recast) - Medium/Large Knockbacks (Ram Charge, Helldive, Regurgication) do not animate as Medium/Large Knockbacks - rather they animate as Small/Medium Knockbacks.   I have attempted forcing various combinations of HitDistortion and Knockback (as they both contribute - see [link](https://github.com/atom0s/XiPackets/tree/main/world/server/0x0028)) - However even supplying the largest Knockback and largest HitDistortion together and verifying the values via Captain has not created the same Large Knockback animation as retail.  **I'm open to any ideas or pathways I may be missing.**

[Helldive Example 1](https://sruon.github.io/actions/#2814321b1f382b0c0001d08d000040020000801a604040004601a51580000000000000ff382b0c00):
```
[2026-05-04 16:54:32.904] Incoming packet 0x028
        |  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F      | 0123456789ABCDEF
    -----------------------------------------------------  ----------------------
      0 | 28 14 32 1B 1F 38 2B 0C 00 01 D0 8D 00 00 40 02    0 | (.2..8+.......@.
      1 | 00 00 80 1A 60 40 40 00 46 01 A5 15 80 00 00 00    1 | ....`@@.F.......
      2 | 00 00 00 FF 38 2B 0C 00 -- -- -- -- -- -- -- --    2 | ....8+..--------
```
scale         = 5, -- knockback: 1, distortion: 1

---

[Helldive Example 2](https://sruon.github.io/actions/#2814f11a1f382b0c0001d08d000040020000801a6040400046016515800000000000001900000000):
```
[2026-05-04 16:54:05.940] Incoming packet 0x028 - Magic Finish
        |  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F      | 0123456789ABCDEF
    -----------------------------------------------------  ----------------------
      0 | 28 14 F1 1A 1F 38 2B 0C 00 01 D0 8D 00 00 40 02    0 | (....8+.......@.
      1 | 00 00 80 1A 60 40 40 00 46 01 65 15 80 00 00 00    1 | ....`@@.F.e.....
      2 | 00 00 00 19 00 00 00 00 -- -- -- -- -- -- -- --    2 | ........--------
```
scale         = 5, -- knockback: 1, distortion: 1

---

[Helldive LSB](https://sruon.github.io/actions/#28127601230300000001d08d0000000000008003204340004601a5128000000000000000) - not the same visual - smaller knockback
```
[2026-05-05 15:53:59.604] Incoming packet 0x028
        |  0  1  2  3  4  5  6  7  8  9  A  B  C  D  E  F      | 0123456789ABCDEF
    -----------------------------------------------------  ----------------------
      0 | 28 12 76 01 23 03 00 00 00 01 D0 8D 00 00 00 00    0 | (.v.#...........
      1 | 00 00 80 03 20 43 40 00 46 01 A5 12 80 00 00 00    1 | .... C@.F.......
      2 | 00 00 00 00 -- -- -- -- -- -- -- -- -- -- -- --    2 | ....------------
```
scale         = 5, -- knockback: 1, distortion: 1

---

## Steps to test these changes

### Basic Testing
1. Toss ChainSpell `!addeffect chainspell 1 1000 1000` and Refresh `!setMod Refresh 1000` on yourself.  Avoid GodMode
1. Find a good location with multiple mobs and grab some
1. Test Single Target and Multi Target Spells
1. Spike one Mob's evasion in a group `!setMod EVA 10000` and cast aoe spells hitting multiple.  Ensure when the boosted eva mob evades (_spell fails to take effect_ message) that the mob does not HitDistort or Knockback. 
1. In general - Physical Spells (denoted by the Aht Urgan symbol in the spell list) cause Hit Distortion if they hit.  Magical Spells do not cause Hit Distortion.  Knockback animation is a case by case basis.
1. Regurgitation is a Special Case - its a magical damaging spell with knockback animation - it cannot _fail to take effect_.
1.  Note: Just like on retail - timing matters.  The server can tell the client to perform an animation but the client has final say.  Causing Hit Distortion while a mob is mid-animation will cause the mob to "no sell" the hit, i.e., ignore the Hit Distortion.  This is especially evident with a spell like Asuran Claws - with 6 spread out hits.  Its very easy to have many of the 6 Hit Distortions cancelled by a concurrent animation.  Its interesting that it seems to be a frame by frame decision of sorts, as it can blank only _some_ of the hits.

| Example Spell | Hit Distortion | Hits | Knockback| AoE?|
| --- | --- | --- | --- | ---|
|Sprout Smack| Yes | 1| No | No|
|Disseverment| Yes | 5| No | No|
|Tail Slap| Yes | 1| Yes| Conal|
|Battle Dance| Yes | 1| No | PBAoE|
|Regurgitation| No | 1| Yes | No|
|Head Butt| Yes | 1| Yes | No|
|Blood Saber| No | 1| No | PBAoE|

