### PR TITLE
[lua] Various battlefield superlinking setup

### DIFF
--- a/scripts/battlefields/Balgas_Dais/divine_punishers.lua
+++ b/scripts/battlefields/Balgas_Dais/divine_punishers.lua
@@ -58,6 +58,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/battlefields/Balgas_Dais/royale_ramble.lua
+++ b/scripts/battlefields/Balgas_Dais/royale_ramble.lua
@@ -64,6 +64,7 @@ content.groups =
 
         },
 
+        superlinkGroup = 1,
         death = handleDeath,
     },
 
@@ -86,6 +87,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         spawned = false,
         death = handleDeath,
     },

--- a/scripts/battlefields/Balgas_Dais/steamed_sprouts.lua
+++ b/scripts/battlefields/Balgas_Dais/steamed_sprouts.lua
@@ -63,6 +63,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/battlefields/Bearclaw_Pinnacle/follow_the_white_rabbit.lua
+++ b/scripts/battlefields/Bearclaw_Pinnacle/follow_the_white_rabbit.lua
@@ -58,6 +58,7 @@ content.groups =
 
         },
 
+        superlinkGroup = 1,
         death = handleDeath,
     },
 
@@ -90,6 +91,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         spawned = false,
         death = handleDeath,
     },

--- a/scripts/battlefields/Bearclaw_Pinnacle/when_hell_freezes_over.lua
+++ b/scripts/battlefields/Bearclaw_Pinnacle/when_hell_freezes_over.lua
@@ -94,6 +94,7 @@ content.groups =
                 bearclawID.mob.SNOW_DEVIL + 21,
             },
         },
+        superlink = true,
         spawned = false,
 
         allDeath = function(battlefield, mob)

--- a/scripts/battlefields/Boneyard_Gully/shell_we_dance.lua
+++ b/scripts/battlefields/Boneyard_Gully/shell_we_dance.lua
@@ -48,6 +48,7 @@ content.groups =
 
         },
 
+        superlinkGroup = 1,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 
@@ -82,6 +83,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/Horlais_Peak/dismemberment_brigade.lua
+++ b/scripts/battlefields/Horlais_Peak/dismemberment_brigade.lua
@@ -57,6 +57,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/battlefields/Horlais_Peak/tails_of_woe.lua
+++ b/scripts/battlefields/Horlais_Peak/tails_of_woe.lua
@@ -63,6 +63,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/battlefields/Mine_Shaft_2716/automaton_assault.lua
+++ b/scripts/battlefields/Mine_Shaft_2716/automaton_assault.lua
@@ -85,6 +85,7 @@ local function buildAutomatonGroup(battlefield, initiatorRace)
 
     return {
         mobIds   = mobIds,
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     }
 end

--- a/scripts/battlefields/Monarch_Linn/beloved_of_the_atlantes.lua
+++ b/scripts/battlefields/Monarch_Linn/beloved_of_the_atlantes.lua
@@ -23,11 +23,13 @@ content.groups =
 {
     {
         mobs      = { 'Watch_Hippogryph' },
+        superlinkGroup = 1,
         allDeath  = utils.bind(content.handleAllMonstersDefeated, content),
     },
 
     {
         mobs      = { 'Guard_Hippogryph' },
+        superlinkGroup = 1,
         spawned  = false,
     },
 }

--- a/scripts/battlefields/Monarch_Linn/uninvited_guests.lua
+++ b/scripts/battlefields/Monarch_Linn/uninvited_guests.lua
@@ -31,6 +31,8 @@ content.groups =
             { monarchLinnID.mob.MAMMET_800 + 10 },
             { monarchLinnID.mob.MAMMET_800 + 20 },
         },
+
+        superlinkGroup = 1,
     },
 
     {
@@ -70,6 +72,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/QuBia_Arena/factory_rejects.lua
+++ b/scripts/battlefields/QuBia_Arena/factory_rejects.lua
@@ -33,6 +33,8 @@ content.groups =
             { qubiaID.mob.DOLL_FACTORY + 7  },
             { qubiaID.mob.DOLL_FACTORY + 14 },
         },
