### PR TITLE
[core] Support GP_CLI_COMMAND_CHARREQ2, allow CHARREQ to query SHIP

### DIFF
--- a/src/map/packets/c2s/0x016_charreq.cpp
+++ b/src/map/packets/c2s/0x016_charreq.cpp
@@ -41,7 +41,7 @@ void GP_CLI_COMMAND_CHARREQ::process(MapSession* PSession, CCharEntity* PChar) c
         return;
     }
 
-    CBaseEntity* PEntity = PChar->GetEntity(this->ActIndex, TYPE_NPC | TYPE_PC);
+    CBaseEntity* PEntity = PChar->GetEntity(this->ActIndex, TYPE_NPC | TYPE_PC | TYPE_SHIP);
     if (!PEntity)
     {
         const auto fullId = ((4096 + PChar->getZone()) << 12) + this->ActIndex;

--- a/src/map/packets/c2s/0x017_charreq2.cpp
+++ b/src/map/packets/c2s/0x017_charreq2.cpp
@@ -21,23 +21,96 @@
 
 #include "0x017_charreq2.h"
 
+#include "common/utils.h"
+
+#include <algorithm>
+#include <array>
+
 #include "entities/charentity.h"
+#include "packets/char_sync.h"
+#include "packets/char_update.h"
+#include "utils/zoneutils.h"
+
+namespace
+{
+constexpr float CHARREQ2_SYNC_RANGE = 50.0f;
+
+auto resolveByUniqueNo(const uint32 uniqueNo) -> CBaseEntity*
+{
+    if (uniqueNo == 0)
+    {
+        return nullptr;
+    }
+
+    if (auto* PEntity = zoneutils::GetEntity(uniqueNo))
+    {
+        return PEntity;
+    }
+
+    return zoneutils::GetChar(uniqueNo);
+}
+} // namespace
 
 auto GP_CLI_COMMAND_CHARREQ2::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
-    // Not implemented.
-    return PacketValidator(PChar)
-        .blockedBy({ BlockedState::InEvent });
+    return PacketValidator(PChar);
 }
 
 void GP_CLI_COMMAND_CHARREQ2::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    if (PChar->isInEvent())
+    const std::array targets{
+        this->ActIndex ? PChar->GetEntity(this->ActIndex) : nullptr,
+        resolveByUniqueNo(this->UniqueNo2),
+        resolveByUniqueNo(this->UniqueNo3),
+    };
+
+    ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2 from {}: ActIndex={} UniqueNo2={} UniqueNo3={} Flg={} Flg2={}",
+                   PChar->getName(),
+                   this->ActIndex,
+                   this->UniqueNo2,
+                   this->UniqueNo3,
+                   this->Flg,
+                   this->Flg2);
+
+    for (size_t i = 0; i < targets.size(); ++i)
     {
-        ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2: Incorrect NPC({},{}) type({}) event({})", this->ActIndex, this->UniqueNo2, this->Flg, PChar->currentEvent->eventId);
-    }
-    else
-    {
-        ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2: Incorrect NPC({},{}) type({})", this->ActIndex, this->UniqueNo2, this->Flg);
+        auto* PTarget = targets[i];
+        if (PTarget == nullptr)
+        {
+            continue;
+        }
+
+        const auto seen = std::ranges::subrange(targets.begin(), targets.begin() + i);
+        if (std::ranges::find(seen, PTarget) != seen.end())
+        {
+            continue;
+        }
+
+        const float dist = distance(PChar->loc.p, PTarget->loc.p);
+        if (dist > CHARREQ2_SYNC_RANGE)
+        {
+            ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2 from {}: target {} ({}) is {:.1f}y away (beyond {}y)", PChar->getName(), PTarget->getName(), PTarget->id, dist, CHARREQ2_SYNC_RANGE);
+        }
+
+        if (PTarget->objtype == TYPE_PC)
+        {
+            auto* PTargetChar = static_cast<CCharEntity*>(PTarget);
+            if (PTargetChar->m_isGMHidden)
+            {
+                continue;
+            }
+
+            PChar->updateEntityPacket(PTargetChar, ENTITY_SPAWN, UPDATE_ALL_CHAR);
+
+            if (dist <= CHARREQ2_SYNC_RANGE)
+            {
+                PChar->pushPacket<CCharSyncPacket>(PTargetChar);
+                PChar->pushPacket<CCharUpdatePacket>(PTargetChar, ENTITY_UPDATE, static_cast<uint8>(UPDATE_NAME));
+            }
+        }
+        else
+        {
+            PChar->updateEntityPacket(PTarget, ENTITY_UPDATE, static_cast<uint8>(UPDATE_ALL_MOB));
+        }
     }
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Tweak CHARREQ to support requesting """SHIP"""NPCs (SubKind 4 entities)
- Support CHARREQ2 packet

They do more or less the same thing but are used in different contexts.

Closes #10194 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
