### PR TITLE
[lua] Add military scrip purchase to Wrath of the Griffon

### DIFF
--- a/scripts/quests/crystalWar/Wrath_of_the_Griffon.lua
+++ b/scripts/quests/crystalWar/Wrath_of_the_Griffon.lua
@@ -1,9 +1,10 @@
 -----------------------------------
--- Boy and the Beast
+-- Wrath of the Griffon
 -----------------------------------
 -- !addquest 7 25
 -- Rholont : !pos -168 -2 56 80
 -- qm8     : !pos -6 0 -295 82
+-- Wyatt   : !pos 124 0 84 80
 -----------------------------------
 local jugnerSID = zones[xi.zone.JUGNER_FOREST_S]
 -----------------------------------
@@ -106,6 +107,26 @@ quest.sections =
 
                 [206] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 3)
+                end,
+            },
+        },
+    },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED and
+                player:hasKeyItem(xi.ki.MILITARY_SCRIP)
+        end,
+
+        [xi.zone.SOUTHERN_SAN_DORIA_S] =
+        {
+            ['Wyatt'] = quest:progressEvent(66):setPriority(1005),
+
+            onEventFinish =
+            {
+                [66] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.MILITARY_SCRIP)
+                    npcUtil.giveCurrency(player, 'gil', 20147)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

After completing the WOTG nation quest Wrath of the Griffon, you are able to sell the military scrip key item to NPC Wyatt.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

`!completequest 7 25`
`!addkeyitem military_scrip`
Talk to Wyatt

## Source

https://1drv.ms/u/c/87e665e10555c452/EYiteOd94sFMrENsGUTYZ-oBUxgEvjothMeusL4Gc3-77g?e=pyeLFu