### PR TITLE
[lua] Fix Mijin Gakure printing 0 damage / Add missing returns to other NIN JAs

### DIFF
--- a/scripts/actions/abilities/futae.lua
+++ b/scripts/actions/abilities/futae.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkFutae(player, target, ability)
+    return xi.job_utils.ninja.checkFutae(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/actions/abilities/innin.lua
+++ b/scripts/actions/abilities/innin.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkInnin(player, target, ability)
+    return xi.job_utils.ninja.checkInnin(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/actions/abilities/issekigan.lua
+++ b/scripts/actions/abilities/issekigan.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkIssekigan(player, target, ability)
+    return xi.job_utils.ninja.checkIssekigan(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/actions/abilities/mijin_gakure.lua
+++ b/scripts/actions/abilities/mijin_gakure.lua
@@ -9,11 +9,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkMijinGakure(player, target, ability)
+    return xi.job_utils.ninja.checkMijinGakure(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    xi.job_utils.ninja.useMijinGakure(player, target, ability, action)
+    return xi.job_utils.ninja.useMijinGakure(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/mikage.lua
+++ b/scripts/actions/abilities/mikage.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkMikage(player, target, ability)
+    return xi.job_utils.ninja.checkMikage(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/actions/abilities/sange.lua
+++ b/scripts/actions/abilities/sange.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkSange(player, target, ability)
+    return xi.job_utils.ninja.checkSange(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)

--- a/scripts/actions/abilities/yonin.lua
+++ b/scripts/actions/abilities/yonin.lua
@@ -9,7 +9,7 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    xi.job_utils.ninja.checkYonin(player, target, ability)
+    return xi.job_utils.ninja.checkYonin(player, target, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds a return to onAbilityCheck / onUseAbility in Mijin Gakure because core needs to know what damage was returned from it in order to put the correct number in the log.

Before
<img width="439" height="48" alt="image" src="https://github.com/user-attachments/assets/a425101a-2aab-4e16-9b3d-0b293840d2e8" />

After
<img width="492" height="43" alt="image" src="https://github.com/user-attachments/assets/ff6ff12e-ec40-45e9-bf7c-763afd472d00" />
 
 EDIT: also added missing returns to other NIN JAs
 
## Steps to test these changes

Use Mijin, see damage in log
