### PR TITLE
fix(dbtool): open modules/init.txt with utf-8 encoding

### DIFF
--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -368,7 +368,7 @@ def write_configs():
 
 
 def fetch_module_files():
-    with open(from_server_path("modules/init.txt"), "r") as file:
+    with open(from_server_path("modules/init.txt"), "r", encoding="utf-8") as file:
         for line in file.readlines():
             if not line.startswith("#") and line.strip() and not line in ["\n", "\r\n"]:
                 line = from_server_path("modules/" + line.strip())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #9639.

On Windows, `open("modules/init.txt", "r")` falls back to the system code page (cp932 in the report) which raises `UnicodeDecodeError` on the file's UTF-8 bytes. The same file is read as UTF-8 elsewhere (`src/map/CMakeLists.txt`, `src/map/utils/moduleutils.cpp`) and is written as UTF-8 by `.github/workflows/docker_build.yml`, so passing `encoding="utf-8"` here just makes `dbtool.py` consistent.

## Steps to test these changes

1. On a Windows machine with a non-UTF-8 system code page (e.g. Japanese/cp932), run `python tools/dbtool.py` with a `modules/init.txt` that contains a non-ASCII module path.
2. Before the change: `UnicodeDecodeError` is raised when reading `modules/init.txt`.
3. After the change: the file is read correctly as UTF-8 and dbtool proceeds normally.
