### PR TITLE
[lua] Forbid BST Tame when trusts in party

### DIFF
--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -256,6 +256,12 @@ xi.job_utils.beastmaster.checkTame = function(player, target, ability)
         return xi.msg.basic.ALREADY_HAS_A_PET, 0
     end
 
+    for _, member in pairs(player:getPartyWithTrusts()) do
+        if member:isTrust() then
+            return xi.msg.basic.UNABLE_TO_USE_JA, 0
+        end
+    end
+
     return 0, 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Noticed while leveling BST I could not Tame the mobs.

<img width="1323" height="549" alt="Screenshot 2026-05-26 234122" src="https://github.com/user-attachments/assets/d4f215c4-8e55-4ef0-ae8b-9b70a22c7317" />

[JP Wiki ref](https://wiki-ffo-jp.translate.goog/html/3323.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
