### PR TITLE
[lua] Nocuous Weapon Repop Time

### DIFF
--- a/scripts/zones/Inner_Horutoto_Ruins/mobs/Boggart.lua
+++ b/scripts/zones/Inner_Horutoto_Ruins/mobs/Boggart.lua
@@ -13,7 +13,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.NOCUOUS_WEAPON, 5, 3600) -- 1 hour
+    xi.mob.phOnDespawn(mob, ID.mob.NOCUOUS_WEAPON, 10, 1, {}) -- True Lottery
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Changes the respawn time to Nocuous Weapon to be a true lottery, and raises the spawn chance to 10%. 

I got three of these done in around an hour.

<img width="260" height="39" alt="1" src="https://github.com/user-attachments/assets/41e59b33-8cba-4aed-b762-52d8094e2236" />

<img width="359" height="44" alt="2" src="https://github.com/user-attachments/assets/0ff7dba3-ac63-4352-91c5-4fd9ab4d9355" />


## Steps to test these changes

Fight Boggarts outside Mage Gate, pop the NM
