### PR TITLE
[mob] Starter zone Mandies no h2h penalty

### DIFF
--- a/scripts/zones/East_Sarutabaruta/mobs/Mandragora.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Mandragora.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 89, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Mandragora.lua
@@ -8,6 +8,10 @@ local ID = zones[xi.zone.WEST_SARUTABARUTA]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 26, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Tiny_Mandragora.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.CANNOT_GUARD, 1)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
 end
 
 entity.onMobSpawn = function(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the starter zone Mandies to have no H2H penalty which brings their damage closer in line with retail.

Currently, due to the h2h penalty, starter zone Mandies hit much lower than retail.
This adjustment brings them closer in line.

Retail:
<img width="803" height="1128" alt="image" src="https://github.com/user-attachments/assets/19702b2e-166a-4dbc-aa84-82f6e5ee3f04" />

LSB with H2H penalty, same stats/race/job/level:

<img width="526" height="385" alt="image" src="https://github.com/user-attachments/assets/16fd54a0-5f10-45f3-b45a-b4bd363ebc3a" />

## Steps to test these changes

Get smacked by mandies.
