### PR TITLE
Fix Emote rate limit to 1 sec

### DIFF
--- a/src/map/packets/c2s/rate_limiter.cpp
+++ b/src/map/packets/c2s/rate_limiter.cpp
@@ -30,7 +30,7 @@ PacketRateLimiter::PacketRateLimiter()
 {
     rateLimits_[0x017] = 1s;    // Invalid NPC Information Response
     rateLimits_[0x03B] = 1s;    // Mannequin Equip
-    rateLimits_[0x05D] = 2s;    // Emotes
+    rateLimits_[0x05D] = 1s;    // Emotes
     rateLimits_[0x083] = 250ms; // Vendor Shop Purchase
     rateLimits_[0x0AA] = 250ms; // Guild Shop Purchase
     rateLimits_[0x0B7] = 1s;    // Assist Channel


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the Emote rate limit to 1 sec to match retail

<img width="314" height="157" alt="emote spam" src="https://github.com/user-attachments/assets/24b704af-e46f-4cf9-bbe9-46ac6fc5df85" />

## Steps to test these changes

Log into retail, spam emotes, notice in the log a message every sec, captures will also support this as shown in the above picture

<img width="313" height="133" alt="emote spame log" src="https://github.com/user-attachments/assets/afea54d2-30a0-4055-89d3-0288dfe720a6" />

