### PR TITLE
[lua] Require San d'Oria 1-2 / 3-1 completion

### DIFF
--- a/scripts/globals/missions.lua
+++ b/scripts/globals/missions.lua
@@ -782,13 +782,13 @@ xi.mission.getMissionRankPoints = function(player, missionID)
     return false
 end
 
--- Tables identifying the nature of a mission by nation (0 = Not Repeatable, 1 = Repeatable, 2 = Do Not Add)
+-- Tables identifying the nature of a mission by nation (0 = Not Repeatable, 1 = Repeatable, 2 = Do Not Add, 3 = Required + Repeatable)
 -- Certain missions do not apply to the gate guard, such as Rank 4; Do Not Add is used for this.
 -- For 3 Nations missions (ID#5) sub-missions are not included in this mask.
 local missionType =
 {
     -- Required Rank             :   1  1  1  2  2  2  2  2  2  2  3  3  3  4  5  5  6  6  7  7  8  8  9  9
-    [xi.mission.log_id.SANDORIA] = { 1, 1, 1, 0, 1, 0, 2, 2, 2, 2, 1, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+    [xi.mission.log_id.SANDORIA] = { 1, 3, 1, 0, 1, 0, 2, 2, 2, 2, 3, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     [xi.mission.log_id.BASTOK]   = { 2, 0, 1, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
     [xi.mission.log_id.WINDURST] = { 2, 0, 0, 0, 1, 0, 2, 2, 2, 2, 0, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
 }
@@ -840,14 +840,20 @@ xi.mission.getMissionMask = function(player)
             )
         then
             if v == 0 then
-                if
-                    not player:hasCompletedMission(nation, missionId)
-                then
+                if not player:hasCompletedMission(nation, missionId) then
                     firstMission = utils.mask.setBit(firstMission, missionId, true)
                     lastRequiredMission = missionId
                 end
             elseif v == 1 then
                 repeatMission = utils.mask.setBit(repeatMission, missionId, true)
+            elseif v == 3 then
+                if not player:hasCompletedMission(nation, missionId) then
+                    firstMission = utils.mask.setBit(firstMission, missionId, true)
+                else
+                    repeatMission = utils.mask.setBit(repeatMission, missionId, true)
+                end
+
+                lastRequiredMission = missionId
             end
         else
             break


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sandy 1-2 and 3-1 are not supposed to be skippable. 
Introduce a new mission "type" denoting a mission as both being required AND repeatable.

## Steps to test these changes
Give yourself max rank points and complete 1-1
<img width="1082" height="648" alt="Screenshot 2026-05-23 140802" src="https://github.com/user-attachments/assets/504f8e50-5fc3-42d1-82c3-993330574b42" />

See only 1-2 is offered
<img width="1259" height="495" alt="Screenshot 2026-05-23 140810" src="https://github.com/user-attachments/assets/726edf4f-757f-4f17-8ba3-cdd4d478046b" />

See 1-3 is offered after 1-2 is completed
<img width="1287" height="691" alt="Screenshot 2026-05-23 141016" src="https://github.com/user-attachments/assets/72c3ae57-2462-45c7-bcab-54e402ebd0e6" />

<!-- Clear and detailed steps to test your changes here -->
