### PR TITLE
[lua] Fix Back to the Beginning Cutscene

### DIFF
--- a/scripts/missions/wotg/02_Back_to_the_Beginning.lua
+++ b/scripts/missions/wotg/02_Back_to_the_Beginning.lua
@@ -25,6 +25,26 @@ mission.reward =
     nextMission = { xi.mission.log_id.WOTG, xi.mission.id.wotg.CAIT_SITH },
 }
 
+local mawEvents =
+{
+    [xi.zone.BATALLIA_DOWNS]         = { 501, 0, 1 },
+    [xi.zone.ROLANBERRY_FIELDS]      = { 501, 1, 1 },
+    [xi.zone.SAUROMUGUE_CHAMPAIGN]   = { 501, 2, 1 },
+    [xi.zone.BATALLIA_DOWNS_S]       = { 701, 0, 1 },
+    [xi.zone.ROLANBERRY_FIELDS_S]    = { 701, 1, 1 },
+    [xi.zone.SAUROMUGUE_CHAMPAIGN_S] = { 701, 2, 1 },
+}
+
+local function mawEvent(zoneId)
+    return mission:progressEvent(unpack(mawEvents[zoneId]))
+end
+
+local function completeMission(player, csid, option, npc)
+    if mission:complete(player) then
+        xi.maws.addMaw(player)
+    end
+end
+
 mission.sections =
 {
     {
@@ -35,85 +55,61 @@ mission.sections =
 
         [xi.zone.BATALLIA_DOWNS] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(501),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.BATALLIA_DOWNS),
 
             onEventFinish =
             {
-                [501] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [501] = completeMission,
             },
         },
 
         [xi.zone.ROLANBERRY_FIELDS] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(501),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.ROLANBERRY_FIELDS),
 
             onEventFinish =
             {
-                [501] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [501] = completeMission,
             },
         },
 
         [xi.zone.SAUROMUGUE_CHAMPAIGN] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(501),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.SAUROMUGUE_CHAMPAIGN),
 
             onEventFinish =
             {
-                [501] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [501] = completeMission,
             },
         },
 
         [xi.zone.BATALLIA_DOWNS_S] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(701),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.BATALLIA_DOWNS_S),
 
             onEventFinish =
             {
-                [701] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [701] = completeMission,
             },
         },
 
         [xi.zone.ROLANBERRY_FIELDS_S] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(701),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.ROLANBERRY_FIELDS_S),
 
             onEventFinish =
             {
-                [701] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [701] = completeMission,
             },
         },
 
         [xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
         {
-            ['Cavernous_Maw'] = mission:progressEvent(701),
+            ['Cavernous_Maw'] = mawEvent(xi.zone.SAUROMUGUE_CHAMPAIGN_S),
 
             onEventFinish =
             {
-                [701] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        xi.maws.addMaw(player)
-                    end
-                end,
+                [701] = completeMission,
             },
         },
     },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Closes #10274
The 3rd param adds the ~2010 change where Cait Sith mentions the Walk of Echoes at the end of the CS as additional dialogue as well

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->

!cs 501 1 1 in Rolanberry Fields vs !cs 501 (bugged)
!cs 501 2 1 in Sauromugue Champaign vs !cs 501 (bugged)

## Sources

Batallia
https://1drv.ms/u/c/87e665e10555c452/ETQMNE6zzOhDkAkOOLZkVogB7F1jovwQJYcrD1Po3cKeAg?e=0FicKV

Rolanberry
https://1drv.ms/u/c/87e665e10555c452/ER-RI3wXKa5Av-hmCiRBPeABfeRSMyHk30SMdaIB-Cavew?e=inahsi

Sauromugue
https://www.dropbox.com/scl/fi/46bcws0xb2ui3fsrxu9ta/WOTG-2-WIN-Snake-on-the-Plains-The-Tigress-The-Tigress-Strikes-2x-Campaign-Battle-Windy-S.zip?rlkey=gc9j9jvtv8yywroxsrjyyez1x&dl=0
