### PR TITLE
[lua] [sql] Fixup Leaping Lizzy/Carnero/Aquarius spawning behavior

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -18,12 +18,22 @@ end
 
 -- is a lottery NM in the table already spawned or primed to pop?
 local function lotteryPrimed(phList)
-    local nm
+    local nm = nil
 
     for k, v in pairs(phList) do
-        nm = GetMobByID(v)
-        if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
-            return true
+        -- if `v` is a table, then it's a table of numbers: { id, id2 }
+        if type(v) == 'table' then
+            for _, innerId in pairs(v) do
+                nm = GetMobByID(innerId)
+                if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+                    return true
+                end
+            end
+        else -- `v` is a number
+            nm = GetMobByID(v)
+            if nm ~= nil and (nm:isSpawned() or nm:getRespawnTime() ~= 0) then
+                return true
+            end
         end
     end
 
@@ -83,9 +93,35 @@ xi.mob.updateNMSpawnPoint = function(mobParam, spawnPointsOverride)
     end
 end
 
+local function getMobEntityObj(phNmId)
+    local mobEntityObj = nil
+
+    if type(phNmId) == 'number' then
+        mobEntityObj = getMobLuaPathObject(GetMobByID(phNmId))
+    elseif type(phNmId) == 'table' then
+        mobEntityObj = getMobLuaPathObject(GetMobByID(utils.randomEntry(phNmId)))
+    end
+
+    return mobEntityObj
+end
+
+local function getNmId(phList, phId)
+    local nmId = nil
+
+    if phList and phList[phId] then
+        if type(phList[phId]) == 'number' then
+            nmId = phList[phId]
+        elseif type(phList[phId]) == 'table' then
+            nmId = utils.randomEntry(phList[phId])
+        end
+    end
+
+    return nmId
+end
+
 -- potential lottery placeholder was killed
 ---@param ph CBaseEntity
----@param phNmId integer
+---@param phNmId integer|table
 ---@param chance integer
 ---@param cooldown integer
 ---@param params table?
@@ -104,11 +140,11 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
     local nmId         = nil
     local nm           = nil
     local phList       = nil
-    local mobEntityObj = getMobLuaPathObject(GetMobByID(phNmId))
+    local mobEntityObj = getMobEntityObj(phNmId)
 
     if mobEntityObj then
         phList = mobEntityObj.phList
-        nmId   = phList and phList[phId]
+        nmId   = getNmId(phList, phId)
         nm     = nmId and GetMobByID(nmId)
     end
 
@@ -176,6 +212,7 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
     end
 
     -- on PH death, replace PH repop with NM repop
+    -- TODO, fetch phId's spawn slot and disable respawn for all mobs in that spawn slot
     DisallowRespawn(phId, true)
     DisallowRespawn(nmId, false)
 

--- a/scripts/specs/types/MobEntity.lua
+++ b/scripts/specs/types/MobEntity.lua
@@ -6,7 +6,7 @@
 ---@field z number
 
 ---@class TMobEntity
----@field phList? table<integer, integer>
+---@field phList? table<integer, integer|integer[]>
 ---@field spawnPoints? table<integer, SpawnPosition|table<integer, SpawnPosition>>
 ---@field onMobInitialize? fun(mob: CBaseEntity)
 ---@field onPath? fun(mob: CBaseEntity)

--- a/scripts/zones/South_Gustaberg/IDs.lua
+++ b/scripts/zones/South_Gustaberg/IDs.lua
@@ -43,7 +43,7 @@ zones[xi.zone.SOUTH_GUSTABERG] =
     },
     mob =
     {
-        CARNERO       = GetFirstID('Carnero'), -- TODO: Implement both NMs, there are 2 IDs
+        CARNERO       = GetTableOfIDs('Carnero'),
         LEAPING_LIZZY = GetTableOfIDs('Leaping_Lizzy'),
         BUBBLY_BERNIE = GetFirstID('Bubbly_Bernie'),
     },

--- a/scripts/zones/South_Gustaberg/mobs/Carnero.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Carnero.lua
@@ -7,6 +7,8 @@ local ID = zones[xi.zone.SOUTH_GUSTABERG]
 ---@type TMobEntity
 local entity = {}
 
