### PR TITLE
[core] Don't clobber look string data for entities that dont have it

### DIFF
--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -587,7 +587,8 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
         std::memcpy(start, name.c_str(), maxLength);
     }
 
-    if (packet->SendFlg.General)
+    //  Don't overwrite data for model size and hitbox size from look string on NPCs
+    if (packet->SendFlg.General && (PEntity->objtype == TYPE_PC || PEntity->objtype == TYPE_PET || PEntity->objtype == TYPE_MOB))
     {
         packet->Flags1.GraphSize = PEntity->modelSize;
         // For some reason, SE reused a player struct where this "g" value is the hitbox size.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: we don't _currently_ store model hitbox size and graph size for non player/mob/pet so we don't want to override what was memcpyed from look string/namevis/whatever

## Steps to test these changes

!cs 705 in whitegate
before:
<img width="659" height="1035" alt="image" src="https://github.com/user-attachments/assets/b466f39e-804b-451e-9e29-13a1017b7d49" />

after:
<img width="681" height="751" alt="image" src="https://github.com/user-attachments/assets/070e1e0b-9466-4c47-8ccb-50a389308957" />


