### PR TITLE
Core: Speed up module loading

### DIFF
--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -214,7 +214,9 @@ void Application::prepareLogging()
 
 void Application::markLoaded()
 {
-    ShowInfoFmt("The {}-server is ready to work...", serverName_);
+    const auto elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - startTime_).count();
+
+    ShowInfoFmt("The {}-server is ready to work after {:.2f} seconds...", serverName_, elapsed);
     ShowInfoFmt("Type 'help' for a list of available commands.");
     ShowInfoFmt("=======================================================================");
 

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -27,6 +27,7 @@
 
 #include <asio.hpp> // for signal_set
 
+#include <chrono>
 #include <memory>
 #include <string>
 
@@ -101,6 +102,8 @@ public:
     auto console() const -> ConsoleService&;
 
 protected:
+    std::chrono::steady_clock::time_point startTime_{ std::chrono::steady_clock::now() };
+
     Scheduler        scheduler_;
     asio::signal_set signals_;
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -100,6 +100,7 @@
 #include <array>
 #include <filesystem>
 #include <numeric>
+#include <ranges>
 #include <string>
 #include <unordered_map>
 
@@ -231,14 +232,28 @@ void init(IPP mapIPP, bool isRunningInCI)
     ShowInfo("luautils: Lua initializing");
 
     // Bind math.randon(...) globally
-    // clang-format off
-        lua["math"]["random"] =
-            sol::overload([]() { return xirand::GetRandomNumber(1.0f); },
-                          [](int n) { return xirand::GetRandomNumber<int>(1, n + 1); },
-                          [](float n) { return xirand::GetRandomNumber<float>(0.0f, n); },
-                          [](int n, int m) { return xirand::GetRandomNumber<int>(n, m + 1); },
-                          [](float n, float m) { return xirand::GetRandomNumber<float>(n, m); });
-    // clang-format on
+    lua["math"]["random"] =
+        sol::overload(
+            []()
+            {
+                return xirand::GetRandomNumber(1.0f);
+            },
+            [](int n)
+            {
+                return xirand::GetRandomNumber<int>(1, n + 1);
+            },
+            [](float n)
+            {
+                return xirand::GetRandomNumber<float>(0.0f, n);
+            },
+            [](int n, int m)
+            {
+                return xirand::GetRandomNumber<int>(n, m + 1);
+            },
+            [](float n, float m)
+            {
+                return xirand::GetRandomNumber<float>(n, m);
+            });
 
     lua.set_function("GarbageCollectStep", &luautils::garbageCollectStep);
     lua.set_function("GarbageCollectFull", &luautils::garbageCollectFull);
@@ -335,522 +350,534 @@ void init(IPP mapIPP, bool isRunningInCI)
     lua.set_function("InitializeFishingContestSystem", &luautils::InitializeFishingContestSystem);
 
     // This binding specifically exists to forcefully crash the server.
