### PR TITLE
[core] JSON logging with structured context

### DIFF
--- a/settings/default/logging.lua
+++ b/settings/default/logging.lua
@@ -37,6 +37,9 @@ xi.settings.logging =
     --]]
     PATTERN = '[%D %T:%e][%&]%^[%n]%$ %v (%!:%#)',
 
+    -- Emit JSON instead of PATTERN.
+    JSON_ENABLED = false,
+
     -- Enable/Disable these logging types globally
     LOG_DEBUG   = true,
     LOG_INFO    = true,

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -23,6 +23,9 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/ipp.h
     ${CMAKE_CURRENT_SOURCE_DIR}/logging.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/logging.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logging_context.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/logging_context.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/logging_json.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lua.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/md52.cpp

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -173,6 +173,13 @@ void logging::ShutDown()
 
 void logging::SetPattern(const std::string& str)
 {
+    detail::gJsonMode = settings::get<bool>("logging.JSON_ENABLED");
+    if (detail::gJsonMode)
+    {
+        spdlog::set_pattern("%v");
+        return;
+    }
+
     // https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
     auto formatter = std::make_unique<spdlog::pattern_formatter>();
     formatter->add_flag<star_formatter_flag>('*');

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "cbasetypes.h"
+#include "logging_context.h"
 #include "macros.h"
 #include "tracy.h"
 
@@ -58,6 +59,24 @@ void AddBacktrace(const std::string& str);
 auto GetBacktrace() -> std::vector<std::string>;
 
 void tapWarningOrError();
+
+namespace detail
+{
+
+inline bool gJsonMode{ false };
+
+struct LogRecord
+{
+    std::string_view levelName;
+    std::string_view file;
+    int              line;
+    std::string_view function;
+    std::string_view msg;
+};
+
+void renderJsonLine(fmt::memory_buffer& buf, const LogRecord& rec);
+
+} // namespace detail
 
 } // namespace logging
 
@@ -124,17 +143,30 @@ inline auto format_as(type v) \
         SPDLOG_LOGGER_ERROR(spdlog::get("error"), fmt::sprintf("%s:%i", File, Line));                             \
     } STATEMENT_CLOSE
 
+#define LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, MsgVar)                                  \
+    if (!::logging::detail::gJsonMode)                                                                  \
+    {                                                                                                   \
+        LOG_TYPE_MACRO(spdlog::get(LogStringName), MsgVar);                                             \
+    }                                                                                                   \
+    else                                                                                                \
+    {                                                                                                   \
+        fmt::memory_buffer _jbuf;                                                                       \
+        ::logging::detail::renderJsonLine(_jbuf, { LogStringName, File, Line, __FUNCTION__, MsgVar }); \
+        LOG_TYPE_MACRO(spdlog::get(LogStringName), std::string_view{ _jbuf.data(), _jbuf.size() });     \
+    }                                                                                                   \
+    STATEMENT_CLOSE
+
 #define LOGGER_BODY(LOG_TYPE_MACRO, LogStringName, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_CONDITIONAL(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_FMT(LOG_TYPE_MACRO, LogStringName, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_CONDITIONAL_FMT(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOG_TYPE_MACRO(spdlog::get(LogStringName), _msgStr); } END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
 
 // Regular Loggers
 // NOTE 1: Trace is not for logging to screen or file; it's for filling the backtrace buffer and reporting to Tracy.

--- a/src/common/logging_context.cpp
+++ b/src/common/logging_context.cpp
@@ -1,0 +1,51 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "logging_context.h"
+
+namespace
+{
+
+auto stack() -> std::vector<logging::Field>&
+{
+    thread_local std::vector<logging::Field> s;
+    return s;
+}
+
+} // namespace
+
+logging::LogScope::LogScope(std::initializer_list<Field> fields)
+: pushedCount_(fields.size())
+{
+    auto& s = stack();
+    s.insert(s.end(), fields.begin(), fields.end());
+}
+
+logging::LogScope::~LogScope()
+{
+    auto& s = stack();
+    s.erase(s.end() - pushedCount_, s.end());
+}
+
+auto logging::currentContext() -> const std::vector<Field>&
+{
+    return stack();
+}

