### PR TITLE
[core] Link earcut.hpp and rapidyaml

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -108,6 +108,17 @@ if(earcut_hpp_ADDED) # header-only
 endif()
 
 CPMAddPackage(
+    NAME rapidyaml
+    GITHUB_REPOSITORY biojppm/rapidyaml
+    GIT_TAG v0.12.0
+    SYSTEM ON
+    OPTIONS
+        "RYML_BUILD_TOOLS OFF"
+        "RYML_BUILD_API OFF"
+        "RYML_INSTALL OFF"
+) # defines: ryml
+
+CPMAddPackage(
     NAME argparse
     GITHUB_REPOSITORY p-ranav/argparse
     GIT_TAG d924b84eba1f0f0adf38b20b7b4829f6f65b6570
@@ -308,6 +319,7 @@ set(MAP_ONLY_EXTERNAL_LIBS
     RecastNavigation::Detour
     fast_obj
     earcut_hpp
+    ryml
     zlibstatic
 )
 

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -97,6 +97,17 @@ CPMAddPackage(
 ) # defines: fast_obj
 
 CPMAddPackage(
+    NAME earcut_hpp
+    GITHUB_REPOSITORY mapbox/earcut.hpp
+    GIT_TAG v2.2.4
+    DOWNLOAD_ONLY ON
+) # defines: earcut_hpp
+if(earcut_hpp_ADDED) # header-only
+    add_library(earcut_hpp INTERFACE)
+    target_include_directories(earcut_hpp SYSTEM INTERFACE ${earcut_hpp_SOURCE_DIR}/include/)
+endif()
+
+CPMAddPackage(
     NAME argparse
     GITHUB_REPOSITORY p-ranav/argparse
     GIT_TAG d924b84eba1f0f0adf38b20b7b4829f6f65b6570
@@ -296,6 +307,7 @@ set(MAP_ONLY_EXTERNAL_LIBS
     RecastNavigation::Recast
     RecastNavigation::Detour
     fast_obj
+    earcut_hpp
     zlibstatic
 )
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
2 new libraries:
- [earcut.hpp](https://github.com/mapbox/earcut.hpp) for defining and sampling arbitrary polygons. To be used for roam areas, spawn points and eventually fishing zones.
  - This is what Eden is using, didn't investigate alternatives too much. Made by MapBox, header only and simple interface.
  - Actual design/usage TBD, depends on YAML to be introduced first.
- [rapidyaml](https://github.com/biojppm/rapidyaml) for parsing and loading upcoming YAMLs
  - Header only, not overly fond of the interface but it gets the job done and it vastly outperformed alternatives by several orders of magnitude in my tests.
  - I have the design more or less done but I need to do a POC before sharing

## Steps to test these changes
Nothing is changing... yet

<!-- Clear and detailed steps to test your changes here -->
