### PR TITLE
[mob] No H2H Penalty for Low Level Monks

### DIFF
--- a/scripts/zones/East_Ronfaure/mobs/Orcish_Grappler.lua
+++ b/scripts/zones/East_Ronfaure/mobs/Orcish_Grappler.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 67, 1, xi.regime.type.FIELDS)
 end

--- a/scripts/zones/East_Sarutabaruta/mobs/Yagudo_Initiate.lua
+++ b/scripts/zones/East_Sarutabaruta/mobs/Yagudo_Initiate.lua
@@ -1,16 +1,12 @@
 -----------------------------------
--- Area: West Ronfaure
---  Mob: Orcish Grappler
+-- Area: East Sarutabaruta
+--  Mob: Yagudo Initiate
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 4, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Grappler.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Orcish_Grappler.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Area: West Ronfaure
+-- Area: Ghelsba Outpost
 --  Mob: Orcish Grappler
 -----------------------------------
 ---@type TMobEntity
@@ -7,10 +7,6 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 4, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/Giddeus/mobs/Yagudo_Initiate.lua
+++ b/scripts/zones/Giddeus/mobs/Yagudo_Initiate.lua
@@ -1,16 +1,12 @@
 -----------------------------------
--- Area: West Ronfaure
---  Mob: Orcish Grappler
+-- Area: Giddeus
+--  Mob: Yagudo Initiate
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 4, 1, xi.regime.type.FIELDS)
 end
 
 return entity

--- a/scripts/zones/West_Sarutabaruta/mobs/Yagudo_Initiate.lua
+++ b/scripts/zones/West_Sarutabaruta/mobs/Yagudo_Initiate.lua
@@ -5,6 +5,10 @@
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_H2H_PENALTY, 1)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 29, 1, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 61, 1, xi.regime.type.FIELDS)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Testing shows that all the Monks under level 10 have no H2H penalty.

This adjusts low level monks to have no H2H penalty.  This includes East Ronfaure, West Ronfaure, East Saruta, West Saruta, Ghelsba, and Giddeus.

<img width="973" height="1029" alt="image" src="https://github.com/user-attachments/assets/f94aa692-59fa-4040-bbd3-fe800e24858b" />

## Steps to test these changes

Mess around with a starter monk, get slapped back to reality.
