### PR TITLE
[fix] Furniture NPCs

### DIFF
--- a/src/map/packets/c2s/0x017_charreq2.cpp
+++ b/src/map/packets/c2s/0x017_charreq2.cpp
@@ -32,5 +32,12 @@ auto GP_CLI_COMMAND_CHARREQ2::validate(MapSession* PSession, const CCharEntity* 
 
 void GP_CLI_COMMAND_CHARREQ2::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    ShowWarning("GP_CLI_COMMAND_CHARREQ2: Incorrect NPC(%u,%u) type(%u)", this->ActIndex, this->UniqueNo2, this->Flg);
+    if (PChar->isInEvent())
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2: Incorrect NPC({},{}) type({}) event({})", this->ActIndex, this->UniqueNo2, this->Flg, PChar->currentEvent->eventId);
+    }
+    else
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2: Incorrect NPC({},{}) type({})", this->ActIndex, this->UniqueNo2, this->Flg);
+    }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Bunch of furniture NPCs were either missing or wrongly named, leading to crashes or missing trees/tables.
- Fixes the rotation on certain furnitures
- Includes a small tweak to CHARREQ2 to print the event ID in the log so that future issues are easier to troubleshoot

## Steps to test these changes
I zoned in every impacted zone to at least make sure it doesn't crash. Verified a handful of zones with retail side by side.