+
+        superlinkGroup = 1,
     },
 
     {
@@ -70,6 +72,7 @@ content.groups =
             end
         end,
 
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/Riverne_Site_B01/wyrmking_descends.lua
+++ b/scripts/battlefields/Riverne_Site_B01/wyrmking_descends.lua
@@ -43,28 +43,27 @@ content.groups =
 {
     {
         mobs = { 'Bahamut_bv2' },
-
-        superlink = true,
+        superlinkGroup = 1,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
     {
         mobs = { 'Ouryu_bv2' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
         mobs = { 'Tiamat_bv2' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
         mobs = { 'Jormungand_bv2' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
         mobs = { 'Vrtra_bv2' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
@@ -84,17 +83,17 @@ content.groups =
     },
     {
         mobs = { 'Pey' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
         mobs = { 'Iruci' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
     {
         mobs = { 'Airi' },
-        superlink = true,
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/Sacrificial_Chamber/amphibian_assault.lua
+++ b/scripts/battlefields/Sacrificial_Chamber/amphibian_assault.lua
@@ -65,6 +65,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         allDeath = handleDeath,
     },
 
@@ -76,6 +77,7 @@ content.groups =
             { sacrificialChamberID.mob.QULL_THE_FALLSTOPPER + 17 }, -- Sahagins Wyvern
         },
 
+        superlink = true,
         spawned = false,
         allDeath = handleDeath,
     },

--- a/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
+++ b/scripts/battlefields/Spire_of_Dem/you_are_what_you_eat.lua
@@ -24,11 +24,13 @@ content.groups =
 {
     {
         mobs      = { 'Ingester' },
+        superlinkGroup = 1,
         allDeath  = utils.bind(content.handleAllMonstersDefeated, content),
     },
 
     {
         mobs      = { 'Neoingester', 'Neogorger', 'Neosatiator', 'Wanderer_enm' },
+        superlinkGroup = 1,
         spawned  = false,
     },
 }

--- a/scripts/battlefields/Spire_of_Holla/simulant.lua
+++ b/scripts/battlefields/Spire_of_Holla/simulant.lua
@@ -42,6 +42,7 @@ content.groups =
                 spireOfHollaID.mob.COGITATOR + 10,
             },
         },
+        superlinkGroup = 1,
         allDeath  = utils.bind(content.handleAllMonstersDefeated, content),
     },
 
@@ -66,6 +67,7 @@ content.groups =
                 spireOfHollaID.mob.COGITATOR + 13,
             },
         },
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/Spire_of_Mea/playing_host.lua
+++ b/scripts/battlefields/Spire_of_Mea/playing_host.lua
@@ -36,6 +36,7 @@ content.groups =
             { spireOfMeaID.mob.ENVIER + 10 },
         },
 
+        superlinkGroup = 1,
         allDeath  = utils.bind(content.handleAllMonstersDefeated, content),
     },
 
@@ -62,6 +63,7 @@ content.groups =
             },
         },
 
+        superlinkGroup = 1,
         spawned = false,
     },
 }

--- a/scripts/battlefields/Waughroon_Shrine/grimshell_shocktroopers.lua
+++ b/scripts/battlefields/Waughroon_Shrine/grimshell_shocktroopers.lua
@@ -58,6 +58,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/battlefields/Waughroon_Shrine/worms_turn.lua
+++ b/scripts/battlefields/Waughroon_Shrine/worms_turn.lua
@@ -87,6 +87,7 @@ content.groups =
             },
         },
 
+        superlink = true,
         allDeath = utils.bind(content.handleAllMonstersDefeated, content),
     },
 }

--- a/scripts/zones/Balgas_Dais/mobs/Aa_Nawu_the_Thunderblade.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Aa_Nawu_the_Thunderblade.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Balgas_Dais/mobs/Cuu_Doko_the_Blizzard.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Cuu_Doko_the_Blizzard.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Domovoi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Domovoi.lua
@@ -8,7 +8,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Balgas_Dais/mobs/Dvorovoi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Dvorovoi.lua
@@ -8,7 +8,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 60)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 -- Dvorovoi uses Paralyga, Blindga, and Flood randomly as spells.

