### PR TITLE
[quest] Ode to the Serpents follow up quest conditional fix

### DIFF
--- a/scripts/quests/ahtUrhgan/Fist_of_the_People.lua
+++ b/scripts/quests/ahtUrhgan/Fist_of_the_People.lua
@@ -22,7 +22,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-            player:hasCompletedQuest(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.ODE_TO_THE_SERPENTS)
+            player:getQuestStatus(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.ODE_TO_THE_SERPENTS) == xi.questStatus.QUEST_ACCEPTED
         end,
 
         [xi.zone.AL_ZAHBI] =

--- a/scripts/quests/ahtUrhgan/When_the_Bow_Breaks.lua
+++ b/scripts/quests/ahtUrhgan/When_the_Bow_Breaks.lua
@@ -21,7 +21,7 @@ quest.sections =
     {
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
-            player:hasCompletedQuest(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.ODE_TO_THE_SERPENTS)
+            player:getQuestStatus(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.ODE_TO_THE_SERPENTS) == xi.questStatus.QUEST_ACCEPTED
         end,
 
         [xi.zone.AL_ZAHBI] =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ode to the Serpents can't be completed without its follow up quests being completed first.

As reported in:
https://github.com/LandSandBoat/server/issues/9966

## Steps to test these changes

Accept Ode to the Serpents.  Its now possible to accept the follow up quests.
