### PR TITLE
[lua] [sql] Implement JA Heady Artifice

### DIFF
--- a/modules/era/lua/actions/abilities/pets/attachments/flame_holder.lua
+++ b/modules/era/lua/actions/abilities/pets/attachments/flame_holder.lua
@@ -17,18 +17,18 @@ local m = Module:new(moduleName)
 
 local validSkills = set
 {
-    xi.automaton.abilities.ARCUBALLISTA,
-    xi.automaton.abilities.ARMOR_PIERCER,
-    xi.automaton.abilities.ARMOR_SHATTERER,
-    xi.automaton.abilities.BONE_CRUSHER,
-    xi.automaton.abilities.CANNIBAL_BLADE,
-    xi.automaton.abilities.CHIMERA_RIPPER,
-    xi.automaton.abilities.DAZE,
-    xi.automaton.abilities.KNOCKOUT,
-    xi.automaton.abilities.MAGIC_MORTAR,
-    xi.automaton.abilities.SLAPSTICK,
-    xi.automaton.abilities.STRING_CLIPPER,
-    xi.automaton.abilities.STRING_SHREDDER,
+    xi.mobSkill.ARCUBALLISTA_AUTOMATON,
+    xi.mobSkill.ARMOR_PIERCER_AUTOMATON,
+    xi.mobSkill.ARMOR_SHATTERER_AUTOMATON,
+    xi.mobSkill.BONE_CRUSHER_AUTOMATON,
+    xi.mobSkill.CANNIBAL_BLADE_AUTOMATON,
+    xi.mobSkill.CHIMERA_RIPPER_AUTOMATON,
+    xi.mobSkill.DAZE_AUTOMATON,
+    xi.mobSkill.KNOCKOUT_AUTOMATON,
+    xi.mobSkill.MAGIC_MORTAR_AUTOMATON,
+    xi.mobSkill.SLAPSTICK_AUTOMATON,
+    xi.mobSkill.STRING_CLIPPER_AUTOMATON,
+    xi.mobSkill.STRING_SHREDDER_AUTOMATON,
 }
 
 m:addOverride('xi.actions.abilities.pets.attachments.flame_holder.onEquip', function(pet, attachment)

--- a/scripts/actions/abilities/heady_artifice.lua
+++ b/scripts/actions/abilities/heady_artifice.lua
@@ -11,8 +11,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return xi.job_utils.puppetmaster.onAbilityCheckHeadyArtiface(player, target, ability)
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/attachments/barrage_turbine.lua
+++ b/scripts/actions/abilities/pets/attachments/barrage_turbine.lua
@@ -7,7 +7,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_BARRAGE_TURBINE', function(automaton, target)
         -- If Barrage Turbine is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.BARRAGE_TURBINE_AUTOMATON) then
             return
         end
 
@@ -22,7 +22,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.BARRAGE_TURBINE, target)
+        automaton:useMobAbility(xi.mobSkill.BARRAGE_TURBINE_AUTOMATON, target)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/disruptor.lua
+++ b/scripts/actions/abilities/pets/attachments/disruptor.lua
@@ -9,7 +9,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_DISRUPTOR', function(automaton, target)
         -- If Disruptor is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.DISRUPTOR) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.DISRUPTOR_AUTOMATON) then
             return
         end
 
@@ -29,7 +29,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.DISRUPTOR, target)
+        automaton:useMobAbility(xi.mobSkill.DISRUPTOR_AUTOMATON, target)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/economizer.lua
+++ b/scripts/actions/abilities/pets/attachments/economizer.lua
@@ -18,7 +18,7 @@ local activationThresholds =
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_ECONOMIZER', function(automaton, target)
         -- If Economizer is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.ECONOMIZER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.ECONOMIZER_AUTOMATON) then
             return
         end
 
@@ -44,7 +44,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.ECONOMIZER, automaton)
+        automaton:useMobAbility(xi.mobSkill.ECONOMIZER_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/eraser.lua
+++ b/scripts/actions/abilities/pets/attachments/eraser.lua
@@ -79,7 +79,7 @@ end
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_ERASER', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.ERASER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.ERASER_AUTOMATON) then
             return
         end
 
@@ -109,7 +109,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.ERASER, eraserTarget)
+        automaton:useMobAbility(xi.mobSkill.ERASER_AUTOMATON, eraserTarget)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/flashbulb.lua
+++ b/scripts/actions/abilities/pets/attachments/flashbulb.lua
@@ -9,7 +9,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_FLASHBULB', function(automaton, target)
         -- If Flashbulb is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.FLASHBULB) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.FLASHBULB_AUTOMATON) then
             return
         end
 
