### PR TITLE
[sql] [lua] Implement Barrier Module I+II / Cleanup Inhibitor + Speedloader.

### DIFF
--- a/scripts/actions/abilities/pets/attachments/barrier_module.lua
+++ b/scripts/actions/abilities/pets/attachments/barrier_module.lua
@@ -1,29 +1,42 @@
 -----------------------------------
--- Attachment: Speedloader II
+-- Attachment: Barrier Module
+-- Grants Shield Mastery TP bonus based on the number of maneuvers active. This effect is handled here because it does not stack.
+-- TODO: Audit Shield Bash Cooldown reduction and block chance.
+-- https://wiki.ffo.jp/html/24442.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local shieldMasteryTable =
+{
+    [0] =  0,
+    [1] = 10,
+    [2] = 20,
+    [3] = 30,
+}
+
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
-    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 900)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
-    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 0)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[0])
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)
     xi.automaton.onManeuverGain(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 attachmentObject.onManeuverLose = function(pet, attachment, maneuvers)
     xi.automaton.onManeuverLose(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 attachmentObject.onUpdate = function(pet, attachment, maneuvers)
     xi.automaton.updateAttachmentModifier(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 return attachmentObject

--- a/scripts/actions/abilities/pets/attachments/barrier_module_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/barrier_module_ii.lua
@@ -1,29 +1,42 @@
 -----------------------------------
--- Attachment: Speedloader II
+-- Attachment: Barrier Module II
+-- Grants Shield Mastery TP bonus based on the number of maneuvers active. This effect is handled here because it does not stack.
+-- TODO: Audit Shield Bash Cooldown reduction and block chance.
+-- https://wiki.ffo.jp/html/24442.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local shieldMasteryTable =
+{
+    [0] =  0,
+    [1] = 10,
+    [2] = 20,
+    [3] = 30,
+}
+
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
-    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 900)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
-    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 0)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[0])
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)
     xi.automaton.onManeuverGain(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 attachmentObject.onManeuverLose = function(pet, attachment, maneuvers)
     xi.automaton.onManeuverLose(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 attachmentObject.onUpdate = function(pet, attachment, maneuvers)
     xi.automaton.updateAttachmentModifier(pet, attachment, maneuvers)
+    pet:setMod(xi.mod.SHIELD_MASTERY_TP, shieldMasteryTable[maneuvers])
 end
 
 return attachmentObject

--- a/scripts/actions/abilities/pets/attachments/inhibitor.lua
+++ b/scripts/actions/abilities/pets/attachments/inhibitor.lua
@@ -6,10 +6,12 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 900)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 0)
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)

--- a/scripts/actions/abilities/pets/attachments/inhibitor_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/inhibitor_ii.lua
@@ -6,10 +6,12 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 900)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 0)
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)

--- a/scripts/actions/abilities/pets/attachments/speedloader.lua
+++ b/scripts/actions/abilities/pets/attachments/speedloader.lua
@@ -6,10 +6,12 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 900)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
+    pet:setMod(xi.mod.AUTO_TP_EFFICIENCY, 0)
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -119,6 +119,10 @@ local attachmentModifiers =
                                 { xi.mod.REGEN,                       {   nil,   nil,   nil,   nil }, true  }, },
     ['auto-repair_kit_iv']  = { { xi.mod.HPP,                         {    20,    20,    20,    20 }, false },
                                 { xi.mod.REGEN,                       {   nil,   nil,   nil,   nil }, true  }, },