-    // clang-format off
-        lua.set_function("ForceCrash", []() { crash(); });
-    // clang-format on
-
-    // clang-format off
-        lua.set_function("BuildString", []()
+    lua.set_function(
+        "ForceCrash",
+        []()
         {
-            return fmt::format("{}-{}\n{}\n{}",
+            crash();
+        });
+
+    lua.set_function(
+        "BuildString",
+        []()
+        {
+            return fmt::format(
+                "{}-{}\n{}\n{}",
                 version::GetGitBranch(),
                 version::GetGitSha(),
                 version::GetGitCommitSubject(),
                 version::GetGitDate());
         });
 
-        // Register Sol Bindings
-        CLuaAbility::Register();
-        CLuaAction::Register();
-        CLuaAttack::Register();
-        CLuaBaseEntity::Register();
-        CLuaBattlefield::Register();
-        CLuaInstance::Register();
-        CLuaLootContainer::Register();
-        CLuaMobSkill::Register();
-        CLuaPetSkill::Register();
-        CLuaWeaponSkill::Register();
-        CLuaTriggerArea::Register();
-        CLuaSpell::Register();
-        CLuaStatusEffect::Register();
-        CLuaTradeContainer::Register();
-        CLuaTreasurePool::Register();
-        CLuaZone::Register();
-        CLuaItem::Register();
-        CLuaItemPuppet::Register();
+    // Register Sol Bindings
+    CLuaAbility::Register();
+    CLuaAction::Register();
+    CLuaAttack::Register();
+    CLuaBaseEntity::Register();
+    CLuaBattlefield::Register();
+    CLuaInstance::Register();
+    CLuaLootContainer::Register();
+    CLuaMobSkill::Register();
+    CLuaPetSkill::Register();
+    CLuaWeaponSkill::Register();
+    CLuaTriggerArea::Register();
+    CLuaSpell::Register();
+    CLuaStatusEffect::Register();
+    CLuaTradeContainer::Register();
+    CLuaTreasurePool::Register();
+    CLuaZone::Register();
+    CLuaItem::Register();
+    CLuaItemPuppet::Register();
 
-        // Load global enums
-        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/enum"))
+    // Load global enums
+    for (const auto& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/enum"))
+    {
+        if (entry.extension() == ".lua")
         {
-            if (entry.extension() == ".lua")
+            const auto relative_path_string = entry.relative_path().generic_string();
+
+            ShowTrace("Loading enum script %s", relative_path_string);
+
+            const auto result = lua.safe_script_file(relative_path_string);
+            if (!result.valid())
             {
-                auto relative_path_string = entry.relative_path().generic_string();
+                const sol::error err = result;
+                ShowError(err.what());
+            }
+        }
+    }
 
-                ShowTrace("Loading enum script %s", relative_path_string);
+    // Load global utilities
+    for (const auto& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/utils"))
+    {
+        if (entry.extension() == ".lua")
+        {
+            const auto relative_path_string = entry.relative_path().generic_string();
 
-                auto result = lua.safe_script_file(relative_path_string);
+            ShowTrace("Loading utility script %s", relative_path_string);
+
+            const auto result = lua.safe_script_file(relative_path_string);
+            if (!result.valid())
+            {
+                const sol::error err = result;
+                ShowError(err.what());
+            }
+        }
+    }
+
+    // Load global data
+    for (const auto& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/data"))
+    {
+        if (entry.extension() == ".lua")
+        {
+            const auto relative_path_string = entry.relative_path().generic_string();
+
+            ShowTrace("Loading data script %s", relative_path_string);
+
+            const auto result = lua.safe_script_file(relative_path_string);
+            if (!result.valid())
+            {
+                const sol::error err = result;
+                ShowError(err.what());
+            }
+        }
+    }
+
+    PopulateIDLookupsByFilename();
+
+    // Collect globals parts so we can apply overrides after modules are registered
+    std::vector<std::vector<std::string>> globalsParts;
+    globalsParts.reserve(64);
+
+    // Then the rest...
+    for (const auto& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts/globals"))
+    {
+        if (entry.extension() == ".lua")
+        {
+            const auto relative_path_string = entry.relative_path().generic_string();
+
+            ShowTrace("Loading global script %s", relative_path_string);
+
+            const auto result = lua.safe_script_file(relative_path_string);
+            if (!result.valid())
+            {
+                const sol::error err = result;
+                ShowError(err.what());
+            }
+
+            std::vector<std::string> parts;
+            for (auto part : entry)
+            {
+                part.replace_extension("");
+                parts.emplace_back(part.string());
+            }
+
+            // Strip leading path components up to and including "scripts"
+            // so parts match the format TryApplyLuaModules expects (same as CacheLuaObjectFromFile)
+            if (const auto it = std::ranges::find(parts, std::string("scripts")); it != parts.end())
+            {
+                parts.erase(parts.begin(), it + 1);
+            }
+            globalsParts.emplace_back(std::move(parts));
+        }
+    }
+
+    // Load Commands
+    for (const auto& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/commands"))
+    {
+        if (entry.extension() == ".lua")
+        {
+            CacheLuaObjectFromFile(entry.relative_path().generic_string());
+        }
+    }
+
+    // Load all lua files (for sanity testing, no need for during regular use)
+    if (isRunningInCI)
+    {
+        ShowInfo("*** CI ONLY: Smoke testing by running all Lua files. ***");
+        for (const auto& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts"))
+        {
+            // Break apart path so that we can verify and ignore specific subdirectories
+            std::vector<std::string> parts;
+            for (auto part : entry)
+            {
+                part.replace_extension("");
+                parts.emplace_back(part.string());
+            }
+
+            // Spec meta files should not be cached, and are only used
+            // for Lua Language Server parsing
+            // Test files are handled by xi_test exclusively
+            if (!parts.empty() && (parts[2] == "specs" || parts[2] == "tests"))
+            {
+                continue;
+            }
+
+            // If we try to reload IDs.lua files, we'll wipe out the results
+            // of GetFirstID() calls, so lets skip over those.
+            if (entry.extension() == ".lua" && entry.filename() != "IDs.lua")
+            {
+                const auto result = lua.safe_script_file(entry.relative_path().generic_string());
                 if (!result.valid())
                 {
-                    sol::error err = result;
+                    const sol::error err = result;
                     ShowError(err.what());
                 }
             }
         }
-
-        // Load global utilities
-        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/utils"))
-        {
-            if (entry.extension() == ".lua")
-            {
-                auto relative_path_string = entry.relative_path().generic_string();
-
-                ShowTrace("Loading utility script %s", relative_path_string);
-
-                auto result = lua.safe_script_file(relative_path_string);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError(err.what());
-                }
-            }
-        }
-
-        // Load global data
-        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/data"))
-        {
-            if (entry.extension() == ".lua")
-            {
-                auto relative_path_string = entry.relative_path().generic_string();
-
-                ShowTrace("Loading data script %s", relative_path_string);
-
-                auto result = lua.safe_script_file(relative_path_string);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError(err.what());
-                }
-            }
-        }
-
-        PopulateIDLookupsByFilename();
-
-        // Then the rest...
-        for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts/globals"))
-        {
-            if (entry.extension() == ".lua")
-            {
-                auto relative_path_string = entry.relative_path().generic_string();
-
-                ShowTrace("Loading global script %s", relative_path_string);
-
-                auto result = lua.safe_script_file(relative_path_string);
-                if (!result.valid())
-                {
-                    sol::error err = result;
-                    ShowError(err.what());
-                }
-            }
-        }
-
-        // Load Commands
-        for (auto const& entry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/commands"))
-        {
-            if (entry.extension() == ".lua")
-            {
-                CacheLuaObjectFromFile(entry.relative_path().generic_string());
-            }
-        }
-
-        // Load all lua files (for sanity testing, no need for during regular use)
-        if (isRunningInCI)
-        {
-            ShowInfo("*** CI ONLY: Smoke testing by running all Lua files. ***");
-            for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>("./scripts"))
-            {
-                // Break apart path so that we can verify and ignore specific subdirectories
-                std::vector<std::string> parts;
-                for (auto part : entry)
-                {
-                    part.replace_extension("");
-                    parts.emplace_back(part.string());
-                }
-
-                // Spec meta files should not be cached, and are only used
-                // for Lua Language Server parsing
-                // Test files are handled by xi_test exclusively
-                if (!parts.empty() && (parts[2] == "specs" || parts[2] == "tests"))
-                {
-                    continue;
-                }
-
-                // If we try to reload IDs.lua files, we'll wipe out the results
-                // of GetFirstID() calls, so lets skip over those.
-                if (entry.extension() == ".lua" && entry.filename() != "IDs.lua")
-                {
-                    auto result = lua.safe_script_file(entry.relative_path().generic_string());
-                    if (!result.valid())
-                    {
-                        sol::error err = result;
-                        ShowError(err.what());
-                    }
-                }
-            }
-        }
-
-        // Handle settings
-        moduleutils::LoadLuaModules(mapIPP);
-
-        filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings" });
-
-        TracyReportLuaMemory(lua.lua_state());
     }
 
-    void cleanup()
+    moduleutils::LoadLuaModules(mapIPP);
+
+    for (const auto& parts : globalsParts)
     {
-        moduleutils::CleanupLuaModules();
+        moduleutils::TryApplyLuaModules(parts);
     }
 
-    void garbageCollectStep()
+    moduleutils::TryApplyRemainingLuaModules();
+
+    filewatcher = std::make_unique<Filewatcher>(std::vector<std::string>{ "scripts", "modules", "settings" });
+
+    TracyReportLuaMemory(lua.lua_state());
+}
+
+void cleanup()
+{
+    moduleutils::CleanupLuaModules();
+}
+
+void garbageCollectStep()
+{
+    TracyZoneScoped;
+    TracyReportLuaMemory(lua.lua_state());
+
+    lua.step_gc(10); // LUA_GCSTEP 10 (performs an incremental step of garbage collection. Step size 10kb.)
+
+    // NOTE: This is just requesting that an incremental step starts. There won't be a before/after change from
+    //       this request!
+    ShowInfo("Garbage Collected (Step)");
+    ShowInfo("Current State Top: %d, Total Memory Used: %dkb", lua_gettop(lua.lua_state()), lua.memory_used() / 1024);
+
+    TracyReportLuaMemory(lua.lua_state());
+}
+
+void garbageCollectFull()
+{
+    TracyZoneScoped;
+    TracyReportLuaMemory(lua.lua_state());
+
+    auto before_mem_kb = lua.memory_used() / 1024;
+
+    lua.collect_garbage(); // LUA_GCCOLLECT (performs a full garbage-collection cycle.)
+
+    auto after_mem_kb = lua.memory_used() / 1024;
+
+    ShowInfo("Garbage Collected (Full)");
+    ShowInfo("Current State Top: %d, Total Memory Used: %dkb -> %dkb", lua_gettop(lua.lua_state()), before_mem_kb, after_mem_kb);
+
+    TracyReportLuaMemory(lua.lua_state());
+}
+
+void TryReloadFilewatchList()
+{
+    const auto changedFiles = filewatcher->popChangedLuaFilesList();
+
+    if (changedFiles.empty())
     {
-        TracyZoneScoped;
-        TracyReportLuaMemory(lua.lua_state());
-
-        lua.step_gc(10); // LUA_GCSTEP 10 (performs an incremental step of garbage collection. Step size 10kb.)
-
-        // NOTE: This is just requesting that an incremental step starts. There won't be a before/after change from
-        //       this request!
-
-        ShowInfo("Garbage Collected (Step)");
-        ShowInfo("Current State Top: %d, Total Memory Used: %dkb", lua_gettop(lua.lua_state()), lua.memory_used() / 1024);
-
-        TracyReportLuaMemory(lua.lua_state());
+        return;
     }
 
-    void garbageCollectFull()
+    // For coherency between looking things up by filename and by Lua global
+    // name we need to nuke the whole lookup cache on any file changes.
+    // detail::cachedObjects.clear();
+
+    for (const auto& [filename, action] : changedFiles)
     {
-        TracyZoneScoped;
-        TracyReportLuaMemory(lua.lua_state());
+        const auto pathStr = filename.generic_string();
+        if (action == Filewatcher::Action::Add || action == Filewatcher::Action::Modified)
+        {
+            ShowInfo("[FileWatcher] %s", pathStr.c_str());
+            CacheLuaObjectFromFile(pathStr, true);
+        }
 
-        auto before_mem_kb = lua.memory_used() / 1024;
-
-        lua.collect_garbage(); // LUA_GCCOLLECT (performs a full garbage-collection cycle.)
-
-        auto after_mem_kb = lua.memory_used() / 1024;
-
-        ShowInfo("Garbage Collected (Full)");
-        ShowInfo("Current State Top: %d, Total Memory Used: %dkb -> %dkb", lua_gettop(lua.lua_state()), before_mem_kb, after_mem_kb);
-
-        TracyReportLuaMemory(lua.lua_state());
+        // TODO: Handle moved and deleted files
     }
+}
 
-    void TryReloadFilewatchList()
+std::vector<std::string> GetContainerFilenamesList()
+{
+    TracyZoneScoped;
+
+    std::vector<std::string> outVec;
+
+    // Scrape for files of the form:
+    // "scripts/quests/(area|expansion)/(filename).lua"
+    // "scripts/missions/(area|expansion)/(filename).lua"
+    // "scripts/battlefields/(zone)/(filename).lua"
+    auto scrapeSubdir = [&](const std::string& subFolder) -> void
     {
-        const auto changedFiles = filewatcher->popChangedLuaFilesList();
-
-        if (changedFiles.empty())
+        for (const auto& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>(subFolder))
         {
-            return;
-        }
+            auto path = entry.relative_path();
 
-        // For coherency between looking things up by filename and by Lua global
-        // name we need to nuke the whole lookup cache on any file changes.
-        // detail::cachedObjects.clear();
+            // TODO(compiler updates):
+            // entry.depth() is not yet available in all of our compilers
+            auto depth = std::distance(path.begin(), path.end());
 
-        for (const auto& [filename, action] : changedFiles)
-        {
-            const auto pathStr = filename.generic_string();
-            if (action == Filewatcher::Action::Add || action == Filewatcher::Action::Modified)
+            bool isHelpersFile = path.filename() == "helpers.lua";
+
+            if (!std::filesystem::is_directory(path) &&
+                path.extension() == ".lua" &&
+                depth == 4 &&
+                !isHelpersFile)
             {
-                ShowInfo("[FileWatcher] %s", pathStr.c_str());
-                CacheLuaObjectFromFile(pathStr, true);
+                outVec.emplace_back(path.replace_extension("").make_preferred().string());
             }
-
-            // TODO: Handle moved and deleted files
         }
-    }
+    };
 
-    std::vector<std::string> GetContainerFilenamesList()
+    scrapeSubdir("scripts/battlefields");
+    scrapeSubdir("scripts/missions");
+    scrapeSubdir("scripts/quests");
+
+    return outVec;
+}
+
+sol::function getEntityCachedFunction(CBaseEntity* PEntity, std::string funcName)
+{
+    TracyZoneScoped;
+    TracyZoneString(funcName);
+    TracyZoneString(PEntity->getName());
+
+    if (PEntity->objtype == TYPE_NPC)
     {
-        TracyZoneScoped;
+        std::string zone_name = PEntity->loc.zone->getName();
+        std::string npc_name  = PEntity->getName();
 
-        std::vector<std::string> outVec;
-
-        // Scrape for files of the form:
-        // "scripts/quests/(area|expansion)/(filename).lua"
-        // "scripts/missions/(area|expansion)/(filename).lua"
-        // "scripts/battlefields/(zone)/(filename).lua"
-        auto scrapeSubdir = [&](std::string const& subFolder) -> void
-        {
-            for (auto const& entry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>(subFolder))
-            {
-                auto path = entry.relative_path();
-
-                // TODO(compiler updates):
-                // entry.depth() is not yet available in all of our compilers
-                auto depth = std::distance(path.begin(), path.end());
-
-                bool isHelpersFile = path.filename() == "helpers.lua";
-
-                if (!std::filesystem::is_directory(path) &&
-                    path.extension() == ".lua" &&
-                    depth == 4 &&
-                    !isHelpersFile)
-                {
-                    outVec.emplace_back(path.replace_extension("").make_preferred().string());
-                }
-            }
-        };
-
-        scrapeSubdir("scripts/battlefields");
-        scrapeSubdir("scripts/missions");
-        scrapeSubdir("scripts/quests");
-
-        return outVec;
-    }
-
-    sol::function getEntityCachedFunction(CBaseEntity* PEntity, std::string funcName)
-    {
-        TracyZoneScoped;
-        TracyZoneString(funcName);
-        TracyZoneString(PEntity->getName());
-
-        if (PEntity->objtype == TYPE_NPC)
-        {
-            std::string zone_name = PEntity->loc.zone->getName();
-            std::string npc_name  = PEntity->getName();
-
-            if (auto cached_func = lua["xi"]["zones"][zone_name]["npcs"][npc_name][funcName]; cached_func.valid())
-            {
-                return cached_func;
-            }
-        }
-        else if (PEntity->objtype == TYPE_MOB)
-        {
-            std::string zone_name = PEntity->loc.zone->getName();
-            std::string mob_name  = PEntity->getName();
-
-            if (auto cached_func = lua["xi"]["zones"][zone_name]["mobs"][mob_name][funcName]; cached_func.valid())
-            {
-                return cached_func;
-            }
-        }
-        else if (PEntity->objtype == TYPE_PET)
-        {
-            std::string mob_name = static_cast<CPetEntity*>(PEntity)->GetScriptName();
-
-            if (auto cached_func = lua["xi"]["pets"][mob_name][funcName]; cached_func.valid())
-            {
-                return cached_func;
-            }
-        }
-        else if (PEntity->objtype == TYPE_TRUST)
-        {
-            std::string mob_name = PEntity->getName();
-
-            if (auto cached_func = lua["xi"]["actions"]["spells"]["trust"][mob_name][funcName]; cached_func.valid())
-            {
-                return cached_func;
-            }
-        }
-
-        // Didn't find it
-        return sol::lua_nil;
-    }
-
-    sol::function getSpellCachedFunction(CSpell* PSpell, std::string funcName)
-    {
-        TracyZoneScoped;
-        TracyZoneString(funcName);
-        TracyZoneString(PSpell->getName());
-
-        auto name = PSpell->getName();
-
-        std::string switchKey = "";
-        switch (PSpell->getSpellGroup())
-        {
-            case SPELLGROUP_WHITE:
-            {
-                switchKey = "white";
-            }
-            break;
-            case SPELLGROUP_BLACK:
-            {
-                switchKey = "black";
-            }
-            break;
-            case SPELLGROUP_SONG:
-            {
-                switchKey = "songs";
-            }
-            break;
-            case SPELLGROUP_NINJUTSU:
-            {
-                switchKey = "ninjutsu";
-            }
-            break;
-            case SPELLGROUP_SUMMONING:
-            {
-                switchKey = "summoning";
-            }
-            break;
-            case SPELLGROUP_BLUE:
-            {
-                switchKey = "blue";
-            }
-            break;
-            case SPELLGROUP_GEOMANCY:
-            {
-                switchKey = "geomancy";
-            }
-            break;
-            case SPELLGROUP_TRUST:
-            {
-                switchKey = "trust";
-            }
-            break;
-            default:
-            {
-                ShowError("luautils::getSpellCachedFunction: Spell %s not inside a folder or doesnt have a SpellGroup", name);
-            }
-            break;
-        }
-
-        if (auto cached_func = lua["xi"]["actions"]["spells"][switchKey][name][funcName]; cached_func.valid())
+        if (auto cached_func = lua["xi"]["zones"][zone_name]["npcs"][npc_name][funcName]; cached_func.valid())
         {
             return cached_func;
         }
+    }
+    else if (PEntity->objtype == TYPE_MOB)
+    {
+        std::string zone_name = PEntity->loc.zone->getName();
+        std::string mob_name  = PEntity->getName();
 
-        // Didn't find it
-        return sol::lua_nil;
+        if (auto cached_func = lua["xi"]["zones"][zone_name]["mobs"][mob_name][funcName]; cached_func.valid())
+        {
+            return cached_func;
+        }
+    }
+    else if (PEntity->objtype == TYPE_PET)
+    {
+        std::string mob_name = static_cast<CPetEntity*>(PEntity)->GetScriptName();
+
+        if (auto cached_func = lua["xi"]["pets"][mob_name][funcName]; cached_func.valid())
+        {
+            return cached_func;
+        }
+    }
+    else if (PEntity->objtype == TYPE_TRUST)
+    {
+        std::string mob_name = PEntity->getName();
+
+        if (auto cached_func = lua["xi"]["actions"]["spells"]["trust"][mob_name][funcName]; cached_func.valid())
+        {
+            return cached_func;
+        }
     }
 
-    // Assumes filename in the form "./scripts/folder0/folder1/folder2/mob_name.lua
-    // Object returned form that script will be cached to:
-    // xi.folder0.folder1.folder2.mob_name
-    void CacheLuaObjectFromFile(std::string const& filename, bool overwriteCurrentEntry /* = false*/)
+    // Didn't find it
+    return sol::lua_nil;
+}
+
+sol::function getSpellCachedFunction(CSpell* PSpell, std::string funcName)
+{
+    TracyZoneScoped;
+    TracyZoneString(funcName);
+    TracyZoneString(PSpell->getName());
+
+    auto name = PSpell->getName();
+
+    std::string switchKey = "";
+    switch (PSpell->getSpellGroup())
     {
-        TracyZoneScoped;
-        TracyZoneString(filename);
-
-        auto path = std::filesystem::path(filename);
-        if (path.empty() || path.extension() == "")
+        case SPELLGROUP_WHITE:
         {
+            switchKey = "white";
+        }
+        break;
+        case SPELLGROUP_BLACK:
+        {
+            switchKey = "black";
+        }
+        break;
+        case SPELLGROUP_SONG:
+        {
+            switchKey = "songs";
+        }
+        break;
+        case SPELLGROUP_NINJUTSU:
+        {
+            switchKey = "ninjutsu";
+        }
+        break;
+        case SPELLGROUP_SUMMONING:
+        {
+            switchKey = "summoning";
+        }
+        break;
+        case SPELLGROUP_BLUE:
+        {
+            switchKey = "blue";
+        }
+        break;
+        case SPELLGROUP_GEOMANCY:
+        {
+            switchKey = "geomancy";
+        }
+        break;
+        case SPELLGROUP_TRUST:
+        {
+            switchKey = "trust";
+        }
+        break;
+        default:
+        {
+            ShowError("luautils::getSpellCachedFunction: Spell %s not inside a folder or doesnt have a SpellGroup", name);
+        }
+        break;
+    }
+
+    if (auto cached_func = lua["xi"]["actions"]["spells"][switchKey][name][funcName]; cached_func.valid())
+    {
+        return cached_func;
+    }
+
+    // Didn't find it
+    return sol::lua_nil;
+}
+
+// Assumes filename in the form "./scripts/folder0/folder1/folder2/mob_name.lua"
+// Object returned from that script will be cached to:
+// xi.folder0.folder1.folder2.mob_name
+void CacheLuaObjectFromFile(const std::string& filename, bool overwriteCurrentEntry /* = false*/)
+{
+    TracyZoneScoped;
+
+    TracyZoneString(filename);
+
+    const auto path = std::filesystem::path(filename);
+    if (path.empty() || path.extension().empty())
+    {
+        return;
+    }
+
+    std::vector<std::string> parts;
+    parts.reserve(8);
+    for (auto part : path)
+    {
+        parts.emplace_back(part.replace_extension("").string());
+    }
+
+    // Handle Lua module files, then return
+    if (!parts.empty() && parts[0] == "modules")
+    {
+        const auto result = lua.safe_script_file(filename);
+        if (!result.valid())
+        {
+            const sol::error err = result;
+            ShowError("luautils::CacheLuaObjectFromFile: Load module error: %s: %s", filename, err.what());
             return;
         }
 
-        // Handle filename -> path conversion
-        std::vector<std::string> parts;
-        for (auto part : path)
+        // Commands are a special case, since they are not a "true" module
+        const sol::table cmdTable = result;
+        if (cmdTable["cmdprops"].valid() && cmdTable["onTrigger"].valid())
         {
-            part.replace_extension("");
-            parts.emplace_back(part.string());
+            lua[sol::create_if_nil]["xi"]["commands"][parts.back()] = cmdTable;
         }
 
-        // Handle Lua module files, then return
-        if (!parts.empty() && parts[0] == "modules")
+        ShowInfo("[FileWatcher] RE-RUNNING MODULE FILE %s", filename);
+        return;
+    }
+
+    // Handle Lua settings files, then return
+    if (!parts.empty() && parts[0] == "settings")
+    {
+        const auto result = lua.safe_script_file(filename);
+        if (!result.valid())
         {
-            auto result = lua.safe_script_file(filename);
-            if (!result.valid())
-            {
-                sol::error err = result;
-                ShowError("luautils::CacheLuaObjectFromFile: Load module error: %s: %s", filename, err.what());
-                return;
-            }
-
-            // Commands are a special case, since they are not a "true" module
-            sol::table cmdTable = result;
-            if (cmdTable["cmdprops"].valid() && cmdTable["onTrigger"].valid())
-            {
-                lua[sol::create_if_nil]["xi"]["commands"][parts.back()] = cmdTable;
-            }
-
-            ShowInfo("[FileWatcher] RE-RUNNING MODULE FILE %s", filename);
+            const sol::error err = result;
+            ShowError("luautils::CacheLuaObjectFromFile: Load settings error: %s: %s", filename, err.what());
             return;
         }
 
-        // Handle Lua settings files, then return
-        if (!parts.empty() && parts[0] == "settings")
+        ShowInfo("[FileWatcher] RELOADING ALL LUA SETTINGS FILES");
+
+        settings::init();
+
+        return;
+    }
+
+    const auto scriptsIt = std::ranges::find(parts, std::string("scripts"));
+    if (scriptsIt == parts.end())
+    {
+        ShowError("luautils::CacheLuaObjectFromFile: Invalid filename: %s", filename);
+        return;
+    }
+
+    // Strip "scripts" and everything before it
+    parts.erase(parts.begin(), scriptsIt + 1);
+
+    // Handle Globals
+    if (!parts.empty() && parts[0] == "globals" && path.extension() == ".lua")
+    {
+        const auto requireName = fmt::format("scripts/globals/{}", fmt::join(parts.cbegin() + 1, parts.cend(), "/"));
+
+        const auto result = lua.safe_script(fmt::format(R"(package.loaded["{}"] = nil; require("{}");)", requireName, requireName));
+        if (!result.valid())
         {
-            auto result = lua.safe_script_file(filename);
-            if (!result.valid())
-            {
-                sol::error err = result;
-                ShowError("luautils::CacheLuaObjectFromFile: Load settings error: %s: %s", filename, err.what());
-                return;
-            }
-
-            ShowInfo("[FileWatcher] RELOADING ALL LUA SETTINGS FILES");
-
-            settings::init();
-
+            const sol::error err = result;
+            ShowError("luautils::CacheLuaObjectFromFile: Load global error: %s: %s", filename, err.what());
             return;
         }
 
-        // Completely ignore specs, they're for the linter, not for runtime.
-        // (BAD THINGS HAPPEN IF YOU RELOAD SPEC FILES AT RUNTIME!)
-        if (parts.size() >= 2 && parts[0] == "scripts" && parts[1] == "specs")
+        moduleutils::TryApplyLuaModules(parts, true);
+        ShowInfo("[FileWatcher] GLOBAL %s -> \"%s\"", filename, requireName);
+        return;
+    }
+
+    // Handle IDs then return
+    if (parts.size() == 3 && parts[2] == "IDs")
+    {
+        PopulateIDLookupsByFilename(path.parent_path().stem().generic_string());
+        ShowInfo("[FileWatcher] IDs %s", filename);
+        return;
+    }
+
+    // Handle Quests, Missions and Battlefields then return
+    if (parts.size() == 3 && (parts[0] == "quests" || parts[0] == "missions" || parts[0] == "battlefields"))
+    {
+        const auto requireName = fmt::format("scripts/{}/{}/{}", parts[0], parts[1], parts[2]);
+
+        if (parts[2] == "helpers")
         {
-            ShowInfo("[FileWatcher] Skipping reload of spec file: %s", filename);
-            return;
-        }
-
-        auto it = std::find(parts.begin(), parts.end(), "scripts");
-        if (it == parts.end())
-        {
-            ShowError("luautils::CacheLuaObjectFromFile: Invalid filename: %s", filename);
-            return;
-        }
-
-        // Now that the list is verified, overwrite it with the same list; without "scripts"
-        parts = std::vector<std::string>(it + 1, parts.end());
-
-        // Handle Globals then return
-        // Globals need to be nil'd before they're reloaded
-        if (parts[0] == "globals" && path.extension() == ".lua")
-        {
-            std::string requireName("scripts/globals");
-
-            for (std::size_t i = 1; i < parts.size(); ++i)
-            {
-                requireName = fmt::format("{}/{}", requireName, parts[i]);
-            }
-
-            auto result = lua.safe_script(fmt::format(R"(package.loaded["{}"] = nil; require("{}");)", requireName, requireName));
-            if (!result.valid())
-            {
-                sol::error err = result;
-                ShowError("luautils::CacheLuaObjectFromFile: Load global error: %s: %s", filename, err.what());
-                return;
-            }
-
-            ShowInfo("[FileWatcher] GLOBAL %s -> \"%s\"", filename, requireName);
-            return;
-        }
-
-        // Handle IDs then return
-        if (parts.size() == 3 && parts[2] == "IDs")
-        {
-            // Strip down to just the zone name
-            auto zoneName = path.parent_path().stem().generic_string();
-
-            PopulateIDLookupsByFilename(zoneName);
-            ShowInfo("[FileWatcher] IDs %s", filename);
-            return;
-        }
-
-        // Handle Quests and Missions then return
-        if (parts.size() == 3 &&
-            (parts[0] == "quests" || parts[0] == "missions" || parts[0] == "battlefields"))
-        {
-            if (parts[2] == "helpers")
-            {
-                std::string requireName = fmt::format("scripts/{}/{}/{}", parts[0], parts[1], parts[2]);
-
-                // clang-format off
-                auto result = lua.safe_script(fmt::format(R"(
+            lua.safe_script(
+                fmt::format(
+                    R"(
                     package.loaded["{0}"] = nil
                     utils.prequire("{0}")
-                )", requireName));
-            // clang-format on
-
+                )",
+                    requireName));
             ShowInfo("[FileWatcher] INTERACTION HELPERS %s", parts[1]);
         }
-        else // Regular interaction files
+        else
         {
-            std::string requireName = fmt::format("scripts/{}/{}/{}", parts[0], parts[1], parts[2]);
-
-            auto result = lua.safe_script(fmt::format(R"(
+            const auto result = lua.safe_script(
+                fmt::format(
+                    R"(
                     if package.loaded["{0}"] then
                         local old = package.loaded["{0}"]
                         package.loaded["{0}"] = nil
@@ -864,18 +891,17 @@ void init(IPP mapIPP, bool isRunningInCI)
                         InteractionGlobal.lookup:addContainer(res)
                     end
                 )",
-                                                      requireName));
+                    requireName));
 
             if (!result.valid())
             {
-                sol::error err = result;
+                const sol::error err = result;
                 ShowError("luautils::CacheLuaObjectFromFile: Load interaction error: %s: %s", filename, err.what());
                 return;
             }
 
             ShowInfo("[FileWatcher] INTERACTION %s -> %s", requireName, parts[2]);
         }
-
         return;
     }
 
@@ -885,36 +911,33 @@ void init(IPP mapIPP, bool isRunningInCI)
         return;
     }
 
-    // Try and load script
-    auto file_result = lua.safe_script_file(filename);
-    if (!file_result.valid())
+    const auto fileResult = lua.safe_script_file(filename);
+    if (!fileResult.valid())
     {
-        sol::error err = file_result;
+        const sol::error err = fileResult;
         ShowError("luautils::CacheLuaObjectFromFile: Load error: %s: %s", filename, err.what());
         return;
     }
 
-    if (!file_result.return_count())
+    if (!fileResult.return_count())
     {
         ShowError("luautils::CacheLuaObjectFromFile: No returned object to cache: %s", filename);
         return;
     }
 
-    // file_result should be good, cache it!
-    // detail::cachedObjects[filename] = file_result;
-
     auto table = lua["xi"].get_or_create<sol::table>();
-    for (auto& part : parts)
+    for (size_t i = 0; i < parts.size(); ++i)
     {
-        if (part == parts.back())
+        const auto& part = parts[i];
+        if (i == parts.size() - 1)
         {
             if (overwriteCurrentEntry)
             {
-                table[sol::override_value][part] = file_result;
+                table[sol::override_value][part] = fileResult;
             }
             else
             {
-                table[sol::update_if_empty][part] = file_result;
+                table[sol::update_if_empty][part] = fileResult;
             }
         }
         else
@@ -923,7 +946,7 @@ void init(IPP mapIPP, bool isRunningInCI)
         }
     }
 
-    moduleutils::TryApplyLuaModules();
+    moduleutils::TryApplyLuaModules(parts, overwriteCurrentEntry);
 }
 
 sol::table GetCacheEntryFromFilename(const std::string& filename)
@@ -1036,7 +1059,7 @@ void LoadExpDifficultyCurves(const sol::table& expToDifficultyTable, const uint8
     std::sort(
         expDifficultyTable.begin(),
         expDifficultyTable.end(),
-        [](std::pair<uint16, EMobDifficulty> const& a, std::pair<uint16, EMobDifficulty> const& b)
+        [](const std::pair<uint16, EMobDifficulty>& a, const std::pair<uint16, EMobDifficulty>& b)
         {
             return a.first > b.first;
         });
@@ -1115,8 +1138,10 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
     }
 
     // Update GetFirstID to use this new lookup
-    // clang-format off
-        lua.set_function("GetFirstID", [&](std::string const& name) -> Maybe<uint32>
+
+    lua.set_function(
+        "GetFirstID",
+        [&](const std::string& name) -> Maybe<uint32>
         {
             if (lookup.find(name) != lookup.end())
             {
@@ -1129,9 +1154,11 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
             }
         });
 
-        std::unordered_map<std::string, sol::table> idLuaTables;
+    std::unordered_map<std::string, sol::table> idLuaTables;
 
-        lua.set_function("GetTableOfIDs", [&](std::string const& name) -> sol::table
+    lua.set_function(
+        "GetTableOfIDs",
+        [&](const std::string& name) -> sol::table
         {
             // Is it already built and cached: return it
             if (idLuaTables.find(name) != idLuaTables.end())
@@ -1157,11 +1184,11 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
             }
 
             // Look up all that match name
-            for (auto const& [lookupName, lookupVec] : lookup)
+            for (const auto& [lookupName, lookupVec] : lookup)
             {
                 if (name == lookupName)
                 {
-                    for (auto const& entryId : lookupVec)
+                    for (const auto& entryId : lookupVec)
                     {
                         table.add(entryId);
                     }
@@ -1178,7 +1205,6 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
 
             return table;
         });
-    // clang-format on
 
     // Pre-require
     auto result = lua.safe_script_file(fmt::format("scripts/zones/{}/IDs.lua", zoneName.c_str()));
@@ -1188,17 +1214,19 @@ void PopulateIDLookups(uint16 zoneId, const std::string& zoneName)
         ShowError(err.what());
     }
 
-    // clang-format off
-        lua.set_function("GetFirstID", [&](std::string const& name) -> void
+    lua.set_function(
+        "GetFirstID",
+        [&](const std::string& name) -> void
         {
             ShowWarning("GetFirstID is designed to be used at load/reload-time only!");
         });
 
-        lua.set_function("GetTableOfIDs", [&](std::string const& name, Maybe<int> optRange) -> void
+    lua.set_function(
+        "GetTableOfIDs",
+        [&](const std::string& name, Maybe<int> optRange) -> void
         {
             ShowWarning("GetTableOfIDs is designed to be used at load/reload-time only!");
         });
-    // clang-format on
 
     // Re-publish to package.loaded. This is the same as loading the contents of a script with require("name").
     lua["package"]["loaded"][fmt::format("scripts/zones/{}/IDs", zoneName)] = lua["zones"][zoneId];
@@ -1208,78 +1236,75 @@ void PopulateIDLookupsByFilename(Maybe<std::string> maybeFilename)
 {
     TracyZoneScoped;
 
-    // clang-format off
-        const auto handleZone = [&](std::string const& zoneName)
+    const auto handleZone = [&](const std::string& zoneName)
+    {
+        uint16 zoneId = [&]() -> uint16
         {
-            uint16 zoneId = [&]() -> uint16
+            const auto rset = db::preparedStmt("SELECT zoneid FROM zone_settings WHERE name = ? LIMIT 1", zoneName);
+            if (rset && rset->rowsCount())
             {
-                const auto rset = db::preparedStmt("SELECT zoneid FROM zone_settings WHERE name = ? LIMIT 1", zoneName);
-                if (rset && rset->rowsCount())
+                if (rset->next())
                 {
-                    if (rset->next())
-                    {
-                        return rset->get<uint16>("zoneid");
-                    }
+                    return rset->get<uint16>("zoneid");
                 }
+            }
 
-                return 0;
-            }();
+            return 0;
+        }();
 
-            PopulateIDLookups(zoneId, zoneName);
-        };
+        PopulateIDLookups(zoneId, zoneName);
+    };
 
-        if (!maybeFilename)
+    if (!maybeFilename)
+    {
+        // Pre-load all zone/IDs files so we can pre-populate their GetFirstID lookups
+        for (const auto& zoneDirEntry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/zones"))
         {
-            // Pre-load all zone/IDs files so we can pre-populate their GetFirstID lookups
-            for (const auto& zoneDirEntry : sorted_directory_iterator<std::filesystem::directory_iterator>("./scripts/zones"))
+            for (const auto& fileEntry : sorted_directory_iterator<std::filesystem::directory_iterator>(zoneDirEntry.relative_path().generic_string()))
             {
-                for (const auto& fileEntry : sorted_directory_iterator<std::filesystem::directory_iterator>(zoneDirEntry.relative_path().generic_string()))
+                if (fileEntry.stem() == "IDs")
                 {
-                    if (fileEntry.stem() == "IDs")
-                    {
-                        // Prepare which zone we're in using the file path
-                        const auto relative_path_string = fileEntry.relative_path().generic_string();
-                        const auto zoneName = fileEntry.parent_path().stem().generic_string();
+                    // Prepare which zone we're in using the file path
+                    const auto relative_path_string = fileEntry.relative_path().generic_string();
+                    const auto zoneName             = fileEntry.parent_path().stem().generic_string();
 
-                        handleZone(zoneName);
-                    }
+                    handleZone(zoneName);
                 }
             }
         }
-        else
-        {
-            handleZone(maybeFilename.value());
-        }
-    // clang-format on
+    }
+    else
+    {
+        handleZone(maybeFilename.value());
+    }
 }
 
 void PopulateIDLookupsByZone(Maybe<uint16> maybeZoneId)
 {
     TracyZoneScoped;
 
-    // clang-format off
-        const auto handleZone = [&](CZone* PZone)
-        {
-            const auto zoneId   = PZone->GetID();
-            const auto zoneName = PZone->getName();
-            PopulateIDLookups(zoneId, zoneName);
-        };
+    const auto handleZone = [&](CZone* PZone)
+    {
+        const auto zoneId   = PZone->GetID();
+        const auto zoneName = PZone->getName();
+        PopulateIDLookups(zoneId, zoneName);
+    };
 
-        if (!maybeZoneId.has_value())
-        {
-            zoneutils::ForEachZone([&](CZone* PZone)
+    if (!maybeZoneId.has_value())
+    {
+        zoneutils::ForEachZone(
+            [&](CZone* PZone)
             {
                 if (PZone->GetIP() != 0)
                 {
                     handleZone(PZone);
                 }
             });
-        }
-        else
-        {
-            handleZone(zoneutils::GetZone(maybeZoneId.value()));
-        }
-    // clang-format on
+    }
+    else
+    {
+        handleZone(zoneutils::GetZone(maybeZoneId.value()));
+    }
 }
 
 // temporary solution for geysers in Dangruf_Wadi
@@ -3683,13 +3708,13 @@ void OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
             return;
         }
 
-        // clang-format off
-            PChar->ForAlliance([PMob, PChar, &onMobDeathEx](CBattleEntity* PMember)
+        PChar->ForAlliance(
+            [PMob, PChar, &onMobDeathEx](CBattleEntity* PMember)
             {
                 if (PMember->getZone() == PChar->getZone())
                 {
                     bool isKiller          = PMember == PChar;
-                    bool   isWeaponSkillKill = (PMob->GetLocalVar("weaponskillHit") & 0xFFFFFF) > 0;
+                    bool isWeaponSkillKill = (PMob->GetLocalVar("weaponskillHit") & 0xFFFFFF) > 0;
 
                     auto result = onMobDeathEx(PMob, PMember, isKiller, isWeaponSkillKill);
                     if (!result.valid())
@@ -3699,15 +3724,14 @@ void OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
                     }
                 }
             });
-        // clang-format on
 
         auto filename = fmt::format("./scripts/zones/{}/mobs/{}.lua", PMob->loc.zone->getName(), PMob->getName());
 
         auto          onMobDeathFramework = lua["InteractionGlobal"]["onMobDeath"];
         sol::function onMobDeath          = getEntityCachedFunction(PMob, "onMobDeath");
 
-        // clang-format off
-            PChar->ForAlliance([PMob, PChar, &onMobDeathFramework, &onMobDeath, &filename, &optParams](CBattleEntity* PPartyMember)
+        PChar->ForAlliance(
+            [PMob, PChar, &onMobDeathFramework, &onMobDeath, &filename, &optParams](CBattleEntity* PPartyMember)
             {
                 CCharEntity* PMember = (CCharEntity*)PPartyMember;
                 if (PMember && PMember->getZone() == PChar->getZone())
@@ -3738,7 +3762,6 @@ void OnMobDeath(CBaseEntity* PMob, CBaseEntity* PKiller)
                     PChar->PAI->EventHandler.triggerListener("DEFEATED_MOB", PMob, PMember, optParams);
                 }
             });
-        // clang-format on
     }
     else
     {
@@ -4665,18 +4688,19 @@ void Terminate()
 {
     TracyZoneScoped;
 
-    // clang-format off
-        zoneutils::ForEachZone([](CZone* PZone)
+    zoneutils::ForEachZone(
+        [](CZone* PZone)
         {
-            PZone->ForEachChar([](CCharEntity* PChar)
-            {
-                PChar->PersistData();
-                charutils::SaveCharPosition(PChar);
-                charutils::SaveCharStats(PChar);
-                charutils::SaveCharExp(PChar, PChar->GetMJob());
-            });
+            PZone->ForEachChar(
+                [](CCharEntity* PChar)
+                {
+                    PChar->PersistData();
+                    charutils::SaveCharPosition(PChar);
+                    charutils::SaveCharStats(PChar);
+                    charutils::SaveCharExp(PChar, PChar->GetMJob());
+                });
         });
-    // clang-format on
+
     std::exit(1);
 }
 
@@ -5566,45 +5590,43 @@ void HandleCustomMenu(CCharEntity* PChar, const std::string& selection)
         return;
     }
 
-    // clang-format off
-        // Messages used to denote the player cancelled the GM tell manually..
-        const std::vector<std::string> cancelMsgs =
-        {
-            // JP: GMTELL(%s):質問(%s):結果(キャンセル)
-            "\x3A\x8C\x8B\x89\xCA\x28\x83\x4C\x83\x83\x83\x93\x83\x5A\x83\x8B\x29",
+    // Messages used to denote the player cancelled the GM tell manually..
+    const std::vector<std::string> cancelMsgs = {
+        // JP: GMTELL(%s):質問(%s):結果(キャンセル)
+        "\x3A\x8C\x8B\x89\xCA\x28\x83\x4C\x83\x83\x83\x93\x83\x5A\x83\x8B\x29",
 
-            // NA: GMTELL(%s): Question(%s): Result (Canceled.)
-            "\x3A\x20\x52\x65\x73\x75\x6C\x74\x20\x28\x43\x61\x6E\x63\x65\x6C\x65\x64\x2E\x29",
-        };
+        // NA: GMTELL(%s): Question(%s): Result (Canceled.)
+        "\x3A\x20\x52\x65\x73\x75\x6C\x74\x20\x28\x43\x61\x6E\x63\x65\x6C\x65\x64\x2E\x29",
+    };
 
-        // Messages used to denote the player cancelled the GM tell automatically due to an event or other conditions..
-        const std::vector<std::string> eventCancelMsgs =
-        {
-            // JP: 現在イベント中です。このgmtellは無効です。
-            "\x8C\xBB\x8D\xDD\x83\x43\x83\x78\x83\x93\x83\x67\x92\x86\x82\xC5\x82\xB7\x81\x42\x82\xB1\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xCD\x96\xB3\x8C\xF8\x82\xC5\x82\xB7\x81\x42",
-            // JP: 現在4つのgmtellを受け付けています。このgmtellは無効です。
-            "\x8C\xBB\x8D\xDD\x34\x82\xC2\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xF0\x8E\xF3\x82\xAF\x95\x74\x82\xAF\x82\xC4\x82\xA2\x82\xDC\x82\xB7\x81\x42\x82\xB1\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xCD\x96\xB3\x8C\xF8\x82\xC5\x82\xB7\x81\x42",
-            // JP: GMTELL(%s):質問(%s):結果(イベントが起動したためキャンセル)
-            "\x3A\x8C\x8B\x89\xCA\x28\x83\x43\x83\x78\x83\x93\x83\x67\x82\xAA\x8B\x4E\x93\xAE\x82\xB5\x82\xBD\x82\xBD\x82\xDF\x83\x4C\x83\x83\x83\x93\x83\x5A\x83\x8B\x29",
+    // Messages used to denote the player cancelled the GM tell automatically due to an event or other conditions..
+    const std::vector<std::string> eventCancelMsgs = {
+        // JP: 現在イベント中です。このgmtellは無効です。
+        "\x8C\xBB\x8D\xDD\x83\x43\x83\x78\x83\x93\x83\x67\x92\x86\x82\xC5\x82\xB7\x81\x42\x82\xB1\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xCD\x96\xB3\x8C\xF8\x82\xC5\x82\xB7\x81\x42",
+        // JP: 現在4つのgmtellを受け付けています。このgmtellは無効です。
+        "\x8C\xBB\x8D\xDD\x34\x82\xC2\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xF0\x8E\xF3\x82\xAF\x95\x74\x82\xAF\x82\xC4\x82\xA2\x82\xDC\x82\xB7\x81\x42\x82\xB1\x82\xCC\x67\x6D\x74\x65\x6C\x6C\x82\xCD\x96\xB3\x8C\xF8\x82\xC5\x82\xB7\x81\x42",
+        // JP: GMTELL(%s):質問(%s):結果(イベントが起動したためキャンセル)
+        "\x3A\x8C\x8B\x89\xCA\x28\x83\x43\x83\x78\x83\x93\x83\x67\x82\xAA\x8B\x4E\x93\xAE\x82\xB5\x82\xBD\x82\xBD\x82\xDF\x83\x4C\x83\x83\x83\x93\x83\x5A\x83\x8B\x29",
 
-            // NA: Currently in an event. This GMTELL was invalidated.
-            "\x43\x75\x72\x72\x65\x6E\x74\x6C\x79\x20\x69\x6E\x20\x61\x6E\x20\x65\x76\x65\x6E\x74\x2E\x20\x54\x68\x69\x73\x20\x47\x4D\x54\x45\x4C\x4C\x20\x77\x61\x73\x20\x69\x6E\x76\x61\x6C\x69\x64\x61\x74\x65\x64\x2E",
-            // NA: Currently four GMTELL's have been received. This GMTELL was invalidated.
-            "\x43\x75\x72\x72\x65\x6E\x74\x6C\x79\x20\x66\x6F\x75\x72\x20\x47\x4D\x54\x45\x4C\x4C\x27\x73\x20\x68\x61\x76\x65\x20\x62\x65\x65\x6E\x20\x72\x65\x63\x65\x69\x76\x65\x64\x2E\x20\x54\x68\x69\x73\x20\x47\x4D\x54\x45\x4C\x4C\x20\x77\x61\x73\x20\x69\x6E\x76\x61\x6C\x69\x64\x61\x74\x65\x64\x2E",
-            // NA: GMTELL(%s): Question(%s): Result (Canceled due to event activation.)
-            "\x3A\x20\x52\x65\x73\x75\x6C\x74\x20\x28\x43\x61\x6E\x63\x65\x6C\x65\x64\x20\x64\x75\x65\x20\x74\x6F\x20\x65\x76\x65\x6E\x74\x20\x61\x63\x74\x69\x76\x61\x74\x69\x6F\x6E\x2E\x29",
-        };
+        // NA: Currently in an event. This GMTELL was invalidated.
+        "\x43\x75\x72\x72\x65\x6E\x74\x6C\x79\x20\x69\x6E\x20\x61\x6E\x20\x65\x76\x65\x6E\x74\x2E\x20\x54\x68\x69\x73\x20\x47\x4D\x54\x45\x4C\x4C\x20\x77\x61\x73\x20\x69\x6E\x76\x61\x6C\x69\x64\x61\x74\x65\x64\x2E",
+        // NA: Currently four GMTELL's have been received. This GMTELL was invalidated.
+        "\x43\x75\x72\x72\x65\x6E\x74\x6C\x79\x20\x66\x6F\x75\x72\x20\x47\x4D\x54\x45\x4C\x4C\x27\x73\x20\x68\x61\x76\x65\x20\x62\x65\x65\x6E\x20\x72\x65\x63\x65\x69\x76\x65\x64\x2E\x20\x54\x68\x69\x73\x20\x47\x4D\x54\x45\x4C\x4C\x20\x77\x61\x73\x20\x69\x6E\x76\x61\x6C\x69\x64\x61\x74\x65\x64\x2E",
+        // NA: GMTELL(%s): Question(%s): Result (Canceled due to event activation.)
+        "\x3A\x20\x52\x65\x73\x75\x6C\x74\x20\x28\x43\x61\x6E\x63\x65\x6C\x65\x64\x20\x64\x75\x65\x20\x74\x6F\x20\x65\x76\x65\x6E\x74\x20\x61\x63\x74\x69\x76\x61\x74\x69\x6F\x6E\x2E\x29",
+    };
 
-        const auto wasCancelled = std::any_of(cancelMsgs.begin(), cancelMsgs.end(), [&selection](const auto& s)
+    const auto wasCancelled = std::any_of(
+        cancelMsgs.begin(), cancelMsgs.end(), [&selection](const auto& s)
         {
             return selection.find(s) != selection.npos;
         });
 
-        const auto wasCancelledEvent = std::any_of(eventCancelMsgs.begin(), eventCancelMsgs.end(), [&selection](const auto& s)
+    const auto wasCancelledEvent = std::any_of(
+        eventCancelMsgs.begin(), eventCancelMsgs.end(), [&selection](const auto& s)
         {
             return selection.find(s) != selection.npos;
         });
-    // clang-format on
 
     const auto context = customMenuContext[PChar->id];
 
@@ -5695,21 +5717,27 @@ SendToDBoxReturnCode SendItemToDeliveryBox(const std::string& playerName, uint16
     // limit the quantity to the stack size of the item
     quantity = std::clamp<uint32>(quantity, 1, stackSize);
 
-    // clang-format off
-        const bool success = db::transaction([&]()
+    const bool success = db::transaction(
+        [&]()
         {
-            const auto rset = db::preparedStmt("INSERT INTO delivery_box (charid, box, itemid, quantity, senderid, sender) VALUES (?, ?, ?, ?, ?, ?)",
-                                               playerID, 1, itemId, quantity, playerID, senderText);
+            const auto rset = db::preparedStmt(
+                "INSERT INTO delivery_box (charid, box, itemid, quantity, senderid, sender) VALUES (?, ?, ?, ?, ?, ?)",
+                playerID,
+                1,
+                itemId,
+                quantity,
+                playerID,
+                senderText);
+
             if (!rset)
             {
                 throw std::runtime_error(fmt::format("Failed to insert item into delivery box for player: {} ({}), itemId: {}", playerName, playerID, itemId));
             }
         });
-        if (!success)
-        {
-            return SendToDBoxReturnCode::QUERY_ERROR;
-        }
-    // clang-format on
+    if (!success)
+    {
+        return SendToDBoxReturnCode::QUERY_ERROR;
+    }
 
     if (quantityMoreThanStackSize)
     {

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2021 LandSandBoat Dev Teams
@@ -29,15 +29,14 @@
 
 #include <filesystem>
 #include <fstream>
-#include <iostream>
-#include <regex>
+#include <ranges>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace
 {
 
-// static storage, init and access
 std::vector<CPPModule*>& cppModules()
 {
     static std::vector<CPPModule*> cppModules{};
@@ -49,12 +48,79 @@ std::vector<CPPModule*>& cppModules()
 namespace moduleutils
 {
 
+namespace
+{
+
+struct Override
+{
+    std::string              filename;
+    std::string              overrideName;
+    std::vector<std::string> nameParts;
+    sol::object              func;
+    bool                     applied{ false };
+};
+
+std::unordered_multimap<std::string, Override> overrides;
+
+auto applyOverride(sol::state& lua, sol::table table, Override& override, bool silent = false) -> bool
+{
+    if (override.nameParts.empty())
+    {
+        return false;
+    }
+
+    for (size_t i = 0; i < override.nameParts.size(); ++i)
+    {
+        const auto& part = override.nameParts[i];
+
+        if (i == override.nameParts.size() - 1)
+        {
+            DebugModules(fmt::format("Applying override: {}", override.overrideName));
+
+            if (table[part] == sol::lua_nil)
+            {
+                DebugModules("Inserting empty function to override for: %s (%s)", override.overrideName, override.filename);
+                table[part] = []()
+                {
+                };
+            }
+            else
+            {
+                DebugModules("Override target exists for: %s (%s)", override.overrideName, override.filename);
+            }
+
+            const auto result = lua["applyOverride"](table, part, override.func, override.overrideName, override.filename);
+            if (!result.valid())
+            {
+                const sol::error err = result;
+                ShowError("applyOverride failed for %s: %s", override.overrideName, err.what());
+                return false;
+            }
+
+            override.applied = true;
+            return true;
+        }
+
+        table = table[part].get_or<sol::table>(sol::lua_nil);
+        if (table == sol::lua_nil)
+        {
+            if (!silent)
+            {
+                ShowError("Cannot navigate to override path: %s (missing %s)", override.overrideName, part);
+            }
+            return false;
+        }
+    }
+    return false;
+}
+
+} // namespace
+
 void RegisterCPPModule(CPPModule* ptr)
 {
     cppModules().emplace_back(ptr);
 }
 
-// Hooks for calling modules
 void OnInit()
 {
     TracyZoneScoped;
@@ -130,41 +196,25 @@ auto OnIncomingPacket(MapSession* PSession, CCharEntity* PChar, CBasicPacket& pa
     return false;
 }
 
-struct Override
-{
-    std::string              filename;
-    std::string              overrideName;
-    std::vector<std::string> nameParts;
-    sol::object              func;
-    bool                     applied;
-};
-
-// Lua-side Module
-// obj.name = name
-// obj.overrides = {}
-// obj.enabled = false
-
-std::vector<Override> overrides;
-
 void LoadLuaModules(IPP mapIPP)
 {
-    // Load the helper file
     lua.safe_script_file("./modules/module_utils.lua");
 
-    // Read lines from init.txt
+    // Read module list from init.txt
     std::vector<std::string> list;
-    std::ifstream            file("./modules/init.txt", std::ios_base::in);
-    std::string              line;
-    while (std::getline(file, line))
     {
-        if (!line.empty() && line.at(0) != '#' && line != "\n" && line != "\r" && line != "\r\n")
+        std::ifstream file("./modules/init.txt", std::ios_base::in);
+        std::string   line;
+        while (std::getline(file, line))
         {
-            auto str = trim("./modules/" + line, " \t\r\n");
-            list.emplace_back(str);
+            if (!line.empty() && line[0] != '#' && line != "\n" && line != "\r" && line != "\r\n")
+            {
+                list.emplace_back(trim("./modules/" + line, " \t\r\n"));
+            }
         }
     }
 
-    // Expand out folders
+    // Expand directories into individual file paths
     std::vector<std::string> expandedList = list;
     for (const auto& entry : list)
     {
@@ -172,114 +222,109 @@ void LoadLuaModules(IPP mapIPP)
         {
             for (const auto& innerEntry : sorted_directory_iterator<std::filesystem::recursive_directory_iterator>(entry))
             {
-                auto path = innerEntry.relative_path();
-                expandedList.emplace_back(path.generic_string());
+                expandedList.emplace_back(innerEntry.relative_path().generic_string());
             }
         }
     }
 
-    // Load zone_settings information
+    // Cache zone -> port mapping for multi-process override filtering
     std::unordered_map<std::string, uint16> zoneSettingsPorts;
 
-    auto rset = db::preparedStmt("SELECT name, zoneport FROM zone_settings");
+    const auto rset = db::preparedStmt("SELECT name, zoneport FROM zone_settings");
     while (rset && rset->next())
     {
         zoneSettingsPorts[rset->get<std::string>("name")] = rset->get<uint16>("zoneport");
     }
 
-    // Load each module file that isn't the helpers.lua file or a directory
+    const auto currentPort = mapIPP.getPort() == 0 ? settings::get<uint16>("network.MAP_PORT") : mapIPP.getPort();
+
     for (const auto& entry : expandedList)
     {
-        auto path          = std::filesystem::path(entry).relative_path();
-        bool isHelpersFile = path.filename() == "module_utils.lua";
+        const auto path = std::filesystem::path(entry).relative_path();
 
-        if (!isHelpersFile &&
-            !std::filesystem::is_directory(path) &&
-            path.extension() == ".lua")
+        if (path.filename() == "module_utils.lua" || std::filesystem::is_directory(path) || path.extension() != ".lua")
         {
-            std::string filename = path.filename().generic_string();
-            std::string relPath  = path.relative_path().generic_string();
-
-            auto res = lua.safe_script_file(relPath);
-            if (!res.valid())
-            {
-                sol::error err = res;
-                ShowError("Failed to load module: %s", filename);
-                ShowError(err.what());
-                continue;
-            }
-
-            if (!res.valid() || res.get_type() != sol::type::table)
-            {
-                ShowError("Failed to load module: Invalid object returned from: %s", filename);
-                continue;
-            }
-
-            // We've confirmed this is a table, treat it as such from now on
-            sol::table table = res;
-
-            // Check the table is a valid command
-            if (table["cmdprops"].valid() && table["onTrigger"].valid())
-            {
-                auto commandName = path.filename().replace_extension("").generic_string();
-                ShowInfo(fmt::format("Registering module command: !{}", commandName));
-                lua[sol::create_if_nil]["xi"]["commands"][commandName] = table;
-                continue;
-            }
-
-            // Check table was created with Module:new() (or manually with the right fields)
-            if (table["overrides"].valid())
-            {
-                bool skipOverrideCheck = false;
-                auto moduleName        = table.get_or("name", std::string());
-
-                ShowInfo(fmt::format("=== Module: {} ===", moduleName));
-
-                for (auto& override : table.get_or("overrides", std::vector<sol::table>()))
-                {
-                    std::string name = override["name"];
-                    sol::object func = override["func"];
-
-                    DebugModules(fmt::format("Preparing override: {}", name));
-
-                    auto parts = split(name, ".");
-
-                    // If you are running multi-process, all of the overrides in all of your modules will try to apply
-                    // themselves. The zones they're targetting might not exist on this process and then error out, so
-                    // we need to sanity check them here by checking the name and port against the database.
-                    if (parts.size() >= 3 && parts[0] == "xi" && parts[1] == "zones")
-                    {
-                        const auto zoneName    = parts[2];
-                        const auto currentPort = mapIPP.getPort() == 0 ? settings::get<uint16>("network.MAP_PORT") : mapIPP.getPort();
-
-                        if (zoneSettingsPorts.find(zoneName) != zoneSettingsPorts.end() && zoneSettingsPorts[zoneName] != currentPort)
-                        {
-                            DebugModules(fmt::format("{} exists on a different port ({}), skipping", zoneName, zoneSettingsPorts[zoneName]));
-                            skipOverrideCheck = true;
-                            continue;
-                        }
-                    }
-
-                    overrides.emplace_back(Override{ filename, name, parts, func, false });
-                }
-
-                if (!skipOverrideCheck && overrides.empty())
-                {
-                    ShowError("No overrides found in module: %s", filename);
-                }
-
-                // NOTE: This continue is for the expandedList loop
-                // TODO: Flatten all of this surrounding logic so it's less fragile
-                continue;
-            }
-
-            // TODO: Come up with a way to differentiate if the user has sent in an invalid table, malformed module (command or overrides),
-            //     : or whether they've just got a data-only table file in their modules directory.
-
-            // If we get here, we haven't managaed to look up (cmdprops + onTrigger) or (overrides) on the table we
-            // got back from the module, so something is wrong with the module.
-            // ShowError("Failed to find valid table fields in module: %s", filename);
+            continue;
         }
+
+        const auto filename = path.filename().generic_string();
+        const auto res      = lua.safe_script_file(path.generic_string());
+        if (!res.valid())
+        {
+            const sol::error err = res;
+            ShowError("Failed to load module: %s", filename);
+            ShowError(err.what());
+            continue;
+        }
+
+        if (res.get_type() != sol::type::table)
+        {
+            ShowError("Failed to load module: Invalid object returned from: %s", filename);
+            continue;
+        }
+
+        const sol::table table = res;
+
+        if (table["cmdprops"].valid() && table["onTrigger"].valid())
+        {
+            const auto commandName = path.stem().generic_string();
+            ShowInfo(fmt::format("Registering module command: !{}", commandName));
+            lua[sol::create_if_nil]["xi"]["commands"][commandName] = table;
+            continue;
+        }
+
+        if (table["overrides"].valid())
+        {
+            const auto moduleName = table.get_or("name", std::string{});
+            ShowInfo(fmt::format("=== Module: {} ===", moduleName));
+
+            bool anyPortFiltered = false;
+
+            const auto prevOverrideCount = overrides.size();
+            for (auto& override : table.get_or("overrides", std::vector<sol::table>{}))
+            {
+                const auto name  = override["name"].get<std::string>();
+                const auto func  = override["func"];
+                const auto parts = split(name, ".");
+
+                DebugModules(fmt::format("Preparing override: {}", name));
+
+                // Multi-process: skip overrides targeting zones on a different port
+                if (parts.size() >= 3 && parts[0] == "xi" && parts[1] == "zones")
+                {
+                    const auto& zoneName = parts[2];
+                    const auto  portIt   = zoneSettingsPorts.find(zoneName);
+                    if (portIt != zoneSettingsPorts.end() && portIt->second != currentPort)
+                    {
+                        DebugModules(fmt::format("{} exists on a different port ({}), skipping", zoneName, portIt->second));
+                        anyPortFiltered = true;
+                        continue;
+                    }
+                }
+
+                overrides.emplace(name.substr(0, name.rfind('.')),
+                                  Override{
+                                      .filename     = filename,
+                                      .overrideName = name,
+                                      .nameParts    = parts,
+                                      .func         = func,
+                                  });
+            }
+
+            // Only warn if no overrides were added AND none were intentionally skipped
+            // due to targeting zones on a different map process port.
+            if (!anyPortFiltered && overrides.size() == prevOverrideCount)
+            {
+                ShowError("No overrides found in module: %s", filename);
+            }
+
+            // NOTE: This continue is for the expandedList loop
+            // TODO: Flatten all of this surrounding logic so it's less fragile
+            continue;
+        }
+
+        // TODO: Differentiate invalid table vs data-only table in modules directory
+        // ShowError("Failed to find valid table fields in module: %s", filename);
     }
 }
 
@@ -288,49 +333,59 @@ void CleanupLuaModules()
     overrides.clear();
 }
 
-void TryApplyLuaModules()
+void TryApplyLuaModules(const std::vector<std::string>& parts, bool isReload)
 {
-    for (auto& override : overrides)
+    if (parts.empty())
+    {
+        return;
+    }
+
+    const size_t start     = (parts[0] == "globals") ? 1 : 0;
+    const auto   lookupKey = fmt::format("xi.{}", fmt::join(parts.cbegin() + start, parts.cend(), "."));
+
+    // Also try the bare filename stem for non-xi globals (e.g. utils, npcUtil convention files)
+    const auto& bareKey = parts.back();
+
+    const auto applyRange = [&](const std::string& key)
+    {
+        const auto [rangeBegin, rangeEnd] = overrides.equal_range(key);
+        for (auto& [_, override] : std::ranges::subrange(rangeBegin, rangeEnd))
+        {
+            if (isReload)
+            {
+                override.applied = false;
+            }
+
+            if (!override.applied)
+            {
+                auto table = lua["_G"];
+                applyOverride(lua, table, override);
+            }
+        }
+    };
+
+    applyRange(lookupKey);
+    if (bareKey != lookupKey)
+    {
+        applyRange(bareKey);
+    }
+}
+
+void TryApplyRemainingLuaModules()
+{
+    auto table = lua["_G"];
+    for (auto& [_, override] : overrides)
     {
         if (!override.applied)
         {
-            sol::table table = lua["_G"];
-            for (auto& part : override.nameParts)
-            {
-                if (part == override.nameParts.back())
-                {
-                    DebugModules(fmt::format("Applying override: {}", override.overrideName));
-
-                    if (table[override.nameParts.back()] == sol::lua_nil)
-                    {
-                        DebugModules("Inserting empty function to override for: %s (%s)", override.overrideName, override.filename);
-                        table[override.nameParts.back()] = []
-                        {
-                            // Empty function
-                        };
-                    }
-
-                    // Function defined in LoadLuaModules()
-                    lua["applyOverride"](table, override.nameParts.back(), override.func, override.overrideName, override.filename);
-
-                    override.applied = true;
-
-                    break;
-                }
-
-                table = table[part].get_or<sol::table>(sol::lua_nil);
-                if (table == sol::lua_nil)
-                {
-                    break;
-                }
-            }
+            applyOverride(lua, table, override, true);
         }
     }
 }
 
 void ReportLuaModuleUsage()
 {
-    for (auto& override : overrides)
+    for (const auto& [_, override] : overrides)
     {
         if (!override.applied)
         {

--- a/src/map/utils/moduleutils.h
+++ b/src/map/utils/moduleutils.h
@@ -26,7 +26,8 @@
 #include "common/logging.h"
 #include "lua/luautils.h"
 
-#include <memory>
+#include <string>
+#include <vector>
 
 // Forward declare
 class CPPModule;
@@ -109,7 +110,8 @@ auto OnIncomingPacket(MapSession* PSession, CCharEntity* PChar, CBasicPacket& pa
 
 void LoadLuaModules(IPP mapIPP);
 void CleanupLuaModules();
-void TryApplyLuaModules();
+void TryApplyLuaModules(const std::vector<std::string>& parts, bool isReload = false);
+void TryApplyRemainingLuaModules();
 void ReportLuaModuleUsage();
 
 }; // namespace moduleutils


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

You're welcome downstream, why don't you submit some work back to us? 🙄 

This will likely be the last ever thing I do for modules, I hate them and wish I'd never written them.

Based on: https://github.com/LandSandBoat/server/issues/10168

I was hoping this would be a gargantuan speedup, but in my testing it's only like, 10-15%

Rather than loop over every override every time we load something, we can be looking them up by parent key.

NOTE: This only works for cache key entries that align with their filenames. `geomagnetic_fount.lua` and `xi.geomagneticFount` will cause a cache miss, and will fall back to the full scan. 

init.txt:
```
custom/commands/
custom/lua/garrison_placeholder_data.lua
custom/lua/quest_workarounds.lua
custom/lua/test_npcs_in_gm_home.lua
rov/
soa/
abyssea/
wotg/
```

Before:
```
[05/28/26 13:49:33:819][map][info] The map-server is ready to work after 173.39 seconds...
```

After:
```
[05/28/26 13:41:35:045][map][info] The map-server is ready to work after 152.78 seconds...
```

No errors after startup, no reporting that certain modules weren't applied, etc.