### PR TITLE
[core] [lua] Stolen items only reset on kill (or BC/QM pops)

### DIFF
--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -229,7 +229,7 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
             player:addItem(despoiled)
         end
 
-        target:itemDespoiled()
+        target:itemDespoiled(true)
 
         -- Attempt to grab the debuff from the DB
         -- If there isn't a debuff assigned to the item stolen, select one at random
@@ -415,7 +415,7 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
 
     if target:isMob() and math.random(1, 100) <= stealChance and stolen ~= 0 then
         player:addItem(stolen)
-        target:itemStolen()
+        target:itemStolen(true)
         ability:setMsg(xi.msg.basic.STEAL_SUCCESS) -- Item stolen successfully
         target:triggerListener('ITEM_STOLEN', target, player, stolen)
         -- Aura Steal does not trigger on successful item steal

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -97,6 +97,10 @@ function npcUtil.popFromQM(player, qm, mobId, params)
         -- spawn
         mob:spawn()
 
+        -- mobs that pop from QM should get their steal items reset even if they didn't die on previous pop
+        mob:itemStolen(false)
+        mob:itemDespoiled(false)
+
         -- claim
         if params.claim then
             mob:updateClaim(player)

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -4123,14 +4123,14 @@ end
 function CBaseEntity:getDespoilDebuff(itemID)
 end
 
----@nodiscard
----@return boolean
-function CBaseEntity:itemStolen()
+---@param stolen boolean
+---@return nil
+function CBaseEntity:itemStolen(stolen)
 end
 
----@nodiscard
----@return boolean
-function CBaseEntity:itemDespoiled()
+---@param despoiled boolean
+---@return nil
+function CBaseEntity:itemDespoiled(despoiled)
 end
 
 ---@nodiscard

--- a/src/map/entities/mobentity.cpp
+++ b/src/map/entities/mobentity.cpp
@@ -658,14 +658,21 @@ bool CMobEntity::ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags)
 void CMobEntity::Spawn()
 {
     TracyZoneScoped;
+
+    // Reset stolen item always for battlefields or only if HP was 0 (mob died)
+    if (this->m_Type & MOBTYPE_BATTLEFIELD || health.hp == 0)
+    {
+        m_ItemStolen    = false;
+        m_ItemDespoiled = false;
+    }
+
     CBattleEntity::Spawn();
+
     m_giveExp        = true;
     m_HiPCLvl        = 0;
     m_HiPartySize    = 0;
     m_THLvl          = 0;
     m_GilfinderLevel = 0;
-    m_ItemStolen     = false;
-    m_ItemDespoiled  = false;
     m_DropItemTime   = 1000ms;
     animationsub     = (uint8)getMobMod(MOBMOD_SPAWN_ANIMATIONSUB);
     SetCallForHelpFlag(false);

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -19317,40 +19317,39 @@ uint16 CLuaBaseEntity::getDespoilDebuff(uint16 itemID)
 
 /************************************************************************
  *  Function: itemStolen()
- *  Purpose : Flags a mob's item as stolen, returns true upon update
- *  Example : target:itemStolen()
- *  Notes   : Used in scripts/globals/job_utils/thief.lua
+ *  Purpose : Flags a mob's item as stolen or not
+ *  Example : target:itemStolen(true)
+ *  Notes   : Used in scripts/globals/job_utils/thief.lua and QM NM popping code
  ************************************************************************/
 
-bool CLuaBaseEntity::itemStolen()
+void CLuaBaseEntity::itemStolen(bool stolen)
 {
     if (m_PBaseEntity->objtype != TYPE_MOB)
     {
         ShowWarning("Attempting to flag stolen item for invalid entity type (%s).", m_PBaseEntity->getName());
-        return false;
+        return;
     }
 
-    static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemStolen = true;
-    return true;
+    static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemStolen = stolen;
+    return;
 }
 
 /************************************************************************
  *  Function: itemDespoiled()
- *  Purpose : Flags a mob's item as despoiled, returns true upon update
+ *  Purpose : Flags a mob's item as despoiled or not
  *  Example : target:itemDespoiled()
- *  Notes   : Used in scripts/globals/job_utils/thief.lua
+ *  Notes   : Used in scripts/globals/job_utils/thief.lua and and QM NM popping code
  ************************************************************************/
 
-bool CLuaBaseEntity::itemDespoiled()
+void CLuaBaseEntity::itemDespoiled(bool despoiled)
 {
     if (m_PBaseEntity->objtype != TYPE_MOB)
     {
         ShowWarning("Attempting to flag despoiled item for invalid entity type (%s).", m_PBaseEntity->getName());
-        return false;
+        return;
     }
 
-    static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemDespoiled = true;
-    return true;
+    static_cast<CMobEntity*>(m_PBaseEntity)->m_ItemDespoiled = despoiled;
 }
 
 /************************************************************************

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -943,8 +943,8 @@ public:
     uint16 getStealItem();
     uint16 getDespoilItem();                // gets ItemID of droplist despoil item from mob (steal item if no despoil item)
     uint16 getDespoilDebuff(uint16 itemID); // gets the status effect id to apply to the mob on successful despoil
-    bool   itemStolen();                    // sets mob's ItemStolen var = true
-    bool   itemDespoiled();                 // sets mob's ItemDespoiled var = true
+    void   itemStolen(bool stolen);         // sets mob's ItemStolen var
+    void   itemDespoiled(bool despoiled);   // sets mob's ItemDespoiled var
     int16  getTHlevel();                    // Returns the Monster's current Treasure Hunter Tier
     void   setTHlevel(int16 newLevel);      // Sets the Monster's current Treasure Hunter Tier
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Stolen items should only reset when the mob spawns with 0 HP, is a battlefield NM, or spawns from a QM

## Steps to test these changes

Repeat steals on no-kill (despawn), see only one item. Repeat steals on kill and get items, repeat steals on QM/BC spawns and get items.
