### PR TITLE
[lua, sql][Module] BRD, DRG, and spell era module adjustments

### DIFF
--- a/modules/abyssea/sql/job_adjustments.sql
+++ b/modules/abyssea/sql/job_adjustments.sql
@@ -39,23 +39,6 @@ UPDATE merits SET upgrade = 0 WHERE name = 'animus_solace';
 UPDATE merits SET upgrade = 0 WHERE name = 'animus_misery';
 
 ------------------------------------
--- WHM Spell Cast Times
--- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
-------------------------------------
-
--- Esuna: Revert cast time from 1 to 3 seconds
-UPDATE spell_list SET castTime = 3000 WHERE name = 'esuna';
-
--- Sacrifice: Revert cast time from 1 to 1.5 seconds
-UPDATE spell_list SET castTime = 1500 WHERE name = 'sacrifice';
-
--- Blindna: Revert cast time from 1 to 3 seconds
-UPDATE spell_list SET castTime = 3000 WHERE name = 'blindna';
-
--- Cursna: Revert cast time from 1 to 3 seconds
-UPDATE spell_list SET castTime = 3000 WHERE name = 'cursna';
-
-------------------------------------
 -- Thief
 ------------------------------------
 
@@ -155,6 +138,21 @@ UPDATE abilities SET recastTime = 900 WHERE name = 'killer_instinct';
 -- Killer Instinct merit: Revert value to 150 seconds per level
 UPDATE merits SET value = 150 WHERE name = 'killer_instinct';
 
+-- Mazurka: Revert to town/field only
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/08/2010)
+SET @TYPE_CITY     = 1;
+SET @TYPE_OUTDOORS = 2;
+SET @MISC_MAZURKA  = 8;
+
+-- Remove mazurka from all zones
+UPDATE zone_settings
+SET misc = misc & ~@MISC_MAZURKA;
+
+-- Reapply to cities and outdoor zones
+UPDATE zone_settings
+SET misc = misc | @MISC_MAZURKA
+WHERE (zonetype & (@TYPE_CITY | @TYPE_OUTDOORS)) <> 0;
+
 ------------------------------------
 -- Samurai
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
@@ -210,13 +208,6 @@ UPDATE abilities SET recastTime = 300 WHERE name = 'yonin';
 
 -- Innin: Revert recast from 3 minutes to 5 minutes and add shared cooldown with Yonin
 UPDATE abilities SET recastTime = 300, recastId = 146 WHERE name = 'innin';
-
--- Tonko: Ichi: Revert cast time from 1.5 to 4 seconds
--- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
-UPDATE spell_list SET castTime = 4000 WHERE name = 'tonko_ichi';
-
--- Monomi: Ichi: Revert cast time from 1.5 to 4 seconds
-UPDATE spell_list SET castTime = 4000 WHERE name = 'monomi_ichi';
 
 -----------------------------------
 -- Dragoon

--- a/modules/abyssea/sql/spell_adjustments.sql
+++ b/modules/abyssea/sql/spell_adjustments.sql
@@ -1,0 +1,74 @@
+------------------------------------
+-- Abyssea Spell SQL Adjustments
+-- This module reverts relevant spells to their pre-Abyssea values
+------------------------------------
+
+------------------------------------
+-- Healing Magic
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+------------------------------------
+
+-- Esuna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'esuna';
+
+-- Sacrifice: Revert cast time from 1 to 1.5 seconds
+UPDATE spell_list SET castTime = 1500 WHERE name = 'sacrifice';
+
+-- Blindna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'blindna';
+
+-- Cursna: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'cursna';
+
+------------------------------------
+-- Enhancing Magic
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(12/14/2011)
+------------------------------------
+
+-- Regen: Revert cast time from 1.5 to 4 seconds
+UPDATE spell_list SET castTime = 4000 WHERE name = 'regen';
+
+-- Regen II: Revert cast time from 1.75 to 4.5 seconds
+UPDATE spell_list SET castTime = 4500 WHERE name = 'regen_ii';
+
+-- Regen III: Revert cast time from 2 to 5 seconds
+UPDATE spell_list SET castTime = 5000 WHERE name = 'regen_iii';
+
+------------------------------------
+-- Singing
+-- Source: https://forum.square-enix.com/ffxi/threads/29150-December-13-2012-%28JST%29-Version-Update
+-- Source: https://forum.square-enix.com/ffxi/threads/27883-dev1138-Bard-Job-Adjustments
+------------------------------------
+
+-- Etudes / Prelude / Sirvente / Dirge: Revert from AoE to single target and cast time to 4 seconds
+UPDATE spell_list SET validTargets = 3, AOE = 0, castTime = 4000 WHERE name IN (
+    'foe_sirvente',
+    'adventurers_dirge',
+    'hunters_prelude',
+    'archers_prelude',
+    'sinewy_etude',
+    'dextrous_etude',
+    'vivacious_etude',
+    'quick_etude',
+    'learned_etude',
+    'spirited_etude',
+    'enchanting_etude',
+    'herculean_etude',
+    'uncanny_etude',
+    'vital_etude',
+    'swift_etude',
+    'sage_etude',
+    'logical_etude',
+    'bewitching_etude'
+);
+
+------------------------------------
+-- Ninjutsu
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+------------------------------------
+
+-- Tonko: Ichi: Revert cast time from 1.5 to 4 seconds
+UPDATE spell_list SET castTime = 4000 WHERE name = 'tonko_ichi';
+
+-- Monomi: Ichi: Revert cast time from 1.5 to 4 seconds
+UPDATE spell_list SET castTime = 4000 WHERE name = 'monomi_ichi';

