### PR TITLE
[core] Decrement equipped ammo / Send item packet update on craft fail

### DIFF
--- a/scripts/tests/systems/items/equip.lua
+++ b/scripts/tests/systems/items/equip.lua
@@ -87,6 +87,17 @@ describe('Equipment', function()
         assert(player:getEquippedItem(xi.slot.MAIN) == nil)
     end)
 
+    it('equipped ammo stack decrements on use', function()
+        player:addItem(xi.item.FIRE_ARROW, 50)
+        player:equipItem(xi.item.FIRE_ARROW, nil, xi.slot.AMMO)
+
+        player:delItem(xi.item.FIRE_ARROW, 1)
+
+        local ammo = player:getEquippedItem(xi.slot.AMMO)
+        assert(ammo)
+        assert(ammo:getQuantity() == 49)
+    end)
+
     it('all visible armor slots accept their piece', function()
         local pieces =
         {

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -119,7 +119,7 @@ CItemState::CItemState(CCharEntity* PEntity, const uint16 targid, const uint8 lo
     m_PEntity->UContainer->SetType(UCONTAINER_USEITEM);
     m_PEntity->UContainer->SetItem(0, m_PItem);
 
-    tx_             = ItemUseTransaction::start(m_PEntity, m_PItem);
+    tx_             = m_PEntity->addTransaction(ItemUseTransaction::start(m_PEntity, m_PItem));
     m_startPos      = m_PEntity->loc.p;
     m_castTime      = m_PItem->getActivationTime();
     m_animationTime = m_PItem->getAnimationTime();
@@ -241,13 +241,9 @@ void CItemState::Cleanup(timer::time_point tick)
 {
     m_PEntity->UContainer->Clean();
 
-    // Clear InTransaction before the ITEM_LIST packet below.
-    if (m_interrupted || !IsCompleted())
+    if (tx_ && tx_->isOpen())
     {
-        if (tx_)
-        {
-            tx_->rollback();
-        }
+        tx_->rollback();
     }
 
     if (m_PItem && (m_interrupted || !IsCompleted()) && !m_PItem->isType(ITEM_EQUIPMENT))

--- a/src/map/ai/states/item_state.h
+++ b/src/map/ai/states/item_state.h
@@ -23,8 +23,6 @@
 
 #include "state.h"
 
-#include <memory>
-
 class CBattleEntity;
 class CCharEntity;
 class CItemUsable;
@@ -62,14 +60,14 @@ public:
 protected:
     bool HasMoved() const;
 
-    CCharEntity*                        m_PEntity;
-    CItemUsable*                        m_PItem;
-    uint8                               m_location;
-    uint8                               m_slot;
-    timer::duration                     m_castTime{};
-    timer::duration                     m_animationTime{};
-    position_t                          m_startPos;
-    bool                                m_interrupted{ false };
-    bool                                m_interruptable{ true };
-    std::unique_ptr<ItemUseTransaction> tx_;
+    CCharEntity*        m_PEntity;
+    CItemUsable*        m_PItem;
+    uint8               m_location;
+    uint8               m_slot;
+    timer::duration     m_castTime{};
+    timer::duration     m_animationTime{};
+    position_t          m_startPos;
+    bool                m_interrupted{ false };
+    bool                m_interruptable{ true };
+    ItemUseTransaction* tx_{ nullptr };
 };

--- a/src/map/items/transactions/synth.cpp
+++ b/src/map/items/transactions/synth.cpp
@@ -251,6 +251,7 @@ void SynthTransaction::releaseAllClaims()
         {
             exitTx(item);
             item->setSubType(ITEM_UNLOCKED);
+            this->player_->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(item, ItemLockFlg::Normal);
         }
 
         this->slots_[i].item = nullptr;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1933,7 +1933,10 @@ uint32 UpdateItem(CCharEntity* PChar, uint8 LocationID, uint8 slotID, int32 quan
         }
     }
 
-    if (PItem->isBusy() && !force)
+    // Equipped ammo decrements its stack on consumption without leaving the slot.
+    const bool isEquippedAmmo = PItem->state() == ItemState::Equipped &&
+                                PChar->getEquip(SLOT_AMMO) == PItem;
+    if (PItem->isBusy() && !isEquippedAmmo && !force)
     {
         ShowWarningFmt("UpdateItem: refusing to mutate busy item {} in state {} (loc={}, slot={}, char={})",
                        ItemID,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Move where the ItemUse transaction is stored so the destructors runs in the right order - this was reported by @Frankie-hz with ASan
- Closes #10038 : Send an explicit unlock item packet to the client when a given material is saved by the synth attempt
- Closes #10018 : Allow equipped ammo to be mutated

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