--- a/scripts/zones/Balgas_Dais/mobs/Gii_Jaha_the_Raucous.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gii_Jaha_the_Raucous.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Myrmidon_Apu-apu.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Myrmidon_Apu-apu.lua
@@ -9,7 +9,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Balgas_Dais/mobs/Myrmidon_Epa-epa.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Myrmidon_Epa-epa.lua
@@ -9,7 +9,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Balgas_Dais/mobs/Myrmidon_Spo-spo.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Myrmidon_Spo-spo.lua
@@ -9,7 +9,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Balgas_Dais/mobs/Opo-opo_Heir.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Opo-opo_Heir.lua
@@ -9,7 +9,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 -- Doesn't fight until Monarch is defeated.

--- a/scripts/zones/Balgas_Dais/mobs/Opo-opo_Monarch.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Opo-opo_Monarch.lua
@@ -10,7 +10,6 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 60)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobFight = function(mob, target)

--- a/scripts/zones/Balgas_Dais/mobs/Voo_Tolu_the_Ghostfist.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Voo_Tolu_the_Ghostfist.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Balgas_Dais/mobs/Yoo_Mihi_the_Haze.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Yoo_Mihi_the_Haze.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Zuu_Xowu_the_Darksmoke.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Zuu_Xowu_the_Darksmoke.lua
@@ -12,7 +12,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Chamber_of_Oracles/mobs/Blizzard_Wyvern.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Blizzard_Wyvern.lua
@@ -7,7 +7,6 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 17)
 end

--- a/scripts/zones/Chamber_of_Oracles/mobs/Centurio_XI-I.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Centurio_XI-I.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Chamber_of_Oracles/mobs/Chaos_Wyvern.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Chaos_Wyvern.lua
@@ -7,7 +7,6 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 17)
 end

--- a/scripts/zones/Chamber_of_Oracles/mobs/Hoplomachus_XI-XXVI.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Hoplomachus_XI-XXVI.lua
@@ -13,7 +13,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Chamber_of_Oracles/mobs/Lightning_Wyvern.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Lightning_Wyvern.lua
@@ -7,7 +7,6 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 17)
 end

--- a/scripts/zones/Chamber_of_Oracles/mobs/Radiant_Wyvern.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Radiant_Wyvern.lua
@@ -7,7 +7,6 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 17)
 end

--- a/scripts/zones/Chamber_of_Oracles/mobs/Retiarius_XI-XIX.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Retiarius_XI-XIX.lua
@@ -13,7 +13,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Chamber_of_Oracles/mobs/Sabotender_Amante.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Sabotender_Amante.lua
@@ -11,7 +11,6 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.PETRIFY)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Chamber_of_Oracles/mobs/Sabotender_Campeon.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Sabotender_Campeon.lua
@@ -53,7 +53,6 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.BIND)
     mob:addImmunity(xi.immunity.PETRIFY)
     mob:setMagicCastingEnabled(false) -- Only casts upon returning from a run!
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Chamber_of_Oracles/mobs/Secutor_XI-XXXII.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Secutor_XI-XXXII.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Horlais_Peak/mobs/Armsmaster_Dekbuk.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Armsmaster_Dekbuk.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Horlais_Peak/mobs/Invulnerable_Mazzgozz.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Invulnerable_Mazzgozz.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Horlais_Peak/mobs/Keeneyed_Aufwuf.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Keeneyed_Aufwuf.lua
@@ -12,7 +12,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Horlais_Peak/mobs/Longarmed_Gottditt.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Longarmed_Gottditt.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Horlais_Peak/mobs/Minds-eyed_Klugwug.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Minds-eyed_Klugwug.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Horlais_Peak/mobs/Undefeatable_Sappdapp.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Undefeatable_Sappdapp.lua
@@ -12,7 +12,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Disfaurit_B_DAurphe.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Disfaurit_B_DAurphe.lua
@@ -10,7 +10,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Jeumouque_B_DAurphe.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Jeumouque_B_DAurphe.lua
@@ -10,7 +10,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Maldaramet_B_DAurphe.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maldaramet_B_DAurphe.lua
@@ -12,7 +12,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 15)
     mob:setMobMod(xi.mobMod.STANDBACK_COOL, 5)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Nephiyl_Keepcollapser.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Nephiyl_Keepcollapser.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Nephiyl_Moatfiller.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Nephiyl_Moatfiller.lua
