### PR TITLE
[lua] Fix Plague Chigoe spawn for The Prankster quest

### DIFF
--- a/scripts/quests/ahtUrhgan/The_Prankster.lua
+++ b/scripts/quests/ahtUrhgan/The_Prankster.lua
@@ -4,7 +4,7 @@
 -- Ahaadah !pos -70 -6 105 50
 -- Aht Whitegate region 11
 -- Aht Whitegate region 12
--- qm4 !pos 460.166 -14.920 256.214 52
+-- qm3 !pos 460.166 -14.920 256.214 52
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_PRANKSTER)
@@ -98,7 +98,7 @@ quest.sections =
 
         [xi.zone.BHAFLAU_THICKETS] =
         {
-            ['qm4'] =
+            ['qm3'] =
             {
                 onTrigger = function(player, npc)
                     if not GetMobByID(ID.mob.PLAGUE_CHIGOE):isSpawned() then
@@ -132,7 +132,7 @@ quest.sections =
         {
             ['Ahaadah'] = quest:event(17),
 
-            ['qm4'] = quest:progressCutscene(2),
+            ['qm3'] = quest:progressCutscene(2),
 
             onEventFinish =
             {

--- a/scripts/zones/Bhaflau_Thickets/DefaultActions.lua
+++ b/scripts/zones/Bhaflau_Thickets/DefaultActions.lua
@@ -2,6 +2,6 @@ local ID = zones[xi.zone.BHAFLAU_THICKETS]
 
 return {
     ['Mythralline_Wellspring'] = { messageSpecial = ID.text.WELLSPRING },
-    ['qm4']                    = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['qm3']                    = { messageSpecial = ID.text.NOTHING_HAPPENS },
     ['Warhorse_Hoofprint']     = { messageSpecial = ID.text.WARHORSE_HOOFPRINT },
 }


### PR DESCRIPTION
Rename the lua references for the ??? (I-8 in Bhaflau Thickets) from qm4 to qm3 to align with the new DB NPC name.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Corrects an incorrect quest marker identifier in "The Prankster" quest script from the May 2026 client update. Changes all references from qm4 to qm3 in the Bhaflau Thickets zone to match the actual quest marker object ID. After applying this PR, The Prankster quest can be completed.

This fix affects:

* Quest event trigger mapping in scripts/quests/ahtUrhgan/The_Prankster.lua
* Default action handler in scripts/zones/Bhaflau_Thickets/DefaultActions.lua
* Quest progress cutscene trigger mapping

## Steps to test these changes

1. Start "The Prankster" quest in Aht Urhgan, and progress to the point where the Plague Chigoe needs to be spawned.
2. Navigate to the quest marker location in Bhaflau Thickets (I-8, pos 460.166 -14.920 256.214).
3. Verify the quest marker interaction triggers correctly and progresses the quest as expected.
4. Confirm no errors appear in server logs related to the quest marker.