@@ -26,7 +26,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.FLASHBULB)
+        automaton:useMobAbility(xi.mobSkill.FLASHBULB_AUTOMATON)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/heat_capacitor.lua
+++ b/scripts/actions/abilities/pets/attachments/heat_capacitor.lua
@@ -9,7 +9,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_HEAT_CAPACITOR', function(automaton, target)
         -- If Heat Capacitor is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.HEAT_CAPACITOR) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.HEAT_CAPACITOR_AUTOMATON) then
             return
         end
 
@@ -24,7 +24,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.HEAT_CAPACITOR, automaton)
+        automaton:useMobAbility(xi.mobSkill.HEAT_CAPACITOR_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/heat_capacitor_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/heat_capacitor_ii.lua
@@ -9,7 +9,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_HEAT_CAPACITOR', function(automaton, target)
         -- If Heat Capacitor is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.HEAT_CAPACITOR) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.HEAT_CAPACITOR_AUTOMATON) then
             return
         end
 
@@ -24,7 +24,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.HEAT_CAPACITOR, automaton)
+        automaton:useMobAbility(xi.mobSkill.HEAT_CAPACITOR_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/mana_converter.lua
+++ b/scripts/actions/abilities/pets/attachments/mana_converter.lua
@@ -17,7 +17,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_MANA_CONVERTER', function(automaton, target)
         -- If Mana Converter is on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.MANA_CONVERTER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.MANA_CONVERTER_AUTOMATON) then
             return
         end
 
@@ -47,7 +47,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.MANA_CONVERTER, automaton)
+        automaton:useMobAbility(xi.mobSkill.MANA_CONVERTER_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/reactive_shield.lua
+++ b/scripts/actions/abilities/pets/attachments/reactive_shield.lua
@@ -8,7 +8,7 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_REACTIVE_SHIELD', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.REACTIVE_SHIELD) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.REACTIVE_SHIELD_AUTOMATON) then
             return
         end
 
@@ -24,7 +24,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.REACTIVE_SHIELD, automaton)
+        automaton:useMobAbility(xi.mobSkill.REACTIVE_SHIELD_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/regulator.lua
+++ b/scripts/actions/abilities/pets/attachments/regulator.lua
@@ -9,7 +9,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_REGULATOR', function(automaton, target)
         -- If Regulator is still on cooldown, do nothing.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.REGULATOR) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.REGULATOR_AUTOMATON) then
             return
         end
 
@@ -29,7 +29,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.REGULATOR, target)
+        automaton:useMobAbility(xi.mobSkill.REGULATOR_AUTOMATON, target)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/replicator.lua
+++ b/scripts/actions/abilities/pets/attachments/replicator.lua
@@ -29,7 +29,7 @@ attachmentObject.onEquip = function(pet)
         end
 
         -- If Replicator is on cooldown, return.
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.REPLICATOR) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.REPLICATOR_AUTOMATON) then
             return
         end
 
@@ -48,7 +48,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.REPLICATOR, automaton)
+        automaton:useMobAbility(xi.mobSkill.REPLICATOR_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/shock_absorber.lua
+++ b/scripts/actions/abilities/pets/attachments/shock_absorber.lua
@@ -6,7 +6,7 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_SHOCK_ABSORBER', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.SHOCK_ABSORBER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.SHOCK_ABSORBER_AUTOMATON) then
             return
         end
 
@@ -20,7 +20,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.SHOCK_ABSORBER, automaton)
+        automaton:useMobAbility(xi.mobSkill.SHOCK_ABSORBER_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/shock_absorber_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/shock_absorber_ii.lua
@@ -6,7 +6,7 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_SHOCK_ABSORBER', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.SHOCK_ABSORBER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.SHOCK_ABSORBER_AUTOMATON) then
             return
         end
 
@@ -20,7 +20,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.SHOCK_ABSORBER, automaton)
+        automaton:useMobAbility(xi.mobSkill.SHOCK_ABSORBER_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/shock_absorber_iii.lua
+++ b/scripts/actions/abilities/pets/attachments/shock_absorber_iii.lua
@@ -6,7 +6,7 @@ local attachmentObject = {}
 
 attachmentObject.onEquip = function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_SHOCK_ABSORBER', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.SHOCK_ABSORBER) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.SHOCK_ABSORBER_AUTOMATON) then
             return
         end
 
@@ -20,7 +20,7 @@ attachmentObject.onEquip = function(pet)
             return
         end
 
-        automaton:useMobAbility(xi.automaton.abilities.SHOCK_ABSORBER, automaton)
+        automaton:useMobAbility(xi.mobSkill.SHOCK_ABSORBER_AUTOMATON, automaton)
     end)
 end
 

