### PR TITLE
[lua, sql] Nyzul Isle bug fix/adjustments

### DIFF
--- a/scripts/globals/nyzul.lua
+++ b/scripts/globals/nyzul.lua
@@ -253,11 +253,17 @@ end
 
 xi.nyzul.specifiedEnemySet = function(mob)
     local instance = mob:getInstance()
+    local targetId = instance:getLocalVar('Nyzul_Specified_Enemy')
 
-    if instance:getStage() == xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMY then
-        if instance:getLocalVar('Nyzul_Specified_Enemy') == 0 then
-            mob:setMobMod(xi.mobMod.CHECK_AS_NM, 1)
-        end
+    -- Clear potential NM status from previous floor
+    mob:setMobMod(xi.mobMod.CHECK_AS_NM, 0)
+
+    if
+        instance:getStage() == xi.nyzul.objective.ELIMINATE_SPECIFIED_ENEMY and
+        targetId ~= 0 and
+        mob:getID() == targetId
+    then
+        mob:setMobMod(xi.mobMod.CHECK_AS_NM, 1)
     end
 end
 
@@ -297,6 +303,10 @@ xi.nyzul.activateRuneOfTransfer = function(instance)
 end
 
 xi.nyzul.vigilWeaponDrop = function(player, mob)
+    if not player then
+        return
+    end
+
     local instance = mob:getInstance()
 
     -- Only floor 100 Bosses to drop 1 random weapon guarenteed and 1 of the disk holders job

--- a/scripts/globals/nyzul/floor_generation.lua
+++ b/scripts/globals/nyzul/floor_generation.lua
@@ -1132,7 +1132,7 @@ local pTableFloorRandomEntities =
 
 local function lampsActivate(instance)
     local floorLayout      = instance:getLocalVar('Nyzul_Isle_FloorLayout')
-    local lampsObjective   = instance:getLocalVar('[Lamps]Objective')
+    local lampsObjective   = instance:getLocalVar('[Lamp]Objective')
     local partySize        = utils.clamp(instance:getLocalVar('partySize'), 3, 5)
     local dTableLampPoints = {}
 
@@ -1315,7 +1315,7 @@ xi.nyzul.prepareMobs = function(instance)
 
             -- Activate Lamps Objective
             [xi.nyzul.objective.ACTIVATE_ALL_LAMPS] = function()
-                instance:setLocalVar('[Lamps]Objective', math.random(xi.nyzul.lampsObjective.REGISTER, xi.nyzul.lampsObjective.ORDER))
+                instance:setLocalVar('[Lamp]Objective', math.random(xi.nyzul.lampsObjective.REGISTER, xi.nyzul.lampsObjective.ORDER))
                 lampsActivate(instance)
             end,
         }
