### PR TITLE
[lua] Audit Missions and Event Skipped Teleporters #2

### DIFF
--- a/scripts/globals/promyvion.lua
+++ b/scripts/globals/promyvion.lua
@@ -215,7 +215,7 @@ xi.promyvion.handlePortal = function(player, npcId, eventId)
         player:getAnimation() == xi.anim.NONE and
         GetNPCByID(npcId):getAnimation() == xi.anim.OPEN_DOOR
     then
-        player:startOptionalCutscene(eventId)
+        player:startOptionalCutscene(eventId, { cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/missions/bastok/1_1_The_Zeruhn_Report.lua
+++ b/scripts/missions/bastok/1_1_The_Zeruhn_Report.lua
@@ -127,7 +127,7 @@ mission.sections =
                     if player:hasKeyItem(xi.ki.ZERUHN_REPORT) then
                         return mission:messageSpecial(zeruhnID.text.MAKARIM_DIALOG_I)
                     else
-                        return mission:progressEvent(121)
+                        return mission:progressEvent(121, { canSkip = true })
                     end
                 end,
             },
@@ -136,7 +136,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if not player:hasKeyItem(xi.ki.ZERUHN_REPORT) then
-                        return mission:progressEvent(120)
+                        return mission:progressEvent(120, { canSkip = true })
                     end
                 end,
             },

--- a/scripts/missions/bastok/3_3_Jeuno.lua
+++ b/scripts/missions/bastok/3_3_Jeuno.lua
@@ -162,14 +162,14 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 2 and
                         npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
                     then
-                        return mission:progressEvent(1)
+                        return mission:progressCutscene(1)
                     end
                 end,
 
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then
                         if player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-                            return mission:progressEvent(1)
+                            return mission:progressCutscene(1)
                         else
                             return mission:messageSpecial(lowerDelkfuttID.text.THE_DOOR_IS_FIRMLY_SHUT_OPEN_KEY):setPriority(1000)
                         end

--- a/scripts/missions/cop/2_3_Distant_Beliefs.lua
+++ b/scripts/missions/cop/2_3_Distant_Beliefs.lua
@@ -54,7 +54,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if mission:getVar(player, 'Status') == 2 then
-                        return mission:progressEvent(36)
+                        return mission:progressCutscene(36)
                     end
                 end,
             },

--- a/scripts/missions/cop/2_4_An_Eternal_Melody.lua
+++ b/scripts/missions/cop/2_4_An_Eternal_Melody.lua
@@ -81,7 +81,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if mission:getVar(player, 'Status') == 1 then
-                        return mission:event(5)
+                        return mission:cutscene(5)
                     end
                 end,
             },

--- a/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
+++ b/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
@@ -198,14 +198,14 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 4 and
                         npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
                     then
-                        return mission:progressEvent(0)
+                        return mission:progressCutscene(0)
                     end
                 end,
 
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 4 then
                         if player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-                            return mission:progressEvent(0)
+                            return mission:progressCutscene(0)
                         else
                             return mission:messageSpecial(lowerDelkfuttID.text.THE_DOOR_IS_FIRMLY_SHUT_OPEN_KEY):setPriority(1000)
                         end

--- a/scripts/missions/windurst/3_3_A_New_Journey.lua
+++ b/scripts/missions/windurst/3_3_A_New_Journey.lua
@@ -86,14 +86,14 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 2 and
                         npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
                     then
-                        return mission:progressEvent(2)
+                        return mission:progressCutscene(2)
                     end
                 end,
 
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then
                         if player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-                            return mission:progressEvent(2)
+                            return mission:progressCutscene(2)
                         else
                             return mission:messageSpecial(lowerDelkfuttID.text.THE_DOOR_IS_FIRMLY_SHUT_OPEN_KEY):setPriority(1000)
                         end

--- a/scripts/quests/hiddenQuests/Crimson_Orb.lua
+++ b/scripts/quests/hiddenQuests/Crimson_Orb.lua
@@ -120,11 +120,11 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if questProgress == 0 then
-                        return quest:progressEvent(24)
+                        return quest:progressEvent(24, { canSkip = true })
                     elseif questProgress == 1 then
