### PR TITLE
[cpp] Allows dualWield to be changed on the fly

### DIFF
--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -76,7 +76,7 @@ CAttackRound::CAttackRound(CBattleEntity* attacker, CBattleEntity* defender)
         }
     }
 
-    if (PSub && attacker->m_dualWield)
+    if (PSub && attacker->IsDualWielding())
     {
         CreateAttacks(PSub, LEFTATTACK);
     }

--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -109,6 +109,16 @@ CBattleEntity::~CBattleEntity()
     TracyZoneScoped;
 }
 
+bool CBattleEntity::IsDualWielding()
+{
+    if (objtype == TYPE_MOB)
+    {
+        return static_cast<CMobEntity*>(this)->getMobMod(MOBMOD_DUAL_WIELD) != 0;
+    }
+
+    return m_dualWield;
+}
+
 auto CBattleEntity::isDead() const -> bool
 {
     return (health.hp <= 0 || status == STATUS_TYPE::DISAPPEAR || PAI->IsCurrentState<CDeathState>() || PAI->IsCurrentState<CDespawnState>());

--- a/src/map/entities/battleentity.h
+++ b/src/map/entities/battleentity.h
@@ -379,6 +379,7 @@ public:
     void  UpdateHealth(); // recalculation of the maximum amount of hp and mp, as well as adjusting their current values
     uint8 UpdateSpeed(bool run = false) override;
 
+    bool          IsDualWielding();
     uint32        GetWeaponDelay(bool tp);                          // returns delay of combined weapons
     float         GetMeleeRange(const CBattleEntity* Target) const; // returns the distance considered to be within melee range of the entity
     virtual float GetRangedAttackRange();                           // returns the maximum valid distance for a ranged attack

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -12987,7 +12987,7 @@ bool CLuaBaseEntity::isDualWielding()
     CBattleEntity* PBattleEntity = dynamic_cast<CBattleEntity*>(m_PBaseEntity);
     if (PBattleEntity)
     {
-        return PBattleEntity->m_dualWield;
+        return PBattleEntity->IsDualWielding();
     }
     else
     {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -630,7 +630,7 @@ int32 CalculateEnspellDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender,
             runeDPS = PWeapon->getDPS();
         }
 
-        if (PAttacker->m_dualWield)
+        if (PAttacker->IsDualWielding())
         {
             runeDPS /= 2; // DPS is divided evenly between hands derived from mainhand only
         }

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -847,17 +847,6 @@ void CalculateMobStats(CMobEntity* PMob, bool recover)
         ((CItemWeapon*)PMob->m_Weapons[SLOT_MAIN])->resetDelay();
     }
 
-    PMob->m_dualWield = false;
-
-    // Deprecate MOBMOD_DUAL_WIELD later, replace if check with value from DB
-    if (PMob->getMobMod(MOBMOD_DUAL_WIELD))
-    {
-        PMob->m_dualWield = true;
-        // if mob is going to dualWield then need to have sub slot
-        // assume it is the same damage as the main slot
-        static_cast<CItemWeapon*>(PMob->m_Weapons[SLOT_SUB])->setDamage(GetWeaponDamage(PMob, SLOT_MAIN));
-    }
-
     uint16 fSTR = GetBaseToRank(PMob->strRank, mLvl);
     uint16 fDEX = GetBaseToRank(PMob->dexRank, mLvl);
     uint16 fVIT = GetBaseToRank(PMob->vitRank, mLvl);
@@ -1010,6 +999,12 @@ void CalculateMobStats(CMobEntity* PMob, bool recover)
     }
 
     SetupJob(PMob);
+
+    // If a mob is going to dual wield, then it needs to have a sub slot.
+    // Assume it is the same damage as the main slot.
+    // Ordering matters. This has to come after SetupJob
+    static_cast<CItemWeapon*>(PMob->m_Weapons[SLOT_SUB])->setDamage(PMob->IsDualWielding() ? GetWeaponDamage(PMob, SLOT_MAIN) : 0);
+
     SetupRoaming(PMob);
 
     // All beastmen drop gil


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Used for things like Pulling the Strings where the mob needs to change jobs. The dual wield was being cached and never updated.

LSB Test: https://www.youtube.com/watch?v=Z1_iAfW5awg
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Go to any ninja mob `!gotoid 16887906`
See that its dual wielding now!

Remove the dual wield and see it only attack once
`!exec target:setMobMod(44, 0)`

Add the dual wield and see it attack twice
`!exec target:setMobMod(44, 1)`
<!-- Clear and detailed steps to test your changes here -->
