### PR TITLE
[lua] Fix CoP 1-3 Promy Entry

### DIFF
--- a/scripts/missions/cop/1_3_The_Mothercrystals.lua
+++ b/scripts/missions/cop/1_3_The_Mothercrystals.lua
@@ -122,6 +122,7 @@ mission.sections =
 
             onZoneIn = function(player, prevZone)
                 if
+                    xi.cop.helpers.shatteredTelepointInfo[prevZone] ~= nil and
                     xi.cop.helpers.numPromyvionCompleted(player) == 2 and
                     not xi.cop.helpers.hasCompletedPromyvion(player, prevZone) and
                     mission:getVar(player, 'Status') == 0
@@ -140,7 +141,7 @@ mission.sections =
                 [155] = function(player, csid, option, npc)
                     -- This event only happens once since there is no sealing component.
                     mission:setVar(player, 'Status', 1)
-                    xi.cop.helpers.sendToPromyvionZone(player:getLocalVar('toPromyvion'))
+                    xi.cop.helpers.sendToPromyvionZone(player, player:getLocalVar('toPromyvion'))
                 end,
             },
         },

--- a/scripts/tests/missions/cop.lua
+++ b/scripts/tests/missions/cop.lua
@@ -120,8 +120,8 @@ describe('Chains of Promathia', function()
             player.assert:inZone(xi.zone.HALL_OF_TRANSFERENCE)
             player.events:expect({ eventId = 155 })
 
-            -- Event upon entering promy
-            player:gotoZone(xi.zone.PROMYVION_MEA)
+            -- event upon entering promy after Hall warp
+            player.assert:inZone(xi.zone.PROMYVION_MEA)
             player.events:expect({ eventId = 52 })
 
             -- enter and beat BCNM


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Fixes a bug that would cause players zoning into their 3rd Promy/Hall of Transference entry to have a black screen. Also adds a guard against prevZone nil indexing (e.g. exiting from inside the Promy back to Hall).

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

Do CoP 1-3 and zone into 3rd set of Hall of Transference after completing the first 2.
