### PR TITLE
[lua] Add isEngaged() to targeted spells in entity_behavior.lua

### DIFF
--- a/scripts/globals/combat/entity_behavior.lua
+++ b/scripts/globals/combat/entity_behavior.lua
@@ -77,7 +77,9 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
             end,
 
             [xi.action.type.DAMAGE_TARGET] = function()
-                table.insert(actionList, { actionId, actionTarget, actionWeight })
+                if actor:isEngaged() then
+                    table.insert(actionList, { actionId, actionTarget, actionWeight })
+                end
             end,
 
             [xi.action.type.DAMAGE_FORCE_SELF] = function()
@@ -205,6 +207,7 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
 
             [xi.action.type.ENFEEBLING_TARGET] = function()
                 if
+                    actor:isEngaged() and
                     not actionTarget:hasStatusEffect(actionCondition) and
                     not xi.data.statusEffect.isEffectNullified(actionTarget, actionCondition, effectTier)
                 then
@@ -273,7 +276,10 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
             end,
 
             [xi.action.type.DRAIN_HP] = function()
-                if not actionTarget:isUndead() then
+                if
+                    actor:isEngaged() and
+                    not actionTarget:isUndead()
+                then
                     if
                         actionCondition == nil or
                         (actionCondition and actor:getHPP() <= actionCondition)
@@ -285,6 +291,7 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
 
             [xi.action.type.DRAIN_MP] = function()
                 if
+                    actor:isEngaged() and
                     not actionTarget:isUndead() and
                     actionTarget:getMP() > 0
                 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds isEngaged() to spells that require a target and cannot be cast on self. This prevents out of combat actors that are using lua spell lists from wasting their spell cast cooldown on a spell they cannot cast.

## Steps to test these changes

!zone Balgas Dais enter Royale Ramble, see mobs buff a lot. 
