### PR TITLE
[cpp] Implement necessary code for Event Skipped

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -2257,6 +2257,13 @@ void CBattleEntity::processActionEffectFlags(const action_t& action) const
             PTarget = loc.zone->GetCharByID(target.actorId);
         }
 
+        // Event action can cancel a skippable event on PC targets
+        if (auto* PChar = dynamic_cast<CCharEntity*>(PTarget); PChar && PChar->isInEvent())
+        {
+            // Checks for if an event is skippable is handled in skipEvent
+            PChar->skipEvent();
+        }
+
         if (PTarget && this->allegiance != PTarget->allegiance)
         {
             emittedHostile = true;

--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -3028,19 +3028,22 @@ void CCharEntity::tryStartNextEvent()
 void CCharEntity::skipEvent()
 {
     TracyZoneScoped;
-    if (!m_Locked && !isInEvent() && (!currentEvent->cutsceneOptions.empty() || currentEvent->interruptText != 0))
+    // Locked players are untargetable and can not skip events.
+    if (!isInEvent() || m_Locked || !currentEvent->canSkip)
     {
-        pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::EventSkipped);
-        pushPacket<GP_SERV_COMMAND_EVENTUCOFF>(this, GP_SERV_COMMAND_EVENTUCOFF_MODE::CancelEvent);
-        m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
-
-        if (currentEvent->interruptText != 0)
-        {
-            pushPacket<GP_SERV_COMMAND_TALKNUM>(currentEvent->targetEntity, currentEvent->interruptText, false);
-        }
-
-        endCurrentEvent();
+        return;
     }
+
+    pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::EventSkipped);
+    pushPacket<GP_SERV_COMMAND_EVENTUCOFF>(this, GP_SERV_COMMAND_EVENTUCOFF_MODE::CancelEvent);
+    m_Substate = CHAR_SUBSTATE::SUBSTATE_NONE;
+
+    if (currentEvent->interruptText != 0)
+    {
+        pushPacket<GP_SERV_COMMAND_TALKNUM>(currentEvent->targetEntity, currentEvent->interruptText, false);
+    }
+
+    endCurrentEvent();
 }
 
 void CCharEntity::setLocked(bool locked)

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -63,6 +63,7 @@ struct EventInfo : EventPrep
     std::vector<int32> cutsceneOptions;
     uint16             interruptText = 0;
     uint32             eventFlags    = 0;
+    bool               canSkip       = false;
 
     bool hasCutsceneOption(int32 _option)
     {
@@ -80,6 +81,7 @@ struct EventInfo : EventPrep
         textTable  = -1;
         eventFlags = 0;
         type       = NORMAL;
+        canSkip    = false;
     }
 };
 

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -1121,6 +1121,7 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         eventToStart->textTable     = table.get_or<int16>("text_table", -1);
         eventToStart->interruptText = table.get_or<int16>("interrupt_text", 0);
         eventToStart->eventFlags    = table.get_or<uint32>("flags", 0);
+        eventToStart->canSkip       = table.get_or("canSkip", false);
 
         sol::object csOption = table["cs_option"];
         if (csOption.is<int32>())

--- a/src/map/packets/c2s/0x05b_eventend.cpp
+++ b/src/map/packets/c2s/0x05b_eventend.cpp
@@ -51,6 +51,7 @@ void GP_CLI_COMMAND_EVENTEND::process(MapSession* PSession, CCharEntity* PChar) 
             if (result != -1 && PChar->currentEvent->hasCutsceneOption(result))
             {
                 PChar->setLocked(true);
+                PChar->currentEvent->canSkip = false;
             }
 
             luautils::OnEventUpdate(PChar, eventId, result);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This code adds a property to events for Event Skipped. It defaults to false and must be defined for an Event Skipped to occur.
- battleentity.cpp: Events can be skipped from enemy attacks, enemy abilities, enemy spells, friendly spells. As such, the event check occurs under processActionEffect, similar to how the fishing interrupts occur.
- charentity.cpp: the skipEvent is dead code that was never implemented. I've updated this function to send Event Skipped if the user is in an event, not locked, and the currentEvent->canSkip variable is true. 
- event_info.h: Sets the canSkip bool and defaults it to false.
- lua_baseentity.cpp: exposes the optional input of "canSkip" to lua.
- 0x05b_eventend.cpp: This is a catch for progressOptionalCutscene. When the event progresses to the stage that setLocked occurs, the event should not be skippable.

This is implemented as a default false as to not change any existing events. It's a framework for events to be updated to allow Event Skipped to occur. When testing on retail, NPCs in Windurst did not elicit an Event Skipped where NPCs in East Sarutabaruta did. Additionally, when in a camera locked event, no Event Skipped occurred.  All events need to be audited for Event Skipped.

A small note, setting canSkip = true in cutscene or progressCutscene does nothing. This is because m_Locked is set which makes the player invulnerable, which makes it impossible to skip an event.

## Steps to test these changes

- No event should be skippable. Go trigger an event and try to have it skipped with an enemy attack and a friendly spell.
- To an event call, add { canSkip = true }. For example, mission:progressEvent(137, { canSkip = true }). Then go and have an enemy attack you and observe the Event Skipped. Then have a friendly player cast a spell on you or an -aga spell on themselves while in your party and observe the Event Skipped.
