### PR TITLE
[core] Stamp Scheduler on MapSession at creation

### DIFF
--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -201,8 +201,8 @@ void IPCClient::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& mess
     }
     else
     {
-        auto* PSession      = networking_.sessions().createPendingSession(message.charId); // Create a pending session that the character might use ahead of time
-        PSession->scheduler = &networking_.scheduler();
+        // Create a pending session that the character might use ahead of time
+        networking_.sessions().createPendingSession(message.charId);
     }
 }
 

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -51,6 +51,7 @@ MapNetworking::MapNetworking(Scheduler& scheduler, MapStatistics& mapStatistics,
 : scheduler_(scheduler)
 , mapStatistics_(mapStatistics)
 , mapIPP_(config.ipp) // TODO: Refactor to not use this, since we have config_ in here
+, mapSessions_(scheduler)
 , config_(config)
 , PBuff{}
 , PBuffCopy{}
@@ -266,7 +267,6 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
                     // TODO: err msg?
                     return -1;
                 }
-                PSession->scheduler = &scheduler_;
             }
             else
             {

--- a/src/map/map_session_container.cpp
+++ b/src/map/map_session_container.cpp
@@ -26,12 +26,18 @@
 #include "status_effect_container.h"
 
 #include "common/database.h"
+#include "common/scheduler.h"
 #include "common/xi.h"
 
 #include "entities/charentity.h"
 
 #include "utils/charutils.h"
 #include "utils/petutils.h"
+
+MapSessionContainer::MapSessionContainer(Scheduler& scheduler)
+: scheduler_(scheduler)
+{
+}
 
 auto MapSessionContainer::createSession(IPP ipp) -> MapSession*
 {
@@ -55,6 +61,7 @@ auto MapSessionContainer::createSession(IPP ipp) -> MapSession*
 
     auto map_session_data = std::make_unique<MapSession>();
 
+    map_session_data->scheduler   = &scheduler_;
     map_session_data->last_update = timer::now();
     map_session_data->client_ipp  = ipp;
 
@@ -78,6 +85,7 @@ auto MapSessionContainer::createPendingSession(uint32 charId) -> MapSession*
 
     auto map_session_data = std::make_unique<MapSession>();
 
+    map_session_data->scheduler   = &scheduler_;
     map_session_data->last_update = timer::now(); // This may need adjustment if sessions feel like they take too long to free
     map_session_data->charID      = charId;
 

--- a/src/map/map_session_container.h
+++ b/src/map/map_session_container.h
@@ -32,6 +32,8 @@ struct MapSession;
 class MapSessionContainer
 {
 public:
+    explicit MapSessionContainer(Scheduler& scheduler);
+
     auto createSession(IPP ipp) -> MapSession*;
     auto createPendingSession(uint32 charId) -> MapSession*;
 
@@ -51,6 +53,7 @@ public:
     void destroyPendingSession(uint32 charId);
 
 private:
+    Scheduler&                                    scheduler_;
     std::map<IPP, std::unique_ptr<MapSession>>    sessions_;         // Confirmed sessions mapped by IP
     std::map<uint32, std::unique_ptr<MapSession>> pending_sessions_; // Pending sessions notified via IPC that a character may be arriving
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

xi_test SIGSEGV on any PC-driven code paths posting to worker threads (which is pretty much just the auditing calls). 
This change just moves where the Scheduler is set to accommodate both use cases.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
