### PR TITLE
[lua] Adds skip FSTR to 1000 Needles

### DIFF
--- a/scripts/actions/mobskills/1000_needles.lua
+++ b/scripts/actions/mobskills/1000_needles.lua
@@ -21,6 +21,10 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.shadowBehavior     = xi.mobskills.shadowBehavior.WIPE_SHADOWS
     params.guaranteedFirstHit = true
     params.skipPDIF           = true
+    params.skipFSTR           = true
+    params.skipParry          = true
+    params.skipGuard          = true
+    params.skipBlock          = true
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds the skip FSTR param to 1000 needles so that damage is always exactly 1000. 

## Steps to test these changes

Find any mob !exec target:useMobAbility(322) see exactly 1000 damage
