### PR TITLE
[core] [C++] [lua] Move Automaton mods from C++ to LUA / Add Cooldowns to Automaton Attachments When Summoned

### DIFF
--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -5,17 +5,105 @@ xi = xi or {}
 xi.pets = xi.pets or {}
 xi.pets.automaton = {}
 
+xi.pets.automaton.frameMods =
+{
+    -----------------------------------
+    -- Harlequin
+    -----------------------------------
+    [xi.automaton.frame.HARLEQUIN] =
+    {
+        mods =
+        {
+            { xi.mod.DMG,              -625 },
+        },
+    },
+
+    -----------------------------------
+    -- Valoredge
+    -----------------------------------
+    [xi.automaton.frame.VALOREDGE] =
+    {
+        mobMods =
+        {
+            { xi.mobMod.CAN_SHIELD_BLOCK, 1 },
+        },
+
+        mods =
+        {
+            { xi.mod.SHIELDBLOCKRATE,    45 },
+            { xi.mod.DMG,             -1250 },
+        },
+    },
+
+    -----------------------------------
+    -- Sharpshot
+    -----------------------------------
+    [xi.automaton.frame.SHARPSHOT] =
+    {
+        mods =
+        {
+            { xi.mod.PIERCE_SDT,       8750 },
+            { xi.mod.DMGBREATH,       -1250 },
+            { xi.mod.DMGMAGIC,        -1250 },
+        },
+    },
+
+    -----------------------------------
+    -- Stormwaker
+    -----------------------------------
+    [xi.automaton.frame.STORMWAKER] =
+    {
+        mods =
+        {
+            { xi.mod.DMGBREATH,       -2500 },
+            { xi.mod.DMGMAGIC,        -2500 },
+        },
+    },
+}
+
+local function applyAutomatonFrameMods(mob)
+    local frameEquipped = mob:getAutomatonFrame()
+    local frameData     = xi.pets.automaton.frameMods[frameEquipped]
+
+    if not frameData then
+        return
+    end
+
+    for _, mobModData in ipairs(frameData.mobMods or {}) do
+        mob:setMobMod(mobModData[1], mobModData[2])
+    end
+
+    for _, modData in ipairs(frameData.mods or {}) do
+        mob:setMod(modData[1], modData[2])
+    end
+end
+
 xi.pets.automaton.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.CAN_PARRY, 1)
+    applyAutomatonFrameMods(mob)
+
     mob:setLocalVar('MANEUVER_DURATION', 60)
+
     mob:addListener('EFFECTS_TICK', 'MANEUVER_DURATION', function(automaton)
         if automaton:getTarget() then
-            local dur = automaton:getLocalVar('MANEUVER_DURATION')
-            automaton:setLocalVar('MANEUVER_DURATION', math.min(dur + 3, 300))
+            local maneuverDuration = automaton:getLocalVar('MANEUVER_DURATION')
+            automaton:setLocalVar('MANEUVER_DURATION', math.min(maneuverDuration + 3, 300))
         end
     end)
 
-    -- Barrage Turbine cannot be used unless the automaton has been active for at least 3 minutes.
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE, 60 * 3)
+    -- All Automaton Attachments have their cooldowns applied on spawn.
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE, 180)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.DISRUPTOR,        60)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.ECONOMIZER,       60)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.ERASER,           30)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.FLASHBULB,        45)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.HEAT_CAPACITOR,   90)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.MANA_CONVERTER,  180)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.PROVOKE,          30)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REACTIVE_SHIELD,  60)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REGULATOR,        60)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REPLICATOR,       60)
+    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.SHOCK_ABSORBER,  180)
 end
 
 xi.pets.automaton.onMobDeath = function(mob)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -596,27 +596,18 @@ void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats,
             default: // case AutomatonFrame::Harlequin:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(4, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
-                PPet->setModifier(Mod::DMG, -625);
                 break;
             case AutomatonFrame::Valoredge:
-                PPet->setModifier(Mod::SHIELDBLOCKRATE, 45);
-                PPet->setMobMod(MOBMOD_CAN_SHIELD_BLOCK, 1);
-                PPet->setModifier(Mod::DMG, -1250);
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(7, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(8, mlvl > 99 ? 99 : mlvl));
                 break;
             case AutomatonFrame::Sharpshot:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
-                PPet->setModifier(Mod::PIERCE_SDT, 8750);
-                PPet->setModifier(Mod::DMGBREATH, -1250);
-                PPet->setModifier(Mod::DMGMAGIC, -1250);
                 break;
             case AutomatonFrame::Stormwaker:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
                 PPet->setModifier(Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
-                PPet->setModifier(Mod::DMGBREATH, -2500);
-                PPet->setModifier(Mod::DMGMAGIC, -2500);
                 break;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves some Automaton modifiers from C++ into LUA

* Moves Frame Specific DT into the automaton global file.
* Moves Parry/Block modifiers into the automaton global file.

Also includes some general fixes to automatons.

* Adds the ability for all automaton frames to parry.
* Puts all attachment related abilities on cooldown when summoning an automaton frame.

## Steps to test these changes
Rebuild, see frames get DT as they did before. Equip ability attachments, summon your automaton, see they can't be used until CD expires. 