--- a/scripts/actions/abilities/pets/attachments/strobe.lua
+++ b/scripts/actions/abilities/pets/attachments/strobe.lua
@@ -8,7 +8,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_STROBE', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.PROVOKE) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.PROVOKE_AUTOMATON) then
             return
         end
 
@@ -23,7 +23,7 @@ attachmentObject.onEquip = function(pet, attachment)
         end
 
         if automaton:checkDistance(target) <= (16 + target:getHitboxSize() + automaton:getHitboxSize()) then -- Needs Verification
-            automaton:useMobAbility(xi.automaton.abilities.PROVOKE)
+            automaton:useMobAbility(xi.mobSkill.PROVOKE_AUTOMATON)
         end
     end)
 end

--- a/scripts/actions/abilities/pets/attachments/strobe_ii.lua
+++ b/scripts/actions/abilities/pets/attachments/strobe_ii.lua
@@ -8,7 +8,7 @@ local attachmentObject = {}
 attachmentObject.onEquip = function(pet, attachment)
     xi.automaton.onAttachmentEquip(pet, attachment)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_STROBE_II', function(automaton, target)
-        if automaton:hasRecast(xi.recast.ABILITY, xi.automaton.abilities.PROVOKE) then
+        if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.PROVOKE_AUTOMATON) then
             return
         end
 
@@ -23,7 +23,7 @@ attachmentObject.onEquip = function(pet, attachment)
         end
 
         if automaton:checkDistance(target) <= (16 + target:getHitboxSize() + automaton:getHitboxSize()) then -- Needs Verification
-            automaton:useMobAbility(xi.automaton.abilities.PROVOKE)
+            automaton:useMobAbility(xi.mobSkill.PROVOKE_AUTOMATON)
         end
     end)
 end

