### PR TITLE
[core] [lua] Improve Attuner backend

### DIFF
--- a/scripts/actions/abilities/pets/attachments/attuner.lua
+++ b/scripts/actions/abilities/pets/attachments/attuner.lua
@@ -4,103 +4,17 @@
 ---@type TAttachment
 local attachmentObject = {}
 
+-- This is handled in xi.combat.physical.calculateMeleePDIF
 attachmentObject.onEquip = function(automaton)
-    automaton:addListener('ENGAGE', 'AUTO_ATTUNER_ENGAGE', function(pet, target)
-        local master = pet:getMaster()
-        if pet:getLocalVar('attuner') > 0 then
-            pet:delMod(xi.mod.ATTP, 5) -- Ignore 5% def
-            pet:delMod(xi.mod.RATTP, 5)
-            for maneuvers = master:countEffect(xi.effect.FIRE_MANEUVER), 1, -1  do
-                if maneuvers == 1 then
-                    pet:delMod(xi.mod.ATTP, 13) -- Ignore 15% def
-                    pet:delMod(xi.mod.RATTP, 13)
-                elseif maneuvers == 2 then
-                    pet:delMod(xi.mod.ATTP, 25) -- Ignore 30% def
-                    pet:delMod(xi.mod.RATTP, 25)
-                elseif maneuvers == 3 then
-                    pet:delMod(xi.mod.ATTP, 39) -- Ignore 45% def
-                    pet:delMod(xi.mod.RATTP, 39)
-                end
-            end
-
-            pet:setLocalVar('attuner', 0)
-        end
-
-        if pet:getMainLvl() < target:getMainLvl() then
-            pet:setLocalVar('attuner', 1)
-            pet:addMod(xi.mod.ATTP, 5) -- Ignore 5% def
-            pet:addMod(xi.mod.RATTP, 5)
-            for maneuvers = 1, master:countEffect(xi.effect.FIRE_MANEUVER) do
-                if maneuvers == 1 then
-                    pet:addMod(xi.mod.ATTP, 13) -- Ignore 15% def
-                    pet:addMod(xi.mod.RATTP, 13)
-                elseif maneuvers == 2 then
-                    pet:addMod(xi.mod.ATTP, 25) -- Ignore 30% def
-                    pet:addMod(xi.mod.RATTP, 25)
-                elseif maneuvers == 3 then
-                    pet:addMod(xi.mod.ATTP, 39) -- Ignore 45% def
-                    pet:addMod(xi.mod.RATTP, 39)
-                end
-            end
-        end
-    end)
-
-    automaton:addListener('DISENGAGE', 'AUTO_ATTUNER_DISENGAGE', function(pet)
-        if pet:getLocalVar('attuner') > 0 then
-            local master = pet:getMaster()
-            pet:delMod(xi.mod.ATTP, 5) -- Ignore 5% def
-            pet:delMod(xi.mod.RATTP, 5)
-            for maneuvers = master:countEffect(xi.effect.FIRE_MANEUVER), 1, -1  do
-                if maneuvers == 1 then
-                    pet:delMod(xi.mod.ATTP, 13) -- Ignore 15% def
-                    pet:delMod(xi.mod.RATTP, 13)
-                elseif maneuvers == 2 then
-                    pet:delMod(xi.mod.ATTP, 25) -- Ignore 30% def
-                    pet:delMod(xi.mod.RATTP, 25)
-                elseif maneuvers == 3 then
-                    pet:delMod(xi.mod.ATTP, 39) -- Ignore 45% def
-                    pet:delMod(xi.mod.RATTP, 39)
-                end
-            end
-
-            pet:setLocalVar('attuner', 0)
-        end
-    end)
 end
 
 attachmentObject.onUnequip = function(pet)
-    pet:removeListener('AUTO_ATTUNER_ENGAGE')
-    pet:removeListener('AUTO_ATTUNER_DISENGAGE')
 end
 
 attachmentObject.onManeuverGain = function(pet, maneuvers)
-    if pet:getLocalVar('attuner') > 0 then
-        if maneuvers == 1 then
-            pet:addMod(xi.mod.ATTP, 13) -- Ignore 15% def
-            pet:addMod(xi.mod.RATTP, 13)
-        elseif maneuvers == 2 then
-            pet:addMod(xi.mod.ATTP, 25) -- Ignore 30% def
-            pet:addMod(xi.mod.RATTP, 25)
-        elseif maneuvers == 3 then
-            pet:addMod(xi.mod.ATTP, 39) -- Ignore 45% def
-            pet:addMod(xi.mod.RATTP, 39)
-        end
-    end
 end
 
 attachmentObject.onManeuverLose = function(pet, maneuvers)
-    if pet:getLocalVar('attuner') > 0 then
-        if maneuvers == 1 then
-            pet:delMod(xi.mod.ATTP, 13) -- Ignore 15% def
-            pet:delMod(xi.mod.RATTP, 13)
-        elseif maneuvers == 2 then
-            pet:delMod(xi.mod.ATTP, 25) -- Ignore 30% def
-            pet:delMod(xi.mod.RATTP, 25)
-        elseif maneuvers == 3 then
-            pet:delMod(xi.mod.ATTP, 39) -- Ignore 45% def
-            pet:delMod(xi.mod.RATTP, 39)
-        end
-    end
 end
 
 return attachmentObject

--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -3899,6 +3899,7 @@ xi.item =
     SHARPSHOT_FRAME                     = 8226,
     STORMWAKER_FRAME                    = 8227,
     STROBE_ATTACHMENT                   = 8449,
