### PR TITLE
Core: Disable hot-reloading of spec files

### DIFF
--- a/scripts/commands/exec.lua
+++ b/scripts/commands/exec.lua
@@ -17,44 +17,56 @@ local function error(player, msg)
 end
 
 commandObj.onTrigger = function(player, str)
-    -- Ensure a command was given..
-    if str == nil or string.len(str) == 0 then
+    if
+        not str or
+        str == ''
+    then
         error(player, 'You must enter a string to execute.')
         return
     end
 
-    -- For safety measures we will nuke the os table..
-    local oldOs = os
+    --
+    -- Set up a safe environment for us to execute the incoming Lua string in
+    --
 
-    -- TODO: Intential assignment to remove access to os during calls
-    ---@diagnostic disable-next-line: assign-type-mismatch
-    os = nil
+    -- Capture things from the current or global scope we might want in the sandbox.
+    local safeEnv =
+    {
+        player = player,
+        target = player:getCursorTarget()
+    }
 
-    -- Define 'player' and 'target' inside the string for use by the caller
-    local definePlayer = 'local player = GetPlayerByName(\'' .. player:getName() .. '\'); '
-    local defineTarget = 'local target = player:getCursorTarget(); '
+    setmetatable(safeEnv, {
+        __index = function(_, key)
+            -- Block the use of powerful libraries
+            if
+                key == 'os' or
+                key == 'io' or
+                key == 'debug' or
+                key == 'require'
+            then
+                player:printToPlayer('Trying to access forbidden global!')
+                return nil
+            end
 
-    -- Ensure the command compiles / is valid..
-    local scriptObj, err0 = loadstring(definePlayer .. defineTarget .. str)
-    if scriptObj == nil then
-        player:printToPlayer('Failed to load the given string.')
-
-        if err0 then
-            player:printToPlayer(err0)
+            -- Otherwise, let them through
+            return _G[key]
         end
+    })
 
-        os = oldOs
+    local scriptObj, compileErr = loadstring(str)
+    if not scriptObj then
+        player:printToPlayer(fmt('Failed to load string: {}', tostring(compileErr)))
         return
     end
 
-    -- Execute the string..
-    local successfullyExecuted, errorMessage = pcall(scriptObj)
-    if not successfullyExecuted then
-        player:printToPlayer('Error calling: ' .. str .. '\n' .. errorMessage)
-    end
+    -- Bind the sandboxed environment to the compiled function.
+    setfenv(scriptObj, safeEnv)
 
-    -- Restore the os table..
-    os = oldOs
+    local success, execErr = pcall(scriptObj)
+    if not success then
+        player:printToPlayer(fmt('Error executing: {}', tostring(execErr)))
+    end
 end
 
 return commandObj

--- a/src/map/command_handler.cpp
+++ b/src/map/command_handler.cpp
@@ -21,274 +21,175 @@
 
 #include "command_handler.h"
 
-#include "autotranslate.h"
 #include "common/database.h"
 #include "common/utils.h"
+
+#include "autotranslate.h"
+
 #include "entities/charentity.h"
+
 #include "lua/lua_baseentity.h"
 #include "lua/luautils.h"
 
+#include <algorithm>
+#include <charconv>
 #include <iostream>
-#include <sstream>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <variant>
 #include <vector>
 
-// NOTE: Auto-translate blocks are dealt with as a string of bytes
 using CommandArg = std::variant<bool, int, double, std::string>;
 
