### PR TITLE
[core] Deny zoning if target zone at capacity

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -17,6 +17,10 @@ xi.settings.map =
 
     MAX_TIME_LASTUPDATE = 60,
 
+    -- Per-zone player cap. 0 disables. GMs reserve the top GM_RESERVED slots.
+    ZONE_PLAYER_CAP         = 700,
+    ZONE_PLAYER_GM_RESERVED = 5,
+
     -- --------------------------------
     -- SQL settings
     -- --------------------------------

--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -414,6 +414,17 @@ void data_session::read_func()
                     ShowWarning(fmt::format("data_session: account {} attempting to login when {} already has {} active session(s), limit is {}", session.accountID, ipAddress, sessionCount, loginLimit));
                 }
 
+                if (loginHelpers::isZoneAtPlayerCap(ZoneID, isGM))
+                {
+                    ShowWarning(fmt::format("data_session: zone {} at player cap, denying charid {} (gm={})", ZoneID, charid, isGM ? 1 : 0));
+                    if (auto viewSession = session.view_session.get())
+                    {
+                        loginHelpers::generateErrorMessage(viewSession->buffer_.data(), loginErrors::errorCode::WORLD_IS_FULL);
+                        viewSession->do_write(0x24);
+                        return;
+                    }
+                }
+
                 if ((isNotMaint && loginLimitOK) || isGM)
                 {
                     if (PrevZone == 0)

--- a/src/login/login_errors.h
+++ b/src/login/login_errors.h
@@ -33,6 +33,7 @@ enum errorCode : uint16_t
     CHARACTER_NAME_UNAVAILABLE = 313, // "The character name you entered is unavailable.\nPlease choose another name."
 
     CHARACTER_ALREADY_LOGGED_IN             = 201, // "Same character already logged in.\nPlease wait a few minutes before trying to reconnect."
+    WORLD_IS_FULL                           = 208, // "Unable to log on to world server.\nServer currently congested." (FFXI-3208)
     FAILED_TO_REGISTER_WITH_THE_NAME_SERVER = 314, // "Failed to register with the name server."
     CHARACTERS_PARAMETERS_ARE_INCORRECT     = 321, // "Character's parameters are incorrect."
     GAMES_DATA_HAS_BEEN_UPDATED             = 331, // "The games data has been updated."

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -55,6 +55,40 @@ session_t& get_authenticated_session(const std::string& ipAddr, const std::strin
     return authenticatedSessions_[ipAddr][sessionHash]; // NOTE: Will construct if doesn't exist
 }
 
+auto isZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool
+{
+    const auto cap = settings::get<uint16>("map.ZONE_PLAYER_CAP");
+    if (cap == 0)
+    {
+        return false;
+    }
+
+    const auto reserved  = settings::get<uint16>("map.ZONE_PLAYER_GM_RESERVED");
+    const auto threshold = isGM ? cap : static_cast<uint16>(cap > reserved ? cap - reserved : 0);
+
+    const auto rset = db::preparedStmt(
+        "SELECT z.zonetype, "
+        "  (SELECT COUNT(*) FROM accounts_sessions s "
+        "    JOIN chars c ON c.charid = s.charid "
+        "    WHERE c.pos_zone = ?) AS pop "
+        "FROM zone_settings z WHERE z.zoneid = ? LIMIT 1",
+        zoneId,
+        zoneId);
+
+    FOR_DB_SINGLE_RESULT(rset)
+    {
+        constexpr uint16 zoneTypeInstanced = 0x100;
+        if (rset->get<uint16>("zonetype") & zoneTypeInstanced)
+        {
+            return false;
+        }
+
+        return rset->get<uint32>("pop") >= threshold;
+    }
+
+    return false;
+}
+
 // https://github.com/atom0s/XiPackets/blob/main/lobby/S2C_0x0004_ResponseError.md
 void generateErrorMessage(uint8* packet, uint16 errorCode)
 {

--- a/src/login/login_helpers.h
+++ b/src/login/login_helpers.h
@@ -87,6 +87,8 @@ enum FEATURE_DISPLAY : uint16
 
 bool isStringMalformed(const std::string& str, std::size_t max_length);
 
+auto isZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool;
+
 session_t& get_authenticated_session(const std::string& ipAddr, const std::string& sessionHash);
 
 // https://github.com/atom0s/XiPackets/blob/main/lobby/S2C_0x0004_ResponseError.md

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -231,6 +231,12 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     return;
                 }
 
+                if (!isMogHouseEntrance && zoneutils::IsZoneAtPlayerCap(PZoneLine->destinationZoneId, PChar->m_GMlevel > 0))
+                {
+                    denyZone(PChar);
+                    return;
+                }
+
                 if (isMogHouseEntrance)
                 {
                     // TODO: for entering another persons mog house, it must be set here

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -50,6 +50,7 @@
 #include "packets/s2c/0x04f_equip_clear.h"
 #include "packets/s2c/0x050_equip_list.h"
 #include "packets/s2c/0x051_grap_list.h"
+#include "packets/s2c/0x053_systemmes.h"
 #include "packets/s2c/0x055_scenarioitem.h"
 #include "packets/s2c/0x061_clistatus.h"
 #include "packets/s2c/0x062_clistatus2.h"
@@ -7304,20 +7305,26 @@ std::string GetConquestPointsName(CCharEntity* PChar)
     }
 }
 
