### PR TITLE
[lua] Added Kannagi and Almace Magian Trial Data

### DIFF
--- a/scripts/globals/magian_data.lua
+++ b/scripts/globals/magian_data.lua
@@ -4544,7 +4544,7 @@ xi.magian.trials =
 
     [1200] = -- Tammuz x8
     {
-        previousTrial = 156,
+        previousTrial = 157,
         requiredItem  =
         {
             itemId       = xi.item.NOBILIS,
@@ -4564,6 +4564,28 @@ xi.magian.trials =
             {
                 [1] = { 45, 7 }, -- DMG:+8
             },
+        },
+    },
+
+    [1201] =
+    {
+        previousTrial = 1200,
+        requiredItem  =
+        {
+            itemId       = xi.item.NOBILIS,
+            itemAugments =
+            {
+                [1] = { 45, 7 }, -- DMG:+8
+            },
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.HELM_OF_BRIAREUS,
+        numRequired = 50,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE,
         },
     },
 
@@ -4714,6 +4736,28 @@ xi.magian.trials =
             {
                 [1] = { 45, 7 }, -- DMG:+8
             },
+        },
+    },
+
+    [1509] =
+    {
+        previousTrial = 1508,
+        requiredItem  =
+        {
+            itemId = xi.item.MOZU,
+            itemAugments =
+            {
+                [1] = { 45, 7 }, -- DMG:+8
+            },
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.HELM_OF_BRIAREUS,
+        numRequired = 50,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI,
         },
     },
 
@@ -6307,6 +6351,42 @@ xi.magian.trials =
         },
     },
 
+    [1940] =
+    {
+        previousTrial = 1201,
+        requiredItem  =
+        {
+            itemId = xi.item.ALMACE,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.SOBEKS_SKIN,
+        numRequired = 50,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE_85,
+        },
+    },
+
+    [2094] =
+    {
+        previousTrial = 1509,
+        requiredItem  =
+        {
+            itemId = xi.item.KANNAGI,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.SOBEKS_SKIN,
+        numRequired = 50,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI_85,
+        },
+    },
+
     [2247] =
     {
         previousTrial = 1786,
@@ -6676,6 +6756,42 @@ xi.magian.trials =
         rewardItem =
         {
             itemId = xi.item.VERETHRAGNA_90,
+        },
+    },
+
+    [2339] =
+    {
+        previousTrial = 1940,
+        requiredItem  =
+        {
+            itemId = xi.item.ALMACE_85,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.APADEMAKS_HORN,
+        numRequired = 75,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE_90,
+        },
+    },
+
+    [2499] =
+    {
+        previousTrial = 2094,
+        requiredItem  =
+        {
+            itemId = xi.item.KANNAGI_85,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.APADEMAKS_HORN,
+        numRequired = 75,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI_90,
         },
     },
 
@@ -7077,6 +7193,42 @@ xi.magian.trials =
         },
     },
 
+    [2772] =
+    {
+        previousTrial = 2339,
+        requiredItem  =
+        {
+            itemId = xi.item.ALMACE_90,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PLATE_OF_HEAVY_METAL,
+        numRequired = 1500,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE_95,
+        },
+    },
+
+    [2932] =
+    {
+        previousTrial = 2499,
+        requiredItem  =
+        {
+            itemId = xi.item.KANNAGI_90,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PLATE_OF_HEAVY_METAL,
+        numRequired = 1500,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI_95,
+        },
+    },
+
     [3093] =
     {
         previousTrial = 2660,
@@ -7347,6 +7499,42 @@ xi.magian.trials =
         rewardItem =
         {
             itemId = xi.item.VERETHRAGNA_99,
+        },
+    },
+
+    [3235] =
+    {
+        previousTrial = 2772,
+        requiredItem  =
+        {
+            itemId = xi.item.ALMACE_95,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PINCH_OF_RIFTCINDER,
+        numRequired = 60,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE_99,
+        },
+    },
+
+    [3395] =
+    {
+        previousTrial = 2932,
+        requiredItem  =
+        {
+            itemId = xi.item.KANNAGI_95,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PINCH_OF_RIFTCINDER,
+        numRequired = 60,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI_99,
         },
     },
 
@@ -7635,6 +7823,42 @@ xi.magian.trials =
         rewardItem =
         {
             itemId = xi.item.VERETHRAGNA_99_II,
+        },
+    },
+
+    [3594] =
+    {
+        previousTrial = 3235,
+        requiredItem  =
+        {
+            itemId = xi.item.ALMACE_99,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PINCH_OF_RIFTCINDER,
+        numRequired = 3000,
+
+        rewardItem =
+        {
+            itemId = xi.item.ALMACE_99_II,
+        },
+    },
+
+    [3600] =
+    {
+        previousTrial = 3395,
+        requiredItem  =
+        {
+            itemId = xi.item.KANNAGI_99,
+        },
+
+        textOffset  = 70,
+        tradeItem   = xi.item.PINCH_OF_RIFTCINDER,
+        numRequired = 3000,
+
+        rewardItem =
+        {
+            itemId = xi.item.KANNAGI_99_II,
         },
     },
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1) Fixes Empyrean Sword Magian Trial path (Trial 1200 linked to previous Trial 157)
2) Added Kannagi Magian Trials (Trials 1509, 2094, 2499, 2932, 3395, and 3600)
3) Added Almace Magian Trials (Trials 1201, 1940, 2339, 2772, 3235, and 3594)

## Steps to test these changes

Warp to Ru'lude Gardens Orange Magian Moogle (!gotoid 17772778)

Give yourself all the following items using the commands in the parentheses:
Nobilis w/ DMG +8 (!additem 19339 1 45 7)
Mozu w/ DMG +8 (!additem 19369 1 45 7)
Helm of Briareus x100 (!additem 2929 100)
Sobek's Skin x100 (!additem 2964 100)
Apademak's Horn x150 (!additem 3289 150)
Heavy Metal Plate x3000 (!additem 3509 3000)
Riftcinder x120 (!additem 3499 120)

Trade either the Nobilis or Mozu to the orange moogle, and follow the magian path until the lvl 99 version. Do the same with the other weapon. The trade for each weapon is:
1) Helm of Briareus x50 
2) Sobek Skin x50
3) Apademak's Horns x50
4) Heavy Metal Plate x1500
5) Riftcinder x 60

Now that you have inventory space again, give yourself 6,000 riftcinder and finish the final trade for a lvl 99_2 version of each weapon.
Riftcinder x6000 (!additem 3499 6000)