--- a/scripts/actions/abilities/pets/automaton/benediction_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/benediction_automaton.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Benediction (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    target:eraseAllStatusEffect()
+
+    local maxHeal = target:getMaxHP() - target:getHP()
+
+    target:addHP(maxHeal)
+    target:wakeUp()
+
+    skill:setMsg(xi.msg.basic.SELF_HEAL)
+
+    return maxHeal
+end
+
+return abilityObject

--- a/scripts/actions/abilities/pets/automaton/chainspell_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/chainspell_automaton.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Chainspell (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    xi.mobskills.mobBuffMove(target, xi.effect.CHAINSPELL, 1, 0, 60)
+
+    skill:setMsg(xi.msg.basic.USES)
+
+    return xi.effect.CHAINSPELL
+end
+
+return abilityObject

--- a/scripts/actions/abilities/pets/automaton/eagle_eye_shot_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/eagle_eye_shot_automaton.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Eagle Eye Shot (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    local params = {}
+
+    params.baseDamage     = math.floor(xi.automaton.getRangedBaseDamage(automaton))
+    params.numHits        = 1
+    params.fTP            = { 9.0, 9.0, 9.0 }
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.PIERCING
+    params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
+    params.skipParry      = true
+    params.skipGuard      = true
+    params.skipBlock      = true
+
+    local info = xi.mobskills.mobRangedMove(automaton, target, skill, action, params)
+
+    if xi.mobskills.processDamage(automaton, target, skill, action, info) then
+        target:takeDamage(info.damage, automaton, info.attackType, info.damageType)
+    end
+
+    return info.damage
+end
+
+return abilityObject

--- a/scripts/actions/abilities/pets/automaton/invincible_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/invincible_automaton.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Invincible (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    xi.mobskills.mobBuffMove(target, xi.effect.INVINCIBLE, 1, 0, 30)
+
+    skill:setMsg(xi.msg.basic.USES)
+
+    return xi.effect.INVINCIBLE
+end
+
+return abilityObject

--- a/scripts/actions/abilities/pets/automaton/manafont_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/manafont_automaton.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Manafont (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    xi.mobskills.mobBuffMove(target, xi.effect.MANAFONT, 1, 0, 60)
+
+    skill:setMsg(xi.msg.basic.USES)
+
+    return xi.effect.MANAFONT
+end
+
+return abilityObject

--- a/scripts/actions/abilities/pets/automaton/mighty_strikes_automaton.lua
+++ b/scripts/actions/abilities/pets/automaton/mighty_strikes_automaton.lua
@@ -1,0 +1,20 @@
+-----------------------------------
+-- Mighty Strikes (Automaton)
+-- TODO: Implement JP Bonuses
+-----------------------------------
+---@type TAbilityAutomaton
+local abilityObject = {}
+
+abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
+    return 0
+end
+
+abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
+    xi.mobskills.mobBuffMove(target, xi.effect.MIGHTY_STRIKES, 1, 0, 45)
+
+    skill:setMsg(xi.msg.basic.USES)
+
+    return xi.effect.MIGHTY_STRIKES
+end
+
+return abilityObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -1047,16 +1047,16 @@ xi.mobSkill =
     WARP_OUT_GESSHO               = 1938,
     WARP_IN_GESSHO                = 1939,
 
-    CHIMERA_RIPPER                = 1940,
-    STRING_CLIPPER                = 1941,
-    ARCUBALLISTA                  = 1942,
-    SLAPSTICK                     = 1943,
-    SHIELD_BASH_AUTOMATON         = 1944, -- Used by the trust Mnejing but may also be used by mobs.
-    PROVOKE_AUTOMATON             = 1945, -- Used by the trust Mnejing but may also be used by mobs.
-    FLASHBULB_AUTOMATON           = 1947, -- Used by the trust Mnejing but may also be used by mobs.
-    DISRUPTOR_AUTOMATON           = 2747, -- Used by the trust Mnejing but may also be used by mobs.
-
-    RANGED_ATTACK_15              = 1949,
+    CHIMERA_RIPPER_AUTOMATON      = 1940,
+    STRING_CLIPPER_AUTOMATON      = 1941,
+    ARCUBALLISTA_AUTOMATON        = 1942,
+    SLAPSTICK_AUTOMATON           = 1943,
+    SHIELD_BASH_AUTOMATON         = 1944,
+    PROVOKE_AUTOMATON             = 1945,
+    SHOCK_ABSORBER_AUTOMATON      = 1946,
+    FLASHBULB_AUTOMATON           = 1947,
+    MANA_CONVERTER_AUTOMATON      = 1948,
+    RANGED_ATTACK_AUTOMATON       = 1949,
 
     WATER_BOMB                    = 1959,
 
@@ -1094,6 +1094,7 @@ xi.mobSkill =
     DARK_SHOT                     = 2016,
 
     -- HUNDRED_FISTS                 = 2020,
+    ERASER_AUTOMATON              = 2021,
 
     TENEBROUS_MIST                = 2022,
     THUNDERSTRIKE                 = 2023,
@@ -1104,9 +1105,12 @@ xi.mobSkill =
     FULMINATION                   = 2028,
 
     ROAR_KHIMAIRA                 = 2030,
+    REACTIVE_SHIELD_AUTOMATON     = 2031,
 
-    DAZE                          = 2066,
-    KNOCKOUT                      = 2067,
+    CANNIBAL_BLADE_AUTOMATON      = 2065,
+    DAZE_AUTOMATON                = 2066,
+    KNOCKOUT_AUTOMATON            = 2067,
+    ECONOMIZER_AUTOMATON          = 2068,
 
     -- MIJIN_GAKURE                  = 2105,
 
@@ -1118,6 +1122,8 @@ xi.mobSkill =
     NECROPURGE                    = 2117,
     BILGESTORM                    = 2118,
     THUNDRIS_SHRIEK               = 2119,
+
+    REPLICATOR_AUTOMATON          = 2132,
 
     RADIANT_SACRAMENT             = 2141,
     MEGA_HOLY                     = 2142,
@@ -1158,6 +1164,10 @@ xi.mobSkill =
     -- OVERDRIVE                     = 2259,
     TRANCE                        = 2260,
     TABULA_RASA                   = 2261,
+
+    BONE_CRUSHER_AUTOMATON        = 2299,
+    ARMOR_PIERCER_AUTOMATON       = 2300,
+    MAGIC_MORTAR_AUTOMATON        = 2301,
 
     DI_HORN_ATTACK                = 2329,
     DI_BITE_ATTACK                = 2330,
@@ -1200,16 +1210,22 @@ xi.mobSkill =
 
     -- TRANCE                        = 2710,
 
+    STRING_SHREDDER_AUTOMATON     = 2743,
+    ARMOR_SHATTERER_AUTOMATON     = 2744,
+    HEAT_CAPACITOR_AUTOMATON      = 2745,
+    BARRAGE_TURBINE_AUTOMATON     = 2746,
+    DISRUPTOR_AUTOMATON           = 2747,
+
     BOOMING_BOMBINATION           = 2770,
 
     -- BENEDICTION                   = 2777,
 
-    -- MIGHTY_STRIKES                = 2939,
-    -- INVINCIBLE                    = 2940,
-    -- EES_?                         = 2941,
-    -- CHAINSPELL                    = 2942,
-    -- BENEDICTION                   = 2943,
-    -- MANAFONT                      = 2944,
+    MIGHTY_STRIKES_AUTOMATON      = 2939,
+    INVINCIBLE_AUTOMATON          = 2940,
+    EES_AUTOMATON                 = 2941,
+    CHAINSPELL_AUTOMATON          = 2942,
+    BENEDICTION_AUTOMATON         = 2943,
+    MANAFONT_AUTOMATON            = 2944,
 
     -- MEIKYO_SHISUI                 = 3175,
 
@@ -1256,6 +1272,7 @@ xi.mobSkill =
 
     -- AZURE_LORE                    = 3481,
     BOLSTER                       = 3482,
+    REGULATOR_AUTOMATON           = 3485,
 
     NOTT                          = 3502,
 

--- a/scripts/globals/automaton.lua
+++ b/scripts/globals/automaton.lua
@@ -4,36 +4,6 @@
 xi = xi or {}
 xi.automaton = xi.automaton or {}
 
-xi.automaton.abilities =
-{
-    CHIMERA_RIPPER  = 1940,
-    STRING_CLIPPER  = 1941,
-    ARCUBALLISTA    = 1942,
-    SLAPSTICK       = 1943,
-    SHIELD_BASH     = 1944,
-    PROVOKE         = 1945,
-    SHOCK_ABSORBER  = 1946,
-    FLASHBULB       = 1947,
-    MANA_CONVERTER  = 1948,
-    RANGED_ATTACK   = 1949,
-    ERASER          = 2021,
-    REACTIVE_SHIELD = 2031,
-    CANNIBAL_BLADE  = 2065,
-    DAZE            = 2066,
-    KNOCKOUT        = 2067,
-    ECONOMIZER      = 2068,
-    REPLICATOR      = 2132,
-    BONE_CRUSHER    = 2299,
-    ARMOR_PIERCER   = 2300,
-    MAGIC_MORTAR    = 2301,
-    STRING_SHREDDER = 2743,
-    ARMOR_SHATTERER = 2744,
-    HEAT_CAPACITOR  = 2745,
-    BARRAGE_TURBINE = 2746,
-    DISRUPTOR       = 2747,
-    REGULATOR       = 3485,
-}
-
 -- [FRAME][HEAD] = Model ID
 local automatonModels =
 {

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -360,14 +360,27 @@ end
 
 -- On Ability Check Heady Artiface
 xi.job_utils.puppetmaster.onAbilityCheckHeadyArtiface = function(player, target, ability)
-    ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
+    local pet = player:getPet()
+    if not pet then
+        return xi.msg.basic.REQUIRES_A_PET, 0
+    elseif not pet:isAutomaton() then
+        return xi.msg.basic.NO_EFFECT_ON_PET, 0
+    else
+        ability:setRecast(math.max(0, ability:getRecast() - player:getMod(xi.mod.ONE_HOUR_RECAST) * 60))
 
-    return 0, 0
+        return 0, 0
+    end
 end
 
 -- On Ability Use Heady Artiface
-xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface = function(player, target, ability)
-    -- target:addStatusEffect(xi.effect.HEADY_ARTIFICE, { power = 18, duration = 1, origin = player, tick = 1 }) -- TODO: implement xi.effect.HEADY_ARTIFICE
+xi.job_utils.puppetmaster.onAbilityUseHeadyArtiface = function(player, target, ability, action)
+    local pet = player:getPet()
+
+    if pet then
+        pet:setLocalVar('headyArtificeUsed', 1)
+
+        action:ID(player:getID(), pet:getID())
+    end
 end
 
 -- On Ability Check Deploy

--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -557,6 +557,34 @@ local function applyAutomatonFrameMods(mob)
     end
 end
 
+local function getHeadyArtificeSkill(mob)
+    local headEquipped  = mob:getAutomatonHead()
+    local maxMP         = mob:getMaxMP()
+    local currentTarget = mob:getTarget()
+
+    if headEquipped == xi.automaton.head.VALOREDGE then
+        if currentTarget and currentTarget:getMainLvl() - mob:getMainLvl() >= 4 then
+            return xi.mobSkill.INVINCIBLE_AUTOMATON
+        end
+    elseif headEquipped == xi.automaton.head.SHARPSHOT then
+        if mob:getAutomatonFrame() == xi.automaton.frame.SHARPSHOT then
+            return xi.mobSkill.EES_AUTOMATON
+        end
+    elseif headEquipped == xi.automaton.head.STORMWAKER then
+        if maxMP > 0 then
+            return xi.mobSkill.CHAINSPELL_AUTOMATON
+        end
+    elseif headEquipped == xi.automaton.head.SOULSOOTHER then
+        return xi.mobSkill.BENEDICTION_AUTOMATON
+    elseif headEquipped == xi.automaton.head.SPIRITREAVER then
+        if maxMP > 0 then
+            return xi.mobSkill.MANAFONT_AUTOMATON
+        end
+    end
+
+    return xi.mobSkill.MIGHTY_STRIKES_AUTOMATON
+end
+
 xi.pets.automaton.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.CAN_PARRY, 1)
     applyAutomatonFrameMods(mob)
@@ -570,19 +598,30 @@ xi.pets.automaton.onMobSpawn = function(mob)
         end
     end)
 
+    mob:addListener('AUTOMATON_AI_TICK', 'HEADY_ARTIFICE_USED', function(mobArg)
+        if mobArg:getLocalVar('headyArtificeUsed') == 1 then
+            if xi.combat.behavior.isEntityBusy(mobArg) then
+                return
+            end
+
+            mobArg:useMobAbility(getHeadyArtificeSkill(mobArg))
+            mobArg:setLocalVar('headyArtificeUsed', 0)
+        end
+    end)
+
     -- All Automaton Attachments have their cooldowns applied on spawn.
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.BARRAGE_TURBINE, 180)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.DISRUPTOR,        60)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.ECONOMIZER,       60)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.ERASER,           30)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.FLASHBULB,        45)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.HEAT_CAPACITOR,   90)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.MANA_CONVERTER,  180)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.PROVOKE,          30)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REACTIVE_SHIELD,  60)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REGULATOR,        60)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.REPLICATOR,       60)
-    mob:addRecast(xi.recast.ABILITY, xi.automaton.abilities.SHOCK_ABSORBER,  180)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.BARRAGE_TURBINE_AUTOMATON, 180)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.DISRUPTOR_AUTOMATON,        60)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.ECONOMIZER_AUTOMATON,       60)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.ERASER_AUTOMATON,           30)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.FLASHBULB_AUTOMATON,        45)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.HEAT_CAPACITOR_AUTOMATON,   90)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.MANA_CONVERTER_AUTOMATON,  180)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.PROVOKE_AUTOMATON,          30)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.REACTIVE_SHIELD_AUTOMATON,  60)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.REGULATOR_AUTOMATON,        60)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.REPLICATOR_AUTOMATON,       60)
+    mob:addRecast(xi.recast.ABILITY, xi.mobSkill.SHOCK_ABSORBER_AUTOMATON,  180)
 end
 
 xi.pets.automaton.onAdditionalEffectAttack = function(attacker, defender, damage)

