### PR TITLE
[Lua] Change Bonnacon window to 1 hour

### DIFF
--- a/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
@@ -8,9 +8,6 @@ local ID = zones[xi.zone.ULEGUERAND_RANGE]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobDeath = function(mob, player, optParams)
-end
-
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.BONNACON, 5, 3600) -- 1 hour
 end

--- a/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Buffalo.lua
@@ -12,7 +12,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.BONNACON, 5, math.random(3600, 86400)) -- 1 to 24 hours
+    xi.mob.phOnDespawn(mob, ID.mob.BONNACON, 5, 3600) -- 1 hour
 end
 
 return entity


### PR DESCRIPTION
The Lottery window opening between 1 to 24 hours just does not make sense. Changing it to 1 hour. https://wiki.ffo.jp/html/12412.html

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

It really doesn't make sense for a lottery NM to randomly open between 1 hour and 24 hours. JP wiki seems to think it's a 1 hour lottery. 
https://wiki.ffo.jp/html/12412.html

The 1 to 24 comes from ffxiclopedia, but just because it took 24 hours to spawn doesn't mean the window opened at 24 hours.
https://ffxiclopedia.fandom.com/wiki/Bonnacon

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