--- a/src/common/logging_context.h
+++ b/src/common/logging_context.h
@@ -1,0 +1,150 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "macros.h"
+
+#include <magic_enum/magic_enum.hpp>
+
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace logging
+{
+
+struct Field;
+
+using Subfields = std::vector<Field>;
+
+struct Field
+{
+    using Value = std::variant<
+        std::int64_t,
+        std::uint64_t,
+        double,
+        bool,
+        std::string_view,
+        std::string,
+        Subfields>;
+
+    std::string_view key;
+    Value            value;
+
+    template <typename T>
+    Field(std::string_view k, T&& v)
+    : key(k)
+    , value(toValue(std::forward<T>(v)))
+    {
+    }
+
+    Field(std::string_view k, std::initializer_list<Field> nested)
+    : key(k)
+    , value(Subfields(nested))
+    {
+    }
+
+private:
+    template <typename T>
+    static auto toValue(T&& v) -> Value
+    {
+        using U = std::remove_cvref_t<T>;
+
+        if constexpr (std::is_same_v<U, bool>)
+        {
+            return v;
+        }
+        else if constexpr (std::is_enum_v<U>)
+        {
+            if (auto name = magic_enum::enum_name(v); !name.empty())
+            {
+                return name;
+            }
+
+            return toValue(static_cast<std::underlying_type_t<U>>(v));
+        }
+        else if constexpr (std::is_integral_v<U> && std::is_signed_v<U>)
+        {
+            return static_cast<std::int64_t>(v);
+        }
+        else if constexpr (std::is_integral_v<U> && std::is_unsigned_v<U>)
+        {
+            return static_cast<std::uint64_t>(v);
+        }
+        else if constexpr (std::is_floating_point_v<U>)
+        {
+            return static_cast<double>(v);
+        }
+        else if constexpr (std::is_same_v<U, std::string>)
+        {
+            if constexpr (std::is_lvalue_reference_v<T>)
+            {
+                return std::string_view(v);
+            }
+            else
+            {
+                return std::move(v);
+            }
+        }
+        else if constexpr (std::is_convertible_v<T, std::string_view>)
+        {
+            return std::string_view(v);
+        }
+        else
+        {
+            static_assert(sizeof(T*) == 0, "logging::Field: unsupported value type");
+            return Value{};
+        }
+    }
+};
+
+class LogScope
+{
+public:
+    LogScope(std::initializer_list<Field> fields);
+    ~LogScope();
+
+    DISALLOW_COPY_AND_MOVE(LogScope)
+
+private:
+    std::size_t pushedCount_{ 0 };
+};
+
+auto currentContext() -> const std::vector<Field>&;
+
+} // namespace logging
+
+// clang-format off
+
+#define LOG_WITH_CAT_INNER(a, b) a##b
+#define LOG_WITH_CAT(a, b)       LOG_WITH_CAT_INNER(a, b)
+
+/// Add key/values to logging context. Popped when LogWith goes out of scope.
+#define LogWith(...) \
+    ::logging::LogScope LOG_WITH_CAT(_ls_, __LINE__){ __VA_ARGS__ }
+
+// clang-format on