--- a/scripts/zones/Mine_Shaft_2716/mobs/Fantoccini_Automaton.lua
+++ b/scripts/zones/Mine_Shaft_2716/mobs/Fantoccini_Automaton.lua
@@ -9,8 +9,8 @@ local petTable =
         job = xi.job.PLD,
         skillList =
         {
-            xi.mobSkill.CHIMERA_RIPPER,
-            xi.mobSkill.STRING_CLIPPER,
+            xi.mobSkill.CHIMERA_RIPPER_AUTOMATON,
+            xi.mobSkill.STRING_CLIPPER_AUTOMATON,
         },
     },
 
@@ -20,8 +20,8 @@ local petTable =
         job = xi.job.RNG,
         skillList =
         {
-            xi.mobSkill.ARCUBALLISTA,
-            xi.mobSkill.DAZE,
+            xi.mobSkill.ARCUBALLISTA_AUTOMATON,
+            xi.mobSkill.DAZE_AUTOMATON,
         },
     },
 
@@ -31,8 +31,8 @@ local petTable =
         job = xi.job.RDM,
         skillList =
         {
-            xi.mobSkill.SLAPSTICK,
-            xi.mobSkill.KNOCKOUT,
+            xi.mobSkill.SLAPSTICK_AUTOMATON,
+            xi.mobSkill.KNOCKOUT_AUTOMATON,
         },
     },
 }

