### PR TITLE
Fix/puk wind dmg on windsday should still gives TP even if the dmg is absorbed. 

### DIFF
--- a/scripts/mixins/families/puk.lua
+++ b/scripts/mixins/families/puk.lua
@@ -21,8 +21,21 @@ g_mixins.families.puk = function(mob)
             [xi.day.DARKSDAY    ] = xi.damageType.DARK,
         }
 
-        -- If the element corresponding to the elemental day of the in-game Vana'diel week is used on a Puk, it will get 100% TP instantly.
+        -- Day element damage gives TP.
         if damageType == elementTable[VanadielDayOfTheWeek()] then
+            puk:addTP(1000)
+        end
+    end)
+
+    mob:addListener('MAGIC_TAKE', 'PUK_MAGIC_TAKE', function(puk, caster, spell)
+        -- On Windsday, wind damage spells grant TP (excluding dot).
+        if
+            VanadielDayOfTheWeek() == xi.day.WINDSDAY and
+            spell:getElement() == xi.element.WIND and
+            spell:getSkillType() == xi.skill.ELEMENTAL_MAGIC and
+            spell:getSpellFamily() ~= xi.magic.spellFamily.ELE_DOT and
+            puk:getMod(xi.mod.WIND_ABSORB) > 0
+        then
             puk:addTP(1000)
         end
     end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR fixes the behavior of the Puk family. On Windsday, when we cast a wind dmg spell on a Puk, the enemy should gain 1000 TP. Because Puks absorb wind damage, they were not gaining the TP.  
Capture: https://www.youtube.com/watch?v=VKB-Zz8PYqw 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
Adjusted the Puk.lua family file.

## Steps to test these changes
<!-- Clear and detailed steps to test your changes here -->
Cast aero on a puk during windsday. Check the mob's TP
Also Tested with Garuda BP Aero II