+    ['barrier_module']      = { { xi.mod.SHIELDBLOCKRATE,             {     0,     5,    10,    15 }, true  },
+                                { xi.mod.AUTO_SHIELD_BASH_DELAY,      {     0,     5,    10,    15 }, false }, },
+    ['barrier_module_ii']   = { { xi.mod.SHIELDBLOCKRATE,             {     0,    10,    20,    30 }, true  },
+                                { xi.mod.AUTO_SHIELD_BASH_DELAY,      {     0,     5,    10,    15 }, false }, },
     ['coiler']              = { { xi.mod.DOUBLE_ATTACK,               {     3,    10,    20,    30 }, true  }, },
     ['coiler_ii']           = { { xi.mod.DOUBLE_ATTACK,               {    10,    15,    25,    35 }, true  }, },
     ['damage_gauge']        = { { xi.mod.AUTO_HEALING_THRESHOLD,      {    50,    60,    70,    85 }, true  },
@@ -133,11 +137,9 @@ local attachmentModifiers =
     ['hammermill']          = { { xi.mod.SHIELD_BASH,                 {    15,    25,    50,   100 }, true  },
                                 { xi.mod.AUTO_SHIELD_BASH_SLOW,       {     0,    12,    19,    25 }, true  }, },
     ['heatsink']            = { { xi.mod.BURDEN_DECAY,                {     1,     3,     4,     5 }, true  }, },
-    ['icemaker']            = { { xi.mod.AUTO_MAB_COEFFICIENT,        {     0,    50,    75,   100 }, false }, },
-    ['inhibitor']           = { { xi.mod.STORETP,                     {     5,    15,    25,    40 }, true  },
-                                { xi.mod.AUTO_TP_EFFICIENCY,          {   900,   900,   900,   900 }, false }, },
-    ['inhibitor_ii']        = { { xi.mod.STORETP,                     {    10,    25,    40,    65 }, true  },
-                                { xi.mod.AUTO_TP_EFFICIENCY,          {   900,   900,   900,   900 }, false }, },
+    ['ice_maker']           = { { xi.mod.AUTO_MAB_COEFFICIENT,        {     0,    50,    75,   100 }, false }, },
+    ['inhibitor']           = { { xi.mod.STORETP,                     {     5,    15,    25,    40 }, true  }, },
+    ['inhibitor_ii']        = { { xi.mod.STORETP,                     {    10,    25,    40,    65 }, true  }, },
     ['loudspeaker']         = { { xi.mod.MATT,                        {     5,    10,    15,    20 }, true  }, },
     ['loudspeaker_ii']      = { { xi.mod.MATT,                        {    10,    15,    20,    25 }, true  }, },
     ['loudspeaker_iii']     = { { xi.mod.MATT,                        {    20,    30,    40 ,   50 }, true  }, },
@@ -174,10 +176,8 @@ local attachmentModifiers =
     ['scope_ii']            = { { xi.mod.RACC,                        {    20,    30,    40,    50 }, true  }, },
     ['scope_iii']           = { { xi.mod.RACC,                        {    30,    40,    55,    70 }, true  }, },
     ['scope_iv']            = { { xi.mod.RACC,                        {    40,    50,    65,    80 }, true  }, },
-    ['speedloader']         = { { xi.mod.SKILLCHAINBONUS,             {    20,    30,    40,    60 }, true  },
-                                { xi.mod.AUTO_TP_EFFICIENCY,          {   900,   900,   900,   900 }, false }, },
-    ['speedloader_ii']      = { { xi.mod.SKILLCHAINBONUS,             {    35,    45,    60,    80 }, true  },
-                                { xi.mod.AUTO_TP_EFFICIENCY,          {   900,   900,   900,   900 }, false }, },
+    ['speedloader']         = { { xi.mod.SKILLCHAINBONUS,             {    20,    30,    40,    60 }, true  }, },
+    ['speedloader_ii']      = { { xi.mod.SKILLCHAINBONUS,             {    35,    45,    60,    80 }, true  }, },
     ['stabilizer']          = { { xi.mod.ACC,                         {     5,    10,    15,    20 }, true  }, },
     ['stabilizer_ii']       = { { xi.mod.ACC,                         {    10,    15,    20,    25 }, true  }, },
     ['stabilizer_iii']      = { { xi.mod.ACC,                         {    20,    30,    40,    50 }, true  }, },
@@ -361,13 +361,7 @@ xi.automaton.updateAttachmentModifier = function(pet, attachment, maneuvers)
                 pet:delMod(modList[1], previousMod)
             end
 
-            -- TP Efficiency shouldn't stack, and all values are the same.  This simplify logic to
-            -- always set the latest, since there's no difference.
-            if modList[1] == xi.mod.AUTO_TP_EFFICIENCY then
-                pet:setMod(modList[1], modValue)
-            else
-                pet:addMod(modList[1], modValue)
-            end
+            pet:addMod(modList[1], modValue)
 
             pet:setLocalVar(attachmentName .. attachmentModPos, math.abs(modValue))
 

--- a/sql/item_puppet.sql
+++ b/sql/item_puppet.sql
@@ -95,7 +95,7 @@ INSERT INTO `item_puppet` VALUES (8552,'barrier_module_ii',3,8192);
 INSERT INTO `item_puppet` VALUES (8553,'shock_absorber_ii',3,8192);
 INSERT INTO `item_puppet` VALUES (8554,'armor_plate_iii',3,16384);
 INSERT INTO `item_puppet` VALUES (8555,'barrier_module',3,4096);
-INSERT INTO `item_puppet` VALUES (8556,'barrier_module',3,20480);
+INSERT INTO `item_puppet` VALUES (8556,'armor_plate_iv',3,20480);
 INSERT INTO `item_puppet` VALUES (8557,'shock_absorber_iii',3,12288);
 INSERT INTO `item_puppet` VALUES (8577,'stabilizer',3,65536);
 INSERT INTO `item_puppet` VALUES (8578,'volt_gun',3,65536);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Implements Barrier Module I and Barrier Module II, an Automaton Attachment that increases chance to block, reduces shield bash cooldown, and grants Shield Mastery based on Earth Maneuvers.
* Cleans up code for Inhibitor & Speedloader.
* Fixes the name of Armor Plate IV in the item_puppet SQL, where it was named a duplicate Barrier Module.
https://wiki.ffo.jp/html/24442.html
* Block values are guessed off of sparse testing in the JP Wiki.
* I was unable to verify the the Shield Bash cooldown despite numerous ways of testing it. I set it at a conservative 5 seconds per Earth Maneuver, and left a TODO to investigate more later.
* I did test/confirm all levels of Shield Mastery, and confirmed they do not stack. 

## Steps to test these changes

Equip Valoredge, Barrier Module 1 + 2, use some Earth Maneuvers, block stuff.