### PR TITLE
Add Parike-Poranke, Brown Mage Practitioner

### DIFF
--- a/scripts/zones/Lower_Jeuno/DefaultActions.lua
+++ b/scripts/zones/Lower_Jeuno/DefaultActions.lua
@@ -1,4 +1,4 @@
-local ID = zones[xi.zone.LOWER_JEUNO]
+﻿local ID = zones[xi.zone.LOWER_JEUNO]
 
 return {
     ['_6t2']            = { event = 64 }, -- Door:Merchant's House
@@ -34,7 +34,6 @@ return {
     ['Navisse']         = { event = 153 },
     ['Odasel']          = { event = 162 },
     ['Omer']            = { event = 206 },
-    ['Parike-Poranke']  = { text = ID.text.PARIKE_PORANKE_DIALOG },
     ['Raji']            = { event = 195 },
     ['Rakuru-Rakoru']   = { event = 10078 },
     ['Ruslan']          = { event = 10008 },

--- a/scripts/zones/Lower_Jeuno/IDs.lua
+++ b/scripts/zones/Lower_Jeuno/IDs.lua
@@ -1,4 +1,4 @@
------------------------------------
+﻿-----------------------------------
 -- Area: Lower_Jeuno
 -----------------------------------
 zones = zones or {}
@@ -55,22 +55,6 @@ zones[xi.zone.LOWER_JEUNO] =
         YIN_POCANAKHU_GET_LOST        = 8021,  -- Hey, what are you tryin' to pull? Get lost!
         MERTAIRE_RING                 = 8069,  -- So, what did you do with that ring? Maybe it's valuable. I'd ask a collector if I were you. Of course, he might just say it's worthless...
         CONQUEST                      = 8081,  -- You've earned conquest points!
-        PARIKE_PORANKE_DIALOG         = 8979,  -- All these people running back and forth... There have to be a few that have munched down more mithkabobs than they can manage. (And if I don't hand in this report to the Orastery soon... Ulp!)
-        PARIKE_PORANKE_1              = 8980,  -- Hey you! Belly bursting? Intestines inflating? Bladder bulging? I can tell by the notch on your belt that you've been overindulging yourself in culinary delights.
-        PARIKE_PORANKE_2              = 8983,  -- I mean, this is a new era. If somebody wants to go around with their flabby-flubber hanging out of their cloaks, they should have every right to do so. If someone wants to walk around town with breath reeking of Kazham pines and roasted sleepshrooms, who am I to stop them?
-        PARIKE_PORANKE_3              = 8984,  -- What? You want me to tend to your tummy trouble? No problem! And don't worry, this won't hurt at all! I'm only going to be flushing your bowels with thousands of tiny lightning bolts. It's all perfectly safe!
-        PARIKE_PORANKE_4              = 8985,  -- Now stand still! You wouldn't want your pelvis to implode, would you? (Let's see... What were those magic words again...?)
-        PARIKE_PORANKE_5              = 8986,  -- Ready? No? Well, too bad!
-        PARIKE_PORANKE_6              = 8994,  -- <name>'s digestive magic skill rises 0.1 points.
-        PARIKE_PORANKE_7              = 8995,  -- <name>'s digestive magic skill rises one level.
-        PARIKE_PORANKE_8              = 8996,  -- Heh heh! I think I'm starting to get the hang of this spellcasting.
-        PARIKE_PORANKE_9              = 8997,  -- Consider this a petite present from your pal Parike-Poranke!
-        PARIKE_PORANKE_10             = 9001,  -- Wait a minute... Don't tell me you came to Parike-Poranke on an empty stomach! This is terrible! The minister will have my head!
-        PARIKE_PORANKE_12             = 9003,  -- Phew! That was close... What were you thinking, crazy adventurer!?
-        PARIKE_PORANKE_13             = 9006,  -- <name>'s all in the name of science skill rises 0.1 points.
-        PARIKE_PORANKE_14             = 9007,  -- <name>'s all in the name of science skill rises one level.
-        PARIKE_PORANKE_15             = 9008,  -- You know, I've learned a lot from my mist--er, I mean, less-than-successful attempts at weight-loss consulting.
-        PARIKE_PORANKE_16             = 9009,  -- To show you my gratitude, let me try out this new spell I thought up yesterday while I was taking a nap!
         NO_KEY                        = 9931,  -- You do not have a usable key in your possession.
         RETRIEVE_DIALOG_ID            = 10211, -- You retrieve <item> from the porter moogle's care.
         WAYPOINT_EXAMINE              = 10372, -- An enigmatic contrivance hovers in silence...

--- a/scripts/zones/Lower_Jeuno/npcs/Parike-Poranke.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Parike-Poranke.lua
@@ -1,0 +1,84 @@
+﻿-----------------------------------
+-- Area: Lower Jeuno
+--  NPC: Parike-Poranke
+-- Type: Adventurer's Assistant, Food Remover, Brown Mage
+-- !pos -33.161 -1 -61.303 245
+-----------------------------------
+
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    -- 10002 - Traded greens with food on board.
+    -- 10003 - Traded with no food.
+
+    if npcUtil.tradeHasExactly(trade, xi.item.BUNCH_OF_GYSAHL_GREENS) then
+        player:confirmTrade()
+
+        local param7 = player:hasStatusEffect(xi.effect.FOOD) and 10002 or 10003
+
+        player:startEvent(10044, 0, 0, 0, 0, 0, 0, 0, param7)
+    end
+end
+
+entity.onTrigger = function(player, npc)
+    -- 10000: Intro.
+    -- 10001: Spiel about wanting to fix peoples food related issues.
+
+    local param7 = player:hasStatusEffect(xi.effect.FOOD) and 10001 or 10000
+
+    player:startEvent(10044, 0, 0, 0, 0, 0, 0, 0, param7)
+end
+
+entity.onEventUpdate = function(player, csid, option)
+    -- An updateEvent with param1 set to 10007 will cause Parike-Poranke to stop the CS short and say: "Wait a minute...My linkshell's ringing.Let me get back to you after I take this call."
+    -- This causes the event CS to end and in the scneario where the player was diseased - they will not be cured. The situation where this should be triggered is currently unknown.
+    -- Does not appear to be related to Parike-Poranke's invlvement with LB 7 and LB 8.
+    -- Does not appear to be related to spam trading Parike-Poranke.
+    -- Otherwise, all updates provide param1 as 10006
+
+    local npc = player:getEventTarget()
+    if not npc then
+        return
+    end
+
+    local param1 = 10006
+    local param2 = 0 -- Total successes or failures
+
+    -- Traded greens w/ food active
+    if option == 10002 then
+        param2 = npc:getLocalVar('Parike_DigestiveSkill') + 1
+        npc:setLocalVar('Parike_DigestiveSkill', param2)
+        player:delStatusEffect(xi.effect.FOOD)
+
+    -- Traded greens w/o food active part 2
+    elseif option == 10003 then
+        param2 = npc:getLocalVar('Parike_ScienceSkill')
+        player:delStatusEffect(xi.effect.DISEASE)
+
+    -- Traded greens w/o food active part 1
+    elseif option == 10004 then
+        param2 = npc:getLocalVar('Parike_ScienceSkill') + 1
+        npc:setLocalVar('Parike_ScienceSkill', param2)
+        player:addStatusEffect(xi.effect.DISEASE, { power = 1, duration = 300, origin = player })
+    end
+
+    player:updateEvent(param1, param2)
+end
+
+entity.onEventFinish = function(player, csid, option)
+    -- Note: These options occur at every 10,000 trades for each track.
+
+    -- Title CS - Digestive
+    if option == 10008 then
+        player:addTitle(xi.title.BROWN_MAGE_GUINEA_PIG)
+        player:addStatusEffect(xi.effect.RERAISE, { power = 3, duration = 3600, origin = player }) -- https://wiki.ffo.jp/html/12891.html claim a RR3 effect is bestowed.
+
+    -- Title CS - Science
+    elseif option == 10009 then
+        player:addTitle(xi.title.BROWN_MAGIC_BY_PRODUCT)
+        player:addStatusEffect(xi.effect.FLEE, { power = 10000, duration = 60, origin = player }) -- https://wiki.ffo.jp/html/16849.html claims 60s and faster than JA Flee.
+    end
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Adds the Brown Mage, Parike-Poranke
2. Adds a new setting to `xi.settings.main` for servers to determine if they wish persist his skill values between restarts, thereby writing updates to ServerVars instead of LocalVars. 
Note: I considered VolatileServerVars but given the read/write ratio - I did not run with that idea.  "With Food "is a 1:1 ratio, "Without Food" is a 2:1 read ratio - so the befit would be slim to none.

## Steps to test these changes

Check the following:
1. Talk to NPC without food active - No "CS" fade, Parike-Poranke talks about people walking by
2. Talk to NPC with food active - CS fade, Parike-Poranke suggests you trade a Gysahl Green
3. Trading Gyshal Green with food active - CS fade, increments success counter
4. Trading Gyshal Green without food active - CS fade, increments failure counter

Without maniuplating lua or the database via the setting `PERSIST_BROWN_MAGIC_SKILL` - the following are very hard to test:
5. 1,000th trade with food - Parike-Poranke gets a .1 skill up to Digestive 
6. 1,000th trade without food - Parike-Poranke gets a .1 skill up to Science
7. 10,000th trade with food - Parike-Poranke gets "one" skill level of Digestive.  
    8. Player gets the BROWN_MAGE_GUINEA_PIG title.  Player gets a RR3 effect
9. 10,000th trade without food - Parike-Poranke gets a .1 skill up to Science
    8. Player gets the BROWN_MAGIC_BY_PRODUCT title.  Player gets a Flee effect

## Fun / Interesting Note
Parike-Poranke has his own Debug Menu - triggered by passing Event 10044 Param7 as anything but 10000, 10001, 10002, and 10003.
This Debug Menu contains the entries "Success 999, Sucess 9999, Failure 999, Failure 9999".
Then, the CS would playout based on the values set via the menu.
_I have not implemented this Debug functionality._
<img width="128" height="94" alt="image" src="https://github.com/user-attachments/assets/b6b6ff4e-e204-4bdb-853d-1662b4d7de4c" />

## Less Fun Note ##
As the capture playlist below shows - I have spent a long time trying to find a way to trigger the event path that exists where Parike-Poranke would stop, mid food expulsion, and say "Wait a minute... My linkshell's ringing. Let me get back to you after I take this call.".

This is entirely controlled serverside during an event update.  For the life of me, I dont know how this happens and while I will continue to look for ways to trigger this event, I believe I've ruled out the following:
- Interactions with LB 7 and LB 8 (Parike-Poranke appears in these LBs) - and LB 9
- Spam Trading Parike-Poranke with fps 0

## Captures and Information
- [Capture Playlist](https://www.youtube.com/playlist?list=PL_htfg_0o7PJxyVjQngy2UCs30NWjsI1k) where I attempted to find the missing branch of Parike-Poranke's diaglog
    - Everything beyond the first video is just a failure to find the Linkshell Call Interruption event
- [wiki.ffo for Parike-Poranke](https://wiki.ffo.jp/html/4314.html)
- [wiki.ffo for Digestive Title](https://wiki.ffo.jp/html/12891.html) - reference to RR3
- [wiki.ffo for ScienceTitle](https://wiki.ffo.jp/html/16849.html) - reference to Flee

