### PR TITLE
[mob] Adjust Tiny Mandragoras to not guard

### DIFF
--- a/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+end
+
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
 end

--- a/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+end
+
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.EXP_LVL_MOD, -2) -- Subtract 2 levels for /check and exp purposes
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR makes sure Tiny Mandragoras cannot guard, because they don't.

200+ hits, not a single guard to be found.

<img width="1334" height="509" alt="image" src="https://github.com/user-attachments/assets/cc43975e-d7ea-4efb-95c2-430963a772c3" />


## Steps to test these changes

Hit some tiny mandies, they won't guard.
