### PR TITLE
Add documentation comment for ossl_comp_zlib_cleanup function

### DIFF
--- a/ext/openssl/include/internal/comp.h
+++ b/ext/openssl/include/internal/comp.h
@@ -9,4 +9,7 @@
 
 #include <openssl/comp.h>
 
+/*
+ * Cleanup function for zlib compression resources.
+ */
 void ossl_comp_zlib_cleanup(void);


### PR DESCRIPTION
## Problem
The function `ossl_comp_zlib_cleanup` in `ext/openssl/include/internal/comp.h` lacked a documentation comment, making it unclear what the function does, its parameters, and return value. This reduced code readability and maintainability.

## Changes
Added a documentation comment to the function declaration, explaining that it is a cleanup function for zlib compression resources. The comment is concise and follows existing code style.

## Verification
This change is purely documentation and does not affect functionality or API. It can be verified by:
- Reviewing the added comment in the header file.
- Compiling the code to ensure no errors are introduced.
- Confirming that the function signature and behavior remain unchanged.