### PR TITLE
[cpp] Stop actions against locked players

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -515,6 +515,15 @@ bool CTargetFind::validEntity(CBattleEntity* PTarget)
         return false;
     }
 
+    // m_Locked targets should not be able to be attacked or have any ability or spell cast on them, including AoEs.
+    // TODO: Should a locked player's pet or trust be excluded as well? Verify on retail. Can add that check by changing PTarget to findMaster(PTarget).
+    // m_Locked is only in a CCharEntity, not all CBattleEntity which do not have m_Locked. Need to account for that.
+    CCharEntity* PChar = dynamic_cast<CCharEntity*>(PTarget);
+    if (PChar != nullptr && PChar->m_Locked)
+    {
+        return false;
+    }
+
     // -------------------------------------------------
     // IMPORTANT: Benediction/self-centered ally-only check
     // This must run BEFORE the "first target always allowed" short-circuit.


### PR DESCRIPTION
Currently, AoE abilities (friendly and enemy) can still hit players who are locked.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If a player is locked using the m_Locked state, no ability, attack, or spell should be able to land on them as tested on retail. The current behavior before this fix was no single target abilities, spells, or attacks could land on the locked player. This fixes a bug where AoE spells and abilities (friendly and enemy) could still impact the player.

Retail
Showing a cutscene in Windurst 1-2 can't have an AoE buff land on the player: https://youtu.be/ymfpEvUMFHA
Showing a zone-in event for Windurst 1-2 can't have an AoE buff land on the player: https://youtu.be/3l9pU2uvRM4

## Steps to test these changes

- Enter a cutscene event. 
- Attempt to cast an AoE ability.