### PR TITLE
[core] Fix hit distortion wrap on overkills

### DIFF
--- a/src/map/action/action.cpp
+++ b/src/map/action/action.cpp
@@ -64,7 +64,7 @@ auto action_result_t::recordDamage(const attack_outcome_t& outcome) -> action_re
             if (const auto* PTarget = outcome.target)
             {
                 // Calculate damage percentage
-                const uint8_t damageHPP  = PTarget->GetMaxHP() > 0 ? static_cast<uint8_t>((outcome.damage * 100) / PTarget->GetMaxHP()) : 0;
+                const int32_t damageHPP  = PTarget->GetMaxHP() > 0 ? (outcome.damage * 100) / PTarget->GetMaxHP() : 0;
                 auto          distortion = HitDistortion::None;
 
                 // Values below need to be refined


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Hit distortion is wrapping around on overkills against mobs with low max HP which I think is causing the Head Butt test to sometimes fail due to the test setting the mob to 1 HP.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
