### PR TITLE
[core] Use slot to determine delay for TP return

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1864,7 +1864,7 @@ auto GetBaseRangedDelay(CBattleEntity* PEntity) -> uint16
     return baseDelay;
 }
 
-auto CalculateTPFromDamageDealt(CBattleEntity* PAttacker, bool isZanshin) -> int32
+auto CalculateTPFromDamageDealt(CBattleEntity* PAttacker, const bool& isZanshin, const SLOTTYPE& slot) -> int32
 {
     if (PAttacker == nullptr)
     {
@@ -1872,9 +1872,14 @@ auto CalculateTPFromDamageDealt(CBattleEntity* PAttacker, bool isZanshin) -> int
         return 0;
     }
 
-    int32 tpReturn = luautils::callGlobal<int32>("xi.combat.tp.getSingleMeleeHitTPReturn", PAttacker, isZanshin);
-
-    return tpReturn;
+    if (slot == SLOT_RANGED || slot == SLOT_AMMO)
+    {
+        return luautils::callGlobal<int32>("xi.combat.tp.getSingleRangedHitTPReturn", PAttacker);
+    }
+    else
+    {
+        return luautils::callGlobal<int32>("xi.combat.tp.getSingleMeleeHitTPReturn", PAttacker, isZanshin);
+    }
 }
 
 auto CalculateTPFromDamageTaken(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 damage, uint16 delay) -> int32
@@ -2267,7 +2272,7 @@ int32 TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHY
         {
             bool isZanshin = physicalAttackType == PHYSICAL_ATTACK_TYPE::ZANSHIN;
 
-            int16 attackerTPReturn = CalculateTPFromDamageDealt(PAttacker, isZanshin);
+            int16 attackerTPReturn = CalculateTPFromDamageDealt(PAttacker, isZanshin, static_cast<SLOTTYPE>(slot));
 
             PAttacker->addTP((int16)(tpMultiplier * attackerTPReturn));
         }
@@ -2396,7 +2401,7 @@ int32 TakeWeaponskillDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, 
         if (primary)
         // Calculate TP Return from WS
         {
-            int16 baseTp = CalculateTPFromDamageDealt(PAttacker, false);
+            int16 baseTp = CalculateTPFromDamageDealt(PAttacker, false, static_cast<SLOTTYPE>(slot));
 
             standbyTp = bonusTP + (int16)((tpMultiplier * baseTp));
         }

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -180,7 +180,7 @@ bool  CanUseWeaponskill(CCharEntity* PChar, CWeaponSkill* PSkill);
 int16 CalculateBaseTP(CBattleEntity* PEntity, int32 delay);
 auto  GetBaseDelay(CBattleEntity* PEntity) -> uint16;       // get base delay of entity, melee only
 auto  GetBaseRangedDelay(CBattleEntity* PEntity) -> uint16; // get base delay of entity, ranged only
-auto  CalculateTPFromDamageDealt(CBattleEntity* PAttacker, bool isZanshin) -> int32;
+auto  CalculateTPFromDamageDealt(CBattleEntity* PAttacker, const bool& isZanshin, const SLOTTYPE& slot) -> int32;
 auto  CalculateTPFromDamageTaken(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 damage, uint16 delay) -> int32;
 void  GenerateCureEnmity(CBattleEntity* PSource, CBattleEntity* PTarget, int32 amount, int32 fixedCE = 0, int32 fixedVE = 0);
 void  GenerateInRangeEnmity(CBattleEntity* PSource, int32 CE, int32 VE);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: all attacks were using main hand for delay when they should not

## Steps to test these changes

/ra and get /ra delay, melee and get melee delay for the purposes of tp return
