### PR TITLE
[core,sql] Support alternative entity lists for instances

### DIFF
--- a/sql/instance_list.sql
+++ b/sql/instance_list.sql
@@ -21,6 +21,7 @@ CREATE TABLE `instance_list` (
   `instance_name` varchar(35) NOT NULL DEFAULT '',
   `instance_zone` smallint(3) unsigned NOT NULL DEFAULT '0',
   `entrance_zone` smallint(3) unsigned NOT NULL DEFAULT '0',
+  `overlay_id` smallint(3) unsigned NULL,
   `time_limit` tinyint(3) unsigned NOT NULL DEFAULT '0',
   `start_x` float(7,3) NOT NULL DEFAULT '0.000',
   `start_y` float(7,3) NOT NULL DEFAULT '0.000',
@@ -41,7 +42,7 @@ CREATE TABLE `instance_list` (
 LOCK TABLES `instance_list` WRITE;
 /*!40000 ALTER TABLE `instance_list` DISABLE KEYS */;
 
-INSERT INTO `instance_list` VALUES (0,'TEST',0,0,0,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (0,'TEST',0,0,NULL,0,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- NOTE: instanceid is made up of: base(zoneID * 100) + offset. The offset is arbitrary.
 -- NOTE: Since there is a growing number of Ambuscade entries, they start at 30000
@@ -51,9 +52,9 @@ INSERT INTO `instance_list` VALUES (0,'TEST',0,0,0,0.000,0.000,0.000,0,NULL,NULL
 --       - Battle content (ordered by expansion and/or release date)
 
 -- ILRUSI_ATOLL (zoneID: 55, starting id: 5500)
-INSERT INTO `instance_list` VALUES (5500,'golden_salvage',55,54,30,386.000,-12.000,17.000,46,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (5501,'lamia_no_13',55,54,30,155.000,-7.000,-175.000,47,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (5502,'extermination',55,54,30,298.099,-3.943,135.234,149,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5500,'golden_salvage',55,54,NULL, 30,386.000,-12.000,17.000,46,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5501,'lamia_no_13',55,54, NULL,30,155.000,-7.000,-175.000,47,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5502,'extermination',55,54,NULL,30,298.099,-3.943,135.234,149,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5503,'demolition_duty',55,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5504,'searat_salvation',55,54,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5505,'apkallu_seizure',55,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
@@ -63,9 +64,9 @@ INSERT INTO `instance_list` VALUES (5502,'extermination',55,54,30,298.099,-3.943
 -- INSERT INTO `instance_list` VALUES (5509,'bellerophons_bliss',55,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- PERIQIA (zoneID: 56, starting id: 5600)
-INSERT INTO `instance_list` VALUES (5600,'shades_of_vengeance',56,79,30,127.000,-15.000,-303.000,0,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (5601,'seagull_grounded',56,79,30,-350.000,-15.245,380.000,0,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (5602,'requiem',56,79,30,-470.000,-9.964,-325.000,190,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5600,'shades_of_vengeance',56,79,NULL,30,127.000,-15.000,-303.000,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5601,'seagull_grounded',56,79,NULL,30,-350.000,-15.245,380.000,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (5602,'requiem',56,79,NULL,30,-470.000,-9.964,-325.000,190,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5603,'saving_private_ryaaf',56,79,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5604,'shooting_down_the_baron',56,79,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (5605,'building_bridges',56,79,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
@@ -76,16 +77,16 @@ INSERT INTO `instance_list` VALUES (5602,'requiem',56,79,30,-470.000,-9.964,-325
 -- INSERT INTO `instance_list` VALUES (5610,'the_price_is_right',56,79,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- THE_ASHU_TALIF (zoneID: 60, starting id: 6000)
-INSERT INTO `instance_list` VALUES (6000,'the_black_coffin',60,54,30,0.000,-22.000,24.000,64,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (6001,'against_all_odds',60,54,30,-9.000,-22.000,17.000,252,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6000,'the_black_coffin',60,54,NULL,30,0.000,-22.000,24.000,64,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6001,'against_all_odds',60,54,NULL,30,-9.000,-22.000,17.000,252,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6002,'scouting_the_ashu_talif',60,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6003,'royal_painter_escort',60,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6004,'targeting_the_captain',60,54,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- LEBROS_CAVERN (zoneID: 63, starting id: 6300)
-INSERT INTO `instance_list` VALUES (6300,'excavation_duty',63,61,30,124.999,-39.309,19.999,0,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (6301,'lebros_supplies',63,61,30,-333.000,-9.921,-259.999,255,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (6302,'troll_fugitives',63,61,30,-459.912,-9.860,342.319,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6300,'excavation_duty',63,61,NULL,30,124.999,-39.309,19.999,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6301,'lebros_supplies',63,61,NULL,30,-333.000,-9.921,-259.999,255,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6302,'troll_fugitives',63,61,NULL,30,-459.912,-9.860,342.319,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6303,'evade_and_escape',63,61,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6304,'siegemaster_assassination',63,61,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6305,'apkallu_breeding',63,61,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
@@ -95,8 +96,8 @@ INSERT INTO `instance_list` VALUES (6302,'troll_fugitives',63,61,30,-459.912,-9.
 -- INSERT INTO `instance_list` VALUES (6309,'better_than_one',63,61,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- MAMOOL_JA_TRAINING_GROUNDS (zoneID: 66, starting id: 6600)
-INSERT INTO `instance_list` VALUES (6600,'imperial_agent_rescue',66,52,30,-20.000,2.276,-405.000,63,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (6601,'preemptive_strike',66,52,30,-60.350,-5.000,27.670,46,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6600,'imperial_agent_rescue',66,52,NULL,30,-20.000,2.276,-405.000,63,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6601,'preemptive_strike',66,52,NULL,30,-60.350,-5.000,27.670,46,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6602,'sagelord_elimination',66,52,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6603,'breaking_morale',66,52,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6604,'the_double_agent',66,52,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
@@ -107,8 +108,8 @@ INSERT INTO `instance_list` VALUES (6601,'preemptive_strike',66,52,30,-60.350,-5
 -- INSERT INTO `instance_list` VALUES (6609,'the_susanoo_shuffle',66,52,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- LEUJAOAM_SANCTUM (zoneID: 69, starting id: 6900)
-INSERT INTO `instance_list` VALUES (6900,'leujaoam_cleansing',69,79,30,280.000,-7.500,35.000,195,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (6901,'orichalcum_survey',69,79,30,-432.000,-27.627,169.000,131,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6900,'leujaoam_cleansing',69,79,NULL,30,280.000,-7.500,35.000,195,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (6901,'orichalcum_survey',69,79,NULL,30,-432.000,-27.627,169.000,131,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6902,'escort_professor_chanoix',69,79,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6903,'shanarha_grass_conservation',69,79,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (6904,'counting_sheep',69,79,15,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
@@ -119,27 +120,27 @@ INSERT INTO `instance_list` VALUES (6901,'orichalcum_survey',69,79,30,-432.000,-
 -- INSERT INTO `instance_list` VALUES (6909,'bloody_rondo',69,79,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- ZHAYOLM_REMNANTS (zoneID: 73, starting id: 7300)
-INSERT INTO `instance_list` VALUES (7300,'zhayolm_remnants',73,72,100,340.000,0.000,-592.000,192,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (7300,'zhayolm_remnants',73,72,NULL,100,340.000,0.000,-592.000,192,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (7301,'zhayolm_remnants_ii',73,72,100,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- ARRAPAGO_REMNANTS (zoneID: 74, starting id: 7400)
-INSERT INTO `instance_list` VALUES (7400,'arrapago_remnants',74,72,100,340.000,0.000,-246.000,63,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (7400,'arrapago_remnants',74,72,NULL,100,340.000,0.000,-246.000,63,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (7401,'arrapago_remnants_ii',74,72,100,340.000,0.000,-246.000,63,NULL,NULL,NULL,NULL);
 
 -- BHAFLAU_REMNANTS (zoneID: 75, starting id: 7500)
-INSERT INTO `instance_list` VALUES (7500,'bhaflau_remnants',75,72,100,340.000,19.000,-552.000,191,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (7500,'bhaflau_remnants',75,72,NULL,100,340.000,19.000,-552.000,191,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (7501,'bhaflau_remnants_ii',75,72,100,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- SILVER_SEA_REMNANTS (zoneID: 76, starting id: 7600)
-INSERT INTO `instance_list` VALUES (7600,'silver_sea_remnants',76,72,100,340.000,12.000,-165.500,63,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (7600,'silver_sea_remnants',76,72,NULL,100,340.000,12.000,-165.500,63,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (7601,'silver_sea_remnants_ii',76,72,100,340.000,12.000,-165.500,63,NULL,NULL,NULL,NULL);
 
 -- NYZUL_ISLE (zoneID: 77, starting id: 7700)
-INSERT INTO `instance_list` VALUES (7700,'path_of_darkness',77,72,30,500.000,0.000,-572.000,192,143,143,143,143);
-INSERT INTO `instance_list` VALUES (7701,'nashmeiras_plea',77,72,45,-444.000,-4.000,420.000,127,143,143,143,143);
-INSERT INTO `instance_list` VALUES (7702,'waking_the_colossus',77,72,15,-444.000,-4.000,420.000,127,187,187,187,187);
+INSERT INTO `instance_list` VALUES (7700,'path_of_darkness',77,72,NULL,30,500.000,0.000,-572.000,192,143,143,143,143);
+INSERT INTO `instance_list` VALUES (7701,'nashmeiras_plea',77,72,NULL,45,-444.000,-4.000,420.000,127,143,143,143,143);
+INSERT INTO `instance_list` VALUES (7702,'waking_the_colossus',77,72,NULL,15,-444.000,-4.000,420.000,127,187,187,187,187);
 -- INSERT INTO `instance_list` VALUES (7703,'forging_a_new_myth',77,72,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (7704,'nyzul_isle_investigation',77,72,30,-20.000,-4.000,-20.000,196,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (7704,'nyzul_isle_investigation',77,72,NULL,30,-20.000,-4.000,-20.000,196,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (7705,'nyzul_isle_uncharted_survey',77,72,30,0.000,0.000,0.000,0,NULL,NULL,NULL,NULL);
 
 -- EVERBLOOM_HOLLOW (zoneID: 86, starting id: 8600)
@@ -148,17 +149,17 @@ INSERT INTO `instance_list` VALUES (7704,'nyzul_isle_investigation',77,72,30,-20
 -- INSERT INTO `instance_list` VALUES (8602,'doomvoid',86,84,0,382,0,-191,74,NULL,NULL,NULL,NULL);
 
 -- RUHOTZ_SILVERMINES (zoneID: 93, starting id: 9300)
-INSERT INTO `instance_list` VALUES (9300,'light_in_the_darkness',93,90,0,-22.500,1.600,40.000,192,NULL,NULL,NULL,NULL);
-INSERT INTO `instance_list` VALUES (9301,'fire_in_the_hole',93,88,0,156.000,0.000,-60.000,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (9300,'light_in_the_darkness',93,90,NULL,0,-22.500,1.600,40.000,192,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (9301,'fire_in_the_hole',93,88,NULL,0,156.000,0.000,-60.000,0,NULL,NULL,NULL,NULL);
 -- INSERT INTO `instance_list` VALUES (9301,'doomvoid',93,84,0,382,0,-191,74,NULL,NULL,NULL,NULL);
 
 -- GHOYUS_REVERIE (zoneID: 129, starting id: 12900)
-INSERT INTO `instance_list` VALUES (12900,'doomvoid',129,84,0,382.000,0.000,-191.000,74,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (12900,'doomvoid',129,84,NULL,0,382.000,0.000,-191.000,74,NULL,NULL,NULL,NULL);
 
 -- MAQUETTE_ABDHALJS_LEGION_A (zoneID: 183, starting id: 18300)
 
 -- RALA_WATERWAYS_U (zoneID: 259, starting id: 25900)
-INSERT INTO `instance_list` VALUES (25900,'behind_the_sluices',259,258,0,-153.000,-5.700,-380.000,0,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (25900,'behind_the_sluices',259,258,NULL,0,-153.000,-5.700,-380.000,0,NULL,NULL,NULL,NULL);
 
 -- YORCIA_WEALD_U (zoneID: 264, starting id: 26400)
 
@@ -177,7 +178,7 @@ INSERT INTO `instance_list` VALUES (25900,'behind_the_sluices',259,258,0,-153.00
 -- DYNAMIS_JEUNO_D (zoneID: 297, starting id: 29700)
 
 -- MAQUETTE_ABDHALJS_LEGION_B (zoneID: 287, starting id: 30000)
-INSERT INTO `instance_list` VALUES (30000,'ambuscade',287,249,30,137.000,12.500,-137.000,32,NULL,NULL,NULL,NULL);
+INSERT INTO `instance_list` VALUES (30000,'ambuscade',287,249,NULL,30,137.000,12.500,-137.000,32,NULL,NULL,NULL,NULL);
 
 /*!40000 ALTER TABLE `instance_list` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -78,6 +78,7 @@ void CInstance::LoadInstance()
                                        "instance_name, "
                                        "time_limit, "
                                        "entrance_zone, "
+                                       "overlay_id, "
                                        "start_x, "
                                        "start_y, "
                                        "start_z, "
@@ -97,6 +98,7 @@ void CInstance::LoadInstance()
 
         m_timeLimit                       = std::chrono::minutes(rset->get<uint32>("time_limit"));
         m_entrance                        = rset->get<uint16>("entrance_zone");
+        overlayId_                        = rset->getOrDefault("overlay_id", 0);
         m_entryloc.x                      = rset->get<float>("start_x");
         m_entryloc.y                      = rset->get<float>("start_y");
         m_entryloc.z                      = rset->get<float>("start_z");
@@ -348,4 +350,11 @@ uint16 CInstance::GetBackgroundMusicDay()
 uint16 CInstance::GetBackgroundMusicNight()
 {
     return m_zone_music_override.m_songNight ? *m_zone_music_override.m_songNight : GetZone()->GetBackgroundMusicNight();
+}
+
+// Certain instances with multiple sub-maps use alternative entity lists replacing the base list
+// The client needs it to know which DATs to load.
+auto CInstance::overlayId() const -> uint32
+{
+    return overlayId_;
 }

--- a/src/map/instance.h
+++ b/src/map/instance.h
@@ -86,6 +86,8 @@ public:
     uint16 GetBackgroundMusicDay();
     uint16 GetBackgroundMusicNight();
 
+    auto overlayId() const -> uint32;
+
 private:
     void LoadInstance();
 
@@ -107,6 +109,7 @@ private:
     INSTANCE_STATUS     m_status{ INSTANCE_NORMAL };
     std::vector<uint32> m_registeredChars;
     std::set<uint32>    m_enteredChars;
+    uint32              overlayId_{ 0 };
 
     std::unordered_map<std::string, uint64_t> localVars_;
 };

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -66,6 +66,10 @@ CInstance* CInstanceLoader::LoadInstance() const
 {
     TracyZoneScoped;
 
+    const auto realZoneId      = m_PZone->GetID();
+    const auto overlayId       = m_PInstance->overlayId();
+    const auto effectiveZoneId = (overlayId != 0) ? overlayId : static_cast<uint32>(realZoneId);
+
     auto rset = db::preparedStmt("SELECT mobname, mobid, pos_rot, pos_x, pos_y, pos_z, "
                                  "respawntime, spawntype, dropid, mob_groups.HP, mob_groups.MP, minLevel, maxLevel, "
                                  "modelid, mJob, sJob, cmbSkill, cmbDmgMult, cmbDelay, behavior, links, mobType, immunity, "
@@ -79,13 +83,18 @@ CInstance* CInstanceLoader::LoadInstance() const
                                  "(mob_species_system.HP / 100) AS hp_scale, (mob_species_system.MP / 100) AS mp_scale, hasSpellScript, spellList, mob_groups.poolid, "
                                  "allegiance, namevis, aggro, mob_pools.skill_list_id, mob_pools.true_detection, detects, "
                                  "mob_species_system.charmable, mob_pools.modelSize, mob_pools.modelHitboxSize "
-                                 "FROM instance_entities INNER JOIN mob_spawn_points ON instance_entities.id = mob_spawn_points.mobid "
-                                 "INNER JOIN mob_groups ON mob_groups.groupid = mob_spawn_points.groupid AND mob_groups.zoneid=((mob_spawn_points.mobid>>12)&0xFFF) "
+                                 "FROM instance_entities "
+                                 "INNER JOIN mob_spawn_points ON instance_entities.id = mob_spawn_points.mobid "
+                                 "INNER JOIN mob_groups ON mob_groups.groupid = mob_spawn_points.groupid AND mob_groups.zoneid = ? "
                                  "INNER JOIN mob_pools ON mob_groups.poolid = mob_pools.poolid "
                                  "INNER JOIN mob_resistances ON mob_resistances.resist_id = mob_pools.resist_id "
                                  "INNER JOIN mob_species_system ON mob_pools.speciesid = mob_species_system.speciesID "
-                                 "WHERE instanceid = ? AND NOT (pos_x = 0 AND pos_y = 0 AND pos_z = 0)",
-                                 m_PInstance->GetID());
+                                 "WHERE instanceid = ? "
+                                 "  AND ((mob_spawn_points.mobid >> 12) & 0xFFF) = ? "
+                                 "  AND NOT (pos_x = 0 AND pos_y = 0 AND pos_z = 0)",
+                                 realZoneId,
+                                 m_PInstance->GetID(),
+                                 effectiveZoneId);
 
     if (!m_PInstance->Failed())
     {
@@ -231,7 +240,7 @@ CInstance* CInstanceLoader::LoadInstance() const
             m_PInstance->InsertMOB(PMob);
         }
 
-        const uint32 zoneMin = (m_PZone->GetID() << 12) + 0x1000000;
+        const uint32 zoneMin = (effectiveZoneId << 12) + 0x1000000;
         const uint32 zoneMax = zoneMin + 1024;
 
         rset = db::preparedStmt("SELECT npcid, name, pos_rot, pos_x, pos_y, pos_z, "

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1050,33 +1050,56 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
     // Load all Name/ID pairs from mobs and npcs
     std::unordered_map<std::string, std::vector<uint32>> lookup;
 
-    // Mobs
-    {
-        const auto rset = db::preparedStmt("SELECT mobname, mobid FROM mob_spawn_points WHERE ((mobid >> 12) & 0xFFF) = ? ORDER BY mobid ASC", zoneId);
-        if (rset && rset->rowsCount())
-        {
-            while (rset->next())
-            {
-                const auto name = rset->get<std::string>("mobname");
-                const auto id   = rset->get<uint32>("mobid");
+    std::vector<uint16> effectiveZones;
+    effectiveZones.push_back(static_cast<uint16>(zoneId));
 
-                lookup[name].emplace_back(id);
-            }
+    const auto overlayRset = db::preparedStmt("SELECT overlay_id FROM instance_list "
+                                              "WHERE instance_zone = ? AND overlay_id IS NOT NULL AND overlay_id != 0",
+                                              zoneId);
+    FOR_DB_MULTIPLE_RESULTS(overlayRset)
+    {
+        effectiveZones.push_back(overlayRset->get<uint16>("overlay_id"));
+    }
+
+    const auto idRange = [](uint16 effectiveZone) -> std::pair<uint32, uint32>
+    {
+        const uint32 idMin = (static_cast<uint32>(effectiveZone) << 12) | 0x01000000;
+        return { idMin, idMin + 0xFFF };
+    };
+
+    // Mobs
+    for (auto effectiveZone : effectiveZones)
+    {
+        const auto [idMin, idMax] = idRange(effectiveZone);
+        const auto rset           = db::preparedStmt("SELECT mobname, mobid FROM mob_spawn_points "
+                                                     "WHERE mobid BETWEEN ? AND ? "
+                                                     "ORDER BY mobid ASC",
+                                           idMin,
+                                           idMax);
+        FOR_DB_MULTIPLE_RESULTS(rset)
+        {
+            const auto name = rset->get<std::string>("mobname");
+            const auto id   = rset->get<uint32>("mobid");
+
+            lookup[name].emplace_back(id);
         }
     }
 
     // NPCs
+    for (auto effectiveZone : effectiveZones)
     {
-        const auto rset = db::preparedStmt("SELECT name, npcid FROM npc_list WHERE ((npcid >> 12) & 0xFFF) = ? ORDER BY npcid ASC", zoneId);
-        if (rset && rset->rowsCount())
+        const auto [idMin, idMax] = idRange(effectiveZone);
+        const auto rset           = db::preparedStmt("SELECT name, npcid FROM npc_list "
+                                                     "WHERE npcid BETWEEN ? AND ? "
+                                                     "ORDER BY npcid ASC",
+                                           idMin,
+                                           idMax);
+        FOR_DB_MULTIPLE_RESULTS(rset)
         {
-            while (rset->next())
-            {
-                const auto name = rset->get<std::string>("name");
-                const auto id   = rset->get<uint32>("npcid");
+            const auto name = rset->get<std::string>("name");
+            const auto id   = rset->get<uint32>("npcid");
 
-                lookup[name].emplace_back(id);
-            }
+            lookup[name].emplace_back(id);
         }
     }
 

--- a/src/map/packets/s2c/0x00a_login.cpp
+++ b/src/map/packets/s2c/0x00a_login.cpp
@@ -154,6 +154,7 @@ GP_SERV_COMMAND_LOGIN::GP_SERV_COMMAND_LOGIN(CCharEntity* PChar, const EventInfo
     packet.WeatherNumber = static_cast<uint16>(PChar->loc.zone->GetWeather());
     packet.WeatherTime   = PChar->loc.zone->GetWeatherChangeTime();
     packet.ZoneNo        = PChar->getZone();
+    packet.ZoneSubNo     = PChar->PInstance ? PChar->PInstance->overlayId() : 0;
     packet.MapNumber     = PChar->getZone();
     packet.SubMapNumber  = PChar->loc.boundary;
     packet.PlayTime      = static_cast<uint32>(timer::count_seconds(PChar->GetPlayTime()));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Certain zones serving as base for instances do use alternative event/text/entity DATs that get chosen by the client when they receive the original LOGIN packet, through the ZoneSubNo parameter.

This effectively means that for example, there are entities in Everbloom Hollow whose unique ID upper bits do not decode to 86 (Everbloom) but to 1018 (the alternative overlay or whatever you wanna call it).

This PR:
- Adds NULL-able overlay_id to instance_list.sql
- Assigns it to the CInstance at load time
- Hooks up the ZoneSubNo param in LOGIN packet
- Ensures the lua caching/instance loading process loads ALL base NPCs/Mobs + ALL overlaid NPCs/Mobs
  - The SQL queries were tweaked to make use of computed ranges because it was painfully slow to bitshift the whole mob/npc table several time

This is required for:
- Certain TVR missions (Reisenjima Henge)
- Odyssey (Walk of Echoes [P1/P2])
- Sortie (Outer RaKaznar [U1/U2/U3])
- MMM (Everbloom Hollow / Goyou's Reverie / Ruhotz Silvermines)
- Meeble Burrows (Everbloom Hollow / Goyou's Reverie / Ruhotz Silvermines)

Note: This also means there will be events and texts with the same IDs but _different_ outcomes in a given zone - but that's a problem for another day

## Steps to test these changes
Didn't include it in the PR but I hooked up Meeble Burrows Researcher in Sauromugue (Everbloom) and got the NPC/Mobs to load and render correctly.

<img width="1398" height="839" alt="Screenshot 2026-05-25 104244" src="https://github.com/user-attachments/assets/1e46442d-64bb-4957-a1b9-bc1a7208e74a" />