-                        return quest:progressEvent(22)
+                        return quest:progressEvent(22, { canSkip = true })
                     elseif questProgress == 2 then
-                        return quest:progressEvent(21)
+                        return quest:progressEvent(21, { canSkip = true })
                     elseif questProgress == 3 then
                         return quest:progressCutscene(25, 0, 0, 0, 136)
                     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47b.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47b.lua
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
                 player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.TO_EACH_HIS_OWN_RIGHT and
                 player:getMissionStatus(player:getNation()) == 3
             then
-                player:startEvent(43)
+                player:startCutscene(43)
             end
         end
     else

--- a/scripts/zones/Castle_Oztroja/npcs/_47c.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47c.lua
@@ -41,7 +41,7 @@ entity.onTrigger = function(player, npc)
                 player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.TO_EACH_HIS_OWN_RIGHT and
                 player:getMissionStatus(player:getNation()) == 3
             then
-                player:startEvent(43)
+                player:startCutscene(43)
             end
         end
     else

--- a/scripts/zones/Castle_Oztroja/npcs/_47j.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47j.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47k.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47k.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47l.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47l.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47m.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47m.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47y.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47y.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_47z.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47z.lua
@@ -25,7 +25,7 @@ entity.onTrigger = function(player, npc)
     end
 
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.UNLIT_TORCH)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m70.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m70.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(11)
+        player:startEvent(11) -- TODO: Check if should be startOptionalCutscene(11, { cs_option = 0, canSkip = true })
     else
         player:messageSpecial(ID.text.PROBABLY_WORKS_WITH_SOMETHING_ELSE)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m71.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m71.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-        player:startEvent(11)
+        player:startEvent(11) -- TODO: Check if should be startOptionalCutscene(11, { cs_option = 0, canSkip = true })
     else
         player:messageSpecial(ID.text.PROBABLY_WORKS_WITH_SOMETHING_ELSE)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m72.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m72.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
         brassDoor and
         brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
     then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.TORCH_LIT)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m73.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m73.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
         brassDoor and
         brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
     then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.TORCH_LIT)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m74.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m74.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
         brassDoor and
         brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
     then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.TORCH_LIT)
     end

--- a/scripts/zones/Castle_Oztroja/npcs/_m75.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_m75.lua
@@ -17,7 +17,7 @@ entity.onTrigger = function(player, npc)
         brassDoor and
         brassDoor:getAnimation() == xi.anim.CLOSE_DOOR
     then
-        player:startEvent(10)
+        player:startEvent(10, { canSkip = true })
     else
         player:messageSpecial(ID.text.TORCH_LIT)
     end

--- a/scripts/zones/Davoi/npcs/_459.lua
+++ b/scripts/zones/Davoi/npcs/_459.lua
@@ -9,7 +9,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.CREST_OF_DAVOI) then
-        player:startEvent(54)
+        player:startEvent(54) -- TODO: Check if this should be a cutscene that can be Event Skipped
     end
 end
 

--- a/scripts/zones/Davoi/npcs/_45d.lua
+++ b/scripts/zones/Davoi/npcs/_45d.lua
@@ -12,7 +12,7 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     if npc:getAnimation() == xi.animation.CLOSE_DOOR then
         if player:hasKeyItem(xi.ki.CRIMSON_ORB) then
-            player:startEvent(42)
+            player:startEvent(42, { canSkip = true })
         end
     end
 end

--- a/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/Zone.lua
@@ -52,7 +52,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         player:getAnimation() == xi.anim.NONE
     then
         -- prevent 2cs at same time
-        player:startOptionalCutscene(149 + triggerArea:getTriggerAreaID()) -- Confirmed to wipe enmity.
+        player:startOptionalCutscene(149 + triggerArea:getTriggerAreaID(), { cs_option = 0, canSkip = true }) -- Confirmed to wipe enmity.
     end
 end
 