+-- TODO: There is a "North" and "South" Carnero (seperate IDs)
+-- Probably split this at some point.
 entity.spawnPoints =
 {
     { x =  277.891, y = -39.854, z = -413.354 },
@@ -63,15 +65,7 @@ entity.spawnPoints =
 
 entity.phList =
 {
-    [ID.mob.CARNERO - 2]  = ID.mob.CARNERO, -- 186.081 -39.990 -367.942
-    [ID.mob.CARNERO - 1]  = ID.mob.CARNERO, -- 164.245 -39.900 -347.878
-    [ID.mob.CARNERO + 11] = ID.mob.CARNERO, -- 160.304 -39.990 -460.400
-    [ID.mob.CARNERO + 12] = ID.mob.CARNERO, -- 201.021 -39.904 -500.721
-    [ID.mob.CARNERO + 25] = ID.mob.CARNERO, -- 277.891 -39.854 -413.354
-    [ID.mob.CARNERO + 32] = ID.mob.CARNERO, -- 274.561 -39.972 -476.762
-    [ID.mob.CARNERO + 33] = ID.mob.CARNERO, -- 275.135 -39.977 -477.840
-    [ID.mob.CARNERO + 35] = ID.mob.CARNERO, -- 213.010 -59.983 -442.766
-    [ID.mob.CARNERO + 36] = ID.mob.CARNERO, -- 211.745 -59.938 -441.313
+    [ID.mob.CARNERO[1] - 1]  = { ID.mob.CARNERO[1], ID.mob.CARNERO[2] }
 }
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/South_Gustaberg/mobs/Leaping_Lizzy.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Leaping_Lizzy.lua
@@ -7,6 +7,7 @@ local ID = zones[xi.zone.SOUTH_GUSTABERG]
 ---@type TMobEntity
 local entity = {}
 
+-- TODO: split into East/West LL
 entity.spawnPoints =
 {
     { x = -364.189, y =  30.000, z = -442.720 },
@@ -77,8 +78,7 @@ entity.spawnPoints =
 
 entity.phList =
 {
-    [ID.mob.LEAPING_LIZZY[1] - 1] = ID.mob.LEAPING_LIZZY[1], -- -275.441 20.451 -347.294
-    [ID.mob.LEAPING_LIZZY[2] - 1] = ID.mob.LEAPING_LIZZY[2], -- -322.871 30.052 -401.184
+    [ID.mob.LEAPING_LIZZY[1] - 1] = { ID.mob.LEAPING_LIZZY[1], ID.mob.LEAPING_LIZZY[2] },
 }
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/South_Gustaberg/mobs/Ornery_Sheep.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Ornery_Sheep.lua
@@ -12,7 +12,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.CARNERO, 5, 1) -- Pure lottery
+    xi.mob.phOnDespawn(mob, ID.mob.CARNERO, 10, 1) -- Pure lottery
 end
 
 return entity

--- a/scripts/zones/South_Gustaberg/mobs/Rock_Lizard.lua
+++ b/scripts/zones/South_Gustaberg/mobs/Rock_Lizard.lua
@@ -18,7 +18,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.LEAPING_LIZZY[1], 9, 1) -- Pure Lottery
+    xi.mob.phOnDespawn(mob, ID.mob.LEAPING_LIZZY[1], 10, 1) -- Pure Lottery
 end
 
 return entity

--- a/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Aquarius.lua
@@ -9,15 +9,9 @@ local entity = {}
 
 entity.phList =
 {
-    [ID.mob.AQUARIUS - 7] = ID.mob.AQUARIUS, -- 170.97 9.414 -12.579
-    [ID.mob.AQUARIUS - 6] = ID.mob.AQUARIUS, -- 174.99 9.589 -16.718
-    [ID.mob.AQUARIUS - 5] = ID.mob.AQUARIUS, -- 182.40 8.707 -33.993
-    [ID.mob.AQUARIUS - 3] = ID.mob.AQUARIUS, -- 163.31 9.590 -58.550
-    [ID.mob.AQUARIUS - 2] = ID.mob.AQUARIUS, -- 162.88 9.591 -58.082
-    [ID.mob.AQUARIUS - 1] = ID.mob.AQUARIUS, -- 195.37 8.972 -73.536
-    [ID.mob.AQUARIUS + 2] = ID.mob.AQUARIUS, -- 149.30 9.742 -64.239
-    [ID.mob.AQUARIUS + 3] = ID.mob.AQUARIUS, -- 146.14 9.712 -51.616
-    [ID.mob.AQUARIUS + 4] = ID.mob.AQUARIUS, -- 149.59 9.765 -61.490
+    [ID.mob.AQUARIUS - 5] = ID.mob.AQUARIUS,
+    [ID.mob.AQUARIUS - 1] = ID.mob.AQUARIUS,
+    [ID.mob.AQUARIUS + 4] = ID.mob.AQUARIUS,
 }
 
 entity.spawnPoints =

--- a/scripts/zones/The_Boyahda_Tree/mobs/Robber_Crab.lua
+++ b/scripts/zones/The_Boyahda_Tree/mobs/Robber_Crab.lua
@@ -14,7 +14,7 @@ end
 
 entity.onMobDespawn = function(mob)
     local params = {}
-    xi.mob.phOnDespawn(mob, ID.mob.AQUARIUS, 5, 1, params) -- can repop instantly
+    xi.mob.phOnDespawn(mob, ID.mob.AQUARIUS, 20, 60 * 60, params) -- can repop in about an hour
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The method in which to spawn Carnero and Leaping Lizzy required a change to phOnDespawn to randomly spawn one or other other copy of the NM

Aquarius's PHs were slotted wrong and not accounted for correctly

## Steps to test these changes

Test spawning Aquarius, Carnero, Leaping Lizzy and some other random NM that doesn't use spawn slots that wasn't changed in this PR and see you can spawn both copies of Carnero, both copies of Leaping Lizzy, and Aquarius

Note that one Aquarius's PHs may spawn during Aquarius being alive because of a current limitation of not being able to temporarily disable the spawn slot that a mob may belong to, when it should not on retail. I left a comment about this in mobs.lua
