### PR TITLE
[core, sql] Optimize Auction House indexes

### DIFF
--- a/sql/auction_house.sql
+++ b/sql/auction_house.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS `auction_house` (
   `sale` int(10) unsigned NOT NULL DEFAULT '0',
   `sell_date` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  KEY `itemid` (`itemid`),
+  KEY `idx_ah_active` (`buyer_name`, `itemid`, `stack`, `price`),
+  KEY `idx_ah_history` (`itemid`, `stack`, `sell_date`),
   KEY `charid` (`seller`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AUTO_INCREMENT=1 ;
 

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 
 #include "common/database.h"
+#include "common/earth_time.h"
 #include "common/logging.h"
 #include "common/mmo.h"
 #include "common/settings.h"
@@ -757,9 +758,10 @@ void CDataLoader::ExpireAHItems(uint16 expireAgeInDays)
 
     std::vector<ListingToExpire> listingsToExpire;
 
-    const auto rset0 = db::preparedStmt("SELECT T0.id,T0.itemid,T1.stacksize, T0.stack, T0.seller FROM auction_house T0 INNER JOIN item_basic T1 ON "
-                                        "T0.itemid = T1.itemid WHERE datediff(now(),from_unixtime(date)) >= ? AND buyer_name IS NULL",
-                                        expireAgeInDays);
+    const auto cutoff = earth_time::timestamp() - static_cast<uint32>(expireAgeInDays) * 86400u;
+    const auto rset0  = db::preparedStmt("SELECT T0.id,T0.itemid,T1.stacksize, T0.stack, T0.seller FROM auction_house T0 INNER JOIN item_basic T1 ON "
+                                         "T0.itemid = T1.itemid WHERE T0.buyer_name IS NULL AND T0.date <= ?",
+                                        cutoff);
 
     const auto expiredAuctions = rset0->rowsCount();
 

--- a/tools/migrations/053_ah_indexes.py
+++ b/tools/migrations/053_ah_indexes.py
@@ -1,0 +1,40 @@
+import mariadb
+
+
+def migration_name():
+    return "Add idx_ah_active and idx_ah_history to auction_house, drop itemid index"
+
+
+def check_preconditions(cur):
+    return
+
+
+def _existing_indexes(cur):
+    cur.execute("SHOW INDEX FROM auction_house")
+    names = set()
+    for row in cur.fetchall():
+        names.add(row[2])
+    return names
+
+
+def needs_to_run(cur):
+    names = _existing_indexes(cur)
+    if "idx_ah_active" not in names or "idx_ah_history" not in names:
+        return True
+    if "itemid" in names:
+        return True
+    return False
+
+
+def migrate(cur, db):
+    try:
+        names = _existing_indexes(cur)
+        if "idx_ah_active" not in names:
+            cur.execute("CREATE INDEX idx_ah_active ON auction_house (buyer_name, itemid, stack, price)")
+        if "idx_ah_history" not in names:
+            cur.execute("CREATE INDEX idx_ah_history ON auction_house (itemid, stack, sell_date)")
+        if "itemid" in names:
+            cur.execute("ALTER TABLE auction_house DROP INDEX itemid")
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

On servers with many historical entries in the AH table, several queries take seconds to execute leading to client time-outs (when they go through xi_search) or watchdog throwing a fit (through xi_map) - on top of being a generally terrible experience.

The main reason they're slow is the filtering being performed on `buyer_name IS NULL` (or NOT) to split entries into either an active listing bucket or an historical listing bucket. 
The existing index doesn't know about any of that, and essentially leads MariaDB to perform a (full or fairly large, depending on the query) table scan, iterating many row before evaluating the condition.

This PR drops the existing index and replaces it with 2 indexes, one optimized for historical listings and the other for active entries.

The existing index NEEDS to be removed, else MariaDB attempts to use it as its cost optimizer judges it (wrongly) as cheaper to use than the composite alternatives.

There's a small tweak included to the xi_search query that performs the sweep for cleaning up the AH as the existing condition forces a full table scan. The new query uses a bounded time range filter that optimizes directly to the relevant rows.

Notes:
- This **will increase AH storage requirements** by a certain amount (25% observed)
- The migration may take a couple of minutes to execute on large tables
- The analysis was done directly in Python but retested in game on items with 30M+ rows

Workflow:
- Seeded 15M+ fake rows into the auction_house table
- Exported every core query into a Python script and measured them a 100 times each (before)
- Ran EXPLAIN ANALYZE on each slow query, which showed various hints such as "Using filesort" or range scans
- Added the indexes, tweaked the query and reexecuted the queries and measured them a 100 times again (after)
- Asked Claude to make me the nice graph below
- Retested in game with items seeded with dozens of millions of historical rows

<img width="1560" height="780" alt="summary_p95" src="https://github.com/user-attachments/assets/ca03d62c-67eb-4f3c-9e12-1a0007ee2a31" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
