### PR TITLE
[core] Adjust worm AI in regards to spellcasting (standback cooldown gone, worms dont cast in melee range)

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -752,13 +752,14 @@ auto CMobController::DoCombatTick(timer::time_point tick) -> Task<void>
     {
         const float currentDistance   = distance(PMob->loc.p, PTarget->loc.p);
         const float rangedAttackRange = PMob->GetRangedAttackRange();
+        const float meleeAttackRange  = PMob->GetMeleeRange(PTarget);
 
         if (IsSpecialSkillReady(currentDistance) && TrySpecialSkill())
         {
             co_return;
         }
 
-        if (IsSpellReady(currentDistance) && TryCastSpell()) // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
+        if (IsSpellReady(currentDistance, meleeAttackRange) && TryCastSpell()) // Try to spellcast (this is done first so things like Chainspell spam is prioritised over TP moves etc.
         {
             co_return;
         }
@@ -1650,13 +1651,19 @@ auto CMobController::IsSpecialSkillReady(const float currentDistance) const -> b
     return m_Tick >= m_LastSpecialTime + std::chrono::seconds(PMob->getMobMod(MOBMOD_SPECIAL_COOL) - bonusTime);
 }
 
-auto CMobController::IsSpellReady(const float currentDistance) const -> bool
+auto CMobController::IsSpellReady(const float& currentDistance, const float& meleeRange) const -> bool
 {
     TracyZoneScoped;
 
     if (PMob->StatusEffectContainer->HasStatusEffect({ EFFECT_CHAINSPELL, EFFECT_MANAFONT }))
     {
         return true;
+    }
+
+    // Worms don't cast in melee range (typically.) The edge cases can be scripted.
+    if (PMob->m_roamFlags & ROAMFLAG_WORM && currentDistance <= meleeRange)
+    {
+        return false;
     }
 
     if (currentDistance > 5)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1666,7 +1666,7 @@ auto CMobController::IsSpellReady(const float& currentDistance, const float& mel
         return false;
     }
 
-    if (currentDistance > 5)
+    if (currentDistance > 5 && (PMob->m_roamFlags & ROAMFLAG_WORM) == 0)
     {
         // Mobs use magic quicker when standing back
         return m_Tick >= (m_nextMagicTime - std::chrono::seconds(PMob->getMobMod(MOBMOD_STANDBACK_COOL)));

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -81,7 +81,7 @@ protected:
     void         FollowRoamPath();
     auto         CanMoveForward(float currentDistance) -> bool;
     auto         IsSpecialSkillReady(float currentDistance) const -> bool;
-    auto         IsSpellReady(float currentDistance) const -> bool;
+    auto         IsSpellReady(const float& currentDistance, const float& meleeRange) const -> bool;
 
     CBattleEntity* PTarget{ nullptr };
 

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -125,7 +125,7 @@ auto CPetController::DoRoamTick(timer::time_point tick) -> Task<void>
             if (isLightSpirit)
             {
                 // This will respect the pet's mob casting cooldown properties via MOBMOD_MAGIC_COOL
-                if (CMobController::IsSpellReady(0) && CMobController::TryCastSpell())
+                if (CMobController::IsSpellReady(0, 0) && CMobController::TryCastSpell())
                 {
                     co_return;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Prevent worms from casting in melee range globally. They can still be scripted to cast, if necessary. I am sure there are some edge cases we may need to account for but this is _seemingly_ the typical behavior.

Disable standback cooldown reduction for worms (it doesn't make sense.)

## Steps to test these changes

voke a worm in melee range and you won't get cast on