### PR TITLE
[ci] add GetTableOfIDs to lua.sh sanity checks

### DIFF
--- a/tools/ci/sanity_checks/lua.sh
+++ b/tools/ci/sanity_checks/lua.sh
@@ -99,6 +99,7 @@ global_objects=(
     BuildString
 
     GetFirstID
+    GetTableOfIDs
 
     LoadExpDifficultyCurves
     ReloadSynthRecipes


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

GetTableOfIDs should have been in the list of globals for sanity checks but wasn't.

## Steps to test these changes

CI passes