--- a/scripts/zones/Navukgo_Execution_Chamber/mobs/Valkeng.lua
+++ b/scripts/zones/Navukgo_Execution_Chamber/mobs/Valkeng.lua
@@ -21,7 +21,7 @@ entity.onMobEngage = function(mob, target)
 end
 
 entity.onMobMobskillChoose = function(mob, target, skillId)
-    return xi.mobSkill.SLAPSTICK
+    return xi.mobSkill.SLAPSTICK_AUTOMATON
 end
 
 -- These are all the spells caped below 75, however testing suggest that he only chooses 4-6 of these spells depending on the fight. More testing is needed to understand the behavior.

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -2967,12 +2967,12 @@ INSERT INTO `mob_skills` VALUES (2930,41,'subduction',1,0.0,15.0,2000,1000,4,0,0
 -- INSERT INTO `mob_skills` VALUES (2936,2680,'tarichutoxin',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2937,2681,'caliginosity',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2938,2682,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2939,2683,'mighty_strikes',0,0.0,7.0,2000,1500,4,4,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2940,2684,'invincible',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2941,2685,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2942,2686,'chainspell',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2943,2687,'benediction',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2944,2688,'manafont',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2939,2111,'mighty_strikes_automaton',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2940,2112,'invincible_automaton',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2941,2113,'eagle_eye_shot_automaton',0,0.0,25.0,2000,0,4,2,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2942,2114,'chainspell_automaton',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2943,2115,'benediction_automaton',1,0.0,20.0,2000,0,1,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2944,2116,'manafont_automaton',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2945,119,'natures_meditation',1,0.0,18.0,2000,1000,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2946,120,'sensilla_blades',1,0.0,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2947,121,'tegmina_buffet',1,0.0,18.0,2000,1000,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements Heady Artifice, a Puppetmaster JA that forces the Automaton to use a 2-hour ability based on the head/frame equipped. I followed the wiki for implementation and used my capture to verify its' claims. The only thing I actually found that wasn't mentioned is that the Valoredge will not use Invincible unless fighting a target 4 levels or higher. 

NOTE: I know the JA permanently sets the variable on the automaton until its used, that's retail accurate. I went AFK for an hour after using it and my automaton blasted the enemy with EES upon being deployed. the JP Wiki also mentions this is how it works. 

## Source
https://wiki.ffo.jp/html/30399.html

## Capture
[PUP_JAs_2026-6-20_12_8.zip](https://github.com/user-attachments/files/29167009/PUP_JAs_2026-6-20_12_8.zip)

## Steps to test these changes

Equip various automaton / frames heads - See Mighty Strikes, Invincible, EES, Manafont, Chainspell, Benediction used with Heady Artifice. 
