### PR TITLE
[lua] Event Skipped and Cutscene Audit for CoP 2-5 to 5-2

### DIFF
--- a/scripts/missions/cop/3_3_The_Road_Forks.lua
+++ b/scripts/missions/cop/3_3_The_Road_Forks.lua
@@ -135,7 +135,7 @@ mission.sections =
                         if mission:getLocalVar(player, 'ivyDefeated') == 1 then
                             local isSanDorian = player:getNation() == xi.nation.SANDORIA and 1 or 0
 
-                            return mission:progressEvent(0, isSanDorian)
+                            return mission:progressCutscene(0, isSanDorian)
                         elseif not GetMobByID(carpentersLandingID.mob.OVERGROWN_IVY):isSpawned() then
                             player:messageText(npc, carpentersLandingID.text.YOU_WISH_TO_KNOW_MISTALLE)
                             player:messageText(npc, carpentersLandingID.text.SQUASH_ANOTHER_WORM)

--- a/scripts/missions/cop/4_1_Sheltering_Doubt.lua
+++ b/scripts/missions/cop/4_1_Sheltering_Doubt.lua
@@ -76,7 +76,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if mission:getVar(player, 'Status') >= 2 then
-                        return mission:progressEvent(7)
+                        return mission:progressCutscene(7)
                     end
                 end,
             },

--- a/scripts/missions/cop/4_2_The_Savage.lua
+++ b/scripts/missions/cop/4_2_The_Savage.lua
@@ -28,7 +28,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if mission:getVar(player, 'Status') == 0 then
-                        return mission:progressEvent(8)
+                        return mission:progressCutscene(8)
                     end
                 end,
             },

--- a/scripts/missions/cop/4_3_The_Secrets_of_Worship.lua
+++ b/scripts/missions/cop/4_3_The_Secrets_of_Worship.lua
@@ -106,7 +106,7 @@ mission.sections =
                     local missionStatus = mission:getVar(player, 'Status')
 
                     if missionStatus == 1 then
-                        return mission:progressEvent(9)
+                        return mission:progressCutscene(9)
                     elseif missionStatus > 1 then
                         return mission:event(502)
                     end
@@ -139,9 +139,9 @@ mission.sections =
 
                     if player:getXPos() > 45 then
                         if missionStatus == 2 then
-                            return mission:progressEvent(6, 0, xi.ki.RELIQUIARIUM_KEY)
+                            return mission:progressCutscene(6, 0, xi.ki.RELIQUIARIUM_KEY)
                         elseif missionStatus == 3 and player:hasKeyItem(xi.ki.RELIQUIARIUM_KEY) then
-                            return mission:progressEvent(5)
+                            return mission:progressCutscene(5)
                         end
                     else
                         return mission:messageSpecial(sacrariumID.text.CANNOT_OPEN_SIDE)
@@ -190,7 +190,7 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if player:getXPos() > 45 then
                         if player:hasKeyItem(xi.ki.RELIQUIARIUM_KEY) then
-                            player:startEvent(110)
+                            player:startCutscene(110)
                         end
                     else
                         return mission:messageSpecial(sacrariumID.text.CANNOT_OPEN_SIDE)

--- a/scripts/missions/cop/5_1_The_Enduring_Tumult_of_War.lua
+++ b/scripts/missions/cop/5_1_The_Enduring_Tumult_of_War.lua
@@ -155,9 +155,9 @@ mission.sections =
                         return mission:noAction()
                     elseif missionStatus == 4 then
                         if player:getZPos() < 318 then
-                            return mission:progressEvent(69)
+                            return mission:progressOptionalCutscene(69, { cs_option = 0, canSkip = true })
                         else
-                            return mission:progressEvent(70)
+                            return mission:progressOptionalCutscene(70, { cs_option = 0, canSkip = true })
                         end
                     end
                 end,

--- a/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
+++ b/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
@@ -65,7 +65,7 @@ local memoryFluxOnTrigger = function(player, npc)
         SpawnMob(fluxInfo[2]):updateClaim(player)
         return mission:messageSpecial(promyvionVahzlID.text.ON_NM_SPAWN)
     elseif not mission:isVarBitsSet(player, 'Option', fluxInfo[1] + 3) then
-        return mission:progressEvent(fluxInfo[3])
+        return mission:progressCutscene(fluxInfo[3])
     end
 end
 

--- a/scripts/zones/Beaucedine_Glacier/npcs/Iron_Grate.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Iron_Grate.lua
@@ -17,17 +17,17 @@ entity.onTrigger = function(player, npc)
     local zPos = player:getZPos()
 
     if xPos < 247 and xPos > 241 then         -- J-8
-        player:startEvent(200)
+        player:startOptionalCutscene(200, { cs_option = 0, canSkip = true })
     elseif zPos < -353 and zPos > -359 then  -- H-10
-        player:startEvent(201)
+        player:startOptionalCutscene(201, { cs_option = 0, canSkip = true })
     elseif xPos > 95 and xPos < 104 and zPos > 153 and zPos < 159 then    -- I-7
-        player:startEvent(202)
+        player:startOptionalCutscene(202, { cs_option = 0, canSkip = true })
     elseif xPos < -193 and xPos > -199 then     -- G-9
-        player:startEvent(203)
+        player:startOptionalCutscene(203, { cs_option = 0, canSkip = true })
     elseif zPos > -47 and zPos < -41 then     -- H-8
