### PR TITLE
[core] [lua] Remove bad useages of const CItem* templates, prevent steal/despoil of rare items you already have

### DIFF
--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -248,9 +248,7 @@ local function calculatePerformanceBoost(pet)
     local performanceBoost = 0
 
     local numLightManeuvers = master and master:countEffect(xi.effect.LIGHT_MANEUVER) or 0
-    for _, attachmentObj in ipairs(pet:getAttachments()) do
-        local attachmentName = attachmentObj:getName()
-
+    for _, attachmentName in pairs(pet:getAttachments()) do
         if isOpticFiber(attachmentName) then
             performanceBoost = performanceBoost + attachmentModifiers[attachmentName][1][2][numLightManeuvers + 1]
         end

--- a/scripts/globals/campaign.lua
+++ b/scripts/globals/campaign.lua
@@ -326,7 +326,11 @@ xi.campaign.sigilOnEventUpdate = function(player, csid, option, npc)
         -- needing to check types.  The first checks job requirement only, followed by
         -- job requirement _and_ level so that the appropriate message is displayed.
 
-        if GetItemByID(itemInfo[1]):getReqLvl() > 0 then
+        local item         = GetItemByID(itemInfo[1])
+        local itemReqLevel = GetItemLevelRequirementsByID(itemInfo[1])
+
+        -- check nil of item, since GetItemLevelRequirementsByID can't return nil (but we can't fetch from it yet either)
+        if item and itemReqLevel > 0 then
             if not player:canEquipItem(itemInfo[1]) then
                 canEquip = 0
             elseif not player:canEquipItem(itemInfo[1], true) then

--- a/scripts/globals/festive_moogle.lua
+++ b/scripts/globals/festive_moogle.lua
@@ -413,11 +413,13 @@ xi.festiveMoogle.onTrade = function(player, npc, trade)
             -- appears to only be valid for the equipment category, and not for items.
             if rewardItems[pellType][1] then
                 for bitPos, rewardItemId in pairs(rewardItems[pellType][1]) do
-                    local itemObj = GetItemByID(rewardItemId)
+                    local itemObj      = GetItemByID(rewardItemId)
+                    local itemObjFlags = GetItemFlagsByID(rewardItemId)
 
+                    -- check nil of item, since GetItemFlagsByID can't return nil (but we can't fetch from it yet either)
                     if
                         itemObj and
-                        bit.band(itemObj:getFlag(), xi.itemFlag.RARE) ~= 0 and
+                        bit.band(itemObjFlags, xi.itemFlag.RARE) ~= 0 and
                         player:hasItem(rewardItemId)
                     then
                         equipmentMask = utils.mask.setBit(equipmentMask, bitPos, true)

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -218,6 +218,20 @@ xi.job_utils.thief.useDespoil = function(player, target, ability, action)
 
     local despoiled = target:getDespoilItem()
 
+    if despoiled ~= 0 then
+        local despoiledItem      = GetItemByID(despoiled)
+        local despoiledItemFlags = GetItemFlagsByID(despoiled)
+
+        -- check nil of item, since GetItemFlagsByID can't return nil (but we can't fetch from it yet either)
+        if
+            despoiledItem and
+            bit.band(despoiledItemFlags, xi.itemFlag.RARE) ~= 0 and
+            player:hasItem(despoiled)
+        then
+            despoiled = 0 -- Failed to despoil rare item the player already has
+        end
+    end
+
     if
         target:isMob() and
         math.random(1, 100) <= despoilChance and
@@ -411,6 +425,20 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
 
     if stolen == 0 then
         stolen = target:getStealItem()
+    end
+
+    if stolen ~= 0 then
+        local stolenItem      = GetItemByID(stolen)
+        local stolenItemFlags = GetItemFlagsByID(stolen)
+
+        -- check nil of item, since GetItemFlagsByID can't return nil (but we can't fetch from it yet either)
+        if
+            stolenItem and
+            bit.band(stolenItemFlags, xi.itemFlag.RARE) ~= 0 and
+            player:hasItem(stolen)
+        then
+            stolen = 0 -- Failed to steal rare item the player already has
+        end
     end
 
     if target:isMob() and math.random(1, 100) <= stealChance and stolen ~= 0 then

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3611,12 +3611,6 @@ end
 function CBaseEntity:removeAllManeuvers()
 end
 
