### PR TITLE
[mob] ToAU Maat damage enrage mechanics

### DIFF
--- a/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
+++ b/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
@@ -24,8 +24,9 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
 
     mob:addListener('TAKE_DAMAGE', 'RAUBAHN_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
-        if damage >= 400 then -- Raubahn uses some sort of stat copy that isn't fully understood after days of testing.  I think it has to do with taking excessive damage.
+        if damage >= 400 then -- This might also increase Raubahn's accuracy.
             mob:messageText(mob, ID.text.RAUBAHN_GREATER_POWER)
+            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
         end
     end)
 end
@@ -36,7 +37,6 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.UFASTCAST, 70)
     mob:setMobMod(xi.mobMod.ROAM_COOL, 8)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 18)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Shamarhaan.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Shamarhaan.lua
@@ -22,6 +22,7 @@ entity.onMobInitialize = function(mob)
     mob:addListener('TAKE_DAMAGE', 'SHAMARHAAN_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
         if damage >= 350 then
             mob:messageText(mob, ID.text.SHAMARHAAN_UNDERESTIMATED)
+            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 end

--- a/scripts/zones/Talacca_Cove/mobs/Qultada.lua
+++ b/scripts/zones/Talacca_Cove/mobs/Qultada.lua
@@ -13,6 +13,7 @@ entity.onMobInitialize = function(mob)
     mob:addListener('TAKE_DAMAGE', 'QULTADA_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
         if damage >= 350 then
             mob:messageText(mob, ID.text.QULTADA_HEAT_UP)
+            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 
@@ -29,7 +30,6 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds damage increased observed from the damage dealt enrage mechanic of taking roughly 18% of the mob's hp in damage.

After observing the same mechanic with actual Maat, what I observed on these mobs wasn't an anomaly. I was hesitant to add this as first.

https://youtu.be/WadMAj9w3d4
https://youtu.be/Ud6JdxIVBCA
https://youtu.be/JfXqw_h2KNw

## Steps to test these changes

Do big damage to the ToAU Maats, observe their anger of the situation kick into high gear.