-        player:startEvent(204)
+        player:startOptionalCutscene(204, { cs_option = 0, canSkip = true })
     elseif xPos > -344 and xPos < -337 and zPos > 153 and zPos < 159 then    -- F-7
-        player:startEvent(205)
+        player:startOptionalCutscene(205, { cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Misareaux_Coast/npcs/_0p2.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/_0p2.lua
@@ -13,7 +13,7 @@ entity.onTrigger = function(player, npc)
         player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.AN_ETERNAL_MELODY or
         player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE)
     then
-        player:startOptionalCutscene(552)
+        player:startCutscene(552)
     end
 end
 

--- a/scripts/zones/Misareaux_Coast/npcs/_0p8.lua
+++ b/scripts/zones/Misareaux_Coast/npcs/_0p8.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_SECRETS_OF_WORSHIP) then
-        player:startOptionalCutscene(502)
+        player:startCutscene(502)
     else
         player:messageSpecial(ID.text.DOOR_CLOSED)
     end

--- a/scripts/zones/PsoXja/npcs/_i97.lua
+++ b/scripts/zones/PsoXja/npcs/_i97.lua
@@ -10,9 +10,9 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local posZ = player:getZPos()
     if player:hasKeyItem(xi.ki.PSOXJA_PASS) and posZ >= 25 then
-        player:startEvent(14)
+        player:startOptionalCutscene(14, { cs_option = 0, canSkip = true })
     elseif posZ < 25 then
-        player:startEvent(17)
+        player:startOptionalCutscene(17, { cs_option = 0, canSkip = true })
     else
         player:messageSpecial(ID.text.DOOR_LOCKED)
     end

--- a/scripts/zones/PsoXja/npcs/_i98.lua
+++ b/scripts/zones/PsoXja/npcs/_i98.lua
@@ -13,9 +13,9 @@ entity.onTrigger = function(player, npc)
         player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_LAST_VERSE)
     then
         if player:getZPos() < 318 then
-            player:startEvent(69)
+            player:startOptionalCutscene(69, { cs_option = 0, canSkip = true })
         else
-            player:startEvent(70)
+            player:startOptionalCutscene(70, { cs_option = 0, canSkip = true })
         end
     else
         player:messageSpecial(ID.text.DOOR_LOCKED)

--- a/scripts/zones/Riverne-Site_A01/globals.lua
+++ b/scripts/zones/Riverne-Site_A01/globals.lua
@@ -22,7 +22,7 @@ local riverneA01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startOptionalCutscene(event, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_A01/npcs/Spatial_Displacement.lua
@@ -10,9 +10,9 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.DISPLACEMENT_OFFSET
     if offset >= 0 and offset <= 2 then
-        player:startOptionalCutscene(offset + 2)
+        player:startOptionalCutscene(offset + 2, { cs_option = 0, canSkip = true })
     elseif offset >= 7 and offset <= 39 then
-        player:startOptionalCutscene(offset)
+        player:startOptionalCutscene(offset, { cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Riverne-Site_B01/globals.lua
+++ b/scripts/zones/Riverne-Site_B01/globals.lua
@@ -22,7 +22,7 @@ local riverneB01Global =
         ..............................................................................................]]
     unstableDisplacementTrigger = function(player, npc, event)
         if npc:getAnimation() == xi.anim.OPEN_DOOR then
-            player:startEvent(event)
+            player:startOptionalCutscene(event, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.SD_VERY_SMALL)
         end

--- a/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
+++ b/scripts/zones/Riverne-Site_B01/npcs/Spatial_Displacement.lua
@@ -10,11 +10,11 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.DISPLACEMENT_OFFSET
     if offset >= 0 and offset <= 31 then
-        player:startOptionalCutscene(offset + 2)
+        player:startOptionalCutscene(offset + 2, { cs_option = 0, canSkip = true })
     elseif offset == 34 then
-        player:startOptionalCutscene(22)
+        player:startOptionalCutscene(22, { cs_option = 0, canSkip = true })
     elseif offset > 35 and offset <= 41 then
-        player:startOptionalCutscene(offset)
+        player:startOptionalCutscene(offset, { cs_option = 0, canSkip = true })
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates events to drop emnity and/or have Event Skipped for CoP 2-5 through 5-2 missions and their respective zones.

## Steps to test these changes

Go to each location with the event flag and test you can get Event Skipped and drop aggro where appropriate.

## Retail Proof

CoP 2-5: https://youtu.be/48X2KiTnFkc
CoP 3-3: https://youtu.be/M5LmXpToZDg
CoP 4-1: https://youtu.be/Dijg8XACdX8
CoP 4-2: https://youtu.be/06IEF5KbpxU
CoP 4-3 Wooden Gate: https://youtu.be/4ms3nJEZ7qU and https://youtu.be/lDSn777SauI
CoP 5-1: https://youtu.be/oTo0h23mn_E
CoP 5-2: https://youtu.be/_l2N1f9pkGI
Beaucedine Gates: https://youtu.be/_WHMgg7acvQ
Riverne: https://youtu.be/qdzmAEDdPN4 and https://youtu.be/KKSBJ95S4ts and https://youtu.be/Rjq7aiCYNdM
Misareaux Coast: https://youtu.be/XSyuMAeUlcE
Pso Key Door: https://youtu.be/BrFTh35ggmA
