### PR TITLE
[core] Revert router ZMQ socket to blocking wait

### DIFF
--- a/src/common/zmq_router_wrapper.h
+++ b/src/common/zmq_router_wrapper.h
@@ -83,7 +83,7 @@ class ZMQRouterWrapper final
                 std::array<zmq::message_t, 2> msgs;
                 try
                 {
-                    if (!zmq::recv_multipart_n(zmqSocket_, msgs.data(), msgs.size(), zmq::recv_flags::dontwait))
+                    if (!zmq::recv_multipart_n(zmqSocket_, msgs.data(), msgs.size(), zmq::recv_flags::none))
                     {
                         IPPMessage msg;
                         while (outgoingQueue_.try_dequeue(msg))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Router socket was changed to dontwait which processes the empty queue in an infinite fashion with 0 wait and uses an entire core.

This PR reverts it to the former socket flags based on the assumption this was done for testing purposes and not for actual issues (of which I am seeing none after retesting).

If not we should probably go the epoll/select route on those sockets.

Closes #10292 

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