-// The below section is a proposed rewrite of commandhandler.
-// It can automatically deduce the types of strings that are passed to it.
-//
-// Test strings:
-// bools: true True false False TRUE FALSE
-// ints: 0 1 0x01 0xFF
-// floats: 1.2 .1 1.4f
-// strings: naked_string \"a string\" \'a string\' \"embedded \'string 1\'\" \'embedded \"string 2\"\'
-//
-// The issue with this, is that there is no easy way to interpret the entire string as one long string
-// without surrounding it with quotes. If this can be nicely handled then the below code is ready
-// to go!
-
-/*
-CommandArg deduceArgType(std::string& str)
-{
-    // Look for auto-translate byte blocks
-    if (str.length() == 6 &&
-        str.front() == -3 &&
-        str.back() == -3)
-    {
-        // Return as-is, no need to further checks or transformations
-        return str;
-    }
-
-    try
-    {
-        float d = std::stof(str);
-        float intpart;
-        if (std::modf(d, &intpart) == 0.0)
-        {
-            return static_cast<int>(intpart);
-        }
-        else
-        {
-            // float
-            return d;
-        }
-    }
-    catch (std::exception&)
-    {
-        // Must be a string of some kind
-    }
-
-    // bools
-    std::string lower = "";
-    for (auto& ch : str)
-    {
-        lower += std::tolower(ch);
-    }
-
-    if (lower == "true") { return true; }
-    if (lower == "false") { return false; }
-
-    // string
-    return str;
-}
-
-std::vector<CommandArg> splitToArgs(std::string const& input)
-{
-    std::string str = trim(input);
-
-    std::vector<CommandArg> args;
-    char currentClosure = '\0';
-    std::string buffer = "";
-    for (auto ch : str)
-    {
-        // Open "" string
-        if (currentClosure == '\0' && ch == '\"')
-        {
-            currentClosure = '\"';
-        }
-        // Open '' string
-        else if (currentClosure == '\0' && ch == '\'')
-        {
-            currentClosure = '\'';
-        }
-        // Close "" string
-        else if (currentClosure == '\"' && ch == '\"')
-        {
-            currentClosure = '\0';
-        }
-        // Close '' string
-        else if (currentClosure == '\'' && ch == '\'')
-        {
-            currentClosure = '\0';
-        }
-        // Encountered unescaped space, submit buffer
-        else if (ch == ' ' && currentClosure == '\0')
-        {
-            args.emplace_back(deduceArgType(buffer));
-            buffer = "";
-        }
-        // Add to buffer
-        else
-        {
-            buffer += ch;
-        }
-    }
-
-    // Reached the end, try to submit the end of the buffer
-    args.emplace_back(deduceArgType(buffer));
-
-    return args;
-}
-*/
-
-int32 CCommandHandler::call(Scheduler& scheduler, sol::state& lua, CCharEntity* PChar, const std::string& commandline)
+auto CCommandHandler::call(Scheduler& scheduler, sol::state& lua, CCharEntity* const PChar, const std::string& commandline) -> CommandResult
 {
     TracyZoneScoped;
-
-    // TODO: stringstreams are slow. Replace with something else.
-    std::istringstream clstream(commandline);
-    std::string        cmdname;
-
-    clstream >> cmdname;
 
     if (!PChar)
     {
         ShowError("cmdhandler::call: nullptr character attempted to use command");
-        return -1;
+        return CommandResult::Failure;
     }
 
-    if (cmdname.empty())
+    constexpr auto trimLeft = [](std::string_view& sv)
+    {
+        sv.remove_prefix(std::min(sv.find_first_not_of(" \t"), sv.size()));
+    };
+
+    constexpr auto popToken = [](std::string_view& sv) -> std::string_view
+    {
+        const auto end   = sv.find_first_of(" \t");
+        const auto token = sv.substr(0, end);
+
+        sv.remove_prefix(end != std::string_view::npos ? end + 1 : sv.size());
+
+        return token;
+    };
+
+    auto cmdView = std::string_view(commandline);
+    trimLeft(cmdView);
+
+    if (cmdView.empty())
     {
         ShowError("cmdhandler::call: function name was empty");
-        return -1;
+        return CommandResult::Failure;
     }
+
+    const auto cmdName = std::string(popToken(cmdView));
 
     TracyZoneString(PChar->name);
     TracyZoneString(commandline);
 
-    auto commandObj = lua["xi"]["commands"][cmdname];
-    if (!commandObj.valid())
+    const auto maybeCommand = lua["xi"]["commands"][cmdName].get<sol::optional<sol::table>>();
+    if (!maybeCommand)
     {
-        ShowError("cmdhandler::call: Function does not exist (%s)", cmdname);
-        return -1;
+        ShowError("cmdhandler::call: Function does not exist (%s)", cmdName.c_str());
+        return CommandResult::Failure;
+    }
+    const auto& commandTable = *maybeCommand;
+
+    const auto maybeCmdProp = commandTable.get<sol::optional<sol::table>>("cmdprops");
+    if (!maybeCmdProp)
+    {
+        ShowError("cmdhandler::call: (%s): Undefined 'cmdprops' table", cmdName.c_str());
+        return CommandResult::Failure;
+    }
+    const auto& cmdprops = *maybeCmdProp;
+
+    const auto maybePerm   = cmdprops.get<sol::optional<int8>>("permission");
+    const auto maybeParams = cmdprops.get<sol::optional<std::string>>("parameters");
+    if (!maybePerm || !maybeParams)
+    {
+        ShowError("cmdhandler::call: (%s): Invalid or missing permission/parameters in cmdprops", cmdName.c_str());
+        return CommandResult::Failure;
     }
 
-    sol::table commandTable = commandObj;
+    const auto& permission = *maybePerm;
+    const auto& parameters = *maybeParams;
 
-    if (!commandTable["cmdprops"].valid())
-    {
-        ShowError("cmdhandler::call: (%s): Undefined 'cmdprops' table", cmdname);
-        return -1;
-    }
-
-    if (!commandTable["cmdprops"]["permission"].valid())
-    {
-        ShowError("cmdhandler::call: (%s): Invalid or no permission field set in cmdprops", cmdname);
-        return -1;
-    }
-
-    if (!commandTable["cmdprops"]["parameters"].valid())
-    {
-        ShowError("cmdhandler::call: (%s): Invalid or no parameters field set in cmdprops", cmdname);
-        return -1;
-    }
-
-    int8        permission = commandTable["cmdprops"]["permission"];
-    std::string parameters = commandTable["cmdprops"]["parameters"];
-
-    // Ensure this user can use this command
     if (permission > PChar->m_GMlevel)
     {
-        ShowWarning("cmdhandler::call: Character %s attempting to use higher permission command %s", PChar->name, cmdname);
-        return -1;
+        ShowWarning("cmdhandler::call: Character %s attempting to use higher permission command %s", PChar->name.c_str(), cmdName.c_str());
+        return CommandResult::Failure;
     }
-    else
-    {
-        if (settings::get<uint8>("map.AUDIT_GM_CMD") <= permission && settings::get<uint8>("map.AUDIT_GM_CMD") > 0)
-        {
-            std::string name       = PChar->name;
-            std::string cmdlinestr = autotranslate::replaceBytes(commandline);
 
-            scheduler.postToWorkerThread(
-                [name, cmdname, cmdlinestr]()
+    const auto auditLevel = settings::get<uint8>("map.AUDIT_GM_CMD");
+    if (auditLevel <= permission && auditLevel > 0)
+    {
+        scheduler.postToWorkerThread(
+            [name = PChar->name, cmd = cmdName, cmdlinestr = autotranslate::replaceBytes(commandline)]() mutable
+            {
+                const auto query = "INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(CURRENT_TIMESTAMP(3), ?, ?, ?)";
+                if (!db::preparedStmt(query, db::escapeString(name), db::escapeString(cmd), db::escapeString(cmdlinestr)))
                 {
-                    const auto query = "INSERT into audit_gm (date_time, gm_name, command, full_string) VALUES(CURRENT_TIMESTAMP(3), ?, ?, ?)";
-                    if (!db::preparedStmt(query, db::escapeString(name), db::escapeString(cmdname), db::escapeString(cmdlinestr)))
-                    {
-                        ShowError("cmdhandler::call: Failed to log GM command.");
-                    }
-                });
-        }
-    }
-
-    // Ensure the onTrigger function exists for this command
-    sol::function onTrigger = commandTable["onTrigger"];
-    if (!onTrigger.valid())
-    {
-        ShowError("cmdhandler::call: (%s) missing onTrigger function", cmdname);
-        return -1;
-    }
-
-    std::vector<CommandArg> args;
-
-    // Prepare parameters
-    std::string param;
-    auto        parameter = parameters.cbegin();
-
-    // Parse and push parameters based on symbol string
-    while (parameter != parameters.cend() && !clstream.eof())
-    {
-        clstream >> param;
-
-        switch (*parameter)
-        {
-            case 'b':
-                args.emplace_back(std::string(commandline));
-                break;
-
-            case 's':
-                if (parameters.size() == 1)
-                {
-                    std::string str = param;
-                    while (!clstream.eof())
-                    {
-                        clstream >> param;
-                        str += " " + param;
-                    }
-                    args.emplace_back(str);
-                    break;
+                    ShowError("cmdhandler::call: Failed to log GM command.");
                 }
-                args.emplace_back(param);
-                break;
-
-            case 'i':
-                args.emplace_back(atoi(param.c_str()));
-                break;
-
-            case 'd':
-                args.emplace_back(atof(param.c_str()));
-                break;
-
-            default:
-                ShowError("cmdhandler::call: (%s) undefined type for param: symbol: %s", cmdname.c_str(), *parameter);
-                break;
-        }
-
-        ++parameter;
+            });
     }
 
-    // Call the function
-    auto result = onTrigger(PChar, sol::as_args(args));
+    const auto maybeOnTrigger = commandTable.get<sol::optional<sol::function>>("onTrigger");
+    if (!maybeOnTrigger)
+    {
+        ShowError("cmdhandler::call: (%s) missing onTrigger function", cmdName.c_str());
+        return CommandResult::Failure;
+    }
+    const auto& onTrigger = *maybeOnTrigger;
+
+    auto args = std::vector<CommandArg>{};
+    args.reserve(parameters.size());
+
+    for (const auto paramType : parameters)
+    {
+        if (paramType == 'b')
+        {
+            args.emplace_back(commandline);
+            continue;
+        }
+
+        trimLeft(cmdView);
+        if (cmdView.empty())
+        {
+            break;
+        }
+
+        if (paramType == 's')
+        {
+            if (parameters.size() == 1)
+            {
+                args.emplace_back(std::string(cmdView));
+                cmdView = {};
+                break;
+            }
+            args.emplace_back(std::string(popToken(cmdView)));
+        }
+        else if (paramType == 'i')
+        {
+            auto       val   = 0;
+            const auto token = popToken(cmdView);
+            std::from_chars(token.data(), token.data() + token.size(), val);
+            args.emplace_back(val);
+        }
+        else if (paramType == 'd')
+        {
+            auto       val   = 0.0;
+            const auto token = popToken(cmdView);
+            std::from_chars(token.data(), token.data() + token.size(), val);
+            args.emplace_back(val);
+        }
+        else
+        {
+            ShowError("cmdhandler::call: (%s) undefined type for param: symbol: %c", cmdName.c_str(), paramType);
+        }
+    }
+
+    const auto result = onTrigger(PChar, sol::as_args(args));
     if (!result.valid())
     {
-        sol::error err = result;
-        ShowError("cmdhandler::call: (%s) error: %s", cmdname.c_str(), err.what());
-        return -1;
+        const sol::error err = result;
+        ShowError("cmdhandler::call: (%s) error: %s", cmdName.c_str(), err.what());
+        return CommandResult::Failure;
     }
 
-    return 0;
+    return CommandResult::Success;
 }

--- a/src/map/command_handler.h
+++ b/src/map/command_handler.h
@@ -28,6 +28,10 @@
 #include <list>
 #include <string>
 
+//
+// Forward declarations
+//
+
 class CCharEntity;
 namespace sol
 {
@@ -36,8 +40,14 @@ class state;
 
 }
 
+enum class CommandResult : uint8
+{
+    Success,
+    Failure,
+};
+
 class CCommandHandler
 {
 public:
-    static int32 call(Scheduler& scheduler, sol::state& lua, CCharEntity* PChar, const std::string& commandline);
+    static auto call(Scheduler& scheduler, sol::state& lua, CCharEntity* PChar, const std::string& commandline) -> CommandResult;
 };

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -777,6 +777,14 @@ void init(IPP mapIPP, bool isRunningInCI)
             return;
         }
 