+    ATTUNER_ATTACHMENT                  = 8453,
     RAAZ_TUSK                           = 8709,
     COPPER_AMAN_VOUCHER                 = 8711,
     RED_MOG_PELL                        = 8714,

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -476,3 +476,38 @@ xi.automaton.getModelId = function(player)
 
     return frameTable[head] or defaultModelId
 end
+
+---@param actor CBaseEntity
+---@param target CBaseEntity
+---@return number
+xi.automaton.handleAttuner = function(actor, target)
+    if
+        actor:isAutomaton() and
+        actor:hasAttachmentSet(xi.item.ATTUNER_ATTACHMENT) and
+        actor:getMainLvl() < target:getMainLvl()
+    then
+        local master = actor:getMaster()
+
+        -- We have reason to believe BG wiki is wrong about the attuner values
+        -- so we are using these for the moment; JP wiki and dev posts imply that it's not as simple as level + 1 and higher gets massive def ignore.
+        if master then
+            local numFireManeuvers = math.min(master:countEffect(xi.effect.FIRE_MANEUVER), 3)
+
+            if numFireManeuvers > 0 and master:hasStatusEffect(xi.effect.OVERDRIVE) then
+                numFireManeuvers = 3
+            end
+
+            local attunerEffect    =
+            {
+                [0] = 0.05,
+                [1] = 0.10,
+                [2] = 0.15,
+                [3] = 0.20
+            }
+
+            return attunerEffect[numFireManeuvers] or 0
+        end
+    end
+
+    return 0
+end

--- a/scripts/globals/combat/physical_utilities.lua
+++ b/scripts/globals/combat/physical_utilities.lua
@@ -644,6 +644,18 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     -- TODO: do flourish and attack mods come before or after food?
     actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.ATT, weaponSlot) * wsAttackMod * flourishBonus))
 
+    -- handle attuner
+    -- note: isAutomaton is checked inside xi.automaton.handleAttuner and could be removed
+    if actor:isAutomaton() then
+        local defIgnore = xi.automaton.handleAttuner(actor, target)
+
+        tpFactor = tpFactor + defIgnore
+
+        if tpFactor > 0 then
+            tpIgnoresDefense = true
+        end
+    end
+
     -- Target Defense Modifiers.
     if tpIgnoresDefense then
         local ignoreDefenseFactor = 1 - tpFactor

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3572,6 +3572,12 @@ function CBaseEntity:hasAttachment(itemID)
 end
 
 ---@nodiscard
+---@param itemID integer
+---@return boolean
+function CBaseEntity:hasAttachmentSet(itemID)
+end
+
+---@nodiscard
 ---@return string
 function CBaseEntity:getAutomatonName()
 end

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -16749,7 +16749,35 @@ auto CLuaBaseEntity::hasAttachment(const uint16 itemID) const -> bool
     }
 
     const CItem* PItem = xi::items::lookup(itemID);
-    return puppetutils::HasAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
+    if (PItem)
+    {
+        return puppetutils::HasAttachment(static_cast<CCharEntity*>(m_PBaseEntity), PItem);
+    }
+
+    return false;
+}
+
+/************************************************************************
+ *  Function: hasAttachmentSet()
+ *  Purpose : Returns true if automaton has attachment set (in current use)
+ *  Example : if player:hasAttachmentSet() then
+ *  Notes   :
+ ************************************************************************/
+
+auto CLuaBaseEntity::hasAttachmentSet(const uint16 itemID) const -> bool
+{
+    if (m_PBaseEntity->objtype != TYPE_PET)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return false;
+    }
+
+    if (static_cast<CPetEntity*>(m_PBaseEntity)->getPetType() == PET_TYPE::AUTOMATON)
+    {
+        return static_cast<CAutomatonEntity*>(m_PBaseEntity)->hasAttachment(itemID - 0x2100);
+    }
+
+    return false;
 }
 
 /************************************************************************
@@ -20808,6 +20836,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("delPetMod", CLuaBaseEntity::delPetMod);
 
     SOL_REGISTER("hasAttachment", CLuaBaseEntity::hasAttachment);
+    SOL_REGISTER("hasAttachmentSet", CLuaBaseEntity::hasAttachmentSet);
     SOL_REGISTER("getAutomatonName", CLuaBaseEntity::getAutomatonName);
     SOL_REGISTER("getAutomatonFrame", CLuaBaseEntity::getAutomatonFrame);
     SOL_REGISTER("setAutomatonFrame", CLuaBaseEntity::setAutomatonFrame);

--- a/src/map/lua/lua_baseentity.h
+++ b/src/map/lua/lua_baseentity.h
@@ -820,6 +820,7 @@ public:
     void delPetMod(uint16 modID, int16 amount);
 
     auto hasAttachment(uint16 itemID) const -> bool;
+    auto hasAttachmentSet(uint16 itemID) const -> bool;
     auto getAutomatonName() const -> std::string;
     auto getAutomatonFrame() const -> Maybe<AutomatonFrame>;
     void setAutomatonFrame(AutomatonFrame frame) const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The way Attuner was handled was _really_ wrong and didn't actually "ignore defense"

## Steps to test these changes

Attack mob higher level than you, get 5%/10%/15%/20% defense ignore for 0/1/2/3 fire maneuvers

Yes, these values are made up. But so are BG wikis because there's no testing. As the comment indicates, JP wiki and dev posts imply it's more complicated than what BG wiki presents.
