### PR TITLE
[C++] [lua] Implement Retail Accurate Automaton Skill Caps

### DIFF
--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -423,6 +423,67 @@ xi.pets.automaton.frameStats =
     },
 }
 
+xi.pets.automaton.skillCaps =
+{
+    -- Base frame ranks, an unlisted skill means no skill unless combined with a head that grants it.
+    frames =
+    {
+        [xi.automaton.frame.HARLEQUIN] =
+        {
+            [xi.skill.AUTOMATON_MELEE ] = xi.skillRank.B_MINUS,
+            [xi.skill.AUTOMATON_RANGED] = xi.skillRank.B_MINUS,
+            [xi.skill.AUTOMATON_MAGIC ] = xi.skillRank.B_MINUS,
+        },
+
+        [xi.automaton.frame.VALOREDGE] =
+        {
+            [xi.skill.AUTOMATON_MELEE] = xi.skillRank.B_PLUS,
+        },
+
+        [xi.automaton.frame.SHARPSHOT] =
+        {
+            [xi.skill.AUTOMATON_MELEE ] = xi.skillRank.C_PLUS,
+            [xi.skill.AUTOMATON_RANGED] = xi.skillRank.B_PLUS,
+        },
+
+        [xi.automaton.frame.STORMWAKER] =
+        {
+            [xi.skill.AUTOMATON_MELEE] = xi.skillRank.C,
+            [xi.skill.AUTOMATON_MAGIC] = xi.skillRank.B_PLUS,
+        },
+    },
+
+    -- Head Bonuses. For skill rank ENUMs, lower is better. Example : xi.skillRank.B_PLUS(3) -2 = xi.skillRank.A_PLUS(1)
+    -- If this bonus is applied to a frame that does not have that skill innately, becomes xi.skillRank.F.
+    heads =
+    {
+        [xi.automaton.head.VALOREDGE] =
+        {
+            [xi.skill.AUTOMATON_MELEE] = -2,
+        },
+
+        [xi.automaton.head.SHARPSHOT] =
+        {
+            [xi.skill.AUTOMATON_RANGED] = -2,
+        },
+
+        [xi.automaton.head.STORMWAKER] =
+        {
+            [xi.skill.AUTOMATON_MAGIC] = -2,
+        },
+
+        [xi.automaton.head.SOULSOOTHER] =
+        {
+            [xi.skill.AUTOMATON_MAGIC] = -2,
+        },
+
+        [xi.automaton.head.SPIRITREAVER] =
+        {
+            [xi.skill.AUTOMATON_MAGIC] = -2,
+        },
+    },
+}
+
 xi.pets.automaton.frameMods =
 {
     -----------------------------------
@@ -432,7 +493,7 @@ xi.pets.automaton.frameMods =
     {
         mods =
         {
-            { xi.mod.DMG,              -625 },
+            { xi.mod.DMG, -625 },
         },
     },
 
@@ -460,9 +521,9 @@ xi.pets.automaton.frameMods =
     {
         mods =
         {
-            { xi.mod.PIERCE_SDT,       8750 },
-            { xi.mod.DMGBREATH,       -1250 },
-            { xi.mod.DMGMAGIC,        -1250 },
+            { xi.mod.PIERCE_SDT,  8750 },
+            { xi.mod.DMGBREATH,  -1250 },
+            { xi.mod.DMGMAGIC,   -1250 },
         },
     },
 
@@ -473,8 +534,8 @@ xi.pets.automaton.frameMods =
     {
         mods =
         {
-            { xi.mod.DMGBREATH,       -2500 },
-            { xi.mod.DMGMAGIC,        -2500 },
+            { xi.mod.DMGBREATH, -2500 },
+            { xi.mod.DMGMAGIC,  -2500 },
         },
     },
 }

--- a/src/map/utils/puppetutils.cpp
+++ b/src/map/utils/puppetutils.cpp
@@ -466,76 +466,70 @@ auto getSkillCap(const CCharEntity* PChar, const SKILLTYPE skill, const uint8 le
         return 0;
     }
 
-    int8 rank = 0;
     if (skill < SKILL_AUTOMATON_MELEE || skill > SKILL_AUTOMATON_MAGIC)
     {
         return 0;
     }
