### PR TITLE
[sql] Fix Pantin Tobe +1 pet acc bonus

### DIFF
--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -128,7 +128,7 @@ INSERT INTO `item_mods_pet` VALUES (11297,5,24,7); -- Stormwaker - MP: 24
 INSERT INTO `item_mods_pet` VALUES (11298,25,10,3); -- Automaton - ACC: 10
 
 -- Pantin Tobe +1
-INSERT INTO `item_mods_pet` VALUES (11299,25,10,3); -- Automaton - ACC: 10
+INSERT INTO `item_mods_pet` VALUES (11299,25,12,3); -- Automaton - ACC: 12
 
 -- Aegas Doublet
 INSERT INTO `item_mods_pet` VALUES (11338,25,3,0);  -- All Pets - ACC: 3


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This PR corrects the automaton accuracy bonus for [Pantin Tobe +1](https://www.bg-wiki.com/ffxi/Pantin_Tobe_%2B1) from +10 to +12.

## Steps to test these changes

Equip item in game, then target your automaton and `!getmod ACC`