--- a/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/Zone.lua
@@ -42,12 +42,12 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     {
         [1] = function()
             player:setCharVar('option', 1)
-            player:startEvent(4)
+            player:startOptionalCutscene(4, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function()
             player:setCharVar('option', 2)
-            player:startEvent(4)
+            player:startOptionalCutscene(4, { cs_option = 0, canSkip = true })
         end,
     }
 end

--- a/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/Zone.lua
@@ -46,7 +46,7 @@ end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local triggerAreaID = triggerArea:getTriggerAreaID()
-    player:startEvent(triggerAreaID - 1)
+    player:startOptionalCutscene(triggerAreaID - 1, { cs_option = 0, canSkip = true })
 end
 
 zoneObject.onTriggerAreaLeave = function(player, triggerArea)

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/Wooden_Ladder.lua
@@ -71,11 +71,11 @@ entity.onTrigger = function(player, npc)
                 player:getCurrentMission(xi.mission.log_id.COP) == xi.mission.id.cop.DISTANT_BELIEFS and
                 xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.DISTANT_BELIEFS, 'Status') == 1
             then
-                player:startEvent(35)
+                player:startEvent(35) -- TODO: Check if you lose agro on this event.
             elseif eventID == 99 then
                 player:messageSpecial(ID.text.DOOR_SEALED_SHUT)
             else
-                player:startOptionalCutscene(eventID)
+                player:startOptionalCutscene(eventID, { cs_option = 0, canSkip = true })
             end
         end
     end

