### PR TITLE
[sql] Adds missing Delimiter to triggers.sql

### DIFF
--- a/sql/triggers.sql
+++ b/sql/triggers.sql
@@ -99,3 +99,5 @@ BEGIN
     INSERT INTO `char_storage`   SET `charid` = NEW.charid;
     INSERT INTO `char_unlocks`   SET `charid` = NEW.charid;
 END $$
+
+DELIMITER ;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes an dbtool hanging on `triggers.sql` occasionally 

Any trigger we add needs the DELIMITER set to $$. After the trigger is created the DELIMITER needs to be set back to ;. Seems like when this was made it was just accidently never added to the file.

This adds the `DELIMITER ;` after the last trigger definition so the mysql client returns to normal statement parsing before dbtool continues
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Run dbtool see it doesnt get stuck on triggers randomly
<!-- Clear and detailed steps to test your changes here -->
