### PR TITLE
Resolve traverser stone bug #9893

### DIFF
--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -13,7 +13,7 @@ CREATE TABLE `char_unlocks` (
   `campaign_windy` int(10) unsigned NOT NULL DEFAULT 0,
   `homepoints` blob DEFAULT NULL,
   `survivals` blob DEFAULT NULL,
-  `traverser_start` TIMESTAMP DEFAULT 0,
+  `traverser_start` TIMESTAMP DEFAULT NULL,
   `traverser_claimed` int(10) unsigned NOT NULL DEFAULT 0,
   `abyssea_conflux` blob DEFAULT NULL,
   `waypoints` blob DEFAULT NULL,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Traverser stone calculation is currently bugged due to the default value of this table being 0 rather than null.

Converts default values to null, which allows timestamps to be properly written when the necessary in-game event is triggered.

Resolves #9893 

## Steps to test these changes

Satisfy requirements to enter Abyssea zones.  Check database table char_unlocks for traverser_start value.  It should be a properly formed timestamp rather than 0.
