### PR TITLE
[lua] Fix Lumber Jack / Weeping Willow despawn interaction.

### DIFF
--- a/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
+++ b/scripts/zones/Batallia_Downs/mobs/Lumber_Jack.lua
@@ -27,6 +27,7 @@ entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.UFASTCAST, 85)
     mob:setMod(xi.mod.DOUBLE_ATTACK, 10)
     mob:setMod(xi.mod.POWER_MULTIPLIER_SPELL, 25)
+    mob:setLocalVar('death', 0)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
@@ -49,7 +50,7 @@ end
 entity.onMobDespawn = function(mob)
     local lumberDeath = mob:getLocalVar('death')
 
-    if lumberDeath then
+    if lumberDeath == 1 then
         -- Lumber Jack died, Set Weeping Willow's respawn time (21-24 hours)
         GetMobByID(mob:getID() -6):setRespawnTime(math.random(75600, 86400))
     else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes the if statement in Lumber Jack despawn to actually respawn Weeping Willow in 30 minutes if it was not defeated. Old code was always entering death branch, causing a despawned Lumber Jack to go on cooldown for 21-24 hours. 

## Steps to test these changes

Spawn Lumber Jack, let it despawn, watch Weeping Willow respawn 30 minutes later. 
