### PR TITLE
[lua] Refactor Economizer

### DIFF
--- a/scripts/actions/abilities/pets/attachments/economizer.lua
+++ b/scripts/actions/abilities/pets/attachments/economizer.lua
@@ -1,21 +1,50 @@
 -----------------------------------
--- Attachment: Economizer
+-- Economizer
+-- Recovers a percentage of missing MP based on dark maneuvers.
+-- Activation threshold is 30% MP, increasing by 10% per dark maneuver.
+-- https://wiki.ffo.jp/html/10435.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local activationThresholds =
+{
+    [0] = 30,
+    [1] = 40,
+    [2] = 50,
+    [3] = 60,
+}
+
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_ECONOMIZER', function(automaton, target)
-        local master = automaton:getMaster()
-        local maneuvers = (master and master:countEffect(xi.effect.DARK_MANEUVER) > 0) and master:countEffect(xi.effect.DARK_MANEUVER) or 7
-        local mpthreshold = 60 - maneuvers * 10
-        local mpp = automaton:getMaxMP() > 0 and math.ceil(automaton:getMP() / automaton:getMaxMP() * 100) or 100
-        if
-            mpp < mpthreshold and
-            not automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.ECONOMIZER)
-        then
-            automaton:useMobAbility(xi.automaton.abilities.ECONOMIZER, automaton)
+        -- If Economizer is still on cooldown, do nothing.
+        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.ECONOMIZER) then
+            return
         end
+
+        local master = automaton:getMaster()
+
+        if not master then
+            return
+        end
+
+        local darkManeuvers = master:countEffect(xi.effect.DARK_MANEUVER)
+        local maxMP = automaton:getMaxMP()
+
+        -- If this automaton has no MP, do nothing.
+        if maxMP == 0 then
+            return
+        end
+
+        local mpPercent = automaton:getMPP()
+        local mpThreshold = activationThresholds[darkManeuvers] or 30
+
+        -- If the automaton's MP is above the threshold, do nothing.
+        if mpPercent > mpThreshold then
+            return
+        end
+
+        automaton:useMobAbility(xi.automaton.abilities.ECONOMIZER, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/automaton/economizer.lua
+++ b/scripts/actions/abilities/pets/automaton/economizer.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- Economizer
+-- Recovers a percentage of missing MP based on dark maneuvers.
+-- Activation threshold is 30% MP, increasing by 10% per dark maneuver.
+-- https://wiki.ffo.jp/html/10435.html
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -10,15 +13,13 @@ end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 180)
-    local maneuvers = master:countEffect(xi.effect.DARK_MANEUVER)
-    local amount = math.floor(automaton:getMaxMP() * 0.2 * maneuvers)
+
+    local darkManeuvers = master:countEffect(xi.effect.DARK_MANEUVER)
+    local mpRecovered = math.floor(automaton:getMaxMP() * 0.2 * darkManeuvers)
+
     skill:setMsg(xi.msg.basic.SKILL_RECOVERS_MP)
 
-    for i = 1, maneuvers do
-        master:delStatusEffectSilent(xi.effect.DARK_MANEUVER)
-    end
-
-    return automaton:addMP(amount)
+    return automaton:addMP(mpRecovered)
 end
 
 return abilityObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Updates Economizer to no longer consume Dark Maneuvers when used.
* Refactors MP Recovery code.

https://wiki.ffo.jp/html/10435.html

## Steps to test these changes

Equip Economizer, use Dark Maneuvers, get MP back. 