-void SendToZone(CCharEntity* PChar, uint16 zoneId)
+auto SendToZone(CCharEntity* PChar, uint16 zoneId) -> bool
 {
     TracyZoneScoped;
 
     if (PChar->PSession->blowfish.status == BLOWFISH_PENDING_ZONE)
     {
-        return;
+        return false;
     }
 
     auto ipp = IPP(zoneutils::GetZoneIPP(zoneId));
     if (ipp.getIP() == 0)
     {
         ShowErrorFmt("charutils::SendToZone : Invalid zoneId {}", zoneId);
-        return;
+        return false;
+    }
+
+    if (zoneutils::IsZoneAtPlayerCap(zoneId, PChar->m_GMlevel > 0))
+    {
+        ShowInfoFmt("charutils::SendToZone : zone {} at player cap, denying {} (gm={})", zoneId, PChar->name, PChar->m_GMlevel);
+        return false;
     }
 
     auto ip   = ipp.getIP();
@@ -7372,6 +7379,8 @@ void SendToZone(CCharEntity* PChar, uint16 zoneId)
     {
         PChar->setPetZoningInfo();
     }
+
+    return true;
 }
 
 void SendDisconnect(CCharEntity* PChar)
@@ -7417,9 +7426,16 @@ void ForceRezone(CCharEntity* PChar)
     }
 }
 
-void HomePoint(CCharEntity* PChar, bool resetHPMP)
+auto HomePoint(CCharEntity* PChar, bool resetHPMP) -> bool
 {
     TracyZoneScoped;
+
+    if (zoneutils::IsZoneAtPlayerCap(PChar->profile.home_point.destination, PChar->m_GMlevel > 0))
+    {
+        PChar->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::CouldNotEnter);
+        PChar->requestedWarp = false;
+        return false;
+    }
 
     // player initiated warp/warp 2 or otherwise
     if (resetHPMP)
@@ -7443,7 +7459,7 @@ void HomePoint(CCharEntity* PChar, bool resetHPMP)
     PChar->updatemask |= UPDATE_HP;
 
     PChar->clearPacketList();
-    SendToZone(PChar, PChar->loc.destination);
+    return SendToZone(PChar, PChar->loc.destination);
 }
 
 bool AddWeaponSkillPoints(CCharEntity* PChar, SLOTTYPE slotid, int wspoints)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -254,11 +254,11 @@ void  SetPoints(CCharEntity* PChar, const char* type, int32 amount);
 int32 GetPoints(CCharEntity* PChar, const char* type);
 void  SetUnityLeader(CCharEntity* PChar, uint8 leaderID);
 auto  GetConquestPointsName(CCharEntity* PChar) -> std::string;
