### PR TITLE
[lua] Fixes addStatusEffect errors and loading errors for misc. modules

### DIFF
--- a/modules/abyssea/lua/helm_adjustments.lua
+++ b/modules/abyssea/lua/helm_adjustments.lua
@@ -5,10 +5,6 @@
 --  Aquilaria Log: https://www.bg-wiki.com/ffxi/September_2010_Version_Update_Changes#Usable_Items
 --  Butterpear and Kapor Log: https://www.bg-wiki.com/ffxi/September_2011_Version_Update_Changes#Wings_of_the_Goddess_Quests
 -----------------------------------
-require('modules/module_utils')
------------------------------------
-local m = Module:new('abyssea_helm_adjustments')
-
 local removals =
 {
     [xi.helmType.LOGGING] =
@@ -56,4 +52,4 @@ for helmType, zones in pairs(removals) do
     end
 end
 
-return m
+return { name = 'abyssea_helm_adjustments' }  -- This is needed for data-only modules

--- a/modules/abyssea/lua/job_adjustments.lua
+++ b/modules/abyssea/lua/job_adjustments.lua
@@ -165,7 +165,7 @@ m:addOverride('xi.job_utils.paladin.useHolyCircle', function(player, target, abi
 
     power = power + player:getMod(xi.mod.HOLY_CIRCLE_POTENCY)
 
-    target:addStatusEffect(xi.effect.HOLY_CIRCLE, power, 0, duration)
+    target:addStatusEffect(xi.effect.HOLY_CIRCLE, { power = power, duration = duration, origin = player })
 
     return xi.effect.HOLY_CIRCLE
 end)
@@ -193,7 +193,7 @@ m:addOverride('xi.job_utils.paladin.useFealty', function(player, target, ability
     local enhFealty = (player:getMerit(xi.merit.FEALTY) / 5) * player:getMod(xi.mod.ENHANCES_FEALTY)
     local duration  = 60 + enhFealty
 
-    player:addStatusEffect(xi.effect.FEALTY, 1, 0, duration)
+    player:addStatusEffect(xi.effect.FEALTY, { power = 1, duration = duration, origin = player })
 
     return xi.effect.FEALTY
 end)
@@ -219,7 +219,7 @@ m:addOverride('xi.job_utils.paladin.useShieldBash', function(player, target, abi
     then
         local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
-            target:addStatusEffect(xi.effect.STUN, 1, 0, math.random(2, 8) * resistanceRate)
+            target:addStatusEffect(xi.effect.STUN, { power = 1, duration = math.random(2, 8) * resistanceRate, origin = player })
         end
     end
 

--- a/modules/rov/lua/job_adjustments.lua
+++ b/modules/rov/lua/job_adjustments.lua
@@ -136,7 +136,7 @@ m:addOverride('xi.job_utils.paladin.useRampart', function(player, target, abilit
 
     -- Apply STONESKIN effect but display as RAMPART icon
     -- TODO: subType 2 not yet implemented for magical only stoneskin
-    target:addStatusEffectEx(xi.effect.STONESKIN, xi.effect.RAMPART, defense, 0, duration, 2, stoneskinHP)
+    target:addStatusEffect(xi.effect.STONESKIN, { power = defense, duration = duration, origin   = player, icon = xi.effect.RAMPART, subType  = 2, subPower = stoneskinHP })
 
     return xi.effect.RAMPART
 end)

--- a/modules/wotg/lua/helm_adjustments.lua
+++ b/modules/wotg/lua/helm_adjustments.lua
@@ -5,10 +5,6 @@
 --  Eastern Ginger Root: https://www.bg-wiki.com/ffxi/June_2008_Version_Update_Changes#Other_Usable_Items
 --  Dyer's Woad: https://www.bg-wiki.com/ffxi/September_2008_Version_Update_Changes#Other_Usable_Items
 -----------------------------------
-require('modules/module_utils')
------------------------------------
-local m = Module:new('wotg_helm_adjustments')
-
 local removals =
 {
     [xi.helmType.HARVESTING] =
@@ -64,4 +60,4 @@ for helmType, zones in pairs(removals) do
     end
 end
 
-return m
+return { name = 'wotg_helm_adjustments' } -- This is needed for data-only modules

--- a/modules/wotg/lua/pdif_caps_revert.lua
+++ b/modules/wotg/lua/pdif_caps_revert.lua
@@ -2,11 +2,6 @@
 -- Original pDIF caps for the base game.
 -- Date : 2007-08-27 (One day before the ToAU 2H update)
 -----------------------------------
-require('modules/module_utils')
------------------------------------
-
-local m = Module:new('original_pdif_caps')
-
 xi.combat.physical.pDifWeaponCapTable[xi.skill.HAND_TO_HAND    ] = 2
 xi.combat.physical.pDifWeaponCapTable[xi.skill.DAGGER          ] = 2
 xi.combat.physical.pDifWeaponCapTable[xi.skill.SWORD           ] = 2
@@ -26,4 +21,4 @@ xi.combat.physical.pDifWeaponCapTable[xi.skill.ARCHERY         ] = 3
 xi.combat.physical.pDifWeaponCapTable[xi.skill.MARKSMANSHIP    ] = 3
 xi.combat.physical.pDifWeaponCapTable[xi.skill.THROWING        ] = 3
 
-return m
+return { name = 'original_pdif_caps' } -- This is needed for data-only modules


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes outdated addStatusEffects for modules

Fixes a couple module errors with override issues. For data-only modules you do not need to call overrides/modules call. The error is: "No overrides found in module".

See modules still work for pdif stuff here
<img width="539" height="448" alt="image" src="https://github.com/user-attachments/assets/02ad1565-9694-470c-b95f-27c34b22c446" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Use either rampart, fealty, shield bash and see no error when modules enabled

Attack for lots of damage and see a pdif cap of 2? Easier to just set a print and see the number return the correct table
<!-- Clear and detailed steps to test your changes here -->