--- a/scripts/zones/Promyvion-Dem/Zone.lua
+++ b/scripts/zones/Promyvion-Dem/Zone.lua
@@ -55,25 +55,25 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     switch (triggerAreaID) : caseof {
         [1] = function() -- Floor 1: Exit Promyvion
-            player:startOptionalCutscene(46)
+            player:startOptionalCutscene(46, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function() -- Floor 2: Return to floor 1
-            player:startOptionalCutscene(41)
+            player:startOptionalCutscene(41, { cs_option = 0, canSkip = true })
         end,
 
         [3] = function() -- Floor 3 (North): Return to floor 2
-            player:startOptionalCutscene(43)
+            player:startOptionalCutscene(43, { cs_option = 0, canSkip = true })
         end,
 
         [4] = function() -- Floor 3 (South): Return to floor 2
-            player:startOptionalCutscene(42)
+            player:startOptionalCutscene(42, { cs_option = 0, canSkip = true })
         end,
 
         [5] = function() -- Floor 4: Return to floor 3
             -- Event 44 -> Return to floor 3 South
             -- Event 45 -> Return to floor 3 North
-            player:startOptionalCutscene(44 + player:getCharVar('[Dem]ReturnNorth'))
+            player:startOptionalCutscene(44 + player:getCharVar('[Dem]ReturnNorth'), { cs_option = 0, canSkip = true })
         end,
 
         [6] = function() -- Floor 1: Portal

--- a/scripts/zones/Promyvion-Holla/Zone.lua
+++ b/scripts/zones/Promyvion-Holla/Zone.lua
@@ -55,25 +55,25 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     switch (triggerAreaID) : caseof {
         [1] = function() -- Floor 1: Exit promyvion
-            player:startOptionalCutscene(46)
+            player:startOptionalCutscene(46, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function() -- Floor 2: Return to floor 1
-            player:startOptionalCutscene(41)
+            player:startOptionalCutscene(41, { cs_option = 0, canSkip = true })
         end,
 
         [3] = function() -- Floor 3 (West): Return to floor 2
-            player:startOptionalCutscene(42)
+            player:startOptionalCutscene(42, { cs_option = 0, canSkip = true })
         end,
 
         [4] = function() -- Floor 3 (East): Return to floor 2
-            player:startOptionalCutscene(45)
+            player:startOptionalCutscene(45, { cs_option = 0, canSkip = true })
         end,
 
         [5] = function() -- Floor 4: Return to floor 3 East or West
             -- Event 43 -> Return to floor 3 East
             -- Event 44 -> Return to floor 3 West
-            player:startOptionalCutscene(43 + player:getCharVar('[Holla]ReturnWest'))
+            player:startOptionalCutscene(43 + player:getCharVar('[Holla]ReturnWest'), { cs_option = 0, canSkip = true })
         end,
 
         [6] = function() -- Floor 1: Portal

--- a/scripts/zones/Promyvion-Mea/Zone.lua
+++ b/scripts/zones/Promyvion-Mea/Zone.lua
@@ -55,25 +55,25 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     switch (triggerAreaID) : caseof {
         [1] = function() -- Floor 1: Exit promyvion
-            player:startOptionalCutscene(46)
+            player:startOptionalCutscene(46, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function() -- Floor 2: Return to floor 1
-            player:startOptionalCutscene(41)
+            player:startOptionalCutscene(41, { cs_option = 0, canSkip = true })
         end,
 
         [3] = function() -- Floor 3 (West): Return to floor 2
-            player:startOptionalCutscene(42)
+            player:startOptionalCutscene(42, { cs_option = 0, canSkip = true })
         end,
 
         [4] = function() -- Floor 3 (East): Return to floor 2
-            player:startOptionalCutscene(43)
+            player:startOptionalCutscene(43, { cs_option = 0, canSkip = true })
         end,
 
         [5] = function() -- Floor 4: Return to floor 3 East or West
             -- Event 44 -> Return to floor 3 West
             -- Event 45 -> Return to floor 3 East
-            player:startOptionalCutscene(44 + player:getCharVar('[Mea]ReturnEast'))
+            player:startOptionalCutscene(44 + player:getCharVar('[Mea]ReturnEast'), { cs_option = 0, canSkip = true })
         end,
 
         [6] = function() -- Floor 1: Portal

--- a/scripts/zones/Promyvion-Vahzl/Zone.lua
+++ b/scripts/zones/Promyvion-Vahzl/Zone.lua
@@ -55,23 +55,23 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     switch (triggerAreaID) : caseof {
         [1] = function() -- Floor 1: Exit promyvion
-            player:startOptionalCutscene(45)
+            player:startOptionalCutscene(45, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function() -- Floor 2: Return to floor 1
-            player:startOptionalCutscene(41)
+            player:startOptionalCutscene(41, { cs_option = 0, canSkip = true })
         end,
 
         [3] = function() -- Floor 3: Return to floor 2
-            player:startOptionalCutscene(42)
+            player:startOptionalCutscene(42, { cs_option = 0, canSkip = true })
         end,
 
         [4] = function() -- Floor 4: Return to floor 3
-            player:startOptionalCutscene(43)
+            player:startOptionalCutscene(43, { cs_option = 0, canSkip = true })
         end,
 
         [5] = function() -- Floor 5: Return to floor 4
-            player:startOptionalCutscene(44)
+            player:startOptionalCutscene(44, { cs_option = 0, canSkip = true })
         end,
 
         [6] = function() -- Floor 1: Portal S

--- a/scripts/zones/RuAun_Gardens/Zone.lua
+++ b/scripts/zones/RuAun_Gardens/Zone.lua
@@ -8,7 +8,7 @@ local zoneObject = {}
 
 local function handleClosingPortal(player, eventId, npcId)
     if GetNPCByID(npcId):getAnimation() == xi.anim.OPEN_DOOR then
-        player:startOptionalCutscene(eventId)
+        player:startOptionalCutscene(eventId, { cs_option = 0, canSkip = true })
     end
 end
 
@@ -106,15 +106,15 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 
     switch (triggerAreaID) : caseof {
         [1] = function()
-            player:startOptionalCutscene(0)
+            player:startOptionalCutscene(0, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function()
-            player:startOptionalCutscene(1)
+            player:startOptionalCutscene(1, { cs_option = 0, canSkip = true })
         end,
 
         [3] = function()
-            player:startOptionalCutscene(36)
+            player:startOptionalCutscene(36, { cs_option = 0, canSkip = true })
         end,
 
         [4] = function()
@@ -158,63 +158,63 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         end,
 
         [14] = function()
-            player:startOptionalCutscene(2)
+            player:startOptionalCutscene(2, { cs_option = 0, canSkip = true })
         end,
 
         [15] = function()
-            player:startOptionalCutscene(6)
+            player:startOptionalCutscene(6, { cs_option = 0, canSkip = true })
         end,
 
         [16] = function()
-            player:startOptionalCutscene(9)
+            player:startOptionalCutscene(9, { cs_option = 0, canSkip = true })
         end,
 
         [17] = function()
-            player:startOptionalCutscene(13)
+            player:startOptionalCutscene(13, { cs_option = 0, canSkip = true })
         end,
 
         [18] = function()
-            player:startOptionalCutscene(16)
+            player:startOptionalCutscene(16, { cs_option = 0, canSkip = true })
         end,
 
         [19] = function()
-            player:startOptionalCutscene(20)
+            player:startOptionalCutscene(20, { cs_option = 0, canSkip = true })
         end,
 
         [20] = function()
-            player:startOptionalCutscene(23)
+            player:startOptionalCutscene(23, { cs_option = 0, canSkip = true })
         end,
 
         [21] = function()
-            player:startOptionalCutscene(27)
+            player:startOptionalCutscene(27, { cs_option = 0, canSkip = true })
         end,
 
         [22] = function()
-            player:startOptionalCutscene(30)
+            player:startOptionalCutscene(30, { cs_option = 0, canSkip = true })
         end,
 
         [23] = function()
-            player:startOptionalCutscene(34)
+            player:startOptionalCutscene(34, { cs_option = 0, canSkip = true })
         end,
 
         [24] = function()
-            player:startOptionalCutscene(4 + math.random(0, 1))
+            player:startOptionalCutscene(4 + math.random(0, 1), { cs_option = 0, canSkip = true })
         end,
 
         [25] = function()
-            player:startOptionalCutscene(11 + math.random(0, 1))
+            player:startOptionalCutscene(11 + math.random(0, 1), { cs_option = 0, canSkip = true })
         end,
 
         [26] = function()
-            player:startOptionalCutscene(18 + math.random(0, 1))
+            player:startOptionalCutscene(18 + math.random(0, 1), { cs_option = 0, canSkip = true })
         end,
 
         [27] = function()
-            player:startOptionalCutscene(25 + math.random(0, 1))
+            player:startOptionalCutscene(25 + math.random(0, 1), { cs_option = 0, canSkip = true })
         end,
 
         [28] = function()
-            player:startOptionalCutscene(32 + math.random(0, 1))
+            player:startOptionalCutscene(32 + math.random(0, 1), { cs_option = 0, canSkip = true })
         end,
 
         [29] = function()
@@ -234,19 +234,19 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         end,
 
         [33] = function()
-            player:startOptionalCutscene(37)
+            player:startOptionalCutscene(37, { cs_option = 0, canSkip = true })
         end,
 
         [34] = function()
-            player:startOptionalCutscene(38)
+            player:startOptionalCutscene(38, { cs_option = 0, canSkip = true })
         end,
 
         [35] = function()
-            player:startOptionalCutscene(39)
+            player:startOptionalCutscene(39, { cs_option = 0, canSkip = true })
         end,
 
         [36] = function()
-            player:startOptionalCutscene(40)
+            player:startOptionalCutscene(40, { cs_option = 0, canSkip = true })
         end,
 
         [37] = function()

--- a/scripts/zones/The_Garden_of_RuHmet/Zone.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/Zone.lua
@@ -192,7 +192,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
                 player:startEvent(183)
             end
         elseif teleportEventsByArea[areaId] then
-            player:startOptionalCutscene(teleportEventsByArea[areaId]) -- Confirmed to wipe enmity.
+            player:startOptionalCutscene(teleportEventsByArea[areaId], { cs_option = 0, canSkip = true }) -- Confirmed to wipe enmity.
         end
     end
 end

--- a/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -77,7 +77,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     local areaId = triggerArea:getTriggerAreaID()
 
     if teleportEventsByArea[areaId] then
-        player:startOptionalCutscene(teleportEventsByArea[areaId])
+        player:startOptionalCutscene(teleportEventsByArea[areaId], { cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/Zone.lua
@@ -40,12 +40,12 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
     {
         [1] = function()
             --player:setCharVar('porter_lock', 1)
-            player:startEvent(0)
+            player:startOptionalCutscene(0, { cs_option = 0, canSkip = true })
         end,
 
         [2] = function()
             --player:setCharVar('porter_lock', 1)
-            player:startEvent(1)
+            player:startOptionalCutscene(1, { cs_option = 0, canSkip = true })
         end,
     }
 end

--- a/scripts/zones/Upper_Delkfutts_Tower/npcs/_4e2.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/npcs/_4e2.lua
@@ -10,13 +10,13 @@ local entity = {}
 
 entity.onTrade = function(player, npc, trade)
     if npcUtil.tradeHas(trade, xi.item.DELKFUTT_KEY) then -- Delkfutt Key
-        player:startEvent(6)
+        player:startOptionalCutscene(6, { cs_option = 0, canSkip = true })
     end
 end
 
 entity.onTrigger = function(player, npc)
     if player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-        player:startEvent(6)
+        player:startOptionalCutscene(6, { cs_option = 0, canSkip = true })
     else
         player:messageSpecial(ID.text.THIS_ELEVATOR_GOES_DOWN)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request audits missions, quests, and zones for events that should drop emnity and events that should have Event Skipped applied. This audit includes:
- Bastok Rank 1 through 5
- Sandoria Mission 3-3 through 5-2
- Windurst Mission 3-3 through 5-2
- CoP 1-1 through 2-4 (1 TODO)
- Phomiuna Aqueducts (Wooden ladders)
- Grand Palace of Hu'Xzoi onTriggerAreaEnter teleports
- Ru'Aun Gardens onTriggerAreaEnter teleports
- The Garden of Ru'Hmet onTriggerAreaEnter teleports
- The Shrine of Ru'Avitau onTriggerAreaEnter teleports
- Castle Oztroja torch doors (1 TODO)
- Davoi gate and orb quest (1 TODO)
- All 3 Delkfutts Tower onTriggerAreaEnter teleports and Elevator
- All 4 Promyvion's onTriggerAreaEnter teleports

Windurst 3-1 drop emnity: https://youtu.be/qLzdQsQvkiA
3-3 Drop Emnity at Door: https://youtu.be/lNna6LmX7AY
Delkfut Tower Teleporters, Event Skipped to drop emnity: https://youtu.be/EksqRcKG48I
Delkfut Tower Elevator: https://youtu.be/myYkUSMBAQ4
Bastok 1-1 Event Skipped: https://youtu.be/8nxNHqjHP1g & https://youtu.be/dZHEz5_fNEw
Sedal-Godjal - Event Skipped to dropped emnity: https://youtu.be/lC7I7txKK6s
Castle Oztroja Torch doors event skipped: https://youtu.be/ldLrRSSQN8s
CoP Aqueducts CS drop Emnity: https://youtu.be/nsNWbaFZZPs
CoP PM2-4 Drop Emnity: https://youtu.be/kQFk8antk4Q
Aqueducts Event Skipped on ladders: https://youtu.be/wDauUACQABA
Promyvion Event Skipped to drop aggro: https://youtu.be/W__2iX3ue_k
     - There is a bug with this where enemies who aggro by scent do not drop enmity.
Davoi Wall Event Skipped: https://youtu.be/krIBg9tnljw

## Steps to test these changes

Try getting attacked by an enemy and trigger each event. Make sure you get Event Skipped when appropriate and drop enmity when appropriate.