### PR TITLE
[lua] Disable parry if neither main nor subjob has parry rank

### DIFF
--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -1103,7 +1103,12 @@ xi.combat.physical.canParry = function(defender, attacker)
         not defender:hasPreventActionEffect(true) -- Not stunned, slept, etc, but can parry when charmed
     then
         if defender:isPC() then
+            if defender:getSkillRank(xi.skill.PARRY) == 0 then
+                return false
+            end
+
             local mainWeapon = defender:getEquippedItem(xi.slot.MAIN)
+
             if mainWeapon then
                 canParry = mainWeapon:getSkillType() ~= xi.skill.HAND_TO_HAND
             end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

You cannot parry if your main or sub doesnt have a rank in parry, apparently.

## Steps to test these changes
use WHM/BLM or WHM/RNG and check if you can parry

then change sub to something that can like THF
