### PR TITLE
[lua] Update COR roll effect luas

### DIFF
--- a/scripts/effects/beast_roll.lua
+++ b/scripts/effects/beast_roll.lua
@@ -15,6 +15,7 @@ end
 effectObject.onEffectLose = function(target, effect)
     target:delPetMod(xi.mod.ATTP, effect:getPower())
     target:delPetMod(xi.mod.RATTP, effect:getPower())
+    xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 
 return effectObject

--- a/scripts/effects/blitzers_roll.lua
+++ b/scripts/effects/blitzers_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.DELAYP, effect:getPower())
+    effect:addMod(xi.mod.DELAYP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.DELAYP, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/casters_roll.lua
+++ b/scripts/effects/casters_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.FASTCAST, effect:getPower())
+    effect:addMod(xi.mod.FASTCAST, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.FASTCAST, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/chaos_roll.lua
+++ b/scripts/effects/chaos_roll.lua
@@ -5,16 +5,15 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ATTP, effect:getPower())
-    target:addMod(xi.mod.RATTP, effect:getPower())
+    effect:addMod(xi.mod.ATTP, effect:getPower())
+    effect:addMod(xi.mod.RATTP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ATTP, effect:getPower())
-    target:delMod(xi.mod.RATTP, effect:getPower())
+    xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 
 return effectObject

--- a/scripts/effects/choral_roll.lua
+++ b/scripts/effects/choral_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SPELLINTERRUPT, effect:getPower())
+    effect:addMod(xi.mod.SPELLINTERRUPT, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SPELLINTERRUPT, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/corsairs_roll.lua
+++ b/scripts/effects/corsairs_roll.lua
@@ -5,8 +5,8 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.EXP_BONUS, effect:getPower())
-    target:addMod(xi.mod.CAPACITY_BONUS, effect:getPower())
+    effect:addMod(xi.mod.EXP_BONUS, effect:getPower())
+    effect:addMod(xi.mod.CAPACITY_BONUS, effect:getPower())
     -- TODO: Exemplar Points (Not Implemented)
 end
 
@@ -14,8 +14,6 @@ effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.EXP_BONUS, effect:getPower())
-    target:delMod(xi.mod.CAPACITY_BONUS, effect:getPower())
     -- TODO: Exemplar Points (Not Implemented)
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end

--- a/scripts/effects/coursers_roll.lua
+++ b/scripts/effects/coursers_roll.lua
@@ -6,14 +6,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    -- target:addMod(xi.mod.SNAPSHOT, effect:getPower())
+    -- effect:addMod(xi.mod.SNAPSHOT, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    -- target:delMod(xi.mod.SNAPSHOT, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/dancers_roll.lua
+++ b/scripts/effects/dancers_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.REGEN, effect:getPower())
+    effect:addMod(xi.mod.REGEN, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.REGEN, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/evokers_roll.lua
+++ b/scripts/effects/evokers_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.REFRESH, effect:getPower())
+    effect:addMod(xi.mod.REFRESH, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.REFRESH, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/fighters_roll.lua
+++ b/scripts/effects/fighters_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.DOUBLE_ATTACK, effect:getPower())
+    effect:addMod(xi.mod.DOUBLE_ATTACK, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.DOUBLE_ATTACK, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/gallants_roll.lua
+++ b/scripts/effects/gallants_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.DMG, -effect:getPower())
+    effect:addMod(xi.mod.DMG, -effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.DMG, -effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/healers_roll.lua
+++ b/scripts/effects/healers_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.CURE_POTENCY_RCVD, effect:getPower())
+    effect:addMod(xi.mod.CURE_POTENCY_RCVD, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.CURE_POTENCY_RCVD, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/hunters_roll.lua
+++ b/scripts/effects/hunters_roll.lua
@@ -5,16 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ACC, effect:getPower())
-    target:addMod(xi.mod.RACC, effect:getPower())
+    effect:addMod(xi.mod.ACC, effect:getPower())
+    effect:addMod(xi.mod.RACC, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ACC, effect:getPower())
-    target:delMod(xi.mod.RACC, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/maguss_roll.lua
+++ b/scripts/effects/maguss_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MDEF, effect:getPower())
+    effect:addMod(xi.mod.MDEF, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MDEF, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/misers_roll.lua
+++ b/scripts/effects/misers_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SAVETP, effect:getPower())
+    effect:addMod(xi.mod.SAVETP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SAVETP, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/monks_roll.lua
+++ b/scripts/effects/monks_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.SUBTLE_BLOW, effect:getPower())
+    effect:addMod(xi.mod.SUBTLE_BLOW, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.SUBTLE_BLOW, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/naturalists_roll.lua
+++ b/scripts/effects/naturalists_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.ENH_MAGIC_DURATION, effect:getPower())
+    effect:addMod(xi.mod.ENH_MAGIC_DURATION, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.ENH_MAGIC_DURATION, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/ninja_roll.lua
+++ b/scripts/effects/ninja_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.EVA, effect:getPower())
+    effect:addMod(xi.mod.EVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.EVA, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/rogues_roll.lua
+++ b/scripts/effects/rogues_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.CRITHITRATE, effect:getPower())
+    effect:addMod(xi.mod.CRITHITRATE, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.CRITHITRATE, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/runeists_roll.lua
+++ b/scripts/effects/runeists_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MEVA, effect:getPower())
+    effect:addMod(xi.mod.MEVA, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MEVA, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/samurai_roll.lua
+++ b/scripts/effects/samurai_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.STORETP, effect:getPower())
+    effect:addMod(xi.mod.STORETP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.STORETP, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/scholars_roll.lua
+++ b/scripts/effects/scholars_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.CONSERVE_MP, effect:getPower())
+    effect:addMod(xi.mod.CONSERVE_MP, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.CONSERVE_MP, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/tacticians_roll.lua
+++ b/scripts/effects/tacticians_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.REGAIN, effect:getPower())
+    effect:addMod(xi.mod.REGAIN, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.REGAIN, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 

--- a/scripts/effects/warlocks_roll.lua
+++ b/scripts/effects/warlocks_roll.lua
@@ -5,14 +5,14 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MACC, effect:getPower())
+    effect:addMod(xi.mod.MACC, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MACC, effect:getPower())
+    xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 
 return effectObject

--- a/scripts/effects/wizards_roll.lua
+++ b/scripts/effects/wizards_roll.lua
@@ -5,14 +5,13 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MATT, effect:getPower())
+    effect:addMod(xi.mod.MATT, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MATT, effect:getPower())
     xi.job_utils.corsair.onRollEffectLose(target, effect)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Updates all COR roll effect luas to apply the mod to the effect and remove it from onEffectLose where possible. 
- Adds a few missing onRollEffectLose function calls.

## Steps to test these changes

- Use COR rolls and allow them to wear off/wipe them
- See the effect properly removes as expected