### PR TITLE
[test] Tweak flaky crafting tests

### DIFF
--- a/scripts/tests/systems/crafting/hq.lua
+++ b/scripts/tests/systems/crafting/hq.lua
@@ -59,10 +59,10 @@ describe('HQ', function()
         local prob     = expectedHQ / 100.0
         local expected = total * prob
         local sigma    = math.sqrt(total * prob * (1.0 - prob))
-        local lo       = expected - 3 * sigma
-        local hi       = expected + 3 * sigma
+        local lo       = expected - 4 * sigma
+        local hi       = expected + 4 * sigma
         assert(hqTotal >= lo and hqTotal <= hi, string.format(
-            'HQ count %d outside 3σ range [%.0f, %.0f] (expected %.1f)',
+            'HQ count %d outside 4σ range [%.0f, %.0f] (expected %.1f)',
             hqTotal, lo, hi, expected))
     end
 

--- a/scripts/tests/systems/crafting/transaction.lua
+++ b/scripts/tests/systems/crafting/transaction.lua
@@ -33,12 +33,27 @@ describe('SynthTransaction', function()
     end)
 
     it('successful synth consumes ingredients and yields the result', function()
-        player:addItem(crystal)
-        player:addItem(ingredient)
+        player:setSkillLevel(xi.skill.WOODWORKING, 10)
 
-        player.actions:craft(crystal, { ingredient })
-        xi.test.world:skipTime(17)
-        xi.test.world:skipTime(15)
+        local maxAttempts = 10
+        local succeeded   = false
+        for _ = 1, maxAttempts do
+            player:addItem(crystal)
+            player:addItem(ingredient)
+
+            player.actions:craft(crystal, { ingredient })
+            xi.test.world:skipTime(17)
+            xi.test.world:skipTime(15)
+
+            if player:hasItem(resultItem) then
+                succeeded = true
+                break
+            end
+
+            player:delContainerItems(xi.inv.INVENTORY)
+        end
+
+        assert(succeeded, 'synth did not succeed within ' .. maxAttempts .. ' attempts')
 
         player.assert.no:hasItem(crystal)
         player.assert.no:hasItem(ingredient)
@@ -48,13 +63,26 @@ describe('SynthTransaction', function()
     end)
 
     it('stack ingredient consumes exactly N from one inventory slot', function()
-        local stackQty = 3
-        player:addItem(crystal)
-        player:addItem(ingredient, stackQty)
+        local stackQty    = 3
+        local maxAttempts = 10
+        local succeeded   = false
+        for _ = 1, maxAttempts do
+            player:addItem(crystal)
+            player:addItem(ingredient, stackQty)
 
-        player.actions:craft(crystal, { ingredient })
-        xi.test.world:skipTime(17)
-        xi.test.world:skipTime(15)
+            player.actions:craft(crystal, { ingredient })
+            xi.test.world:skipTime(17)
+            xi.test.world:skipTime(15)
+
+            if player:hasItem(resultItem) then
+                succeeded = true
+                break
+            end
+
+            player:delContainerItems(xi.inv.INVENTORY)
+        end
+
+        assert(succeeded, 'synth did not succeed within ' .. maxAttempts .. ' attempts')
 
         assert(player:getItemCount(ingredient) == stackQty - 1,
             string.format('expected %d remaining, got %d', stackQty - 1, player:getItemCount(ingredient)))

--- a/scripts/tests/systems/soultrapper.lua
+++ b/scripts/tests/systems/soultrapper.lua
@@ -99,7 +99,7 @@ describe('Soultrapper', function()
         player:delItem(xi.item.SOUL_PLATE, 1, xi.inv.INVENTORY)
 
         -- Reuse after 30s
-        xi.test.world:skipTime(30)
+        xi.test.world:skipTime(31)
         player.actions:useItem(euvhi, soultrapper:getSlotID())
         xi.test.world:skipTime(1)
         xi.test.world:tickEntity(player)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Attempt to fix some of the recurring test failures

- Run certain crafting tests in a loop to tolerate success-rate 99% clamping failures
- Widen HQ-rate bands until we can reliably run more iterations
- Wait 1 more second for Soultrapper test 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
