### PR TITLE
[sql] Set Blade Bat in Inner Horutoto to non-aggressive

### DIFF
--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -13156,7 +13156,7 @@ INSERT INTO `mob_groups` VALUES (34,6890,191,'Celaeno',0,128,0,0,0,0,NULL);
 
 INSERT INTO `mob_groups` VALUES (1,372,192,'Battue_Bats',300,0,244,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,1737,192,'Goblin_Thug',300,0,1170,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (3,443,192,'Blade_Bat',300,0,461,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,7355,192,'Blade_Bat',300,0,461,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,1744,192,'Goblin_Weaver',300,0,1183,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,2475,192,'Magicked_Bones_club',300,0,2867,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,4915,192,'Troika_Bats',300,0,244,0,0,0,'ABYSSEA');

--- a/sql/mob_pools.sql
+++ b/sql/mob_pools.sql
@@ -7447,7 +7447,8 @@ INSERT INTO `mob_pools` VALUES (7351,'Succubus_Bats_Uleguerand_Range','Succubus_
 INSERT INTO `mob_pools` VALUES (7352,'Nightmare_Bats_Newton_Movalpolos','Nightmare_Bats',181,0x0000040100000000000000000000000000000000,1,1,5,240,100,0,1,0,1,0,0,64,238,643,8,0,0,0,0,2015,47,1,16);
 INSERT INTO `mob_pools` VALUES (7353,'Nightmare_Bats_Uleguerand_Range','Nightmare_Bats',181,0x0000040100000000000000000000000000000000,1,1,5,240,100,0,1,0,1,0,0,64,238,643,8,0,0,0,0,2015,47,1,16);
 INSERT INTO `mob_pools` VALUES (7354,'Macro_Test','Macro_Test',49,0x0000AF0100000000000000000000000000000000,1,1,1,240,100,0,0,0,0,2,0,0,0,0,0,0,0,32,0,0,0,0,10);
--- 1 Unused space at 3687 or fresh blocks at 7355.
+INSERT INTO `mob_pools` VALUES (7355,'Blade_Bat_Inner_Horutoto','Blade_Bat',173,0x0000000100000000000000000000000000000000,1,1,11,240,100,0,0,0,0,0,0,0,322,641,8,0,0,0,0,46,46,0,11);
+-- 1 Unused space at 3687 or fresh blocks at 7356.
 
 -- Jug pet pools (skipped to allow keeping them sequential)
 INSERT INTO `mob_pools` VALUES (7500,'Pet_Sweet_Caroline','Pet_Sweet_Caroline',350,0x00008E0B00000000000000000000000000000000,2,2,1,480,100,0,0,0,0,8,0,32,605,129,0,0,0,0,0,766,178,0,12);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Duplicates a Mob Group for Blade Bat for Inner Horutoto
- Sets this version of Blade Bat to non-aggressive

As recorded on Retail with a level 1 character: https://youtube.com/live/AII2v-fYeow

## Steps to test these changes

!zone Inner Horutoto
!gotoname Blade_Bat 1
!changejob war 1

Verify that Blade Bat in Inner Horutoto is no longer aggressive.