--- a/modules/rov/lua/job_adjustments.lua
+++ b/modules/rov/lua/job_adjustments.lua
@@ -106,25 +106,6 @@ end)
 -- end)
 
 -----------------------------------
--- Red Mage
------------------------------------
-
--- TODO: Blind II / Blind
--- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
---  - Remove fixed 180 duration, revert to between 80 and 300 seconds
---  - Potency: Blind: (User INT - Opponent MND + 60)/4   Blind II: (User INT - Opponent MND + 100)/4
-
--- TODO: Paralyze / Paralyze II
---  - Remove fixed 120 duration, revert to between 30 and 120 seconds
-
--- TODO: Poison / Poison II / Poisonga
---  - Revert potencies to pre-RoV values
-
--- TODO: Bio / Bio II / Bio III / Dia / Dia II / Dia III
--- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
---  - Revert potencies to pre-RoV values
-
------------------------------------
 -- Paladin
 -----------------------------------
 
@@ -150,23 +131,6 @@ m:addOverride('xi.effects.stoneskin.onEffectGain', function(target, effect)
         effect:addMod(xi.mod.STONESKIN, effect:getPower())
     end
 end)
-
------------------------------------
--- Dark Knight
------------------------------------
-
--- Dread Spikes: Revert duration from 3 minutes to 1 minute.
--- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
-m:addOverride('xi.effects.dread_spikes.onEffectGain', function(target, effect)
-    super(target, effect)
-    effect:setDuration(60000)
-end)
-
--- TODO Absorb-STAT: Add decay tick and set 90 second duration to boost effects
--- TODO Drain II: Set duration of max HP boost to 60 seconds.
--- Source:
---   Decay Removal: http://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
---   Duration Change: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
 
 -----------------------------------
 -- Ranger
@@ -226,33 +190,6 @@ m:addOverride('xi.effects.yonin.onEffectGain', function(target, effect)
     effect:addMod(xi.mod.ENMITY, effect:getPower())
 end)
 
