### PR TITLE
[C++] [lua] Change ordering of LoadAutomaton() in lua_baseentity

### DIFF
--- a/scripts/commands/changejob.lua
+++ b/scripts/commands/changejob.lua
@@ -37,6 +37,20 @@ commandObj.onTrigger = function(player, jobId, level, master)
         end
     end
 
+    if jobId == xi.job.PUP then
+        if player:getAutomatonName() == '' then
+            player:setPetName(xi.petType.AUTOMATON, xi.petName.MK_IV)
+        end
+
+        if not player:hasAttachment(xi.item.HARLEQUIN_FRAME) then
+            player:unlockAttachment(xi.item.HARLEQUIN_FRAME)
+        end
+
+        if not player:hasAttachment(xi.item.HARLEQUIN_HEAD) then
+            player:unlockAttachment(xi.item.HARLEQUIN_HEAD)
+        end
+    end
+
     -- change job and (optionally) level
     player:changeJob(jobId)
     if level ~= nil then

--- a/scripts/commands/changesjob.lua
+++ b/scripts/commands/changesjob.lua
@@ -37,6 +37,20 @@ commandObj.onTrigger = function(player, jobId, level)
         end
     end
 
+    if jobId == xi.job.PUP then
+        if player:getAutomatonName() == '' then
+            player:setPetName(xi.petType.AUTOMATON, xi.petName.MK_IV)
+        end
+
+        if not player:hasAttachment(xi.item.HARLEQUIN_FRAME) then
+            player:unlockAttachment(xi.item.HARLEQUIN_FRAME)
+        end
+
+        if not player:hasAttachment(xi.item.HARLEQUIN_HEAD) then
+            player:unlockAttachment(xi.item.HARLEQUIN_HEAD)
+        end
+    end
+
     -- change job and (optionally) level
     player:changesJob(jobId)
     if level ~= nil then

--- a/src/map/lua/lua_baseentity.cpp
+++ b/src/map/lua/lua_baseentity.cpp
@@ -6924,6 +6924,7 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
         PChar->jobs.unlocked |= (1 << newJob);
         PChar->SetMJob(newJob);
         charutils::ApplyAllEquipMods(PChar);
+        puppetutils::LoadAutomaton(PChar);
 
         if (newJob == JOB_BLU)
         {
@@ -6937,7 +6938,6 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
             blueutils::UnequipAllBlueSpells(PChar);
         }
 
-        puppetutils::LoadAutomaton(PChar);
         charutils::SetStyleLock(PChar, false);
         luautils::CheckForGearSet(PChar); // check for gear set on gear change
         jobpointutils::RefreshGiftMods(PChar);
@@ -6970,6 +6970,7 @@ void CLuaBaseEntity::changeJob(uint8 newJob)
         PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(PChar);
         PChar->pushPacket<CCharStatusPacket>(PChar);
+        charutils::SendExtendedJobPackets(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MERITS>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY1>(PChar);
         PChar->pushPacket<GP_SERV_COMMAND_MISCDATA::MONSTROSITY2>(PChar);
@@ -7073,6 +7074,7 @@ void CLuaBaseEntity::changesJob(uint8 subJob)
 
     PChar->jobs.unlocked |= (1 << subJob);
     PChar->SetSJob(subJob);
+    puppetutils::LoadAutomaton(PChar);
     charutils::UpdateSubJob(PChar);
 
     if (subJob == JOB_BLU)
@@ -7084,7 +7086,7 @@ void CLuaBaseEntity::changesJob(uint8 subJob)
         blueutils::UnequipAllBlueSpells(PChar);
     }
 
-    puppetutils::LoadAutomaton(PChar);
+    charutils::SendExtendedJobPackets(PChar);
 }
 
 /************************************************************************


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

!changejob PUP was giving an error when switching to the job without a frame unlocked. After editing the GM command to award the frames if they didn't have any I was still getting an error. 

Digging a little further I found that the ordering for LoadAutomaton() was being called after UnequipAllBlueSpells(); - this was forcing the extended job packet to attempt to load before the frames could be setup. Also adds missing SendExtendedJobPackets(); in both the main job and subjob path - mirroring the same flow as myroom_job.cpp. 

## Steps to test these changes

Make a brand new character, !changejob PUP 1 , see no error in map log, see Harlequin frames awarded/equipped immediately. Change to other jobs, see no errors. 
