### PR TITLE
[core] [C++] [lua] Add MP Cost Reduction Mod, Implement Power Cooler

### DIFF
--- a/scripts/actions/abilities/pets/attachments/power_cooler.lua
+++ b/scripts/actions/abilities/pets/attachments/power_cooler.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Attachment: Power Cooler
+-- Description: Reduces MP cost of spells based on Ice Maneuvers. 10% at 0, 20% at 1, 35% at 2, and 50% at 3 maneuvers.
+-----------------------------------
+---@type TAttachment
+local attachmentObject = {}
+
+attachmentObject.onEquip = function(pet, attachment)
+    xi.automaton.onAttachmentEquip(pet, attachment)
+end
+
+attachmentObject.onUnequip = function(pet, attachment)
+    xi.automaton.onAttachmentUnequip(pet, attachment)
+end
+
+attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)
+    xi.automaton.onManeuverGain(pet, attachment, maneuvers)
+end
+
+attachmentObject.onManeuverLose = function(pet, attachment, maneuvers)
+    xi.automaton.onManeuverLose(pet, attachment, maneuvers)
+end
+
+attachmentObject.onUpdate = function(pet, attachment, maneuvers)
+    xi.automaton.updateAttachmentModifier(pet, attachment, maneuvers)
+end
+
+return attachmentObject

--- a/scripts/enum/mod.lua
+++ b/scripts/enum/mod.lua
@@ -686,19 +686,20 @@ xi.mod =
     DARK_ARTS_EFFECT                = 335,
     LIGHT_ARTS_SKILL                = 336,
     DARK_ARTS_SKILL                 = 337,
-    LIGHT_ARTS_REGEN                = 338, -- Regen bonus HP from Light Arts and Tabula Rasa
+    LIGHT_ARTS_REGEN                = 338,  -- Regen bonus HP from Light Arts and Tabula Rasa
     REGEN_DURATION                  = 339,
     HELIX_EFFECT                    = 478,
     HELIX_DURATION                  = 477,
     STORMSURGE_EFFECT               = 400,
     SUBLIMATION_BONUS               = 401,
-    GRIMOIRE_SPELLCASTING           = 489, -- "Grimoire: Reduces spellcasting time" bonus
+    GRIMOIRE_SPELLCASTING           = 489,  -- "Grimoire: Reduces spellcasting time" bonus
     WYVERN_BREATH                   = 402,
-    UNCAPPED_WYVERN_BREATH          = 284, -- Uncapped wyvern breath boost. Used on retail for augments, normal gear should use WYVERN_BREATH.
-    REGEN_DOWN                      = 404, -- poison
-    REFRESH_DOWN                    = 405, -- plague, reduce mp
-    REGAIN_DOWN                     = 406, -- plague, reduce tp
-    MAGIC_DAMAGE                    = 311, --  Magic damage added directly to the spell's base damage
+    UNCAPPED_WYVERN_BREATH          = 284,  -- Uncapped wyvern breath boost. Used on retail for augments, normal gear should use WYVERN_BREATH.
+    REGEN_DOWN                      = 404,  -- poison
+    REFRESH_DOWN                    = 405,  -- plague, reduce mp
+    REGAIN_DOWN                     = 406,  -- plague, reduce tp
+    MAGIC_DAMAGE                    = 311,  --  Magic damage added directly to the spell's base damage
+    MP_COST_REDUCTION               = 1197, -- Reduces MP cost of all spells by percentage (e.g. mod value 10 = -10% MP cost)
 
     -- Gear set modifiers
     DA_DOUBLE_DMG_RATE              = 408,  -- Double attack's double damage chance %.

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -160,6 +160,7 @@ local attachmentModifiers =
     ['optic_fiber']         = { { xi.mod.AUTO_PERFORMANCE_BOOST,      {    10,    20,    25,    30 }, false }, },
     ['optic_fiber_ii']      = { { xi.mod.AUTO_PERFORMANCE_BOOST,      {    15,    30,    37,    45 }, false }, },
     ['percolator']          = { { xi.mod.COMBAT_SKILLUP_RATE,         {     5,    10,    15,    20 }, true  }, },
+    ['power_cooler']        = { { xi.mod.MP_COST_REDUCTION,           {    10,    20,    35,    50 }, true  }, },
     ['repeater']            = { { xi.mod.DOUBLE_SHOT_RATE,            {    10,    15,    35,    65 }, true  }, },
     ['resister']            = { { xi.mod.STATUSRES,                   {     5,    10,    20,    30 }, true  }, },
     ['resister_ii']         = { { xi.mod.STATUSRES,                   {    10,    20,    40,    60 }, true  }, },

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -326,7 +326,8 @@ enum class Mod
     MAX_SWINGS              = 978,  // Max swings for "Occasionally attacks X times"
     ADDITIONAL_SWING_CHANCE = 979,  // Chance that allows for an additional swing despite of multiple hits, mostly for Amood weapons
 
-    MAGIC_DAMAGE = 311, // Magic damage added directly to the spell's base damage
+    MAGIC_DAMAGE      = 311,  // Magic damage added directly to the spell's base damage
+    MP_COST_REDUCTION = 1197, // Reduces spell MP cost by a percentage.
 
     // FOOD!
     FOOD_HPP      = 176, //
@@ -1152,7 +1153,7 @@ enum class Mod
     // The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
     // 570 through 825 used by WS DMG mods these are not spares.
     //
-    // SPARE IDs: 1197 and onward
+    // SPARE IDs: 1198 and onward
 };
 
 // temporary workaround for using enum class as unordered_map key until compilers support it

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5920,6 +5920,13 @@ uint16 CalculateSpellCost(CBattleEntity* PEntity, CSpell* PSpell)
             cost += (int16)(base * (PEntity->getMod(Mod::WHITE_MAGIC_COST) / 100.0f));
         }
     }
+
+    const auto mpCostReduction = PEntity->getMod(Mod::MP_COST_REDUCTION);
+    if (mpCostReduction > 0)
+    {
+        cost = cost * (1.f - static_cast<float>(mpCostReduction) / 100.f);
+    }
+
     if (xirand::GetRandomNumber(100) < (PEntity->getMod(Mod::NO_SPELL_MP_DEPLETION)))
     {
         cost = 0;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds a new "MP Cost Reduction" mod. Decreases the cost of all spells by a flat percentage.
* Adds Power Cooler, a Automaton Attachment that decreases mana costs of spells, based off Ice Maneuvers.

@WinterSolstice8 helped me with the C++ portion. 

Values lifted from this official forum post
https://forum.square-enix.com/ffxi/threads/1026-%E3%81%8B%E3%82%89%E3%81%8F%E3%82%8A%E5%A3%AB%E5%85%A5%E9%96%80?p=149542#post149542

## Steps to test these changes
Rebuild, change job to WHM 99
Target yourself, !exec target:setMod(xi.mod.MP_COST_REDUCTION, 50)
Cast Reraise 3, see 75 MP taken instead of 150. 
Change job to PUP 99, equip Power Cooler on your Automaton
Summon + Use Ice Maneuver
Target Automaton and !getmod MP_COST_REDUCTION - See 10 / 20 / 35 / 50 based off of Ice Maneuvers. 