### PR TITLE
[cpp] Fixes underflow in avatar perpetuation

### DIFF
--- a/sql/pet_list.sql
+++ b/sql/pet_list.sql
@@ -106,7 +106,7 @@ INSERT INTO `pet_list` VALUES (72,'StormwakerFrame',5127,1,99,0,0,3);
 -- INSERT INTO `pet_list` VALUES (73, 'AdventuringFellow', 0, 1, 99, 0, 0);
 -- 74 is Chocobo in the enum..
 INSERT INTO `pet_list` VALUES (75,'Luopan',6040,1,99,0,0,0);
-INSERT INTO `pet_list` VALUES (76,'Siren',7047,1,99,0,0,2);
+INSERT INTO `pet_list` VALUES (76,'Siren',7047,1,99,0,3,2);
 INSERT INTO `pet_list` VALUES (77,'SweetCaroline',7500,99,119,7200,0,3);
 INSERT INTO `pet_list` VALUES (78,'AmiableRoche',7501,99,110,7200,0,2);      -- nat max 110, merit max 110
 INSERT INTO `pet_list` VALUES (79,'HeadbreakerKen',7502,99,115,7200,0,2);    -- nat max 115, merit max 115

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -2163,16 +2163,29 @@ void CStatusEffectContainer::TickRegen(timer::time_point tick)
             {
                 CPetEntity* PPet          = (CPetEntity*)m_POwner->PPet;
                 ELEMENT     petElement    = static_cast<ELEMENT>(PPet->m_Element);
-                uint8       petElementIdx = static_cast<uint8>(petElement) - 1;
+                bool        elementValid  = petElement >= ELEMENT_FIRE && petElement <= ELEMENT_DARK; // Check if the element is not 0 (None) or out of bounds
+                uint8       petElementIdx = 0;
                 ELEMENT     dayElement    = battleutils::GetDayElement();
                 auto        weather       = battleutils::GetWeather(PChar, false);
+
+                if (!elementValid)
+                {
+                    ShowWarning("CStatusEffectContainer::TickRegen() - Pet %s (PetID %u) has invalid element %u for avatar perpetuation. Check pet_list.sql.",
+                                PPet->getName(),
+                                PPet->m_PetID,
+                                PPet->m_Element);
+                }
+                else
+                {
+                    petElementIdx = static_cast<uint8>(petElement) - 1;
+                }
 
                 static const Mod     strong[8]        = { Mod::FIRE_AFFINITY_PERP, Mod::ICE_AFFINITY_PERP, Mod::WIND_AFFINITY_PERP, Mod::EARTH_AFFINITY_PERP, Mod::THUNDER_AFFINITY_PERP, Mod::WATER_AFFINITY_PERP, Mod::LIGHT_AFFINITY_PERP, Mod::DARK_AFFINITY_PERP };
                 static const Weather weatherStrong[8] = { Weather::HotSpell, Weather::Snow, Weather::Wind, Weather::DustStorm, Weather::Thunder, Weather::Rain, Weather::Auroras, Weather::Gloom };
 
                 // Day / Weather elemental matches.
-                bool dayMatch     = dayElement == petElement;
-                bool weatherMatch = weather == weatherStrong[petElementIdx] || weather == static_cast<Weather>(static_cast<uint16_t>(weatherStrong[petElementIdx]) + 1);
+                bool dayMatch     = elementValid && dayElement == petElement;
+                bool weatherMatch = elementValid && (weather == weatherStrong[petElementIdx] || weather == static_cast<Weather>(static_cast<uint16_t>(weatherStrong[petElementIdx]) + 1));
 
                 // Halve perpetuation cost before all regular reductions.
                 bool halfFromCarby   = PChar->getMod(Mod::HALF_PERPETUATION_CARBUNCLE) != 0 && PPet->m_PetID == PETID_CARBUNCLE;
@@ -2188,7 +2201,10 @@ void CStatusEffectContainer::TickRegen(timer::time_point tick)
                 perpetuationCost = perpetuationCost - PChar->getMod(Mod::PERPETUATION_REDUCTION);
 
                 // Apply elemental affinity perpetuation bonus/penalty.
-                perpetuationCost = perpetuationCost - PChar->getMod(strong[petElementIdx]);
+                if (elementValid)
+                {
+                    perpetuationCost = perpetuationCost - PChar->getMod(strong[petElementIdx]);
+                }
 
                 // Apply day element perpetuation reduction.
                 if (dayMatch)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes an underflow in petElementIdx when the element is 0. This should never 0 in the sql to begin with so added a warning and continuation of perpetuation cost.

Warning that will show if it is 0:
<img width="1256" height="151" alt="image" src="https://github.com/user-attachments/assets/829effc7-9bb4-48bf-8764-88e3eb7d5c62" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!changejob smn 99
Summon Siren see everything works
Summon any avatar see they still take MP away
<!-- Clear and detailed steps to test your changes here -->
