### PR TITLE
Fix swapped door reference for a Pso'Xja elevator

### DIFF
--- a/scripts/zones/PsoXja/npcs/@09a.lua
+++ b/scripts/zones/PsoXja/npcs/@09a.lua
@@ -22,8 +22,8 @@ entity.onSpawn = function(npc)
     local elevator =
     {
         id = xi.elevator.TIMED_AUTOMATIC,
-        lowerDoor = npc:getID() + 1,
-        upperDoor = npc:getID() + 2,
+        lowerDoor = npc:getID() + 2,
+        upperDoor = npc:getID() + 1,
         elevator = npc:getID(),
         reversedAnimations = true,
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the automatic doors for the south elevator in Pso'Xja (labelled as elevator 2 on maps 9 and 10 on the Fandom wiki)

## Steps to test these changes

!pos 261 0 249 9

Turn around, and use the elevator when it comes. Verify that the door on top is opened when the elevator is at the top, closed when it's not. Verify that the door on the bottom is opened when the elevator is at the bottom, closed when it's not.
