### PR TITLE
[core] Do not treat all SubKind 4 NPCs as always relevant

### DIFF
--- a/src/map/transport.cpp
+++ b/src/map/transport.cpp
@@ -169,6 +169,8 @@ void CTransportHandler::InitializeTransport(IPP mapIPP)
             continue;
         }
 
+        static_cast<CNpcEntity*>(zoneTown.ship.npc)->m_alwaysRelevant = true;
+
         zoneTown.ship.animationArrive = rset->get<uint8>("anim_arrive");
         zoneTown.ship.animationDepart = rset->get<uint8>("anim_depart");
 
@@ -452,6 +454,8 @@ void CTransportHandler::insertElevator(Elevator_t elevator)
         ShowError("Elevator could not load NPC entity. Ignoring this elevator.");
         return;
     }
+
+    elevator.Elevator->m_alwaysRelevant = true;
 
     // check to see if this elevator already exists
     for (auto& i : ElevatorList)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -893,44 +893,47 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
     //     : spatial partitioning to only check entities within a certain range of the player.
     //     : This would change this loop to look like:
     //     : Compare previous and current spatial partitioning results to determine which entities to add/remove from the spawn list.
-    for (const auto& [_, PCurrentEntity] : m_npcList)
+    const auto syncSpawn = [&](const EntityList_t& list, auto&& shouldBeSpawned)
     {
         auto& spawnList = PChar->SpawnNPCList;
-
-        const auto id               = PCurrentEntity->id;
-        const auto itr              = spawnList.find(id);
-        const auto isInSpawnList    = itr != spawnList.end();
-        const auto isInRange        = isWithinDistance(PChar->loc.p, PCurrentEntity->loc.p, ENTITY_RENDER_DISTANCE);
-        const auto isVisibleStatus  = PCurrentEntity->status == STATUS_TYPE::NORMAL || PCurrentEntity->status == STATUS_TYPE::UPDATE;
-        const auto isAlwaysRelevant = PCurrentEntity->objtype == TYPE_NPC && static_cast<CNpcEntity*>(PCurrentEntity)->m_alwaysRelevant;
-
-        const auto tryAddToSpawnList = [&]()
+        for (const auto& [_, PEntity] : list)
         {
-            if (!isInSpawnList)
+            const auto itr        = spawnList.find(PEntity->id);
+            const auto inSpawnSet = itr != spawnList.end();
+            const auto want       = shouldBeSpawned(PEntity);
+
+            if (want && !inSpawnSet)
             {
-                spawnList.insert(itr, SpawnIDList_t::value_type(id, PCurrentEntity));
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+                spawnList.insert(itr, SpawnIDList_t::value_type(PEntity->id, PEntity));
+                PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
-        };
-
-        const auto tryRemoveFromSpawnList = [&]()
-        {
-            if (isInSpawnList)
+            else if (!want && inSpawnSet)
             {
                 spawnList.erase(itr);
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_DESPAWN, UPDATE_NONE);
+                PChar->updateEntityPacket(PEntity, ENTITY_DESPAWN, UPDATE_NONE);
             }
-        };
+        }
+    };
 
-        if (isVisibleStatus && (isInRange || isAlwaysRelevant))
-        {
-            tryAddToSpawnList();
-        }
-        else
-        {
-            tryRemoveFromSpawnList();
-        }
-    }
+    syncSpawn(m_npcList, [&](CBaseEntity* PEntity)
+              {
+                  const auto inRange       = isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
+                  const auto visibleStatus = PEntity->status == STATUS_TYPE::NORMAL || PEntity->status == STATUS_TYPE::UPDATE;
+                  const auto alwaysRel     = PEntity->objtype == TYPE_NPC && static_cast<CNpcEntity*>(PEntity)->m_alwaysRelevant;
+                  return visibleStatus && (inRange || alwaysRel);
+              });
+
+    // Registered transports are broadcast at zone-in by SpawnTransport and driven by TransportTimer; everything else
+    // in m_TransportList is a static SubKind=4 prop that gets proximity-spawned regardless of status.
+    syncSpawn(m_TransportList, [&](CBaseEntity* PEntity)
+              {
+                  if (static_cast<CNpcEntity*>(PEntity)->m_alwaysRelevant)
+                  {
+                      return false;
+                  }
+
+                  return isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
+              });
 }
 
 void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
@@ -1244,6 +1247,11 @@ void CZoneEntities::SpawnTransport(CCharEntity* PChar)
 
     FOR_EACH_PAIR_CAST_SECOND(CNpcEntity*, PEntity, m_TransportList)
     {
+        if (!PEntity->m_alwaysRelevant)
+        {
+            continue;
+        }
+
         PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I added a bunch of SubKind 4 NPCs in Lower Jeuno which the codebase presently treats as if they are Airships and blast to all player in zone. 
Adding 32 of such NPCs in Lower Jeuno has meant the client culls aggressively other NPCs beyond 5y.

This is what XiPackets say about SubKind 4 NPCs

> Additional Information - SubKind - 4
> When this SubKind is used, the packet is used to update and/or prepare an airship, boat, or similar kinds of entities. (Note: Some gardening plants use this SubKind as well!)

SE uses this SubKind for furnitures in certain conditions but they are almost never broadcast without distance check (as verified on retail)

This PR changes the m_TransportList loop to only process entities explicitly marked as always relevant AND tags elevators and airships with it when they are instantiated. All other entities in this list are processed as part of the SpawnNPC loop with a distance check.

Incidentally, this makes event 20089 (something Mumor related) in Lower Jeuno if you happen to be within 50y of the entities. 
I don't know if retail just relies on CHARREQ2 in this case to load them at event time or if they move you somewhere as part of the event or if they just force send the packets explicitly. I'll check back when the event comes back this summer.

I don't believe this is the right long-term fix but I'm already working on the CHAR_NPC rework on the side and this PR is relatively harmless.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
