### PR TITLE
[lua] [sql] Up in Arms Improvements

### DIFF
--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -265,9 +265,10 @@ xi.mobSkill =
     METALLIC_BODY_1               =  448,
 
     GRAVITY_WHEEL                 =  457, -- Mammet-800
-
+    INK_JET_1                     =  458,
+    HARD_MEMBRANE_1               =  459,
     CROSS_ATTACK_1                =  460,
-
+    REGENERATION_1                =  461,
     MAELSTROM_1                   =  462,
 
     PSYCHOMANCY                   =  464, -- Mammet-800
@@ -785,6 +786,7 @@ xi.mobSkill =
     GERJIS_GRIP                   = 1322,
 
     -- EES_?                         = 1327,
+    INK_JET_ATTACK                = 1328,
 
     HOOF_VOLLEY                   = 1330,
     COUNTERSTANCE_3               = 1331, -- The Waughroon Kid

--- a/scripts/zones/Waughroon_Shrine/mobs/Fee.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Fee.lua
@@ -8,20 +8,20 @@ local ID = zones[xi.zone.WAUGHROON_SHRINE]
 ---@type TMobEntity
 local entity = {}
 
--- [Tentacles] { Phase HP%, Delay Reduction, Regain, Base Damage Multiplier, Skill ID for Auto-Attack }
+-- [Tentacles] { Phase HP%, Delay, Regain, Base Damage Multiplier, Skill ID for Auto-Attack }
 local tentacleTable =
 {
-    [0] = { 0,  700,   0,   0, 704 },
+    [0] = { 0,  600,   0,   0, 704 },
     [1] = { 33, 700,  50, 450,   0 },
-    [2] = { 44, 300, 100, 300,   0 },
-    [3] = { 55, 150, 125, 250,   0 },
-    [4] = { 66, 100, 150, 200,   0 },
-    [5] = { 77,   0, 175, 150,   0 },
-    [6] = { 88, -50, 200, 100,   0 },
+    [2] = { 44, 560, 100, 300,   0 },
+    [3] = { 55, 360, 125, 250,   0 },
+    [4] = { 66, 280, 150, 200,   0 },
+    [5] = { 77, 140, 175, 150,   0 },
+    [6] = { 88,  70, 200, 100,   0 },
 }
 
 local function setupPhase(mob, currentTentacles)
-    mob:setMod(xi.mod.DELAYP, tentacleTable[currentTentacles][2])
+    mob:setDelay(tentacleTable[currentTentacles][2])
     mob:setMod(xi.mod.REGAIN, tentacleTable[currentTentacles][3])
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, tentacleTable[currentTentacles][4])
     mob:setMobSkillAttack(tentacleTable[currentTentacles][5])
@@ -57,6 +57,27 @@ entity.onMobFight = function(mob, target)
     else
         mob:messageText(mob, ID.text.ONE_TENTACLE_WOUNDED, false)
     end
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    if skillId == xi.mobSkill.INK_JET_ATTACK then
+        return 0
+    end
+
+    local skillList = {}
+
+    if mob:checkDistance(target) >= 12 then
+        table.insert(skillList, xi.mobSkill.HARD_MEMBRANE_1)
+        table.insert(skillList, xi.mobSkill.REGENERATION_1)
+    end
+
+    if mob:getLocalVar('currentTentacles') == 0 then
+        table.insert(skillList, xi.mobSkill.MAELSTROM_1)
+    else
+        table.insert(skillList, xi.mobSkill.INK_JET_1)
+    end
+
+    return skillList[math.random(1, #skillList)]
 end
 
 return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1356,7 +1356,7 @@ INSERT INTO `mob_skills` VALUES (1322,984,'gerjis_grip',4,0.0,14.0,2000,1500,4,0
 -- INSERT INTO `mob_skills` VALUES (1325,1069,'wz_trsap_03',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1326,988,'final_retribution',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1327,1071,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1328,991,'ink_jet_fee',0,0.0,12.0,2000,0,4,4,0,3,0,0,0);
+INSERT INTO `mob_skills` VALUES (1328,991,'ink_jet_fee',4,12.0,7.0,2000,0,4,4,0,3,0,0,0);
 INSERT INTO `mob_skills` VALUES (1329,990,'gala_macabre',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1330,910,'hoof_volley',0,0.0,7.0,2000,1500,4,0,0,6,0,0,0);
 INSERT INTO `mob_skills` VALUES (1331,437,'counterstance_3',0,0.0,7.0,2000,0,1,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds additional polish to the BCNM "Up in Arms"

* Converts delay percentages into absolute values with a fresh capture from retail.
* Moves skill list into LUA - Only enabling Hard Membrane / Regeneration if its' target is out of range. 

## Capture

https://youtu.be/85EILCdHkGk
https://www.youtube.com/watch?v=J__m-26izzo

## Steps to test these changes

Run Up in Arms in Waughroon Shrine
