### PR TITLE
[lua] Block teleports while in events

### DIFF
--- a/scripts/effects/teleport.lua
+++ b/scripts/effects/teleport.lua
@@ -11,6 +11,11 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
+    -- Prevents others from teleporting the target out of an event.
+    if target:isInEvent() and effect:getOriginID() ~= target:getID() then
+        return
+    end
+
     local destination = effect:getPower()
 
     if target:isMob() then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Restricts player from teleporting another player during an event. This will not restrict teleports like outpost warps which fire after the event ends and is initiated by the player. Event skipped still allows teleports.

Player in event who can't be teleported: Pre-Windurst 1-1 https://youtu.be/Qif-dYQ2ozo
Player in event who can't be teleported: Windurst 1-1 first cutscene https://youtu.be/N7E9pBqgLOA
Player talking to Jack of Clubs who can't be teleported: https://imgur.com/a/sSCWkrh
Player talking to random NPC who can't be teleported: https://youtu.be/97g54qykXkI
Event skipped fires and player can be teleported: https://youtu.be/7JC50IojXTg

## Steps to test these changes

Try teleporting someone while they are in an event. Add canSkip and see teleports still fire. Try outpost warps to see they still work.
