### PR TITLE
[lua] Refactor Target Marker

### DIFF
--- a/scripts/actions/abilities/pets/attachments/target_marker.lua
+++ b/scripts/actions/abilities/pets/attachments/target_marker.lua
@@ -1,88 +1,66 @@
 -----------------------------------
 -- Attachment: Target Marker
+-- Grants an accuracy bonus to foes higher level than the automaton based on active Thunder Maneuvers.
+-- https://wiki.ffo.jp/html/9133.html
+-- TODO: Investigate real values. SE claims this code is "very complicated" and this attachment has recieved numerous bug fixes in the ilvl era.
+-- These are made up placeholder values, chosen to be slightly stronger than Stabilizer II.
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local accuracyTable =
+{
+    [0] = 20,
+    [1] = 30,
+    [2] = 40,
+    [3] = 50,
+}
+
 attachmentObject.onEquip = function(automaton)
-    automaton:addListener('ENGAGE', 'AUTO_TARGETMARKER_ENGAGE', function(pet, target)
-        local ignored = pet:getLocalVar('targetmarker')
-        if ignored > 0 then
-            pet:delMod(xi.mod.ACC, ignored)
-            pet:setLocalVar('targetmarker', 0)
+    automaton:addListener('AUTOMATON_AI_TICK', 'AUTO_TARGET_MARKER_TICK', function(pet, target)
+        local master = pet:getMaster()
+
+        if not master then
+            return
         end
 
-        if pet:getMainLvl() < target:getMainLvl() then
-            local master = pet:getMaster()
-            local maneuvers = master:countEffect(xi.effect.THUNDER_MANEUVER)
-            local eva = target:getEVA()
-            local percentage = 0.05
-            if maneuvers == 1 then
-                percentage = 0.15
-            elseif maneuvers == 2 then
-                percentage = 0.30
-            elseif maneuvers == 3 then
-                percentage = 0.45
+        local thunderManeuvers     = master:countEffect(xi.effect.THUNDER_MANEUVER)
+        local storedAccuracyBonus  = pet:getLocalVar('targetMarkerAccuracyBonus')
+        local updatedAccuracyBonus = accuracyTable[thunderManeuvers] or 0
+
+        -- If target is not higher level than the Automaton, do nothing.
+        if pet:getMainLvl() >= target:getMainLvl() then
+            if storedAccuracyBonus > 0 then
+                pet:delMod(xi.mod.ACC, storedAccuracyBonus)
+                pet:delMod(xi.mod.RACC, storedAccuracyBonus)
+                pet:setLocalVar('targetMarkerAccuracyBonus', 0)
             end
 
-            local accbonus = math.floor(eva * percentage)
-            pet:addMod(xi.mod.ACC, accbonus)
-            pet:setLocalVar('targetmarker', accbonus)
+            return
         end
-    end)
 
-    automaton:addListener('DISENGAGE', 'AUTO_TARGETMARKER_DISENGAGE', function(pet)
-        local ignored = pet:getLocalVar('targetmarker')
-        if ignored > 0 then
-            pet:delMod(xi.mod.ACC, ignored)
-            pet:setLocalVar('targetmarker', 0)
+        -- If the accuracy bonus based on the current number of Thunder Maneuvers is the same as the stored bonus, do nothing.
+        if updatedAccuracyBonus == storedAccuracyBonus then
+            return
         end
+
+        -- If we make it here, update the accuracy bonus and store the new value as a local variable.
+        pet:addMod(xi.mod.ACC, updatedAccuracyBonus - storedAccuracyBonus)
+        pet:addMod(xi.mod.RACC, updatedAccuracyBonus - storedAccuracyBonus)
+        pet:setLocalVar('targetMarkerAccuracyBonus', updatedAccuracyBonus)
     end)
 end
 
 attachmentObject.onUnequip = function(pet)
-    pet:removeListener('AUTO_TARGETMARKER_ENGAGE')
-    pet:removeListener('AUTO_TARGETMARKER_DISENGAGE')
-end
+    pet:removeListener('AUTO_TARGET_MARKER_TICK')
 
-attachmentObject.onManeuverGain = function(pet, maneuvers)
-    local ignored = pet:getLocalVar('targetmarker')
-    local target = pet:getTarget()
-    if ignored > 0 and target then
-        local eva = target:getEVA()
-        local percentage = 0.05
-        if maneuvers == 1 then
-            percentage = 0.15
-        elseif maneuvers == 2 then
-            percentage = 0.30
-        elseif maneuvers == 3 then
-            percentage = 0.45
-        end
-
-        local accbonus = math.floor(eva * percentage)
-        pet:addMod(xi.mod.ACC, accbonus - ignored)
-        pet:setLocalVar('targetmarker', accbonus)
+    local accuracyBonus = pet:getLocalVar('targetMarkerAccuracyBonus')
+    if accuracyBonus > 0 then
+        pet:delMod(xi.mod.ACC, accuracyBonus)
+        pet:delMod(xi.mod.RACC, accuracyBonus)
     end
-end
 
-attachmentObject.onManeuverLose = function(pet, maneuvers)
-    local ignored = pet:getLocalVar('targetmarker')
-    local target = pet:getTarget()
-    if ignored > 0 and target then
-        local eva = target:getEVA()
-        local percentage = 0.05
-        if maneuvers == 1 then
-            percentage = 0.05
-        elseif maneuvers == 2 then
-            percentage = 0.15
-        elseif maneuvers == 3 then
-            percentage = 0.30
-        end
-
-        local accbonus = math.floor(eva * percentage)
-        pet:delMod(xi.mod.ACC, ignored - accbonus)
-        pet:setLocalVar('targetmarker', accbonus)
-    end
+    pet:setLocalVar('targetMarkerAccuracyBonus', 0)
 end
 
 return attachmentObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors Target Marker with new (made up, severely nerfed) accuracy values. Old code was giving up to 45% of the targets evasion as an accuracy bonus, which could result in an accuracy bonus in the hundreds. There isn't any testing on this attachment, and it has received numerous bug fixes in the ilvl era. SE has claimed the code is "very complicated". For now, until proper testing is done, this PR sets its accuracy values just above Stabilizer II.

You can read more about it here : https://wiki.ffo.jp/html/9133.html

## Steps to test these changes

Equip Target Marker, use Thunder Maneuvers, /checkparam against higher level targets, gain accuracy bonus. Lose it EM or lower, or on overloads. 
