### PR TITLE
[lua] Refactor Mana Converter

### DIFF
--- a/scripts/actions/abilities/pets/attachments/mana_converter.lua
+++ b/scripts/actions/abilities/pets/attachments/mana_converter.lua
@@ -1,27 +1,53 @@
 -----------------------------------
--- Attachment: Mana Converter
+-- Mana Converter
+-- Converts HP to MP. The amount of MP restored is based on the amount of HP lost.
+-- MP is restored over 30 seconds in the form of a Refresh effect.
+-- https://wiki.ffo.jp/html/5329.html
 -----------------------------------
+local activationThresholds =
+{
+    [1] = 40,
+    [2] = 60,
+    [3] = 70,
+}
+
 ---@type TAttachment
 local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_MANA_CONVERTER', function(automaton, target)
+        -- If Mana Converter is on cooldown, do nothing.
+        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.MANA_CONVERTER) then
+            return
+        end
+
         local master = automaton:getMaster()
-        local maneuvers = master and master:countEffect(xi.effect.DARK_MANEUVER) or 0
-        local mpthreshold = -1
 
-        if maneuvers == 1 then
-            mpthreshold = 40
-        elseif maneuvers == 2 then
-            mpthreshold = 60
-        elseif maneuvers == 3 then
-            mpthreshold = 65
+        if not master then
+            return
         end
 
-        local mpp = (automaton:getMaxMP() > 0) and math.ceil(automaton:getMP() / automaton:getMaxMP() * 100) or 100
-        if mpp < mpthreshold and automaton:getLocalVar('convert') < VanadielTime() then
-            automaton:useMobAbility(xi.automaton.abilities.MANA_CONVERTER, automaton)
+        local darkManeuvers = master:countEffect(xi.effect.DARK_MANEUVER)
+
+        -- If no dark maneuvers are active, do nothing.
+        if darkManeuvers == 0 then
+            return
         end
+
+        local mpThreshold = activationThresholds[darkManeuvers]
+
+        if not mpThreshold then
+            return
+        end
+
+        local mpPercent = automaton:getMPP()
+
+        -- If MP is above the threshold, do nothing.
+        if mpPercent > mpThreshold then
+            return
+        end
+
+        automaton:useMobAbility(xi.automaton.abilities.MANA_CONVERTER, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/automaton/mana_converter.lua
+++ b/scripts/actions/abilities/pets/automaton/mana_converter.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- Mana Converter
+-- Converts HP to MP. The amount of MP restored is based on the amount of HP lost.
+-- MP is restored over 30 seconds in the form of a Refresh effect.
+-- https://wiki.ffo.jp/html/5329.html
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -10,16 +13,17 @@ end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 180)
-    local hp = target:getHP()
-    local duration = 30
-    local amount = math.floor((hp / 2) / 10)
-    local difference = math.ceil(hp / 2 - (amount * 10))
+
+    local currentHP = target:getHP()
+    local hpCost = math.floor(currentHP / 2)
+    local refreshAmount = math.floor(hpCost / 10)
+
     skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
 
-    target:addMP(difference) -- To prevent possible loss of MP from flooring the refresh
-    target:setHP(math.floor(hp / 2))
+    target:setHP(currentHP - hpCost)
+
     target:delStatusEffect(xi.effect.REFRESH)
-    target:addStatusEffect(xi.effect.REFRESH, { power = amount, duration = duration, origin = automaton, tick = 3 })
+    target:addStatusEffect(xi.effect.REFRESH, { power = refreshAmount, duration = 30, origin = automaton, tick = 3 })
 
     return xi.effect.REFRESH
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cleans up code for Mana Converter. Old code was checking a variable that was never set. It also was giving floored (rounded off) MP amounts back to the automaton, which it does not do, as noted by the wiki : https://wiki.ffo.jp/html/5329.html

## Steps to test these changes

Equip Mana Converter, summon with Deus Ex Machina, use Dark Maneuvers, see HP converted to a strong Refresh
