### PR TITLE
[lua] Fix Onward to Adoulin waypoint warping to Ceizak

### DIFF
--- a/scripts/globals/waypoint.lua
+++ b/scripts/globals/waypoint.lua
@@ -482,11 +482,7 @@ xi.waypoint.onEventFinish = function(player, csid, option, npc)
 
         player:setLocalVar('waypointPaid', 0)
 
-        if player:getCurrentMission(xi.mission.log_id.SOA) == xi.mission.id.soa.ONWARD_TO_ADOULIN then
-            player:setPos(169.638, 0.491, -27.128, 207, xi.zone.CEIZAK_BATTLEGROUNDS)
-        else
-            player:setPos(unpack(waypoint[4]))
-        end
+        player:setPos(unpack(waypoint[4]))
     elseif option == 1000 then
         -- Decline Confirmation (Default Off)
         player:setTeleportMenu(xi.teleport.type.WAYPOINT, true)

--- a/scripts/missions/soa/1_3_Onward_to_Adoulin.lua
+++ b/scripts/missions/soa/1_3_Onward_to_Adoulin.lua
@@ -35,6 +35,7 @@ mission.sections =
                 [10120] = function(player, csid, option, npc)
                     if option == 1 then
                         player:setMissionStatus(mission.areaId, 1)
+                        player:setPos(169.638, 0.491, -27.128, 207, xi.zone.CEIZAK_BATTLEGROUNDS)
                     end
                 end,
             },

--- a/scripts/zones/Lower_Jeuno/npcs/Waypoint.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Waypoint.lua
@@ -22,11 +22,15 @@ entity.onTrigger = function(player, npc)
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)
-    xi.waypoint.onEventUpdate(player, csid, option, npc)
+    if csid == 10121 then
+        xi.waypoint.onEventUpdate(player, csid, option, npc)
+    end
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    xi.waypoint.onEventFinish(player, csid, option, npc)
+    if csid == 10121 then
+        xi.waypoint.onEventFinish(player, csid, option, npc)
+    end
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fix black screen when doing SoA 1-3, properly warps you to Ceizak Battlegrounds 

## Steps to test these changes

Complete 1-3 and correctly warp to Ceizak 

<!-- Clear and detailed steps to test your changes here -->

## Sources

- SOA Onward to Adoulin
  [Dropbox](https://www.dropbox.com/s/kfgkvl3476mn7w3/SOA%201-3%20-%20Onward%20to%20Adoulin.zip?dl=0)