### PR TITLE
[lua] Add ENM Timer NPCs and some additional ENM KIs

### DIFF
--- a/scripts/enum/unique_event.lua
+++ b/scripts/enum/unique_event.lua
@@ -1,4 +1,4 @@
------------------------------------
+﻿-----------------------------------
 -- Unique Events
 -----------------------------------
 xi = xi or {}
@@ -24,4 +24,5 @@ xi.uniqueEvent =
     MHAURA_INTRODUCTION    =  8,
     HYRIA_INTRODUCTION     =  9,
     VANESSA_ENM_COMPLETE   = 10,
+    ENM_TIMER_NPCS_INTRO   = 11,
 }

--- a/scripts/globals/enm.lua
+++ b/scripts/globals/enm.lua
@@ -1,0 +1,105 @@
+﻿-----------------------------------
+-- Shared functionality for ENM timer NPCs
+-- Ophelia (Southern San dOria)
+-- Gregory (Bastok Mines)
+-- Istvan (Windurst Woods)
+-- Moritz (Upper Jeuno)
+-----------------------------------
+
+xi = xi or {}
+xi.enm = xi.enm or {}
+
+local cutscenes =
+{
+    ['Moritz' ] = { introduction = 10028, recurring = 10029, default = 10027 },
+    ['Ophelia'] = { introduction =   752, recurring =   753, default =   751 },
+    ['Gregory'] = { introduction =   257, recurring =   258, default =   256 },
+    ['Istvan' ] = { introduction =   693, recurring =   694, default =   692 },
+}
+
+local enmOptionToEnablementCriteria =
+{
+    [  1] = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = '[ENM]abandonmentTimer' }, --Spire Of Holla
+    [  2] = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = '[ENM]antipathyTimer'   }, --Spire Of Dem
+    [  3] = { missionReq = xi.mission.id.cop.THE_RITES_OF_LIFE,    cooldownPlayerVar = '[ENM]animusTimer'      }, --Spire Of Mea
+    [  4] = { missionReq = xi.mission.id.cop.SLANDEROUS_UTTERINGS, cooldownPlayerVar = '[ENM]acrimonyTimer'    }, --Spire Of Vahzl
+    [  5] = { missionReq = xi.mission.id.cop.AN_ETERNAL_MELODY,    cooldownPlayerVar = '[ENM]MonarchBeard'     }, --Monarch Linn
+    [  6] = { missionReq = xi.ki.PSOXJA_PASS,                      cooldownPlayerVar = '[ENM]AstralCovenant'   }, --The Shrouded Maw
+    [  7] = { missionReq = nil,                                    cooldownPlayerVar = '[ENM]OperatingLever'   }, --Mine Shaft 2716 Lever
+    [  8] = { missionReq = nil,                                    cooldownPlayerVar = '[ENM]ZephyrFan'        }, --Bearclaw Pinnacle
+    [  9] = { missionReq = nil,                                    cooldownPlayerVar = '[ENM]MiasmaFilter'     }, --Boneyard Gully
+    [100] = { missionReq = nil,                                    cooldownPlayerVar = '[ENM]GateDial'         }, --Mine Shaft 2716 Dial
+}
+
+local function hasPlayerTriggeredEnmCoolDown(player)
+    for _, v in pairs(enmOptionToEnablementCriteria) do
+        if player:getCharVar(v.cooldownPlayerVar) > 0 then
+            return true
+        end
+    end
+
+    return false
+end
+
+local function getBitmaskForAvailableENMs(player)
+    -- The cutscene allows filtering of which ENMs are shown to the player
+    -- 2^option aligns the bitmask to the ENM
+    local bitmask            = 0
+    local copMissionProgress = player:getCurrentMission(xi.mission.log_id.COP)
+
+    for i = 1, 5 do
+        if copMissionProgress <= enmOptionToEnablementCriteria[i].missionReq then
+            bitmask = bitmask + bit.lshift(1, i)
+        end
+    end
+
+    -- Special case for AstralCovenant, which is holding a ki vs a mission
+    if not player:hasKeyItem(xi.ki.PSOXJA_PASS) then
+        bitmask = bitmask + bit.lshift(1, 6)
+    end
+
+    -- Note: Bearclaw Pinnacle, Boneyard Gully, and Mine Shaft 2716 are never actually filtered - they have no pre-req
+    return bitmask
+end
+
+xi.enm.timerNpcOnTrigger = function(player, npc)
+    local hasPlayerAckdIntro = player:hasCompletedUniqueEvent(xi.uniqueEvent.ENM_TIMER_NPCS_INTRO)
+    -- using hasPlayerAckdIntro to prevent re-querying multiple player vars (enm timers) post introduction
+    -- players must complete an ENM before these NPCs will interact with them
+    if hasPlayerAckdIntro or hasPlayerTriggeredEnmCoolDown(player) then
+        if not hasPlayerAckdIntro then
+            player:startEvent(cutscenes[npc:getName()].introduction, getBitmaskForAvailableENMs(player))
+        else
+            player:startEvent(cutscenes[npc:getName()].recurring, getBitmaskForAvailableENMs(player))
+        end
+    else
+        player:startEvent(cutscenes[npc:getName()].default)
+    end
+end
+
+xi.enm.timerNpcOnEventUpdate = function(player, csid, option)
+    -- update required for a decline
+    if option == 0 then
+        player:updateEvent(1)
+        return
+    end
+
+    local enmAvailableVanaTime = player:getCharVar(enmOptionToEnablementCriteria[option].cooldownPlayerVar)
+    if enmAvailableVanaTime > VanadielTime() then
+        player:updateEvent(0, enmAvailableVanaTime)
+    else
+        player:updateEvent(0)
+    end
+end
+
+xi.enm.timerNpcOnEventFinish = function(player, csid, option)
+    local npc = player:getEventTarget()
+    -- Handle intro CS
+    if
+        csid == cutscenes[npc:getName()].introduction and option >= 0 and
+        option <= 100
+    then
+        -- verified via capture, all NPCs share a single Intro CS.  Once done at one NPC, the rest do not trigger it.
+        player:setUniqueEvent(xi.uniqueEvent.ENM_TIMER_NPCS_INTRO)
+    end
+end

