### PR TITLE
[lua] [sql] Implement Nott for Trusts

### DIFF
--- a/scripts/actions/mobskills/myrkr.lua
+++ b/scripts/actions/mobskills/myrkr.lua
@@ -11,7 +11,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local amount = math.floor(xi.mobskills.calculateDuration(skill:getTP(), 20, 60) * mob:getMaxMP() / 100)
+    local mpPercent = xi.combat.physical.calculateTPfactor(skill:getTP(), { 20, 40, 60 })
+    local amount    = math.floor(mob:getMaxMP() * mpPercent / 100)
 
     mob:addMP(amount)
     skill:setMsg(xi.msg.basic.SKILL_RECOVERS_MP)

--- a/scripts/actions/mobskills/nott.lua
+++ b/scripts/actions/mobskills/nott.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Dagan
+-- Nott
 -- Family: Humanoid Club Weaponskill
 -- Description: Restores HP and MP. Amount restored varies with TP.
 -----------------------------------
@@ -7,10 +7,14 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    mob:messageBasic(xi.msg.basic.READIES_SKILL, 0, xi.mobSkill.NOTT)
+
     return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    action:setCategory(xi.action.category.WEAPONSKILL_FINISH)
+
     local hpPercent = xi.combat.physical.calculateTPfactor(skill:getTP(), { 22, 33, 52 })
     local mpPercent = xi.combat.physical.calculateTPfactor(skill:getTP(), { 15, 22, 35 })
     local hp        = math.floor(mob:getMaxHP() * hpPercent / 100)

--- a/scripts/actions/spells/trust/apururu_uc.lua
+++ b/scripts/actions/spells/trust/apururu_uc.lua
@@ -27,10 +27,11 @@ spellObject.onMobSpawn = function(mob)
 
     -- Unity ranking high : xi.trust.message(mob, xi.trust.messageOffset.TEAMWORK_1)
 
-    -- TODO: Nott weaponskill needs implemented and logic added here for Apururu to use at 50% MP at level 50.
     -- TODO: UC trusts are supposed to get bonuses depending on unity ranking. Needs research.
     -- TODO: Custom spawn messages if Unity ranking is higher.
     -- TODO: Setup conditional behaviors for Devotion, Martyr
+
+    mob:addGambit(ai.t.SELF, { { ai.c.MPP_LT, 51 }, { ai.c.LVL_GTE, 50 }, { ai.c.TP_GTE, 1000 } }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.NOTT })
 
     mob:addGambit(ai.t.SELF, { ai.c.MPP_LT, 25 }, { ai.r.JA, ai.s.SPECIFIC, xi.ja.CONVERT })
 

--- a/scripts/actions/spells/trust/sylvie_uc.lua
+++ b/scripts/actions/spells/trust/sylvie_uc.lua
@@ -22,7 +22,6 @@ spellObject.onMobSpawn = function(mob)
 
     local mJob   = master:getMainJob()
 
-    -- TODO: Nott weaponskill needs implemented and logic added here for Apururu to use at 50% MP at level 50.
     -- Has Regain (50/tick) and uses Nott when MP falls below 66%.
     -- cure IV cures 456 HP @99
 
@@ -33,6 +32,8 @@ spellObject.onMobSpawn = function(mob)
     if mob:getMainLvl() >= 99 then
         mob:addMod(xi.mod.GEOMANCY_BONUS, 3)
     end
+
+    mob:addGambit(ai.t.SELF, { { ai.c.MPP_LT, 66 }, { ai.c.LVL_GTE, 50 }, { ai.c.TP_GTE, 1000 } }, { ai.r.MS, ai.s.SPECIFIC, xi.mobSkill.NOTT })
 
     mob:addGambit(ai.t.PARTY, { ai.c.HPP_LT, 25 }, { ai.r.MA, ai.s.HIGHEST, xi.magic.spellFamily.CURE })
 

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -1257,6 +1257,8 @@ xi.mobSkill =
     -- AZURE_LORE                    = 3481,
     BOLSTER                       = 3482,
 
+    NOTT                          = 3502,
+
     DAYBREAK_TRUST                = 3652, -- August Trust
     TARTARIC_SIGIL_TRUST          = 3653, -- August Trust
     NULL_FIELD_TRUST              = 3654, -- August Trust

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -3530,7 +3530,7 @@ INSERT INTO `mob_skills` VALUES (3496,2505,'hollow_smite',0,0.0,7.0,2000,1500,4,
 -- INSERT INTO `mob_skills` VALUES (3499,3243,'soturis_fury',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3500,3244,'celidons_torment',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3501,3245,'tachi_mudo',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (3502,89,'nott',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (3502,89,'nott',0,0.0,7.0,2000,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (3503,3247,'justicebreaker',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3504,3248,'rancid_breath',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (3505,3249,'geotic_spin',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Implements Nott, a skill similar to Dagan that restores HP/MP
* Adds Nott Gambit support to Apururu (UC) and Sylvie (UC)
* Includes some minor bug fixes to Dagan and Myrkr mobskills.

## Steps to test these changes

!changejob to any job 50 or higher
!addalltrusts
Summon Apururu (UC)
See them use Nott @ 50% MP or below with 1000 TP

## Source

https://www.bg-wiki.com/ffxi/Nott