### PR TITLE
[Core] [C++] Add missing DT to Automaton Frames on Setup

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -596,20 +596,27 @@ void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats,
             default: // case AutomatonFrame::Harlequin:
                 tempSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(Mod::DMG, -625);
                 break;
             case AutomatonFrame::Valoredge:
                 PPet->setModifier(Mod::SHIELDBLOCKRATE, 45);
                 PPet->setMobMod(MOBMOD_CAN_SHIELD_BLOCK, 1);
+                PPet->setModifier(Mod::DMG, -1250);
                 tempSkills.evasion = battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl));
                 break;
             case AutomatonFrame::Sharpshot:
                 tempSkills.evasion = battleutils::GetMaxSkill(1, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(Mod::PIERCE_SDT, 8750);
+                PPet->setModifier(Mod::DMGBREATH, -1250);
+                PPet->setModifier(Mod::DMGMAGIC, -1250);
                 break;
             case AutomatonFrame::Stormwaker:
                 tempSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(Mod::DMGBREATH, -2500);
+                PPet->setModifier(Mod::DMGMAGIC, -2500);
                 break;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds missing DT to Automaton Frames
<img width="1070" height="219" alt="image" src="https://github.com/user-attachments/assets/910108af-8917-4192-91fb-1e7f74197e9c" />

https://wiki.ffo.jp/html/2006.html

-6.25% DT to Harlequin Frames
-12.50% DT to Valoredge
-12.50% Pierce DT,MDT,BDT to Sharpshot
-25% MDT/BDT to Stormwaker

This stacks with Stout Servant

## Steps to test these changes

Summon each automaton frame and check its respective DT cut with !getmod