--- a/src/common/logging_json.cpp
+++ b/src/common/logging_json.cpp
@@ -1,0 +1,169 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "logging.h"
+
+#include <chrono>
+#include <iterator>
+#include <span>
+#include <utility>
+
+namespace
+{
+
+struct JsonStr
+{
+    std::string_view s;
+};
+
+auto basename(std::string_view file) -> std::string_view
+{
+    const auto slash = file.find_last_of("/\\");
+    return slash == std::string_view::npos ? file : file.substr(slash + 1);
+}
+
+} // namespace
+
+template <>
+struct fmt::formatter<JsonStr>
+{
+    static constexpr auto parse(format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    static auto format(const JsonStr& v, format_context& ctx) -> format_context::iterator
+    {
+        auto out = ctx.out();
+        for (unsigned char c : v.s)
+        {
+            switch (c)
+            {
+                case '"':
+                    out = fmt::format_to(out, R"(\")");
+                    break;
+                case '\\':
+                    out = fmt::format_to(out, R"(\\)");
+                    break;
+                case '\b':
+                    out = fmt::format_to(out, R"(\b)");
+                    break;
+                case '\f':
+                    out = fmt::format_to(out, R"(\f)");
+                    break;
+                case '\n':
+                    out = fmt::format_to(out, R"(\n)");
+                    break;
+                case '\r':
+                    out = fmt::format_to(out, R"(\r)");
+                    break;
+                case '\t':
+                    out = fmt::format_to(out, R"(\t)");
+                    break;
+                default:
+                    if (c < 0x20)
+                    {
+                        out = fmt::format_to(out, R"(\u{:04x})", c);
+                    }
+                    else
+                    {
+                        *out++ = static_cast<char>(c);
+                    }
+            }
+        }
+        return out;
+    }
+};
+
+namespace
+{
+
+void appendFieldValue(fmt::memory_buffer& buf, const logging::Field::Value& value);
+
+void appendFields(fmt::memory_buffer& buf, std::span<const logging::Field> fields)
+{
+    auto out   = std::back_inserter(buf);
+    bool first = true;
+    for (const auto& f : fields)
+    {
+        if (!std::exchange(first, false))
+        {
+            buf.push_back(',');
+        }
+        fmt::format_to(out, R"("{}":)", JsonStr{ f.key });
+        appendFieldValue(buf, f.value);
+    }
+}
+
+void appendFieldValue(fmt::memory_buffer& buf, const logging::Field::Value& value)
+{
+    auto out = std::back_inserter(buf);
+    std::visit(
+        [&]<typename T>(const T& v)
+        {
+            if constexpr (std::is_same_v<T, std::string> || std::is_same_v<T, std::string_view>)
+            {
+                fmt::format_to(out, R"("{}")", JsonStr{ v });
+            }
+            else if constexpr (std::is_same_v<T, logging::Subfields>)
+            {
+                buf.push_back('{');
+                appendFields(buf, v);
+                buf.push_back('}');
+            }
+            else
+            {
+                fmt::format_to(out, "{}", v);
+            }
+        },
+        value);
+}
+
+} // namespace
+
+void logging::detail::renderJsonLine(fmt::memory_buffer& buf, const LogRecord& rec)
+{
+    const auto now    = std::chrono::system_clock::now();
+    const auto secs   = std::chrono::time_point_cast<std::chrono::seconds>(now);
+    const auto millis = std::chrono::duration_cast<std::chrono::milliseconds>(now - secs).count();
+    const auto tt     = std::chrono::system_clock::to_time_t(secs);
+
+    fmt::format_to(std::back_inserter(buf),
+                   R"({{"ts":"{:%Y-%m-%dT%H:%M:%S}.{:03d}Z",)"
+                   R"("lvl":"{}",)"
+                   R"("source":{{"file":"{}","line":{},"function":"{}"}},)"
+                   R"("msg":"{}")",
+                   fmt::gmtime(tt),
+                   static_cast<int>(millis),
+                   JsonStr{ rec.levelName },
+                   JsonStr{ basename(rec.file) },
+                   rec.line,
+                   JsonStr{ rec.function },
+                   JsonStr{ rec.msg });
+
+    if (const auto& ctx = logging::currentContext(); !ctx.empty())
+    {
+        buf.push_back(',');
+        appendFields(buf, ctx);
+    }
+
+    buf.push_back('}');
+}

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -120,6 +120,8 @@ void IPCClient::handleIncomingMessages()
         const auto firstByte = out.data<uint8>()[0];
         const auto msgType   = ipc::toString(static_cast<ipc::MessageType>(firstByte));
 
+        LogWith({ "ipc_msg", msgType });
+
         // TODO: Make an IPP for the world server, so we can use it here
         DebugIPCFmt("Incoming {} message", msgType);
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2389,6 +2389,8 @@ int32 OnTrigger(CCharEntity* PChar, CBaseEntity* PNpc)
 {
     TracyZoneScoped;
 
+    LogWith({ "npc", { { "name", PNpc->getName() }, { "id", PNpc->id } } });
+
     // Clicking objects does nothing if the player is mid synthesis
     if (PChar->animation == ANIMATION_SYNTH)
     {
@@ -2436,6 +2438,8 @@ int32 OnTrigger(CCharEntity* PChar, CBaseEntity* PNpc)
 int32 OnEventUpdate(CCharEntity* PChar, uint16 eventID, uint32 result)
 {
     TracyZoneScoped;
+
+    LogWith({ "event", { { "id", eventID }, { "type", "update" } } });
 
     ShowTraceFmt("luautils::OnEventUpdate: {} ({}), id: {}, result: {}",
                  PChar->getName(),
@@ -2497,6 +2501,8 @@ int32 OnEventUpdate(CCharEntity* PChar, const std::string& updateString)
 int32 OnEventFinish(CCharEntity* PChar, uint16 eventID, uint32 result)
 {
     TracyZoneScoped;
+
+    LogWith({ "event", { { "id", eventID }, { "type", "finish" } } });
 
     ShowTraceFmt("luautils::OnEventFinish: {} ({}), id: {}, result: {}",
                  PChar->getName(),

--- a/src/map/packet_system.cpp
+++ b/src/map/packet_system.cpp
@@ -371,6 +371,9 @@ constexpr auto packetHandlers_ = buildPacketHandlers();
 
 void PacketSystem::dispatch(uint16 packetId, MapSession* PSession, CCharEntity* PChar, CBasicPacket& data)
 {
+    LogWith({ "char", { { "id", PChar->id }, { "name", PChar->getName() } } },
+            { "packet", { { "id", packetId } } });
+
     if (const auto handler = packetHandlers_[packetId])
     {
         if (rateLimiter_.isLimited(PChar, packetId))

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -147,6 +147,8 @@ auto GP_CLI_COMMAND_ACTION::validate(MapSession* PSession, const CCharEntity* PC
 
 void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) const
 {
+    LogWith({ "action", { { "type", static_cast<GP_CLI_COMMAND_ACTION_ACTIONID>(this->ActionID) }, { "target_id", this->ActIndex } } });
+
     const auto actionStr = fmt::format("Player Action: {}: {} -> ActIndex: {}", PChar->getName(), actionToStr(static_cast<GP_CLI_COMMAND_ACTION_ACTIONID>(this->ActionID)), this->ActIndex);
     ShowTrace(actionStr);
     DebugActions(actionStr);

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1834,6 +1834,7 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
     TracyZoneString(m_zone->getName());
+    LogWith({ "zone", { { "name", m_zone->getName() }, { "id", m_zone->GetID() } } });
 
     luautils::OnZoneTick(this->m_zone);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

> [05/25/26 20:47:37:342][map][error] CLuaBaseEntity::StartEventHelper: Could not start event, Character Entity already triggered. (StartEventHelper:1066)

Frequently faced with such messages in LSB logs. Fine if you're debugging with a single client, absolutely useless when running with thousands of clients.

This inevitably leads to having to add extra context into the logging message itself by using *Fmt macros and adding PChar->name etc. 

> ShowWarningFmt("{} attempting to buy item {} without meeting shop requirement!", PChar->getName(), itemId);

Works decently well but is not meaningfully enforced leading to inconsistent log messages.

I am proposing to adopt structured (JSON) logging as an opt-in output mode.

The concept is fairly simple: you sprinkle `LogWith` at key strategic points with highly relevant information such as the character performing an action, or the name of the mob you're processing and _every_ downstream operation logging anything will automatically get that context printed. `LogWith` can be called multiple times in the same chain, augmenting the set of contextual information in the message. Each addition to the context is removed when the relevant LogWith macro goes out of scope.

> LogWith({ "npc", { { "name", PNpc->getName() }, { "id", PNpc->id } } });

You then end up with log messages that look like this without having to repeat the inclusion of contextual information at every Log macro.

> {"ts":"2026-05-29T19:58:43.160Z","lvl":"debug","source":{"file":"0x112_battlefield_req.cpp","line":34,"function":"GP_CLI_COMMAND_BATTLEFIELD_REQ::process"},"msg":"GP_CLI_COMMAND_BATTLEFIELD_REQ: Not implemented. Kind: 0","char":{"id":3,"name":"Lsb"},"packet":{"id":274}}

This being JSON means it can also be very simply indexed by Splunk/Loki/whatever.

Notes:
  - Hand-rolled JSON formatting because spdlog still doesn't have a built-in formatter in 2026 and nlohmann would require heap allocs at every log line
  - No performance impact if opted out. When enabled it doesn't meaningfully deviate from existing pattern writer: 500ns per log line, 200ns per scope push/pop

## Steps to test these changes
logging.JSON_ENABLED = true