### PR TITLE
[lua] Windurst rank 1 and 2 enmity drop and Battlefield event skip

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -944,7 +944,7 @@ end
 
 function Battlefield.onExitTrigger(player, npc)
     if player:getBattlefield() then
-        return Battlefield:progressOptionalCutscene(32003, { cs_option = 3 })
+        return Battlefield:progressOptionalCutscene(32003, { cs_option = 3, canSkip = true })
     end
 end
 

--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -51,11 +51,11 @@ end
 
 local examineGizmo = function(player, gizmoIndex, successCS, failCS)
     if mission:getVar(player, 'RandomGizmo') == gizmoIndex then
-        return mission:progressEvent(successCS)
+        return mission:progressCutscene(successCS)
     else
         if not mission:isVarBitsSet(player, 'GizmoExamined', gizmoIndex) then
             mission:setVarBit(player, 'GizmoExamined', gizmoIndex)
-            return mission:progressEvent(failCS)
+            return mission:progressCutscene(failCS)
         else
             return mission:messageSpecial(innerHorutotoRuinsID.text.EXAMINED_RECEPTACLE)
         end
@@ -203,7 +203,7 @@ mission.sections =
         [xi.zone.INNER_HORUTOTO_RUINS] =
         {
             -- Gate: Magical Gizmo
-            ['_5c5'] = mission:progressEvent(42),
+            ['_5c5'] = mission:progressCutscene(42),
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/1_2_The_Heart_of_the_Matter.lua
+++ b/scripts/missions/windurst/1_2_The_Heart_of_the_Matter.lua
@@ -58,7 +58,7 @@ local gizmoOnTrigger = function(player, gizmoNum, placeCS, collectCS)
         -- has orb been placed here?
         if not mission:isVarBitsSet(player, 'GizmoUsed', gizmoNum) then
             -- place orb
-            return mission:event(placeCS)
+            return mission:cutscene(placeCS)
         else
             -- orb has been already been placed
             player:messageSpecial(msgBase) -- "A dark Mana Orb is already placed here."
@@ -67,7 +67,7 @@ local gizmoOnTrigger = function(player, gizmoNum, placeCS, collectCS)
     elseif player:getMissionStatus(mission.areaId) == 4 then
         -- collect orb
         if not mission:isVarBitsSet(player, 'GizmoEmpty', gizmoNum) then
-            return mission:event(collectCS)
+            return mission:cutscene(collectCS)
         else
             --orb has already been retrieved
             player:messageSpecial(msgBase + 3) -- "You have already retrieved a glowing Mana Orb from here."
@@ -236,7 +236,7 @@ mission.sections =
 
         [xi.zone.EAST_SARUTABARUTA] =
         {
-            ['Pore-Ohre'] = mission:progressEvent(46),
+            ['Pore-Ohre'] = mission:progressCutscene(46),
 
             onEventFinish =
             {
@@ -256,7 +256,7 @@ mission.sections =
 
         [xi.zone.EAST_SARUTABARUTA] =
         {
-            ['Pore-Ohre'] = mission:event(47),
+            ['Pore-Ohre'] = mission:event(47), -- TODO: Is this a skippable event or cutscene?
         },
 
         [xi.zone.OUTER_HORUTOTO_RUINS] =
@@ -341,7 +341,7 @@ mission.sections =
 
         [xi.zone.OUTER_HORUTOTO_RUINS] =
         {
-            ['_5e9'] = mission:event(44),
+            ['_5e9'] = mission:cutscene(44),
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/1_3_The_Price_of_Peace.lua
+++ b/scripts/missions/windurst/1_3_The_Price_of_Peace.lua
@@ -177,8 +177,8 @@ mission.sections =
 
         [xi.zone.GIDDEUS] =
         {
-            ['Ghoo_Pakya'] = mission:progressEvent(49),
-            ['Laa_Mozi']   = mission:progressEvent(45),
+            ['Ghoo_Pakya'] = mission:progressCutscene(49),
+            ['Laa_Mozi']   = mission:progressCutscene(45),
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/2_1_Lost_for_Words.lua
+++ b/scripts/missions/windurst/2_1_Lost_for_Words.lua
@@ -254,7 +254,7 @@ mission.sections =
 
         [xi.zone.INNER_HORUTOTO_RUINS] =
         {
-            ['_5ca'] = mission:progressEvent(46),
+            ['_5ca'] = mission:progressCutscene(46),
 
             onEventFinish =
             {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds enmity drop for all appropriate events for Windurst Rank 1 and 2 missions. 
Also adds in the Event Skipped for Battlefields.

All enmity drops are validated below with retail:
Battlefield Event Skipped: https://youtu.be/UShwycGLG_s
1-1 line 206: https://youtu.be/t9GHDiKSAUU
1-1 line 58: https://youtu.be/E4VSocLTCeo
1-1 line 54: https://youtu.be/8LJPIz8Vnvk
1-2 line 61: https://youtu.be/beAhbeswnM4
1-2 line 239: https://youtu.be/BGx1HRyL4mw
1-2 line 344: https://youtu.be/kb5pybfonTQ
1-2 line 70: https://youtu.be/W3C6ANRzlis
1-3 line 180: https://youtu.be/HBupaA43OyE
1-3 line 181: https://youtu.be/8EB7EvYHSz4
2-1 line 257: https://youtu.be/fB8_eg92emY


## Steps to test these changes

See if enmity drops in all the events marked.
See if event skipped occurs in battlefield exits.