### PR TITLE
[lua] Fix Automaton Attachment Disruptor

### DIFF
--- a/scripts/actions/abilities/pets/attachments/disruptor.lua
+++ b/scripts/actions/abilities/pets/attachments/disruptor.lua
@@ -1,25 +1,40 @@
 -----------------------------------
--- Attachment: Disruptor
+-- Disruptor
+-- https://wiki.ffo.jp/html/24445.html
+-- Removes one beneficial effect from the target.
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_DISRUPTOR', function(automaton, target)
-        local master = automaton:getMaster()
-        if
-            master and
-            master:countEffect(xi.effect.DARK_MANEUVER) > 0 and
-            automaton:getLocalVar('dispel') < VanadielTime() and
-            target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
-            automaton:checkDistance(target) < (7 + target:getHitboxSize() + automaton:getHitboxSize()) -- needs verification
-        then
-            automaton:useMobAbility(xi.automaton.abilities.DISRUPTOR)
+        -- If Disruptor is still on cooldown, do nothing.
+        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.DISRUPTOR) then
+            return
         end
+
+        -- If the target has no dispelable effects, do nothing.
+        if not target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+            return
+        end
+
+        local master = automaton:getMaster()
+
+        if not master then
+            return
+        end
+
+        -- If no Dark Maneuvers are active, do nothing.
+        if master:countEffect(xi.effect.DARK_MANEUVER) == 0 then
+            return
+        end
+
+        automaton:useMobAbility(xi.automaton.abilities.DISRUPTOR, target)
     end)
 end
 
 attachmentObject.onUnequip = function(pet)
+    pet:removeListener('ATTACHMENT_DISRUPTOR')
 end
 
 attachmentObject.onManeuverGain = function(pet, maneuvers)

--- a/scripts/actions/abilities/pets/automaton/disruptor.lua
+++ b/scripts/actions/abilities/pets/automaton/disruptor.lua
@@ -1,5 +1,7 @@
 -----------------------------------
 -- Disruptor
+-- https://wiki.ffo.jp/html/24445.html
+-- Removes one beneficial effect from the target.
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -10,6 +12,7 @@ end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 60)
+
     local effect = target:dispelStatusEffect()
     if effect ~= xi.effect.NONE then
         skill:setMsg(xi.msg.basic.SKILL_ERASE)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Cleans up old code in Disruptor. Old code was checking a variable against vanadiel time which was never being set anywhere.

## Steps to test these changes

Equip Disruptor, use Dark Maneuvers, Dispel things
