### PR TITLE
[core] Fix trust release messaging, improve despawn animation

### DIFF
--- a/src/map/entities/charentity.cpp
+++ b/src/map/entities/charentity.cpp
@@ -1043,10 +1043,6 @@ void CCharEntity::RemoveTrust(CTrustEntity* PTrust)
 
     if (trustIt != PTrusts.end())
     {
-        if (PTrust->animation == ANIMATION_DESPAWN)
-        {
-            luautils::OnMobDespawn(PTrust);
-        }
         PTrust->PAI->Despawn();
         PTrusts.erase(trustIt);
     }

--- a/src/map/entities/trustentity.h
+++ b/src/map/entities/trustentity.h
@@ -52,6 +52,7 @@ public:
     void OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action) override;
 
     uint32 m_TrustID{};
+    bool   isReleased = false; // Track trust releasing (see c2s 0x01A action)
 
 private:
     static constexpr int8 m_defaultShieldSize = 3;

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -202,9 +202,11 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             // Releasing a trust
-            if (auto* PTrust = dynamic_cast<CTrustEntity*>(PNpc))
+            if (auto* PTrust = dynamic_cast<CTrustEntity*>(PNpc); PTrust && !PTrust->isReleased)
             {
                 uint32_t trustTargId = PTrust->targid;
+
+                PTrust->isReleased = true;
 
                 // Emit despawn message
                 // TODO: probably change off OnMobDespawn to a listener or a trust specific OnPartyLeave callback

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -204,7 +204,33 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             // Releasing a trust
             if (auto* PTrust = dynamic_cast<CTrustEntity*>(PNpc))
             {
-                PChar->RemoveTrust(PTrust);
+                uint32_t trustTargId = PTrust->targid;
+
+                // Emit despawn message
+                // TODO: probably change off OnMobDespawn to a listener or a trust specific OnPartyLeave callback
+                // note: this will get called a second time later, but PTrust->PMaster is nullptr by the time that happens so the despawn message is never emitted.
+                luautils::OnMobDespawn(PTrust);
+
+                PChar->PAI->QueueAction(
+                    queueAction_t(
+                        2s,
+                        false,
+                        [trustTargId](CBaseEntity* CharEntity)
+                        {
+                            // We can't trust using a pointer here in case somehow the trust has been usurped
+                            // So use the POD of the trusts's targID, look it back up, and check the PChar is still it's master
+                            auto PDelayedTrust = dynamic_cast<CTrustEntity*>(CharEntity->GetEntity(trustTargId, TYPE_TRUST));
+                            auto PDelayedChar  = dynamic_cast<CCharEntity*>(CharEntity);
+
+                            if (PDelayedTrust && PDelayedChar && PDelayedTrust->PMaster == PDelayedChar)
+                            {
+                                // For some reason they use ANIMATION_DEATH to play the special despawn.
+                                PDelayedTrust->animation = ANIMATION_DEATH;
+                                PDelayedTrust->updatemask |= UPDATE_HP;
+
+                                PDelayedChar->RemoveTrust(PDelayedTrust);
+                            }
+                        }));
                 return;
             }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Trust release messaging was broken because PMaster was nullptr when OnMobDespawn hit
Despawn animation when releasing was wrong because apparently trusts just use ANIMATION_DEATH for that too?

## Steps to test these changes

Despawn trust manually with the menu or /returnfaith all or whatever
See messaging and special despawn animation
