### PR TITLE
[lua]  Fix WoTG Nation quest req for Cait Sith mission

### DIFF
--- a/scripts/missions/wotg/02_Back_to_the_Beginning.lua
+++ b/scripts/missions/wotg/02_Back_to_the_Beginning.lua
@@ -14,6 +14,8 @@
 -- Rolanberry Fields [S]    : !pos -198 8 360 91
 -- Sauromugue Champaign [S] : !pos 369 8 -227 98
 -----------------------------------
+require('scripts/missions/wotg/helpers')
+-----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.WOTG, xi.mission.id.wotg.BACK_TO_THE_BEGINNING)
 
@@ -27,7 +29,8 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId
+            return currentMission == mission.missionId and
+                xi.wotg.helpers.meetsMission3Reqs(player)
         end,
 
         [xi.zone.BATALLIA_DOWNS] =

--- a/scripts/missions/wotg/03_Cait_Sith.lua
+++ b/scripts/missions/wotg/03_Cait_Sith.lua
@@ -9,8 +9,6 @@
 -- EAST_RONFAURE_S      : !zone 81
 -- SOUTHERN_SAN_DORIA_S : !zone 80
 -----------------------------------
-require('scripts/missions/wotg/helpers')
------------------------------------
 
 local mission = Mission:new(xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH)
 
@@ -24,8 +22,7 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and
-                xi.wotg.helpers.meetsMission3Reqs(player)
+            return currentMission == mission.missionId
         end,
 
         [xi.zone.SOUTHERN_SAN_DORIA_S] =


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Currently you can skip the entire Back to the Beginning WOTG mission 2. As soon as you complete the first WoTG cutscene and start mission 2 you can turn around and click a maw and immediately start the Cait Sith mission when normally it requires you to do the first 3 city nation mission quest lines (I don't have the decoupling module enabled). Just moving the gate req from the start of Mission 3 to the end of mission 2 instead.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Start Back to the Beginning and click a maw and do not get the Cait Sith mission cutscene. 
!completequest 7 16 then click the maw and get the cutscene
