### PR TITLE
[Fix] 2 broken `onTriggerAreaEnter` cases

### DIFF
--- a/scripts/quests/ahtUrhgan/COR_AF3_Against_All_Odds.lua
+++ b/scripts/quests/ahtUrhgan/COR_AF3_Against_All_Odds.lua
@@ -27,7 +27,7 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-            onRegionEnter =
+            onTriggerAreaEnter =
             {
                 [5] = function(player, region)
                     return quest:progressEvent(797)
@@ -88,7 +88,7 @@ quest.sections =
                 end,
             },
 
-            onRegionEnter =
+            onTriggerAreaEnter =
             {
                 [1] = function(player, region)
                     if quest:getVar(player, 'Prog') == 0 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Replaces `onRegionEnter` with `onTriggerAreaEnter`

## Steps to test these changes
Run the quest