--- a/scripts/missions/cop/3_5_Darkness_Named.lua
+++ b/scripts/missions/cop/3_5_Darkness_Named.lua
@@ -1,4 +1,4 @@
------------------------------------
+﻿-----------------------------------
 -- Darkness Named
 -- Promathia 3-5
 -----------------------------------
@@ -46,6 +46,7 @@ mission.sections =
                             npcUtil.tradeHasExactly(trade, xi.item.GRAY_CHIP)
                         )
                     then
+                        -- ToDo Uncaptured CS 51 seems to imply you traded the wrong item
                         return mission:progressEvent(52, xi.settings.main.GIL_RATE * 500)
                     end
                 end,

--- a/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
+++ b/scripts/zones/Attohwa_Chasm/npcs/Jakaka.lua
@@ -24,9 +24,9 @@ entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.MIASMA_FILTER) then
         player:startEvent(11)
     else
-        if miasmaFilterCD >= GetSystemTime() then
+        if miasmaFilterCD >= VanadielTime then
             -- Both Vanadiel time and unix timestamps are based on seconds. Add the difference to the event.
-            player:startEvent(14, VanadielTime() + (miasmaFilterCD - GetSystemTime()))
+            player:startEvent(14, miasmaFilterCD)
         else
             if
                 player:hasItem(xi.item.POUCH_OF_PARRADAMO_STONES) or
@@ -43,7 +43,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 12 then
         npcUtil.giveKeyItem(player, xi.ki.MIASMA_FILTER)