----@nodiscard
----@param slotId integer
----@return CItem?
-function CBaseEntity:getAttachment(slotId)
-end
-
 ---@param itemId integer
 ---@param slotId integer
 ---@return nil
@@ -3624,7 +3618,7 @@ function CBaseEntity:setAttachment(itemId, slotId)
 end
 
 ---@nodiscard
----@return CItem[]
+---@return table
 function CBaseEntity:getAttachments()
 end
 

--- a/scripts/specs/core/Globals.lua
+++ b/scripts/specs/core/Globals.lua
@@ -27,6 +27,18 @@ function GetItemByID(itemId)
 end
 
 ---@nodiscard
+---@param itemId xi.item
+---@return number
+function GetItemFlagsByID(itemId)
+end
+
+---@nodiscard
+---@param itemId xi.item
+---@return number
+function GetItemLevelRequirementsByID(itemId)
+end
+
+---@nodiscard
 ---@param npcid integer
 ---@param instanceObj CInstance?
 ---@return CBaseEntity?

--- a/scripts/tests/systems/items/puppet_attachments.lua
+++ b/scripts/tests/systems/items/puppet_attachments.lua
@@ -16,18 +16,24 @@ describe('Puppet attachments', function()
     end)
 
     it('equipped attachment is visible on the spawned automaton', function()
-        player:setAttachment(xi.item.STROBE_ATTACHMENT, 0)
+        player:setAttachment(xi.item.STROBE_ATTACHMENT, 5)
         player:spawnPet(xi.petId.AUTOMATON)
 
-        local pet = player:getPet()
-        assert(pet)
+        local pet         = player:getPet()
+        local attachments = nil
+        local item        = nil
+        if pet then
+            attachments = pet:getAttachments()
+        end
 
-        local attachments = pet:getAttachments()
         assert(attachments)
 
-        local item = attachments[0]
+        if attachments then
+            item = attachments[5]
+        end
+
         assert(item)
-        assert(item:getName() == 'strobe',
-            string.format('expected strobe, got %s', item:getName()))
+        assert(item == 'strobe',
+            string.format('expected strobe, got %s', item))
     end)
 end)

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16858,31 +16858,6 @@ void CLuaBaseEntity::removeAllManeuvers() const
 }
 
 /************************************************************************
- *  Function: getAttachment(slotId)
- *  Purpose : Gets the attachment of an automaton in the slot specified
- *  Example : pet:getAttachment(1)
- ************************************************************************/
-
-auto CLuaBaseEntity::getAttachment(const uint8 slotId) const -> const CItem*
-{
-    auto* PAutomaton = dynamic_cast<CAutomatonEntity*>(m_PBaseEntity);
-
-    if (PAutomaton == nullptr)
-    {
-        ShowWarning("Invalid Entity accessing function.");
-        return nullptr;
-    }
-
-    uint8 slotItem = PAutomaton->getAttachment(slotId);
-    if (slotItem != 0)
-    {
-        return xi::items::lookup(0x2100 + slotItem); // TODO: Stop storing by offset
-    }
-
-    return nullptr;
-}
-
-/************************************************************************
  *  Function: setAttachment(attachmentItemID, slotID)
  *  Purpose : Sets the attachment of an automaton in the slot specified
  *  Example : player:setAttachment(8465, 0)
@@ -16926,7 +16901,20 @@ auto CLuaBaseEntity::getAttachments() const -> sol::table
 
         if (attachmentItemId != 0)
         {
-            attachmentTable[attachmentSlot] = CLuaItemPuppet(xi::items::lookup<CItemPuppet>(0x2100 + attachmentItemId));
+            const auto PAttachment = xi::items::lookup<CItemPuppet>(0x2100 + attachmentItemId);
+
+            if (PAttachment)
+            {
+                attachmentTable[attachmentSlot] = PAttachment->getName();
+            }
+            else
+            {
+                attachmentTable[attachmentSlot] = "";
+            }
+        }
+        else
+        {
+            attachmentTable[attachmentSlot] = "";
         }
     }
 
@@ -20709,7 +20697,6 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getActiveManeuverCount", CLuaBaseEntity::getActiveManeuverCount);
     SOL_REGISTER("removeOldestManeuver", CLuaBaseEntity::removeOldestManeuver);
     SOL_REGISTER("removeAllManeuvers", CLuaBaseEntity::removeAllManeuvers);
-    SOL_REGISTER("getAttachment", CLuaBaseEntity::getAttachment);
     SOL_REGISTER("setAttachment", CLuaBaseEntity::setAttachment);
     SOL_REGISTER("getAttachments", CLuaBaseEntity::getAttachments);
     SOL_REGISTER("updateAttachments", CLuaBaseEntity::updateAttachments);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -828,7 +828,6 @@ public:
     auto getActiveManeuverCount() const -> uint8;
     void removeOldestManeuver() const;
     void removeAllManeuvers() const;
-    auto getAttachment(uint8 slotId) const -> const CItem*;
     auto getAttachments() const -> sol::table;
     void setAttachment(uint8 attachmentItemID, uint8 slotID) const;
     void updateAttachments() const;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -244,6 +244,8 @@ void init(IPP mapIPP, bool isRunningInCI)
     lua.set_function("GarbageCollectFull", &luautils::garbageCollectFull);
     lua.set_function("GetZone", &luautils::GetZone);
     lua.set_function("GetItemByID", &luautils::GetItemByID);
+    lua.set_function("GetItemFlagsByID", &luautils::GetItemFlagsByID);
+    lua.set_function("GetItemLevelRequirementsByID", &luautils::GetItemLevelRequirementsByID);
     lua.set_function("GetNPCByID", &luautils::GetNPCByID);
     lua.set_function("GetMobByID", &luautils::GetMobByID);
     lua.set_function("GetEntityByID", &luautils::GetEntityByID);
@@ -1264,6 +1266,36 @@ auto GetItemByID(uint32 itemId) -> const CItem*
     TracyZoneScoped;
 
     return xi::items::lookup(itemId);
+}
+
+// GetItemByID currently fails because we can't properly guarantee the constness of `const CItem*`
+// We fetch the template and then intend to return an item, but that's really just not set up to work properly
+// So instead we return non-reference values from the item templates that cannot be modified
+// Remove me when we come up with a better way to fetch item templates in lua
+auto GetItemFlagsByID(uint32 itemId) -> ItemFlag
+{
+    const auto* item = xi::items::lookup(itemId);
+    if (item)
+    {
+        return item->getFlag();
+    }
+
+    return ItemFlag::None;
+}
+
+// GetItemByID currently fails because we can't properly guarantee the constness of `const CItem*`
+// We fetch the template and then intend to return an item, but that's really just not set up to work properly
+// So instead we return non-reference values from the item templates that cannot be modified
+// Remove me when we come up with a better way to fetch item templates in lua
+auto GetItemLevelRequirementsByID(uint32 itemId) -> uint8
+{
+    const auto* item = xi::items::lookup<CItemEquipment>(itemId);
+    if (item)
+    {
+        return item->getReqLvl();
+    }
+
+    return 0;
 }
 
 CBaseEntity* GetNPCByID(uint32 npcid, const sol::object& instanceObj)

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -217,6 +217,8 @@ void SendEntityVisualPacket(uint32 npcId, const char* command);
 void InitInteractionGlobal();
 auto GetZone(uint16 zoneId) -> CZone*;
 auto GetItemByID(uint32 itemId) -> const CItem*;
+auto GetItemFlagsByID(uint32 itemId) -> ItemFlag;
+auto GetItemLevelRequirementsByID(uint32 itemId) -> uint8;
 auto GetNPCByID(uint32 npcid, const sol::object& instanceObj) -> CBaseEntity*;
 auto GetMobByID(uint32 mobid, const sol::object& instanceObj) -> CBaseEntity*;
 auto GetEntityByID(uint32 mobid, const sol::object& instanceObj, const sol::object& arg3) -> CBaseEntity*;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Basically, we were fetching directly from CItem templates instead of a copy which was really not good. I removed an unused use of it (GetAttachment by slot ID) and fixed the rest.

I found this issue while trying to make Steal/Despoil fail to steal if the stolen item is rare and you already have it and talked the issue over with Zach 

## Steps to test these changes

See nothing change with PUP. Fix issue with campaign.lua and festive_moogle.lua.
Check stealing a Warp Scroll from Maat when you have one already, and when you dont have one already