### PR TITLE
[lua] Under Observation spell casting logic

### DIFF
--- a/scripts/zones/Horlais_Peak/mobs/Sobbing_Eyes.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Sobbing_Eyes.lua
@@ -52,13 +52,15 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)
-    local spellList =
-    {
-        xi.magic.spell.FIRAGA,
-        xi.magic.spell.BINDGA,
-        xi.magic.spell.BREAKGA,
-        xi.magic.spell.STUN,
-    }
+    local spellList = {}
+
+    if mob:checkDistance(target) > 4 then
+        table.insert(spellList, xi.magic.spell.BINDGA)
+        table.insert(spellList, xi.magic.spell.BREAKGA)
+    else
+        table.insert(spellList, xi.magic.spell.FIRAGA)
+        table.insert(spellList, xi.magic.spell.STUN)
+    end
 
     return spellList[math.random(1, #spellList)]
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Sobbing Eyes in UO only cast Bindga/Breakga if its' target is outside of melee range. (Specifically 4.1 yalms or greater)

## Capture

https://www.youtube.com/watch?v=ZJzqqbOXFMo

## Steps to test these changes

Run UO - Bind -> Stand at 4.1 -> Get Bindga/Breakga cast on you -> Get Firaga/Stun cast in melee range only.
