### PR TITLE
[lua] Convert Bugfix

### DIFF
--- a/scripts/actions/abilities/convert.lua
+++ b/scripts/actions/abilities/convert.lua
@@ -9,6 +9,10 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
+    if player:getMP() == 0 then
+        return xi.msg.basic.CANNOT_PERFORM, 0
+    end
+
     return 0, 0
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When players attempt to convert on retail at 0 MP the ability cannot be used and you are given the "player cannot perform that action message"

<img width="1882" height="145" alt="image" src="https://github.com/user-attachments/assets/d759ab64-ff53-4160-a4a7-c3fa2e3e81af" />

Currently on LSB, at 0 MP, convert is able to be used but it does not swap your HP/MP. 

This bugfix prevents convert from being used at all at 0 MP and displays the proper message.

## Steps to test these changes

Change job to RDM
Set MP to 0
Attempt to convert
see "player cannot perform that action.)

<img width="501" height="157" alt="image" src="https://github.com/user-attachments/assets/9e76a8ed-a5b0-41ad-a1a7-4ef6db150236" />

