### PR TITLE
[cpp] Enable cutscene immunity on zone-in events

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -118,9 +118,10 @@ CCharEntity::CCharEntity()
     eventPreparation = new EventPrep();
     currentEvent     = new EventInfo();
 
-    inSequence = false;
-    gotMessage = false;
-    m_Locked   = false;
+    inSequence       = false;
+    gotMessage       = false;
+    m_Locked         = false;
+    m_zoneInCutscene = false;
 
     accid        = 0;
     m_GMlevel    = 0;
@@ -2921,7 +2922,8 @@ void CCharEntity::endCurrentEvent()
     currentEvent->reset();
     eventPreparation->reset();
     setLocked(false);
-    m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
+    m_zoneInCutscene = false;
+    m_Substate       = CHAR_SUBSTATE::SUBSTATE_NONE;
     tryStartNextEvent();
 }
 

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -749,7 +749,8 @@ public:
 
     void clearCharVarsWithPrefix(const std::string& prefix);
 
-    bool m_Locked{}; // Is the player locked in a cutscene
+    bool m_Locked{};         // Is the player locked in a cutscene
+    bool m_zoneInCutscene{}; // Is the player currently in a zone-in cutscene
 
     // Starts a synth with skillType X
     bool startSynth(SKILLTYPE synthSkill);

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -79,6 +79,7 @@ struct EventInfo : EventPrep
         strings.clear();
         textTable  = -1;
         eventFlags = 0;
+        type       = NORMAL;
     }
 };
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1989,6 +1989,8 @@ void OnZoneIn(CCharEntity* PChar)
         return;
     }
 
+    PChar->m_zoneInCutscene = false;
+
     CZone*      prevZone    = zoneutils::GetZone(PChar->loc.prevzone);
     std::string prevZoneStr = "Unknown";
     if (prevZone)
@@ -2024,6 +2026,14 @@ void OnZoneIn(CCharEntity* PChar)
     else if (result.get_type() == sol::type::number)
     {
         PChar->currentEvent->eventId = result.get<int32>();
+    }
+
+    // On zone-in events
+    if (PChar->currentEvent->eventId >= 0)
+    {
+        PChar->currentEvent->type = CUTSCENE;
+        PChar->m_zoneInCutscene   = true;
+        PChar->setLocked(true);
     }
 }
 

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -285,7 +285,7 @@ void CCharUpdatePacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 
         packet->ModelHitboxSize = static_cast<uint8_t>(PChar->modelHitboxSize * 10); // TODO: verify this value and if it changes (Monstrosity?)
 
         packet->Flags1.MonsterFlag = false; // TODO: Is this ever set for Monstrosity PVP?
-        packet->Flags1.HideFlag    = false;
+        packet->Flags1.HideFlag    = PChar->m_zoneInCutscene;
         packet->Flags1.SleepFlag   = 0;                                                                // Something to do with events. // TODO: figure out when/if this is set. Probably when you're in a cutscene?
         packet->Flags1.unknown_0_3 = PChar->loc.zone ? PChar->loc.zone->CanUseMisc(MISC_TREASURE) : 0; // Set global treasure pool
         packet->Flags1.unknown_0_4 = 0;


### PR DESCRIPTION
This enables the cutscene immunity using setLocked. It also adds in invisibility until the cutscene is done.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This code change effects all zone-in events. It does two things:
- Sets the zone-in event to act like a Cutscene by setting PChar->setLocked(true). setLocked(true) removes emnity and makes it so you can not be targeted by single-target attacks and friendly spells.
- While in a zone-in event, the player is invisible to the other players.

charentity.h: Added m_zoneInCutscene bool for the state.
charentity.cpp: Set the default m_zoneInCutscene state to false.
event_info.h: Updated the reset to have the default type reset back to NORMAL.
luautils.cpp: Sets the m_zoneInCutscene to false as a fail safe. Then checks for a zone-in event and sets locked, type, and state.
char_update.cpp: Updates the packet to other players to set the visibility of the player based on the m_zoneInCutscene bool.

## Steps to test these changes

You need two characters to test this. They should be in the same party.
- Check zone-in events. The easiest one to get to is Windurst 1-2. As a Windurst affiliated character, do !addmission 2 1. Make sure you are not in East Sarutabaruta, then do !setmissionstatus <Character Name> 5 2. Zone into East Sarutabaruta at the same location your second character is so you can observe.
- Check if a non zone-in event handles normally. Zone into anywhere and make sure you are vulnerable and visible to your second character.
