### PR TITLE
[lua] Fix Western Adoulin Auction House/Rent-a-Room waypoints

### DIFF
--- a/scripts/globals/waypoint.lua
+++ b/scripts/globals/waypoint.lua
@@ -199,19 +199,7 @@ local function getWaypointIndex(npcObj)
 
     for indexVal, npcData in ipairs(waypointList) do
         if npcData:getID() == waypointNpcId then
-            local resultIndex = indexVal
-            -- NOTE: Western Adoulin Auction House and Rent-a-Room are special cases where
-            -- the NPC ID order does not follow Waypoint data order.  The below is a workaround
-            -- for that exception
-            if zoneObject:getID() == xi.zone.WESTERN_ADOULIN then
-                if indexVal == 5 then
-                    resultIndex = 6
-                elseif indexVal == 6 then
-                    resultIndex = 5
-                end
-            end
-
-            return waypointStartIndex[zoneObject:getID()] + resultIndex
+            return waypointStartIndex[zoneObject:getID()] + indexVal
         end
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

The Western Adoulin getWaypointIndex swap was a workaround for the Auction House / Rent-a-Room IDs being in reverse order vs waypointInfo. The May 2026 npc_list reorder fixed that ordering but left the swap, which now mismaps the two waypoints to each other. This removes the swap

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Attune to the Western Adoulin Auction House and Rent-A-Room Waypoints and see they now teleport to the correct location.