### PR TITLE
Update Variable/Polar Hare Drop

### DIFF
--- a/sql/mob_droplist.sql
+++ b/sql/mob_droplist.sql
@@ -16629,8 +16629,11 @@ INSERT INTO `mob_droplist` VALUES (2011,4,0,1000,2014,0);        -- Vial Of Bird
 -- ZoneID:   5 - Polar Hare
 -- ZoneID:   5 - Variable Hare
 INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,4358,@COMMON);  -- Slice Of Hare Meat (Common, 15%)
+INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,4358,@RARE); 	 -- Slice Of Hare Meat (Rare, 5%)
 INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,856,@UNCOMMON); -- Rabbit Hide (Uncommon, 10%)
+INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,856,@VRARE); 	 -- Rabbit Hide (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,4382,@RARE);    -- Frost Turnip (Rare, 5%)
+INSERT INTO `mob_droplist` VALUES (2012,0,0,1000,4382,@VRARE);   -- Frost Turnip (Very Rare, 1%)
 INSERT INTO `mob_droplist` VALUES (2012,2,0,1000,4382,0);        -- Frost Turnip (Steal)
 INSERT INTO `mob_droplist` VALUES (2012,4,0,1000,856,0);         -- Rabbit Hide (Despoil)
 INSERT INTO `mob_droplist` VALUES (2012,4,0,1000,4358,0);        -- Slice Of Hare Meat (Despoil)


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates the drop tables of variable hare and polar hare to more accurately represent observed drop rates on ffxidb

https://www.ffxidb.com/zones/5/variable-hare

Rather than simply rounding down the drop rates to get something "close enough", I excluded the possibility of other options. This adjustment assumes that the TH0 data has some poisoned TH1+, and the TH3+ data can have upwards of TH8 applied.

In this case, it's not possible to see an observed drop rate of 55% at TH3+ unless all 12,639 hares were killed with TH8. Since that's impossible, the drop rate *must* be higher than a base of 15%.

The same applies to an observed drop rate of 21% at TH0. While it's possible that this data is poisoned by TH1 from pets, trusts, or subjob, it would require something like 30% of the 15,747 to be killed this way. Same goes for the 477 kills with TH2.

NOTE: There are other statistically probable results from this data, but this result is the most likely given the information we have available to us and the functionality of the drop table.

Example: We may be fundamentally misunderstanding drop tables and monsters have a fall-through table. That means "rabbits can only drop 1 rabbit meat" --> "this rabbit actually has a 20% chance, then a 10% chance, then a 5% chance to drop rabbit meat" 

## Steps to test these changes

read way too deep into numbers on ffxidb assuming its kind of bricked data