+        // Completely ignore specs, they're for the linter, not for runtime.
+        // (BAD THINGS HAPPEN IF YOU RELOAD SPEC FILES AT RUNTIME!)
+        if (parts.size() >= 2 && parts[0] == "scripts" && parts[1] == "specs")
+        {
+            ShowInfo("[FileWatcher] Skipping reload of spec file: %s", filename);
+            return;
+        }
+
         auto it = std::find(parts.begin(), parts.end(), "scripts");
         if (it == parts.end())
         {

--- a/src/map/packets/c2s/0x0b5_chat_std.cpp
+++ b/src/map/packets/c2s/0x0b5_chat_std.cpp
@@ -122,7 +122,9 @@ void GP_CLI_COMMAND_CHAT_STD::process(MapSession* PSession, CCharEntity* PChar) 
     if (firstChar == '!' && !jailutils::InPrison(PChar))
     {
         // TODO: Don't pass around Scheduler& through PSession
-        if (CCommandHandler::call(*PSession->scheduler, lua, PChar, rawMessageWithoutFirstChar) == 0 || PChar->m_GMlevel > 0)
+        auto& scheduler = *PSession->scheduler;
+        if (CCommandHandler::call(scheduler, lua, PChar, rawMessageWithoutFirstChar) == CommandResult::Success ||
+            PChar->m_GMlevel > 0)
         {
             // A command was handled OR a GM may have mistyped.
             return;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

A mixed goody bag of things. See the commits.

This started as me remembering I've wanted to remove stringstream from commandhandler for ages, and getting distracted with other stuff.

Test case:
<img width="391" height="301" alt="image" src="https://github.com/user-attachments/assets/66b9993e-9cb9-4810-a2eb-f1776937dd03" />

Before:
<img width="949" height="865" alt="image" src="https://github.com/user-attachments/assets/27aba542-0382-4aa0-a330-ae271e58693c" />

After:
<img width="954" height="751" alt="image" src="https://github.com/user-attachments/assets/6554ed66-9c64-46a5-aeb7-786014f91f4f" />

So, it's measurably better. I know it's _MUCH_ faster, but I couldn't be bothered to get a large and varied corpus together to prove it. Just trust me bro... (Not using streams is a big win, generally)