@@ -11,7 +11,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Nephiyl_Pinnacletosser.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Nephiyl_Pinnacletosser.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Nephiyl_Rampartbreacher.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Nephiyl_Rampartbreacher.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/QuBia_Arena/mobs/Vaicoliaux_B_DAurphe.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Vaicoliaux_B_DAurphe.lua
@@ -10,7 +10,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Cyaneous-toed_Yallberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Cyaneous-toed_Yallberry.lua
@@ -18,7 +18,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Hyohh_the_Conchblower.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Hyohh_the_Conchblower.lua
@@ -20,7 +20,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Pevv_the_Riverleaper.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Pevv_the_Riverleaper.lua
@@ -13,7 +13,6 @@ entity.onMobInitialize = function(mob)
     xi.pet.setMobPet(mob, 2, 'Sahagins_Wyvern')
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Qull_the_Fallstopper.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Qull_the_Fallstopper.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Rauu_the_Whaleswooner.lua
@@ -12,7 +12,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Sable-tongued_Gonberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Sable-tongued_Gonberry.lua
@@ -17,7 +17,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
 end
 

--- a/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Vermilion-eared_Noberry.lua
@@ -18,7 +18,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 3)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Sacrificial_Chamber/mobs/Virid-faced_Shanberry.lua
+++ b/scripts/zones/Sacrificial_Chamber/mobs/Virid-faced_Shanberry.lua
@@ -16,7 +16,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 8)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Throne_Room/mobs/Count_Andromalius.lua
+++ b/scripts/zones/Throne_Room/mobs/Count_Andromalius.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 6)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 7)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Throne_Room/mobs/Demons_Elemental.lua
+++ b/scripts/zones/Throne_Room/mobs/Demons_Elemental.lua
@@ -7,10 +7,6 @@
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {

--- a/scripts/zones/Throne_Room/mobs/Duke_Amduscias.lua
+++ b/scripts/zones/Throne_Room/mobs/Duke_Amduscias.lua
@@ -5,7 +5,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 6)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 7)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)

--- a/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
+++ b/scripts/zones/Throne_Room/mobs/Duke_Dantalian.lua
@@ -14,7 +14,6 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 3)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 6)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 7)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Throne_Room/mobs/Grand_Marquis_Chomiel.lua
+++ b/scripts/zones/Throne_Room/mobs/Grand_Marquis_Chomiel.lua
@@ -12,7 +12,6 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 6)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 7)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 return entity

--- a/scripts/zones/Waughroon_Shrine/mobs/BiFho_Jestergrin.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/BiFho_Jestergrin.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Waughroon_Shrine/mobs/EaTho_Cruelheart.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/EaTho_Cruelheart.lua
@@ -10,10 +10,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Waughroon_Shrine/mobs/KaNha_Jabbertongue.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/KaNha_Jabbertongue.lua
@@ -12,7 +12,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Waughroon_Shrine/mobs/KuTya_Hotblood.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/KuTya_Hotblood.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/Waughroon_Shrine/mobs/YoBhu_Hideousmask.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/YoBhu_Hideousmask.lua
@@ -9,10 +9,6 @@ mixins = { require('scripts/mixins/job_special') }
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
-end
-
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 4)
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 4)

--- a/scripts/zones/Waughroon_Shrine/mobs/ZoDhu_Legslicer.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/ZoDhu_Legslicer.lua
@@ -11,7 +11,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
-    mob:setMobMod(xi.mobMod.SUPERLINK, 1)
 end
 
 entity.onMobSpawn = function(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes superlinking in several battlefields by letting it be handled by the battlefield framework. A follow up to Franks PR.

* Battlefields where the monsters are grouped in a single bracket (all spawned at once) are now defined with superlink = true

* Battlefields where the monsters are in different brackets due to being spawned at different points during the fight are now linked with superlinkGroup = 1,

* Battlefields setup with content:addEssentialMobs already have superlink applied automatically.

* Removes superlink mobmod from several enemies, as it is no longer needed.

## Steps to test these changes

Run Automaton Assault, Wyrmking Descends, When Hell Freezes Over, Steamed Spouts or any of the other changed BCNMs, see superlink now works.