--- San Spells: Add +5 Magic Attack and +5 Magic Accuracy per merit rank
--- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
-local sanSpellOverrides =
-{
-    { path = 'xi.actions.spells.ninjutsu.katon_san.onSpellCast',  merit = xi.merit.KATON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.hyoton_san.onSpellCast', merit = xi.merit.HYOTON_SAN },
-    { path = 'xi.actions.spells.ninjutsu.huton_san.onSpellCast',  merit = xi.merit.HUTON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.doton_san.onSpellCast',  merit = xi.merit.DOTON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.raiton_san.onSpellCast', merit = xi.merit.RAITON_SAN },
-    { path = 'xi.actions.spells.ninjutsu.suiton_san.onSpellCast', merit = xi.merit.SUITON_SAN },
-}
-
-for _, entry in ipairs(sanSpellOverrides) do
-    m:addOverride(entry.path, function(caster, target, spell)
-        local meritBonus = caster:getMerit(entry.merit)
-        caster:addMod(xi.mod.MATT, meritBonus)
-        caster:addMod(xi.mod.MACC, meritBonus)
-
-        local damage = super(caster, target, spell)
-
-        caster:delMod(xi.mod.MATT, meritBonus)
-        caster:delMod(xi.mod.MACC, meritBonus)
-
-        return damage
-    end)
-end
-
 -----------------------------------
 -- Dragoon
 -----------------------------------
@@ -306,6 +243,16 @@ m:addOverride('xi.job_utils.dragoon.useHealingBreath', function(wyvern, target, 
     end
 
     return totalHPRestored
+end)
+
+-- Elemental Breath: Revert to consume TP on breath usage
+-- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
+m:addOverride('xi.job_utils.dragoon.useDamageBreath', function(wyvern, target, skill, action, damageType)
+    local result = super(wyvern, target, skill, action, damageType)
+
+    wyvern:setTP(0)
+
+    return result
 end)
 
 -- Spirit Link: Revert to pre-September 2015 healing formula.

--- a/modules/rov/lua/spell_adjustments.lua
+++ b/modules/rov/lua/spell_adjustments.lua
@@ -1,0 +1,198 @@
+-----------------------------------
+-- Module: Spell Adjustments (Rhapsodies of Vana'diel Era)
+-- Desc: Reverts spell changes introduced during the RoV era
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('rov_spell_adjustments')
+
+-----------------------------------
+-- Enfeebling Magic
+-----------------------------------
+
+-- Dia family: Revert defense down values.
+-- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
+local function castEraDia(caster, target, spell, tier, dotPower, duration, defenseDown)
+    local damage = xi.spells.damage.useDamageSpell(caster, target, spell)
+
+    -- Check for Bio.
+    local bio = target:getStatusEffect(xi.effect.BIO)
+    if
+        not bio or
+        (bio and bio:getTier() < tier)
+    then
+        target:delStatusEffect(xi.effect.BIO)
+        local power = dotPower + caster:getMod(xi.mod.DIA_DOT)
+
+        target:addStatusEffect(xi.effect.DIA, { power = power, duration = duration, origin = caster, tick = 3, subPower = defenseDown, tier = tier })
+    end
+
+    return damage
+end
+
+m:addOverride('xi.actions.spells.white.dia.onSpellCast', function(caster, target, spell)
+    return castEraDia(caster, target, spell, 1, 1, 60, 5)
+end)
+
+m:addOverride('xi.actions.spells.white.dia_ii.onSpellCast', function(caster, target, spell)
+    return castEraDia(caster, target, spell, 3, 2, 120, 10)
+end)
+
+m:addOverride('xi.actions.spells.white.dia_iii.onSpellCast', function(caster, target, spell)
+    return castEraDia(caster, target, spell, 5, 3, 180, 15)
+end)
+
+m:addOverride('xi.actions.spells.white.diaga.onSpellCast', function(caster, target, spell)
+    return castEraDia(caster, target, spell, 1, 1, 60, 5)
+end)
+
+-- TODO: Blind II / Blind
+-- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
+--  - Remove fixed 180 duration, revert to between 80 and 300 seconds
+--  - Potency: Blind: (User INT - Opponent MND + 60)/4   Blind II: (User INT - Opponent MND + 100)/4
+
+-- TODO: Paralyze / Paralyze II
+--  - Remove fixed 120 duration, revert to between 30 and 120 seconds
+
+-- TODO: Poison / Poison II / Poisonga
+--  - Revert potencies to pre-RoV values
+
+-----------------------------------
+-- Dark Magic
+-----------------------------------
+
+-- Bio family: Revert attack down values.
+-- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
+local function calculateBioPower(caster, tier)
+    local skillLevel = caster:getSkillLevel(xi.skill.DARK_MAGIC)
+
+    if tier == 2 then
+        return utils.clamp(math.ceil(skillLevel / 40), 1, 3)
+    elseif tier == 4 then
+        return utils.clamp(math.floor((skillLevel + 29) / 40), 3, 8)
+    end
+
+    local power = 0
+    if skillLevel > 291 then
+        power = 13 + math.floor((skillLevel - 291) / 27) -- 13 + 1 every 27 skill levels.
+    elseif skillLevel > 246 then
+        power = 9 + math.floor((skillLevel - 246) / 11) -- 9 + 1 every 11 skill levels.
+    else
+        power = 5 + math.floor((skillLevel - 106) / 35) -- 5 + 1 every 35 skill levels.
+    end
+
+    return utils.clamp(power, 5, 17)
+end
+
+local function castEraBio(caster, target, spell, tier, duration, attackDown)
+    local damage = xi.spells.damage.useDamageSpell(caster, target, spell)
+
+    -- Check for Dia.
+    local dia = target:getStatusEffect(xi.effect.DIA)
+    if
+        not dia or
+        (dia and dia:getTier() < tier)
+    then
+        target:delStatusEffect(xi.effect.DIA)
+        local power = calculateBioPower(caster, tier)
+
+        target:addStatusEffect(xi.effect.BIO, { power = power, duration = duration, origin = caster, tick = 3, subPower = attackDown, tier = tier })
+    end
+
+    return damage
+end
+
+m:addOverride('xi.actions.spells.black.bio.onSpellCast', function(caster, target, spell)
+    return castEraBio(caster, target, spell, 2, 60, 5)
+end)
+
+m:addOverride('xi.actions.spells.black.bio_ii.onSpellCast', function(caster, target, spell)
+    return castEraBio(caster, target, spell, 4, 120, 10)
+end)
+
+m:addOverride('xi.actions.spells.black.bio_iii.onSpellCast', function(caster, target, spell)
+    return castEraBio(caster, target, spell, 6, 180, 15)
+end)
+
+-- Dread Spikes: Revert duration from 3 minutes to 1 minute.
+-- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
+m:addOverride('xi.effects.dread_spikes.onEffectGain', function(target, effect)
+    super(target, effect)
+    effect:setDuration(60000)
+end)
+
+-- TODO Absorb-STAT: Add decay tick and set 90 second duration to boost effects
+-- TODO Drain II: Set duration of max HP boost to 60 seconds.
+-- Source:
+--   Decay Removal: http://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
+--   Duration Change: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
+
+-----------------------------------
+-- Singing
+-----------------------------------
+
+-- TODO (pending exposure of pTables in magic scripts):
+-- Update scripts/globals/spells/enhancing_song.lua pTable entries:
+-- Source: https://forum.square-enix.com/ffxi/threads/55899-September.-10-2019-%28JST%29-Version-Update?p=619588&viewfull=1#post619588
+--  xi.magic.spell.FOE_SIRVENTE      : MERIT_ID 0 -> xi.merit.FOE_SIRVENTE,      POWER_BASE 35 -> 0
+--  xi.magic.spell.ADVENTURERS_DIRGE : MERIT_ID 0 -> xi.merit.ADVENTURERS_DIRGE, POWER_BASE 32 -> 5
+
+--  POWER_CAP value: current -> target:
+--  Source: https://forum.square-enix.com/ffxi/threads/52095-Feb.-10-2017-%28JST%29-Version-Update
+--  xi.magic.spell.FIRE_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.ICE_CAROL        : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.WIND_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.EARTH_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.LIGHTNING_CAROL  : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.WATER_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.LIGHT_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.DARK_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
+--  xi.magic.spell.SWORD_MADRIGAL   : POWER_CAP 45  -> 15, MULTIPLIER 4.5 -> 2, DIVISOR 18 -> 23.25, SKILL_REQUIREMENT 85 -> 40
+--  xi.magic.spell.BLADE_MADRIGAL   : POWER_CAP 60  -> 30, MULTIPLIER 6   -> 2
+--  xi.magic.spell.SHEEPFOE_MAMBO   : POWER_CAP 48  -> 15, MULTIPLIER 5   -> 2.5
+--  xi.magic.spell.DRAGONFOE_MAMBO  : POWER_CAP 72  -> 23, MULTIPLIER 7   -> 2.5
+--  xi.magic.spell.ADVANCING_MARCH  : POWER_CAP 108 -> 64, MULTIPLIER 11  -> 16
+--  xi.magic.spell.VICTORY_MARCH    : POWER_CAP 163 -> 96, POWER_BASE 43  -> 53
+--  xi.magic.spell.KNIGHTS_MINNE    : POWER_CAP 30  -> 13, MULTIPLIER 3   -> 2.5, DIVISOR 10  -> 15, POWER_BASE 8  -> 5
+--  xi.magic.spell.KNIGHTS_MINNE_II : POWER_CAP 69  -> 27, MULTIPLIER 7   -> 2.5, DIVISOR 10  -> 15, POWER_BASE 12 -> 6
+--  xi.magic.spell.KNIGHTS_MINNE_III: POWER_CAP 108 -> 40, MULTIPLIER 11  -> 2.5, DIVISOR 10  -> 15, POWER_BASE 18 -> 10
+--  xi.magic.spell.KNIGHTS_MINNE_IV : POWER_CAP 164 -> 48, MULTIPLIER 16  -> 2.5, DIVISOR 10  -> 15, POWER_BASE 30 -> 12
+--  xi.magic.spell.VALOR_MINUET     : POWER_CAP 30  -> 16, MULTIPLIER 3   -> 2.5, DIVISOR 4.3 -> 6
+--  xi.magic.spell.VALOR_MINUET_II  : POWER_CAP 69  -> 32, MULTIPLIER 6   -> 2.5, DIVISOR 3.9 -> 6, SKILL_REQUIREMENT 100 -> 85
+--  xi.magic.spell.VALOR_MINUET_III : POWER_CAP 108 -> 48, MULTIPLIER 9   -> 2.5, DIVISOR 3.5 -> 6
+--  xi.magic.spell.VALOR_MINUET_IV  : POWER_CAP 164 -> 56, MULTIPLIER 11  -> 2.5, DIVISOR 3.3 -> 15, POWER_BASE 31 -> 29
+--  xi.magic.spell.HUNTERS_PRELUDE  : POWER_CAP 45  -> 15, MULTIPLIER 4.5 -> 2
+--  xi.magic.spell.ARCHERS_PRELUDE  : POWER_CAP 60  -> 30, MULTIPLIER 6   -> 2
+
+-----------------------------------
+-- Ninjutsu
+-----------------------------------
+
+-- San Spells: Add +5 Magic Attack and +5 Magic Accuracy per merit rank
+-- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
+local sanSpellOverrides =
+{
+    { path = 'xi.actions.spells.ninjutsu.katon_san.onSpellCast',  merit = xi.merit.KATON_SAN  },
+    { path = 'xi.actions.spells.ninjutsu.hyoton_san.onSpellCast', merit = xi.merit.HYOTON_SAN },
+    { path = 'xi.actions.spells.ninjutsu.huton_san.onSpellCast',  merit = xi.merit.HUTON_SAN  },
+    { path = 'xi.actions.spells.ninjutsu.doton_san.onSpellCast',  merit = xi.merit.DOTON_SAN  },
+    { path = 'xi.actions.spells.ninjutsu.raiton_san.onSpellCast', merit = xi.merit.RAITON_SAN },
+    { path = 'xi.actions.spells.ninjutsu.suiton_san.onSpellCast', merit = xi.merit.SUITON_SAN },
+}
+
+for _, entry in ipairs(sanSpellOverrides) do
+    m:addOverride(entry.path, function(caster, target, spell)
+        local meritBonus = caster:getMerit(entry.merit)
+        caster:addMod(xi.mod.MATT, meritBonus)
+        caster:addMod(xi.mod.MACC, meritBonus)
+
+        local damage = super(caster, target, spell)
+
+        caster:delMod(xi.mod.MATT, meritBonus)
+        caster:delMod(xi.mod.MACC, meritBonus)
+
+        return damage
+    end)
+end
+
+return m

--- a/modules/rov/sql/job_adjustments.sql
+++ b/modules/rov/sql/job_adjustments.sql
@@ -35,6 +35,11 @@ UPDATE traits SET level = 55 WHERE name = 'max hp boost' AND job = 2 AND rank = 
 UPDATE traits SET level = 70 WHERE name = 'max hp boost' AND job = 2 AND rank = 4;
 
 ------------------------------------
+-- White Mage
+-- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
+------------------------------------
+
+------------------------------------
 -- Black Mage
 -- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
 ------------------------------------
@@ -64,10 +69,6 @@ UPDATE merits SET upgrade = 0 WHERE name = 'melee_accuracy';
 -- Paladin
 ------------------------------------
 
--- Remove PLD from Banishga
--- Source: https://forum.square-enix.com/ffxi/threads/56243
-UPDATE spell_list SET jobs = 0x00000F00000000000000000000000000000000000000 WHERE name = 'banishga';
-
 -- Rampart: Revert recast from 3 to 5 minutes
 -- Source: https://forum.square-enix.com/ffxi/threads/56444-February-12-2020-%28JST%29-Version-Update
 UPDATE abilities SET recastTime = 300 WHERE name = 'rampart';
@@ -77,11 +78,27 @@ UPDATE merits SET value = 10 WHERE name = 'rampart_recast';
 
 ------------------------------------
 -- Ranger
--- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
 ------------------------------------
 
 -- Velocity Shot: Revert recast from 1 minute to 5 minutes
+-- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
 UPDATE abilities SET recastTime = 300 WHERE name = 'velocity_shot';
+
+-- Archery and Marksmanship: Revert skill rank increase from A+ to A.
+-- Source: https://forum.square-enix.com/ffxi/threads/47481-Jun-25-2015-%28JST%29-Version-Update
+UPDATE skill_ranks SET rng = 2 WHERE name = 'archery';
+UPDATE skill_ranks SET rng = 2 WHERE name = 'marksmanship';
+
+------------------------------------
+-- Bard
+-- Source: https://forum.square-enix.com/ffxi/threads/55360-May.-10-2019-%28JST%29-Version-Update
+------------------------------------
+
+-- Foe Sirvente/Adventurer's Dirge: Set merit ranks to 5 and merit value to 5 per rank.
+UPDATE merits SET upgrade = 5, value = 5 WHERE name IN ('foe_sirvente', 'adventurers_dirge');
+
+-- Disable OOE BRD Group 2 merits
+UPDATE merits SET upgrade = 0 WHERE name IN ('con_anima', 'con_brio');
 
 -----------------------------------
 -- Ninja

--- a/modules/rov/sql/spell_adjustments.sql
+++ b/modules/rov/sql/spell_adjustments.sql
@@ -1,0 +1,47 @@
+------------------------------------
+-- Rhapsodies of Vana'diel Spell SQL Adjustments
+-- This module reverts relevant spells to their pre-RoV values
+------------------------------------
+
+------------------------------------
+-- Enhancing Magic
+-- Source: https://forum.square-enix.com/ffxi/threads/46531
+------------------------------------
+
+-- Protectra: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'protectra';
+
+-- Protectra II: Revert cast time from 1.25 to 3.75 seconds
+UPDATE spell_list SET castTime = 3750 WHERE name = 'protectra_ii';
+
+-- Protectra III: Revert cast time from 1.5 to 4.5 seconds
+UPDATE spell_list SET castTime = 4500 WHERE name = 'protectra_iii';
+
+-- Protectra IV: Revert cast time from 1.75 to 5.25 seconds
+UPDATE spell_list SET castTime = 5250 WHERE name = 'protectra_iv';
+
+-- Protectra V: Revert cast time from 2 to 7 seconds
+UPDATE spell_list SET castTime = 7000 WHERE name = 'protectra_v';
+
+-- Shellra: Revert cast time from 1 to 3 seconds
+UPDATE spell_list SET castTime = 3000 WHERE name = 'shellra';
+
+-- Shellra II: Revert cast time from 1.25 to 3.75 seconds
+UPDATE spell_list SET castTime = 3750 WHERE name = 'shellra_ii';
+
+-- Shellra III: Revert cast time from 1.5 to 4.5 seconds
+UPDATE spell_list SET castTime = 4500 WHERE name = 'shellra_iii';
+
+-- Shellra IV: Revert cast time from 1.75 to 5.25 seconds
+UPDATE spell_list SET castTime = 5250 WHERE name = 'shellra_iv';
+
+-- Shellra V: Revert cast time from 2 to 6 seconds
+UPDATE spell_list SET castTime = 6000 WHERE name = 'shellra_v';
+
+------------------------------------
+-- Divine Magic
+------------------------------------
+
+-- Remove PLD from Banishga
+-- Source: https://forum.square-enix.com/ffxi/threads/56243
+UPDATE spell_list SET jobs = 0x00000F00000000000000000000000000000000000000 WHERE name = 'banishga';

--- a/modules/wotg/sql/job_adjustments.sql
+++ b/modules/wotg/sql/job_adjustments.sql
@@ -9,27 +9,6 @@
 -- White Mage
 ------------------------------------
 
--- Banish II: Revert cast time from 2.5 to 3.75 seconds
-UPDATE `spell_list` SET `castTime` = 3750 WHERE `name` = 'banish_ii';
-
--- Banish III: Revert cast time from 3 to 5.5 seconds
-UPDATE `spell_list` SET `castTime` = 5500 WHERE `name` = 'banish_iii';
-
--- Raise II: Revert MP from 150 to 200, cast time from 14 to 20 seconds
-UPDATE `spell_list` SET `mpCost` = 200, `castTime` = 20000 WHERE `name` = 'raise_ii';
-
--- Raise III: Revert MP from 150 to 250, cast time from 13 to 20 seconds
-UPDATE `spell_list` SET `mpCost` = 250, `castTime` = 20000 WHERE `name` = 'raise_iii';
-
--- Reraise: Revert WHM level from 25 to 33
-UPDATE `spell_list` SET `jobs` = 0x00002100000000000000000000000000000000230000 WHERE `name` = 'reraise';
-
--- Reraise II: Revert WHM level from 56 to 60, MP from 150 to 175, cast time from 7.5 to 8 seconds
-UPDATE `spell_list` SET `jobs` = 0x00003C00000000000000000000000000000000460000, `mpCost` = 175, `castTime` = 8000 WHERE `name` = 'reraise_ii';
-
--- Reraise III: Revert WHM level from 70 to 75, MP from 150 to 200, cast time from 7 to 8 seconds
-UPDATE `spell_list` SET `jobs` = 0x00004B000000000000000000000000000000005B0000, `mpCost` = 200, `castTime` = 8000 WHERE `name` = 'reraise_iii';
-
 -- Martyr: Revert range from 20 to 6 yalms
 UPDATE `abilities` SET `range` = 6.0 WHERE `name` = 'martyr';
 

--- a/modules/wotg/sql/spell_adjustments.sql
+++ b/modules/wotg/sql/spell_adjustments.sql
@@ -1,0 +1,35 @@
+------------------------------------
+-- Wings of the Goddess Spell SQL Adjustments
+-- This module reverts relevant spells to their pre-WotG values
+------------------------------------
+
+------------------------------------
+-- Divine Magic
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/08/2009)
+------------------------------------
+
+-- Banish II: Revert cast time from 2.5 to 3.75 seconds
+UPDATE `spell_list` SET `castTime` = 3750 WHERE `name` = 'banish_ii';
+
+-- Banish III: Revert cast time from 3 to 5.5 seconds
+UPDATE `spell_list` SET `castTime` = 5500 WHERE `name` = 'banish_iii';
+
+------------------------------------
+-- Healing Magic
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/08/2009)
+------------------------------------
+
+-- Raise II: Revert MP from 150 to 200, cast time from 14 to 20 seconds
+UPDATE `spell_list` SET `mpCost` = 200, `castTime` = 20000 WHERE `name` = 'raise_ii';
+
+-- Raise III: Revert MP from 150 to 250, cast time from 13 to 20 seconds
+UPDATE `spell_list` SET `mpCost` = 250, `castTime` = 20000 WHERE `name` = 'raise_iii';
+
+-- Reraise: Revert WHM level from 25 to 33
+UPDATE `spell_list` SET `jobs` = 0x00002100000000000000000000000000000000230000 WHERE `name` = 'reraise';
+
+-- Reraise II: Revert WHM level from 56 to 60, MP from 150 to 175, cast time from 7.5 to 8 seconds
+UPDATE `spell_list` SET `jobs` = 0x00003C00000000000000000000000000000000460000, `mpCost` = 175, `castTime` = 8000 WHERE `name` = 'reraise_ii';
+
+-- Reraise III: Revert WHM level from 70 to 75, MP from 150 to 200, cast time from 7 to 8 seconds
+UPDATE `spell_list` SET `jobs` = 0x00004B000000000000000000000000000000005B0000, `mpCost` = 200, `castTime` = 8000 WHERE `name` = 'reraise_iii';


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reorganizes spell related modules to be in their own spell_adjustment module rather than categorized by job.
- Adds Bio and Dia adjustments to reduce the respective attack and defense down effects.
- Adds Bard merit and mazurka adjustments to the existing modules. Also populated a TODO for pending song buff value adjustments that are pending global adjustments to magic tables.
- Prelude, Etudes, Foe Sirvente, and Adventurer's Dirge set to single target and reduced cast time
- Adds missing DRG era adjustment to wipe wyvern's current TP when they use an elemental breath
- Adjusts cast times for Protectra, Shellra, and Regen.

## Steps to test these changes
- Load all affected modules in init.txt
- Test the listed abilities or spells in game to see the commented logic occurs
