### PR TITLE
[lua] Energetic Eruca Audits pt. 2

### DIFF
--- a/scripts/zones/Mount_Zhayolm/mobs/Energetic_Eruca.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Energetic_Eruca.lua
@@ -8,6 +8,23 @@ local ID = zones[xi.zone.MOUNT_ZHAYOLM]
 ---@type TMobEntity
 local entity = {}
 
+local function handleRegain(mob)
+    local dayElement = VanadielDayElement()
+    local regain     = mob:getMod(xi.mod.REGAIN)
+
+    if
+        dayElement == xi.element.FIRE and
+        regain == 0
+    then
+        mob:setMod(xi.mod.REGAIN, 30)
+    elseif
+        dayElement ~= xi.element.FIRE and
+        regain ~= 0
+    then
+        mob:setMod(xi.mod.REGAIN, 0)
+    end
+end
+
 entity.phList =
 {
     -- Verified that there is only one PH
@@ -24,7 +41,15 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMod(xi.mod.SLASH_SDT,  -10000) -- Immune to slashing damage
+    mob:setMod(xi.mod.SLASH_SDT, -10000) -- Immune to slashing damage
+end
+
+entity.onMobRoam = function(mob)
+    handleRegain(mob)
+end
+
+entity.onMobFight = function(mob, target)
+    handleRegain(mob)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR is related to https://github.com/LandSandBoat/server/pull/10150 - I realized I forgot to include the Eruca family behavior of TP regain on Firesday. However, I did not add the Eruca family mixin specifically because this NM does not go to sleep and become non-aggressive during certain game hours. It only needs the TP regain behavior, so I've added it into the NMs lua instead.

I do not have a recorded capture of the above behavior but it is corroborated by [JP wiki](https://wiki.ffo.jp/html/6174.html). 

## Steps to test these changes

!spawnmob ID 17027466 and witness the changes.