@@ -1435,10 +1435,6 @@ xi.nyzul.prepareMobs = function(instance)
             spawnPointIndex   = math.random(1, #dTableSpawnPoint)
             spawnPoint        = dTableSpawnPoint[spawnPointIndex]
 
-            -- Spawn Mob.
-            GetMobByID(mobID, instance):setSpawn(spawnPoint.x, spawnPoint.y, spawnPoint.z, math.random(0, 255))
-            SpawnMob(mobID, instance)
-
             -- Remove table entry.
             table.remove(dTableEnemies, randomEnemy)
             table.remove(dTableSpawnPoint, spawnPointIndex)
@@ -1454,6 +1450,10 @@ xi.nyzul.prepareMobs = function(instance)
             end
 
             enemyAmount = enemyAmount - 1
+
+            -- Spawn Mob. Do this last so everything is set for mob spawn logic in their lua script triggers properly.
+            GetMobByID(mobID, instance):setSpawn(spawnPoint.x, spawnPoint.y, spawnPoint.z, math.random(0, 255))
+            SpawnMob(mobID, instance)
         end
     end
 end

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sorrowful_Sage.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Sorrowful_Sage.lua
@@ -8,21 +8,16 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    -- local rank = xi.besieged.getMercenaryRank(player)
-    -- local haveimperialIDtag
-    -- local tokens = 3--player:getAssaultPoint(ILRUSI_ASSAULT_POINT)
---[[
-    if player:hasKeyItem(xi.ki.IMPERIAL_ARMY_ID_TAG) then
-        haveimperialIDtag = 1
-    else
-        haveimperialIDtag = 0
-    end
+    local rank          = xi.besieged.getMercenaryRank(player)
+    local haveIDTag     = player:hasKeyItem(xi.ki.IMPERIAL_ARMY_ID_TAG) and 1 or 0
+    local assaultPoints = player:getAssaultPoint(xi.assault.assaultArea.NYZUL_ISLE)
 
-    if rank > 0 then
-        player:startEvent(278, rank, haveimperialIDtag, tokens, player:getCurrentAssault())
-    else]]
+    if rank > 0 and xi.settings.main.NYZUL_ENABLED then
+        -- TODO: Add toggle for displaying Nyzul Isle Uncharted Area Survey option
+        player:startEvent(278, rank, haveIDTag, assaultPoints, player:getCurrentAssault())
+    else
         player:startEvent(284) -- no rank
-    --end
+    end
 end
 
 entity.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Nyzul_Isle/npcs/Runic_Lamp.lua
+++ b/scripts/zones/Nyzul_Isle/npcs/Runic_Lamp.lua
@@ -14,8 +14,8 @@ entity.onTrigger = function(player, npc)
         return
     end
 
-    local lampObjective = instance:getLocalVar('[Lamps]Objective')
-    local lampRegister  = instance:getLocalVar('[Lamps]lampRegister')
+    local lampObjective = instance:getLocalVar('[Lamp]Objective')
+    local lampRegister  = instance:getLocalVar('[Lamp]lampRegister')
     local lampOrder     = npc:getLocalVar('[Lamp]order')
     local wait          = npc:getLocalVar('[Lamp]Wait') - GetSystemTime()
 
@@ -72,11 +72,11 @@ entity.onEventFinish = function(player, csid, option, npc)
         return
     end
 
-    local lampObjective = instance:getLocalVar('[Lamps]Objective')
+    local lampObjective = instance:getLocalVar('[Lamp]Objective')
     local lampCount     = instance:getLocalVar('[Lamp]count') + 1
     local pressCount    = instance:getLocalVar('[Lamp]pressCount')
     local lampOrder     = npc:getLocalVar('[Lamp]order')
-    local lampRegister  = instance:getLocalVar('[Lamps]lampRegister')
+    local lampRegister  = instance:getLocalVar('[Lamp]lampRegister')
     local winCondition  = false
 
     -- TODO: Change this comment with what is option 1
@@ -108,13 +108,10 @@ entity.onEventFinish = function(player, csid, option, npc)
     -- TODO: Change this comment with what is option 2
     elseif csid == 3 and option == 2 then
         if lampObjective == xi.nyzul.lampsObjective.ORDER then
-            print('registering lamp, register: '..instance:getLocalVar('[Lamps]lampRegister'))
             lampRegister = lampRegister + bit.lshift(1, lampOrder)
-            instance:setLocalVar('[Lamps]lampRegister', lampRegister)
+            instance:setLocalVar('[Lamp]lampRegister', lampRegister)
             instance:setLocalVar('[Lamp]pressCount', pressCount + 1)
             npc:setLocalVar('[Lamp]press', pressCount + 1)
-            -- print('lamp registered, register: '..instance:getLocalVar('[Lamps]lampRegister'))
-            -- print('lamp count: '..instance:getLocalVar('[Lamp]count')..' press count: '..instance:getLocalVar('[Lamp]pressCount'))
 
             if lampCount == 3 and lampRegister > 13 then
                 for i = ID.npc.RUNIC_LAMP_OFFSET, ID.npc.RUNIC_LAMP_OFFSET + 2 do
@@ -123,13 +120,12 @@ entity.onEventFinish = function(player, csid, option, npc)
                     if lamp then
                         local lampPress = lamp:getLocalVar('[Lamp]press')
                         local setOrder  = lamp:getLocalVar('[Lamp]order')
-                        -- print('lamp: '..i..' lampPress: '..lampPress..' setOrder: '..setOrder)
                         lamp:setAnimationSub(1)
 
                         if lampPress ~= setOrder then
                             lamp:timer(10000, function(lampNpc)
                                 lampNpc:setAnimationSub(0)
-                                instance:setLocalVar('[Lamps]lampRegister', 0)
+                                instance:setLocalVar('[Lamp]lampRegister', 0)
                                 instance:setLocalVar('[Lamp]pressCount', 0)
                             end)
                         else
@@ -150,13 +146,12 @@ entity.onEventFinish = function(player, csid, option, npc)
                     if lamp then
                         local lampPress = lamp:getLocalVar('[Lamp]press')
                         local setOrder  = lamp:getLocalVar('[Lamp]order')
-                        -- print('lamp: '..i..' lampPress: '..lampPress..' setOrder: '..setOrder)
                         lamp:setAnimationSub(1)
 
                         if lampPress ~= setOrder then
                             lamp:timer(10000, function(lampNpc)
                                 lampNpc:setAnimationSub(0)
-                                instance:setLocalVar('[Lamps]lampRegister', 0)
+                                instance:setLocalVar('[Lamp]lampRegister', 0)
                                 instance:setLocalVar('[Lamp]pressCount', 0)
                             end)
                         else
@@ -177,13 +172,12 @@ entity.onEventFinish = function(player, csid, option, npc)
                     if lamp then
                         local lampPress = lamp:getLocalVar('[Lamp]press')
                         local setOrder  = lamp:getLocalVar('[Lamp]order')
-                        -- print('lamp: '..i..' lampPress: '..lampPress..' setOrder: '..setOrder)
                         lamp:setAnimationSub(1)
 
                         if lampPress ~= setOrder then
                             lamp:timer(10000, function(lampNpc)
                                 lampNpc:setAnimationSub(0)
-                                instance:setLocalVar('[Lamps]lampRegister', 0)
+                                instance:setLocalVar('[Lamp]lampRegister', 0)
                                 instance:setLocalVar('[Lamp]pressCount', 0)
                             end)
                         else
@@ -204,7 +198,7 @@ entity.onEventFinish = function(player, csid, option, npc)
                 instance:setLocalVar('procedureTime', GetSystemTime() + 6)
                 npc:timer(6000, function(npcLamp)
                     instance:setLocalVar('lampsCorrect', 0)
-                    instance:setLocalVar('[Lamps]lampRegister', 0)
+                    instance:setLocalVar('[Lamp]lampRegister', 0)
                     instance:setLocalVar('[Lamp]pressCount', 0)
                     instance:setLocalVar('procedureTime', 0)
                     instance:setProgress(15)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -302,10 +302,11 @@ xi.settings.main =
     MAX_FAKE_ENTRIES     = 15,
 
     -- NYZUL
-    RUNIC_DISK_SAVE      = true, -- Allow anyone participating in Nyzul to save progress. Set to false so only initiator can save progress.
-    ENABLE_NYZUL_CASKETS = true, -- Enable Treasure casket pops from NMs.
-    ENABLE_VIGIL_DROPS   = true, -- Enable Vigil Weapon drops from NMs.
-    ACTIVATE_LAMP_TIME   = 6000, -- Time in miliseconds for lamps to stay lit. TODO: Get retail confirmation.
+    NYZUL_ENABLED        = false, -- true/false. Enable Nyzul Isle content and functionality.
+    RUNIC_DISK_SAVE      = true,  -- Allow anyone participating in Nyzul to save progress. Set to false so only initiator can save progress.
+    ENABLE_NYZUL_CASKETS = true,  -- Enable Treasure casket pops from NMs.
+    ENABLE_VIGIL_DROPS   = true,  -- Enable Vigil Weapon drops from NMs.
+    ACTIVATE_LAMP_TIME   = 6000,  -- Time in miliseconds for lamps to stay lit. TODO: Get retail confirmation.
 
     -- CHOCOBO RAISING (HEAVILY-IN-DEVELOPMENT, USE AT YOUR OWN RISK)
     -- GM command: `!chocoboraising`

--- a/sql/instance_entities.sql
+++ b/sql/instance_entities.sql
@@ -1979,6 +1979,7 @@ INSERT INTO `instance_entities` VALUES (7704,17092617);
 INSERT INTO `instance_entities` VALUES (7704,17092618);
 INSERT INTO `instance_entities` VALUES (7704,17092619);
 INSERT INTO `instance_entities` VALUES (7704,17092620);
+INSERT INTO `instance_entities` VALUES (7704,17093424); -- Weather
 -- mobs
 INSERT INTO `instance_entities` VALUES (7704,17092629);
 INSERT INTO `instance_entities` VALUES (7704,17092630);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Some minor adjustments I encountered while testing the assault PR to ensure other instances weren't affected.
- Adds a server setting to enable Sorrowful Sage providing assault orders instead of having his logic commented out.
- Could not begin Nyzul Isle due to a lacking weather NPC in instance_entities.sql. 
- Specified enemies weren't being flagged as a NM properly, makes some minor logic adjustments to correct that

## Steps to test these changes

- Give yourself the prerequisite key items and missions to begin assault
- Enable nyzul and speak with Sorrowful Sage to obtain nyzul isle assault orders
- Enter Nyzul Isle and see that you can still complete objectives and complete the assault properly.