### PR TITLE
[cpp] Fixes linking issue for battlefield framework with superLinkGroup

### DIFF
--- a/scripts/battlefields/Sacrificial_Chamber/temple_of_uggalepih.lua
+++ b/scripts/battlefields/Sacrificial_Chamber/temple_of_uggalepih.lua
@@ -47,6 +47,8 @@ content.groups =
             },
         },
 
+        superlink = true,
+
         allDeath = function(battlefield, mob)
             battlefield:setStatus(xi.battlefield.status.WON)
         end,

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -368,6 +368,7 @@ void CLuaBattlefield::addGroups(const sol::table& groups, bool hasMultipleArenas
     // The entities to be added to the battlefield
     std::set<uint32> entities;
     std::set<uint32> spawnedEntities;
+    std::set<uint32> explicitPartyEntities;
 
     std::vector<BattlefieldGroup> battlefieldGroups;
     for (const auto& entry : groups)
@@ -490,6 +491,8 @@ void CLuaBattlefield::addGroups(const sol::table& groups, bool hasMultipleArenas
                 {
                     party->AddMember(PMob);
                 }
+
+                explicitPartyEntities.insert(entity->id);
             }
         }
 
@@ -586,7 +589,8 @@ void CLuaBattlefield::addGroups(const sol::table& groups, bool hasMultipleArenas
 
                 for (const auto& modifier : mobMods.get<sol::table>())
                 {
-                    PMob->setMobMod(modifier.first.as<uint16>(), modifier.second.as<uint16>());
+                    const auto mobMod = modifier.first.as<uint16>();
+                    PMob->setMobMod(mobMod, modifier.second.as<uint16>());
                 }
                 PMob->saveMobModifiers();
             }
@@ -678,6 +682,37 @@ void CLuaBattlefield::addGroups(const sol::table& groups, bool hasMultipleArenas
         }
 
         m_PLuaBattlefield->addGroup(group);
+    }
+
+    // Rebuild party links after all the battlefield groups have their modifiers applied
+    // This avoids ordering bugs when SUPERLINK/SUBLINK or other link-affecting state
+    // are assigned after the zone-load party pass.
+    for (uint32 entityID : entities)
+    {
+        if (explicitPartyEntities.find(entityID) != explicitPartyEntities.end())
+        {
+            continue;
+        }
+
+        auto* PMob = dynamic_cast<CMobEntity*>(zoneutils::GetEntity(entityID, TYPE_MOB));
+        if (PMob != nullptr && PMob->PParty != nullptr)
+        {
+            PMob->PParty->RemoveMember(PMob);
+        }
+    }
+
+    for (uint32 entityID : entities)
+    {
+        if (explicitPartyEntities.find(entityID) != explicitPartyEntities.end())
+        {
+            continue;
+        }
+
+        CBaseEntity* entity = zoneutils::GetEntity(entityID, TYPE_MOB);
+        if (entity != nullptr)
+        {
+            m_PLuaBattlefield->GetZone()->FindPartyForMob(entity);
+        }
     }
 
     if (m_PLuaBattlefield->GetArmouryCrate() != 0)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -378,8 +378,8 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
             }
 
             // Determine if these mobs should be in the same party.
-            // Force-link mobs with SUPERLINK only group with mobs sharing the same
-            // SUPERLINK value (used by BCNMs/Dynamis to link all mobs in an instance).
+            // Check SUPERLINK first in cases that forceLink is enables with SUPERLINK. (Like BCNMs/Dynamis)
+            // If no SUPERLINK then check if forceLink is enabled and the mob should force link.
             // Otherwise, mobs link by family or sublink as normal.
             bool  match     = false;
             int16 superlink = PMob->getMobMod(MOBMOD_SUPERLINK);
@@ -389,9 +389,7 @@ void CZoneEntities::FindPartyForMob(CBaseEntity* PEntity)
             }
             else if (forceLink)
             {
-                match = PCurrentMob->ShouldForceLink() &&
-                        ((PCurrentMob->m_Link && PCurrentMob->m_SuperFamily == PMob->m_SuperFamily) ||
-                         (sublink && sublink == PCurrentMob->getMobMod(MOBMOD_SUBLINK)));
+                match = PCurrentMob->ShouldForceLink();
             }
             else
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes superlink and superLinkGroup in BCNMs.
- Restores the correct force-link behavior accidently removed in a previous PR
- Re-links the parties after the modifiers are added to the battlefield framework. This means the ordering is now:
1. Build/spawn groups as before.
2. Run group setup callbacks.
3. Rebuild parties for non-explicit-party battlefield mobs:
    - remove existing party membership
    - rerun FindPartyForMob with final mob state
- Adjusted one BCNM to add superlink for proper behavior.

Testing videos:
https://www.youtube.com/watch?v=LLZlMZdXsvM
https://www.youtube.com/watch?v=GaPHn8T32Cg
Darkness named: https://youtu.be/d6AT0NSmjfo?t=46
Emptiness works as well:
<img width="605" height="416" alt="image" src="https://github.com/user-attachments/assets/d0347efb-0f81-44f4-b4c2-ee521a2190ff" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!zone sacrificial chamber
Enter The Temple of Uggalepih
Run to the back left of the arena behind the mobs.
Pull the far left mob.
See everything aggros you

!zone Mine Shaft
Enter Pulling The Strings
Run behind the moblin
Aggro it with anything
See Fantocciniman aggro with it
<!-- Clear and detailed steps to test your changes here -->
