### PR TITLE
[login] Mark char data structs as stale on successful login

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -129,7 +129,7 @@ void data_session::read_func()
 
                 uint32_t i = 0;
 
-                // Generate on first time read from db
+                // Generate on first time read from db or after the account logs out after a log in
                 if (!generatedCharInfo)
                 {
                     characterInfoResponse            = {};
@@ -513,7 +513,8 @@ void data_session::read_func()
                 viewSession->socket_.lowest_layer().close();
                 session.view_session = nullptr;
 
-                session.incrementKeyValue = 0; // Reset incremented key after inserting into db
+                session.incrementKeyValue = 0;     // Reset incremented key after inserting into db
+                generatedCharInfo         = false; // Reset this so next time we log out it regenerates the char info
 
                 const auto payload = ipc::toBytesWithHeader(ipc::CharZone{
                     .charId            = charid,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I noticed while doing some devving that my login screen was stale, and sure enough it was. So this PR fixes that

## Steps to test these changes

log in, change some gear, log out, see that the change is reflected.