-        player:setCharVar('[ENM]MiasmaFilter', GetSystemTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar('[ENM]MiasmaFilter', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif csid == 13 then
         npcUtil.giveItem(player, xi.item.FLAXEN_POUCH)
     end

--- a/scripts/zones/Bastok_Mines/DefaultActions.lua
+++ b/scripts/zones/Bastok_Mines/DefaultActions.lua
@@ -18,7 +18,6 @@ return {
     ['Goraow']               = { event = 105 },
     ['Gorvik']               = { event = 185 },
     ['Gray_Wolf']            = { event = 19 },
-    ['Gregory']              = { event = 256 },
     ['Gumbah']               = { event = 52 },
     ['Hound_Nose']           = { event = 132 },
     ['Leonie']               = { event = 568 },

--- a/scripts/zones/Bastok_Mines/npcs/Gregory.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Gregory.lua
@@ -1,0 +1,25 @@
+﻿-----------------------------------
+-- Area: Bastok Mines
+--  NPC: Gregory
+-- Type: ENM Quest Timer
+-- !pos 51.530 -1 -83.940 234
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.enm.timerNpcOnTrigger(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Lower_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Lower_Jeuno/DefaultActions.lua
@@ -15,7 +15,6 @@ return {
     ['Faursel']         = { event = 10065 },
     ['Garnev']          = { event = 207 },
     ['Geuhbe']          = { event = 10033 },
-    ['Ghebi_Damomohe']  = { event = 106, options = 4 },
     ['Greyson']         = { event = 20082 },
     ['Guide_Stone']     = { messageSpecial = ID.text.GUIDE_STONE },
     ['Gurdern']         = { event = 112 },

--- a/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Ghebi_Damomohe.lua
@@ -1,12 +1,48 @@
------------------------------------
+﻿-----------------------------------
 -- Area: Lower Jeuno
 --  NPC: Ghebi Damomohe
 -- Starts and Finishes Quest: Tenshodo Membership
+-- ENM Quest Activator
 -- !pos 16 0 -5 245
 -- TODO Enum shop items
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    local astralCovenantCD = player:getCharVar('[ENM]AstralCovenant')
+
+    if
+        npcUtil.tradeHas(trade, xi.item.FLORID_STONE) and
+        player:hasKeyItem(xi.ki.PSOXJA_PASS) and
+        astralCovenantCD < VanadielTime()
+    then
+        player:startEvent(10047, 1782)
+        player:confirmTrade()
+    end
+end
+
+--TODO: Need a capture of a player with PSOXJA_PASS and Tenshodo Membership quest avaiable to see how they interact
+-- for now, Tenshodo Membership will block ENM.
+entity.onTrigger = function(player, npc)
+    local astralCovenantCD = player:getCharVar('[ENM]AstralCovenant')
+
+    if
+        player:hasKeyItem(xi.ki.PSOXJA_PASS) and
+        not player:hasKeyItem(xi.ki.ASTRAL_COVENANT)
+    then
+        if astralCovenantCD < VanadielTime() then
+            -- Tells player about Florid Stone - option 1 value 4 filters the "hidden" selection for Tenshodo Membership
+            player:startEvent(106, 4, 1, xi.item.FLORID_STONE, xi.ki.PSOXJA_PASS, xi.ki.ASTRAL_COVENANT)
+        else
+            -- Tells player they are on cooldown
+            player:startEvent(106, 4, 2, xi.ki.ASTRAL_COVENANT, astralCovenantCD)
+        end
+    else
+        -- Standard interaction
+        player:startEvent(106, 4)
+    end
+end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 106 and option == 0 then
@@ -18,6 +54,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         }
 
         xi.shop.general(player, stock, xi.fameArea.NORG)
+    elseif csid == 10047 then
+        player:setCharVar('[ENM]AstralCovenant', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        npcUtil.giveKeyItem(player, xi.ki.ASTRAL_COVENANT)
     end
 end
 

--- a/scripts/zones/RuLude_Gardens/npcs/Venessa.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Venessa.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- Area: Ru'Lude Gardens
 --  NPC: Venessa
+-- Type: ENM
 -----------------------------------
+---@type TNpcEntity
 local entity = {}
 
 local rewardMap =

--- a/scripts/zones/Southern_San_dOria/DefaultActions.lua
+++ b/scripts/zones/Southern_San_dOria/DefaultActions.lua
@@ -37,7 +37,6 @@ return {
     ['Malecharisant']        = { text = ID.text.WEST_GATE },
     ['Maugie']               = { event =  46 },
     ['Melledanne']           = { event = 943 },
-    ['Ophelia']              = { event = 751 },
     ['Paouala']              = { event =  82 },
     ['Phillone']             = { event =  29 },
     ['qm2']                  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },

--- a/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Ophelia.lua
@@ -1,0 +1,25 @@
+﻿-----------------------------------
+-- Area: Southern San d'Oria
+--  NPC: Ophelia
+-- Type: ENM Quest Timer
+-- !pos -25 2 -94.6 230
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.enm.timerNpcOnTrigger(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Tavnazian_Safehold/DefaultActions.lua
+++ b/scripts/zones/Tavnazian_Safehold/DefaultActions.lua
@@ -33,7 +33,6 @@ return {
     ['Mengrenaux']              = { event = 270 },
     ['Meret']                   = { event = 584 },
     ['Merol']                   = { event = 340 },
-    ['Morangeart']              = { event = 523 },
     ['Nery']                    = { event = 372 },
     ['Noam']                    = { event = 363 },
     ['Odeya']                   = { event = 150 },

--- a/scripts/zones/Tavnazian_Safehold/npcs/Morangeart.lua
+++ b/scripts/zones/Tavnazian_Safehold/npcs/Morangeart.lua
@@ -1,0 +1,41 @@
+﻿-----------------------------------
+-- Area: Tavnazian Safehold
+--  NPC: Morangeart
+-- Type: ENM Quest Activator
+-- !pos -74.308 -24.782 -28.475 26
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    local monarchBeardCD = player:getCharVar('[ENM]MonarchBeard')
+
+    if player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY then
+        if player:hasKeyItem(xi.ki.MONARCH_BEARD) then
+            player:startEvent(520)
+        else
+            if monarchBeardCD < VanadielTime() then
+                player:startEvent(521)
+            else
+                player:startEvent(522, monarchBeardCD)
+            end
+        end
+    else
+        player:startEvent(523)
+    end
+end
+
+entity.onEventUpdate = function(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    if csid == 521 then
+        npcUtil.giveKeyItem(player, xi.ki.MONARCH_BEARD)
+        player:setCharVar('[ENM]MonarchBeard', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+    end
+end
+
+return entity

--- a/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
+++ b/scripts/zones/Uleguerand_Range/npcs/Zebada.lua
@@ -24,9 +24,9 @@ entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.ZEPHYR_FAN) then
         player:startEvent(12)
     else
-        if zephyrFanCD >= GetSystemTime() then
+        if zephyrFanCD >= VanadielTime() then
             -- Both Vanadiel time and unix timestamps are based on seconds. Add the difference to the event.
-            player:startEvent(15, VanadielTime() + (zephyrFanCD - GetSystemTime()))
+            player:startEvent(15, zephyrFanCD)
         else
             if
                 player:hasItem(xi.item.HANDFUL_OF_CHAMNAET_ICE) or
@@ -43,7 +43,7 @@ end
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 13 then
         npcUtil.giveKeyItem(player, xi.ki.ZEPHYR_FAN)
-        player:setCharVar('[ENM]ZephyrFan', GetSystemTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
+        player:setCharVar('[ENM]ZephyrFan', VanadielTime() + (xi.settings.main.ENM_COOLDOWN * 3600)) -- Current time + (ENM_COOLDOWN*1hr in seconds)
     elseif csid == 14 then
         npcUtil.giveItem(player, xi.item.COTTON_POUCH)
     end

--- a/scripts/zones/Upper_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Upper_Jeuno/DefaultActions.lua
@@ -35,7 +35,6 @@ return {
     ['Mhao_Kehtsoruho'] = { event = 10173 },
     ['Migliorozz']      = { event = 10026 },
     ['Mojuro-Nojuro']   = { event = 128 },
-    ['Moritz']          = { event = 10027 },
     ['Nekha_Shachaba']  = { event = 123 },
     ['Nevela']          = { event = 69 },
     ['Olgald']          = { event = 10122 },

--- a/scripts/zones/Upper_Jeuno/npcs/Moritz.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/Moritz.lua
@@ -1,0 +1,25 @@
+﻿-----------------------------------
+-- Area: Upper Jeuno
+--  NPC: Moritz
+-- Type: ENM Quest Timer
+-- !pos 2.1 1.8 60.5 244
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.enm.timerNpcOnTrigger(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
+end
+
+return entity

--- a/scripts/zones/Windurst_Woods/DefaultActions.lua
+++ b/scripts/zones/Windurst_Woods/DefaultActions.lua
@@ -25,7 +25,6 @@ return {
     ['Hayah_Dahbalesahma'] = { event = 263 },
     ['Hlif']               = { event = 434 },
     ['Hohl_Nhaesin']       = { event = 342 },
-    ['Istvan']             = { event = 692 },
     ['Iya_Rihyo']          = { event = 419 },
     ['Kapeh_Myohrye']      = { event = 340 }, -- There is at current an unknown mission/quest/status that alters their dialog. Windurst citizens get something different than other nations.
     ['Khomi_Tibariah']     = { event = 262 },

--- a/scripts/zones/Windurst_Woods/npcs/Istvan.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Istvan.lua
@@ -1,0 +1,25 @@
+﻿-----------------------------------
+-- Area: Windurst Woods
+--  NPC: Istvan
+-- Type: ENM Quest Timer
+-- !pos 116.294 -6 -98.164 241
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+end
+
+entity.onTrigger = function(player, npc)
+    xi.enm.timerNpcOnTrigger(player, npc)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+    xi.enm.timerNpcOnEventUpdate(player, csid, option)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    xi.enm.timerNpcOnEventFinish(player, csid, option)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Adds the following NPCs which are ENM Timer NPCs.  These NPCs will inform players of their current ENM cooldowns once the player has completed an ENM.
    1. Upper Jeuno - Moritz
    2. Windurst Woods - Istvan
    3. South Sandy - Ophelia
    4. Bastok Mines - Gregory
1. Adds a global file - `enm.lua` 
    1. Created to follow rule of 3/DRY.  
    2. Can be used to migrate other shared ENM information in the future - hence the generic name.
1. Adds the following ENM KI access:
    1. Tavnazian Safehold - Morangeart - Monarch Beard
        1.  Enables Monarch Linn ENMs - No changes made to the actual ENM fights
    1. Lower Jeuno - Ghebi Damomohe - Astral Covenant
        1. Enables Test Your Mite -  No changes made to the actual ENM fights
3.  Updates multiple DefaultAction luas to remove default only behavior for these NPCs

## Breaking Change for Live Servers
1. Modifies the following ENM NPCs to use `VanadielTime()` when working with cooldowns - fixing display errors.
    1. Attohwa Chasm - Jakaka
    1. Uleguerand Range - Zebada
    2. **This change will break ENM Cooldowns for all players for these two NPCs**   
        1. Players will have values set far into the future vs VanadielTime(). 
        1. Advised to purge the following CharVars from all players:
            1.  `[ENM]MiasmaFilter`
            2. `[ENM]ZephyrFan`

## Known TODOs:
The following interactions are uncaptured at this time
1. *Ghebi Damomohe - Tenshodo Membership vs ENM*
    2.  Event Decompile and Testing with !CS show that the hidden quest selection and ENM information can be generated at the same time - however it is unknown if retail actually does this.
    4. Char Requirements: 
        5. Rank 3 Jeuno Fame.  
        6. Never started or completed Tenshodo Membership.  
        7. Completed CoP up to gaining a PsoXja Pass.
        8. Has not completed all of COP - Ideally stopping right after Diabolos
            9. This will allow verification of filtering based on access.
    10. For now, this impl allows an active Tenshodo Membership to block ENM access.
11. *Ghebi Damomohe - Unrelated to this change - Missing CS 51*
    12. While investigating decompiled events - I cam across a CS we are missing which appears to happen during Darkness Named.  
    13. It seems trading the wrong chips (maybe the goblin sold chips) will cause the trade to be rejected.
    14. Can be captured by the same char that captures case 1
15. Verification

## Capture References:
- Multiple on Capture Discord thanks to Siknoz - search Moritz
- [Playlist of multiple captain interactions](https://youtube.com/playlist?list=PL_htfg_0o7PJrM6AoRqMX9tp9X9DXOxG6&si=0BAfJurb86OGcEyQ)
    - I plan to expand this list in a few days when my ENM timers are off cooldown.

## Steps to test these changes

1. Set Mission and/or KI progress to enable accessing ENM KIs
2. Clear (delete) all ENM timer vars on the character (to test step 4)
3. Navigate to one of the Timer NPCs (`!pos` commands are on each NPC)
4. Note that the NPCs dont interact, and just give a line of dialogue.  No intro with and acceptance dialog.
5. Obtain an ENM KI - note which has been obtained
6. Navigate to one of the Timer NPCs (`!pos` commands are on each NPC)
7. Get the intro dialog and decline
8. Cycle between the remaining NPCs, continually decline
9. After checking all NPCs, accept
10. In the ENM selections, try different combinations like hitting esc, declining, selecting ENMs on cooldown, and selecting ENMs not on cooldown.
11. Note that only ENMs the player has access to populate the list.
12. Note that the 3 ENMs with no pre-reqs are always available
13. Repeat with different ENM KIs by obtaining them (or setting CharVars through Heidi)