### PR TITLE
[lua] Fix Duplicate CoP XP Reward

### DIFF
--- a/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
@@ -7,19 +7,20 @@ local spireOfDemID = zones[xi.zone.SPIRE_OF_DEM]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.SPIRE_OF_DEM,
-    battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_DEM,
-    canLoseExp    = false,
-    isMission     = true,
-    allowTrusts   = true,
-    maxPlayers    = 6,
-    levelCap      = 30,
-    timeLimit     = utils.minutes(30),
-    index         = 0,
-    entryNpc      = '_0j0',
-    exitNpcs      = { '_0j1', '_0j2', '_0j3' },
+    zoneId         = xi.zone.SPIRE_OF_DEM,
+    battlefieldId  = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_DEM,
+    canLoseExp     = false,
+    isMission      = true,
+    allowTrusts    = true,
+    maxPlayers     = 6,
+    levelCap       = 30,
+    timeLimit      = utils.minutes(30),
+    index          = 0,
+    entryNpc       = '_0j0',
+    exitNpcs       = { '_0j1', '_0j2', '_0j3' },
 
-    grantXP = 1500,
+    grantXP        = 1500,
+    grantXPLockout = true,
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)

--- a/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
@@ -7,19 +7,20 @@ local spireOfHollaID = zones[xi.zone.SPIRE_OF_HOLLA]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.SPIRE_OF_HOLLA,
-    battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_HOLLA,
-    canLoseExp    = false,
-    isMission     = true,
-    allowTrusts   = true,
-    maxPlayers    = 6,
-    levelCap      = 30,
-    timeLimit     = utils.minutes(30),
-    index         = 0,
-    entryNpc      = '_0h0',
-    exitNpcs      = { '_0h1', '_0h2', '_0h3' },
+    zoneId         = xi.zone.SPIRE_OF_HOLLA,
+    battlefieldId  = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_HOLLA,
+    canLoseExp     = false,
+    isMission      = true,
+    allowTrusts    = true,
+    maxPlayers     = 6,
+    levelCap       = 30,
+    timeLimit      = utils.minutes(30),
+    index          = 0,
+    entryNpc       = '_0h0',
+    exitNpcs       = { '_0h1', '_0h2', '_0h3' },
 
-    grantXP = 1500,
+    grantXP        = 1500,
+    grantXPLockout = true,
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)

--- a/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
@@ -7,19 +7,20 @@ local spireOfMeaID = zones[xi.zone.SPIRE_OF_MEA]
 -----------------------------------
 
 local content = Battlefield:new({
-    zoneId        = xi.zone.SPIRE_OF_MEA,
-    battlefieldId = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_MEA,
-    canLoseExp    = false,
-    isMission     = true,
-    allowTrusts   = true,
-    maxPlayers    = 6,
-    levelCap      = 30,
-    timeLimit     = utils.minutes(30),
-    index         = 0,
-    entryNpc      = '_0l0',
-    exitNpcs      = { '_0l1', '_0l2', '_0l3' },
+    zoneId         = xi.zone.SPIRE_OF_MEA,
+    battlefieldId  = xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_MEA,
+    canLoseExp     = false,
+    isMission      = true,
+    allowTrusts    = true,
+    maxPlayers     = 6,
+    levelCap       = 30,
+    timeLimit      = utils.minutes(30),
+    index          = 0,
+    entryNpc       = '_0l0',
+    exitNpcs       = { '_0l1', '_0l2', '_0l3' },
 
-    grantXP = 1500,
+    grantXP        = 1500,
+    grantXPLockout = true,
 })
 
 function content:entryRequirement(player, npc, isRegistrant, trade)

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -408,6 +408,7 @@ end
 --  - requiredKeyItems: Key items required to be able to enter the battlefield - these are removed upon entry unless 'keep = true' (optional)
 --  - title: Title given to players upon victory (optional)
 --  - grantXP: Amount of XP to grant upon victory (optional)
+--  - grantXPLockout: If true, players can only receive the grantXP once per day, resetting at JST midnight. (optional)
 --  - lossEventParams: Parameters given to the loss event (32002). Defaults to none. (optional)
 ---@diagnostic disable-next-line: duplicate-set-field
 function Battlefield:new(data)
@@ -436,6 +437,7 @@ function Battlefield:new(data)
 
     obj.title            = data.title
     obj.grantXP          = data.grantXP
+    obj.grantXPLockout   = data.grantXPLockout
     obj.levelCap         = data.levelCap or 0
     obj.allowSubjob      = (data.allowSubjob == nil or data.allowSubjob) or false
     obj.allowTrusts      = data.allowTrusts and data.allowTrusts or false
@@ -928,6 +930,14 @@ function Battlefield:onEventFinishWin(player, csid, option, npc)
     end
 
     if self.grantXP then
+        if self.grantXPLockout then
+            if self:getVar(player, 'XP') > GetSystemTime() then
+                return
+            end
+
+            self:setVar(player, 'XP', JstMidnight())
+        end
+
         player:addExp(self.grantXP)
     end
 end

--- a/scripts/missions/cop/helpers.lua
+++ b/scripts/missions/cop/helpers.lua
@@ -158,7 +158,6 @@ xi.cop.helpers.spireEventFinish = function(mission, player, csid, option, npc)
 
         player:addKeyItem(xi.ki.LIGHT_OF_HOLLA + promyvionId)
         player:messageSpecial(zones[player:getZoneID()].text.CANT_REMEMBER, xi.ki.LIGHT_OF_HOLLA + promyvionId)
-        player:addExp(1500)
         mission:setVar(player, 'Option', 0)
 
         local numCompletedPromyvions = xi.cop.helpers.numPromyvionCompleted(player)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

A few things.

* Adds a new optional parameter for regular battlefields called grantXPLockout, defaults to nil, but when set to true places a character variable upon victory that expires at JST Midnight which will block subsequent XP gains until it expires.

* Adds this new optional parameter to the 3 CoP Promyvion battlefields, as they cannot be setup as mission battlefields (which already have this functionality built in)

* Removes the duplicate 1500 EXP found in the CoP helpers file, letting the battlefield and the new character variable drive XP rewards instead.

## Steps to test these changes

!zone Spire of Dem
Run Ancient Flames Beckon -> Get XP
Run it again -> Get No XP

Run the ENM in Spire of Dem -> Get XP
Run it again -> Get XP again