### PR TITLE
[lua] Add level penalty to picklocking Treasure Chests / Treasure Coffers

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1722,6 +1722,7 @@ ID.text.CHEST_UNLOCKED + 7 : The chest appears to be locked. If only you had %, 
 xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
     -- Treasure data.
     local zoneId        = player:getZoneID()
+    local playerLevel   = player:getMainLvl()
     local ID            = zones[zoneId]
     local containerType = npcTable[npc:getName()]
 
@@ -1785,13 +1786,23 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
     -----------------------------------
     -- Handle failure states.
     -----------------------------------
-    local randomRoll  = math.random(1, 100)
-    local outcome     = 0
-    local outcomeRate = 0
+    local outcome      = 0
+    local outcomeRate  = 0
+    local levelPenalty = keyUsed == keyType.ZONE_KEY and 0 or utils.clamp(5 * (treasureLevel - playerLevel), 0, thiefKeyInfo[keyUsed][containerType][1])
+
+    -- Build result distribution rate table.
+    local rateTable =
+    {
+        [1] = thiefKeyInfo[keyUsed][containerType][1] - levelPenalty,
+        [2] = thiefKeyInfo[keyUsed][containerType][2] + levelPenalty,
+        [3] = thiefKeyInfo[keyUsed][containerType][3],
+        [4] = thiefKeyInfo[keyUsed][containerType][4],
+    }
 
     for i = 1, 4 do
-        outcomeRate = outcomeRate + thiefKeyInfo[keyUsed][containerType][i]
-        if randomRoll <= outcomeRate then
+        outcomeRate = outcomeRate + rateTable[i]
+
+        if math.random(1, 100) <= outcomeRate then
             outcome = i
             break
         end
@@ -1818,7 +1829,7 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         kneelBeforeChest(player, npc)
 
         player:timer(2000, function(playerEntity)
-            local weaknessDuration = 5 + player:getMainLvl() - treasureLevel
+            local weaknessDuration = 5 + playerLevel - treasureLevel
             weaknessDuration       = math.floor(weaknessDuration / 5)
             weaknessDuration       = utils.clamp(weaknessDuration, 5, 60) * 60 -- Clamp and convert to seconds.
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds decreased success/increased failure rate to opening Treasure Coffers and Treasure Chests when using picklocking tools.
(Leaves Trap/Mimic rate unaffected)

Based on @ThrisStraizo treasure chest and treasure coffer picking tests, a 5% penalty per THF level under the treasureLevel is applied.

Addresses bug #9986

## Steps to test these changes

!changejob thf 1
!zone FeiYin
!additem living_key 99
!gotoname Treasure_Chest
Trade Living Key to Treasure Chest

- It should no longer be possible for low level players to pick locks, unless they are within a certain level range.
- Players that match or exceed the treasureLevel are unaffected.
- Zone Key users are unaffected.