-    switch (PChar->getAutomatonFrame())
+
+    const auto frame    = static_cast<uint8>(PChar->getAutomatonFrame());
+    const auto head     = static_cast<uint8>(PChar->getAutomatonHead());
+    const auto skillKey = static_cast<uint8>(skill);
+
+    const auto maybeSkillCaps = lua["xi"]["pets"]["automaton"]["skillCaps"].get<sol::optional<sol::table>>();
+    if (!maybeSkillCaps)
     {
-        default: // case Harlequin:
-            rank = 5;
-            break;
-        case AutomatonFrame::Valoredge:
-            if (skill == SKILL_AUTOMATON_MELEE)
-            {
-                rank = 2;
-            }
-            break;
-        case AutomatonFrame::Sharpshot:
-            if (skill == SKILL_AUTOMATON_MELEE)
-            {
-                rank = 6;
-            }
-            else if (skill == SKILL_AUTOMATON_RANGED)
-            {
-                rank = 3;
-            }
-            break;
-        case AutomatonFrame::Stormwaker:
-            if (skill == SKILL_AUTOMATON_MELEE)
-            {
-                rank = 7;
-            }
-            else if (skill == SKILL_AUTOMATON_MAGIC)
-            {
-                rank = 3;
-            }
-            break;
+        ShowError("puppetutils::getSkillCap() - Missing xi.pets.automaton.skillCaps");
+        return 0;
     }
 
-    switch (PChar->getAutomatonHead())
+    const auto& skillCaps = *maybeSkillCaps;
+
+    const auto maybeFrames = skillCaps["frames"].get<sol::optional<sol::table>>();
+    if (!maybeFrames)
     {
-        case AutomatonHead::Valoredge:
-            if (skill == SKILL_AUTOMATON_MELEE)
-            {
-                rank -= 1;
-            }
-            break;
-        case AutomatonHead::Sharpshot:
-            if (skill == SKILL_AUTOMATON_RANGED)
-            {
-                rank -= 1;
-            }
-            break;
-        case AutomatonHead::Stormwaker:
-            if (skill == SKILL_AUTOMATON_MELEE || skill == SKILL_AUTOMATON_MAGIC)
-            {
-                rank -= 1;
-            }
-            break;
-        case AutomatonHead::Soulsoother:
-        case AutomatonHead::Spiritreaver:
-            if (skill == SKILL_AUTOMATON_MAGIC)
-            {
-                rank -= 2;
-            }
-            break;
-        default:
-            break;
+        ShowError("puppetutils::getSkillCap() - Missing xi.pets.automaton.skillCaps.frames");
+        return 0;
     }
 
-    // only happens if a head gives bonus to a rank of 0 - making it G or F rank
+    const auto& frames = *maybeFrames;
+
+    const auto maybeFrameCaps = frames[frame].get<sol::optional<sol::table>>();
+    if (!maybeFrameCaps)
+    {
+        ShowErrorFmt("puppetutils::getSkillCap() - Missing automaton skill caps for frame {}", static_cast<uint16>(frame));
+        return 0;
+    }
+
+    const auto& frameCaps = *maybeFrameCaps;
+
+    // Grab the skill cap for the frame, then apply the bonus from the head if applicable.
+    int8 rank = 0;
+
+    const auto maybeFrameRank = frameCaps[skillKey].get<sol::optional<int8>>();
+    if (maybeFrameRank)
+    {
+        rank = *maybeFrameRank;
+    }
+
+    const auto maybeHeads = skillCaps["heads"].get<sol::optional<sol::table>>();
+    if (maybeHeads)
+    {
+        const auto& heads = *maybeHeads;
+
+        const auto maybeHeadCaps = heads[head].get<sol::optional<sol::table>>();
+        if (maybeHeadCaps)
+        {
+            const auto& headCaps = *maybeHeadCaps;
+
+            const auto maybeHeadRank = headCaps[skillKey].get<sol::optional<int8>>();
+            if (maybeHeadRank)
+            {
+                rank += *maybeHeadRank;
+            }
+        }
+    }
+
+    // Handle automaton frames with no native skill being combined with heads that give a bonus to that rank.
     if (rank < 0)
     {
         rank = 13 + rank;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Implements retail accurate automaton skill caps with spreadsheet from @sruon
* Adds a lookup table for the skill caps to automaton pets global
* Works seamlessly with merit packet fix from @WinterSolstice8 https://github.com/LandSandBoat/server/pull/10312

<img width="541" height="292" alt="image" src="https://github.com/user-attachments/assets/0fe3e2fc-771e-45e7-a7d3-368125ee0543" />

(B- Skill with +10 skill applied 5/5 Merits)

## Steps to test these changes

Mix and match automaton frames, get 100% accurate skill caps. 

## Source

https://docs.google.com/spreadsheets/d/1P1hKWKbeuUCNKoyzDGKzNE9p7K_bjX5VlqC4CSda8v0/edit?gid=581833385#gid=581833385