-void  SendToZone(CCharEntity* PChar, uint16 zoneId);
+auto  SendToZone(CCharEntity* PChar, uint16 zoneId) -> bool;
 void  SendDisconnect(CCharEntity* PChar);
 void  ForceLogout(CCharEntity* PChar);
 void  ForceRezone(CCharEntity* PChar);
-void  HomePoint(CCharEntity* PChar, bool resetHPMP);
+auto  HomePoint(CCharEntity* PChar, bool resetHPMP) -> bool;
 bool  AddWeaponSkillPoints(CCharEntity*, SLOTTYPE, int);
 
 int32 GetCharVar(CCharEntity* PChar, const std::string& var);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1343,6 +1343,40 @@ auto GetZoneIPP(uint16 zoneId) -> uint64
     return ipp;
 }
 
+auto IsZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool
+{
+    const auto cap = settings::get<uint16>("map.ZONE_PLAYER_CAP");
+    if (cap == 0)
+    {
+        return false;
+    }
+
+    const auto reserved  = settings::get<uint16>("map.ZONE_PLAYER_GM_RESERVED");
+    const auto threshold = isGM ? cap : static_cast<uint16>(cap > reserved ? cap - reserved : 0);
+
+    const auto rset = db::preparedStmt(
+        "SELECT z.zonetype, "
+        "  (SELECT COUNT(*) FROM accounts_sessions s "
+        "    JOIN chars c ON c.charid = s.charid "
+        "    WHERE c.pos_zone = ?) AS pop "
+        "FROM zone_settings z WHERE z.zoneid = ? LIMIT 1",
+        zoneId,
+        zoneId);
+
+    FOR_DB_SINGLE_RESULT(rset)
+    {
+        const auto zoneType = rset->get<uint16>("zonetype");
+        if (zoneType & ZONE_TYPE::INSTANCED)
+        {
+            return false;
+        }
+
+        return rset->get<uint32>("pop") >= threshold;
+    }
+
+    return false;
+}
+
 /************************************************************************
  *                                                                       *
  *  Check whether or not the zone is a residential area                  *

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -80,6 +80,7 @@ auto IsZoneAssignedToThisProcess(IPP mapIPP, ZONEID zoneId) -> bool;
 void ForEachZone(const std::function<void(CZone*)>& func);
 void ForEachZone(const std::vector<uint16>& zoneIds, const std::function<void(CZone*)>& func);
 auto GetZoneIPP(uint16 zoneId) -> uint64;                    // returns IPP for zone ID
+auto IsZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool;    // returns true if the zone is at capacity and the entry should be denied
 auto IsResidentialArea(const CCharEntity* PChar) -> bool;    // returns whether or not the area is a residential zone
 auto IsAlwaysOutOfNationControl(REGION_TYPE region) -> bool; // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -2011,8 +2011,10 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
             if (ready)
             {
                 PChar->clearPacketList();
-                charutils::HomePoint(PChar, PChar->isDead());
-                shouldErase = true;
+                if (charutils::HomePoint(PChar, PChar->isDead()))
+                {
+                    shouldErase = true;
+                }
             }
         }
         else if (PChar->loc.destination != 0xFFFF)
@@ -2021,8 +2023,10 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
             if (ready)
             {
                 PChar->clearPacketList();
-                charutils::SendToZone(PChar, PChar->loc.destination);
-                shouldErase = true;
+                if (charutils::SendToZone(PChar, PChar->loc.destination))
+                {
+                    shouldErase = true;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Check if target (possibly cross-process) zone is already at or near the 700 player cap before actually sending a player. 
Applies to lobby and zonelines and homepoints. GMs get 5 reserved slots.

## Steps to test these changes
<img width="1683" height="773" alt="Screenshot 2026-05-29 231338" src="https://github.com/user-attachments/assets/dd642668-b2c6-4502-b692-1c681ab90bfb" />
<img width="1722" height="184" alt="image" src="https://github.com/user-attachments/assets/f2ee9815-d467-4be3-b6a3-8d26644bc89c" />

<!-- Clear and detailed steps to test your changes here -->
