### PR TITLE
[lua] Refactor Reactive Shield

### DIFF
--- a/scripts/actions/abilities/pets/attachments/reactive_shield.lua
+++ b/scripts/actions/abilities/pets/attachments/reactive_shield.lua
@@ -1,19 +1,30 @@
 -----------------------------------
--- Attachment: Reactive Shield
+-- Reactive Shield
+-- Grants Blaze Spikes to the automaton for 60 seconds.
+-- https://wiki.ffo.jp/html/10431.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_REACTIVE_SHIELD', function(automaton, target)
-        local master = automaton:getMaster()
-        if
-            not automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.REACTIVE_SHIELD) and
-            master and
-            master:countEffect(xi.effect.FIRE_MANEUVER) > 0
-        then
-            automaton:useMobAbility(xi.automaton.abilities.REACTIVE_SHIELD, automaton)
+        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.REACTIVE_SHIELD) then
+            return
         end
+
+        local master = automaton:getMaster()
+
+        if not master then
+            return
+        end
+
+        local fireManeuvers = master:countEffect(xi.effect.FIRE_MANEUVER)
+
+        if fireManeuvers == 0 then
+            return
+        end
+
+        automaton:useMobAbility(xi.automaton.abilities.REACTIVE_SHIELD, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/automaton/reactive_shield.lua
+++ b/scripts/actions/abilities/pets/automaton/reactive_shield.lua
@@ -1,5 +1,8 @@
 -----------------------------------
 -- Reactive Shield
+-- Grants Blaze Spikes to the automaton for 60 seconds.
+-- https://wiki.ffo.jp/html/10431.html
+-- Power formula derived from brief testing. TODO: Gather more data and refine formula.
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -9,12 +12,14 @@ abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
 end
 
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
-    automaton:addRecast(xi.recast.ABILITY, skill:getID(), 65)
-    local pMod = automaton:getSkillLevel(xi.skill.AUTOMATON_MAGIC)
-    local duration = 60
-    local power = math.floor((pMod / 56)^3 / 8) + 4 -- No idea how the actual formula used Automaton skill level, so heres a placeholder (4 @ lvl 1, 10 @ lvl 61, 20 @ lvl 75, 62 @ lvl 99)
+    automaton:addRecast(xi.recast.ABILITY, skill:getID(), 60)
 
-    if target:addStatusEffect(xi.effect.BLAZE_SPIKES, { power = power, duration = duration, origin = automaton }) then
+    local skillLevel   = math.max(automaton:getSkillLevel(xi.skill.AUTOMATON_MELEE), automaton:getSkillLevel(xi.skill.AUTOMATON_RANGED), automaton:getSkillLevel(xi.skill.AUTOMATON_MAGIC))
+    local intelligence = automaton:getStat(xi.mod.INT)
+
+    local power = math.floor(skillLevel / 16) + math.floor(intelligence / 8)
+
+    if target:addStatusEffect(xi.effect.BLAZE_SPIKES, { power = power, duration = 60, origin = automaton }) then
         skill:setMsg(xi.msg.basic.SKILL_GAIN_EFFECT)
     else
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Refactors code in Reactive Shield with a more accurate power formula. Did some brief testing at Lv. 50, 60, 70 & 99 and came up with...

damage = math.floor((skill / 16( + (INT / 6))

It's not perfect, and will sometimes deliver damage 1-2 damage too low, but it's a massive improvement over what was there before. There may be a dINT component as well, but I left a TODO to verify it further.

[ReactiveShield.zip](https://github.com/user-attachments/files/28691462/ReactiveShield.zip)

Lv.70
INT 54 
251 Skill
22-24 Damage

Lv.60
INT 45
203 Skill
17-19 Damage

Lv.50
INT 38
153 Skill
14-15 Damage

Lv.99
INT 81
Skill 424
42-45 Damage

Lv.99
INT 81+77
Skill 424
53-56 Damage

## Steps to test these changes

Equip Reactive Shield, use Fire Maneuvers, get Blaze Spikes. 
