### PR TITLE
[lua] Wire PsoXja elevators to the right gates

### DIFF
--- a/scripts/zones/PsoXja/npcs/@095.lua
+++ b/scripts/zones/PsoXja/npcs/@095.lua
@@ -22,8 +22,8 @@ entity.onSpawn = function(npc)
     local elevator =
     {
         id = xi.elevator.TIMED_AUTOMATIC,
-        lowerDoor = npc:getID() - 1,
-        upperDoor = npc:getID() - 2,
+        lowerDoor = npc:getID() + 2,
+        upperDoor = npc:getID() + 1,
         elevator = npc:getID(),
         reversedAnimations = true,
     }

--- a/scripts/zones/PsoXja/npcs/@096.lua
+++ b/scripts/zones/PsoXja/npcs/@096.lua
@@ -22,8 +22,8 @@ entity.onSpawn = function(npc)
     local elevator =
     {
         id = xi.elevator.TIMED_AUTOMATIC,
-        lowerDoor = npc:getID() + 5,
-        upperDoor = npc:getID() + 4,
+        lowerDoor = npc:getID() + 2,
+        upperDoor = npc:getID() + 1,
         elevator = npc:getID(),
         reversedAnimations = true,
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As far as I can tell, these 2 elevators have always been using the wrong gates. 
When I renamed the elevators and gates to their right DAT-sourced names, it led the elevators to then pilot the opposite gates. Too tired to explain more.

Closes #10241 

## Steps to test these changes
!pos -300 23.5 340 9
!pos -339 0 335.4 9

Should be able to enter/exit top and bottom. Elevators should run opposite in sync.

<!-- Clear and detailed steps to test your changes here -->
