### PR TITLE
[sql] Check for chest illusion before failure checks

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1784,6 +1784,18 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
     end
 
     -----------------------------------
+    -- Handle Illusion.
+    -----------------------------------
+    if
+        bypassType == 0 and
+        GetSystemTime() < npc:getLocalVar('illusionCooldown')
+    then
+        player:messageSpecial(ID.text.CHEST_UNLOCKED + 6)
+        moveTreasure(npc, respawnType.REGULAR)
+        return 0
+    end
+
+    -----------------------------------
     -- Handle failure states.
     -----------------------------------
     local outcome      = 0
@@ -1938,18 +1950,6 @@ xi.treasure.onTrade = function(player, npc, trade, bypassType, bypassReward)
         end)
 
         return treasureMap
-    end
-
-    -----------------------------------
-    -- Handle Illusion.
-    -----------------------------------
-    if GetSystemTime() < npc:getLocalVar('illusionCooldown') then
-        player:timer(2000, function(playerEntity)
-            playerEntity:messageSpecial(ID.text.CHEST_UNLOCKED + 6)
-            moveTreasure(npc, respawnType.REGULAR)
-        end)
-
-        return 0
     end
 
     -----------------------------------


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR changes key checks to check for an illusion before failure state while respecting any bypasses.

## Steps to test these changes

Pick a chest while it is on cooldown and see that your key isn't consumed and you don't suddenly have a mimic eating you.
