### PR TITLE
Core: Refactor StatusEffectContainer to hide allocations

### DIFF
--- a/scripts/tests/benchmarks/status_effects.lua
+++ b/scripts/tests/benchmarks/status_effects.lua
@@ -18,6 +18,7 @@
 --   XI_BENCH_ENTITIES  entities to spread effects across (default 50)
 --   XI_BENCH_TICKS     effect ticks to advance in the tick test (default 100)
 --   XI_BENCH_ROUNDS    repeat count for add/remove timing (default 30)
+--   XI_BENCH_DRAIN_US  estimated network drain CPU per entity per tick (default 25)
 -- -----------------------------------------------------------------------------
 
 if os.getenv('XI_RUN_BENCHMARKS') ~= '1' then
@@ -29,9 +30,10 @@ local function envNumber(name, default)
     return (value and value > 0) and math.floor(value) or default
 end
 
-local NUM_ENTITIES = envNumber('XI_BENCH_ENTITIES', 50)
-local NUM_TICKS    = envNumber('XI_BENCH_TICKS', 100)
-local ROUNDS       = envNumber('XI_BENCH_ROUNDS', 30)
+local NUM_ENTITIES        = envNumber('XI_BENCH_ENTITIES', 50)
+local NUM_TICKS           = envNumber('XI_BENCH_TICKS', 100)
+local ROUNDS              = envNumber('XI_BENCH_ROUNDS', 30)
+local DRAIN_US_PER_ENTITY = envNumber('XI_BENCH_DRAIN_US', 25)
 
 local EFFECTS = {
     xi.effect.PROTECT,       xi.effect.SHELL,         xi.effect.REGEN,
@@ -49,6 +51,9 @@ describe('#benchmark Status Effect Container', function()
 
     -- effect-operations performed by one addAll()/removeAll() pass
     local opsPerPass = NUM_ENTITIES * #EFFECTS
+
+    -- accumulated wall-clock spent in the modelled network drain
+    local drainTime = 0
 
     setup(function()
         xi.test.world:tick()
@@ -78,6 +83,19 @@ describe('#benchmark Status Effect Container', function()
         end
     end
 
+    -- TODO: Build this into the test harness
+    local function drain()
+        for _, entity in ipairs(entities) do
+            entity.packets:clear()
+        end
+
+        local target = os.clock() + (NUM_ENTITIES * DRAIN_US_PER_ENTITY) / 1e6
+        while os.clock() < target do
+            -- busy-wait: model the network tick occupying the main thread
+        end
+        drainTime = drainTime + (NUM_ENTITIES * DRAIN_US_PER_ENTITY) / 1e6
+    end
+
     -- Report wall-clock for a measured region, normalised per effect-operation.
     local function report(label, seconds, ops)
         print(string.format('[BENCH] %-22s %9.2f ms total | %8.3f us/op | %d ops',
@@ -86,6 +104,7 @@ describe('#benchmark Status Effect Container', function()
 
     it(string.format('add / overwrite / remove (%d entities x %d effects, %d rounds)', NUM_ENTITIES, #EFFECTS, ROUNDS), function()
         local addFresh, addOver, remove = 0, 0, 0
+        drainTime = 0
 
         for _ = 1, ROUNDS do
             -- Clear, then tick once (untimed) to force DeleteStatusEffects to actually
@@ -93,37 +112,47 @@ describe('#benchmark Status Effect Container', function()
             -- below inserts into a clean container instead of one full of dead entries.
             removeAll()
             xi.test.world:tick(xi.tick.EFFECT)
+            drain() -- network tick
 
             local t0 = os.clock()
             addAll() -- fresh insert path
             addFresh = addFresh + (os.clock() - t0)
+            drain() -- network tick
 
             t0 = os.clock()
             addAll() -- effect already present: overwrite/refresh path
             addOver = addOver + (os.clock() - t0)
+            drain() -- network tick
 
             t0 = os.clock()
             removeAll()
             remove = remove + (os.clock() - t0)
+            drain() -- network tick
         end
 
         report('add (fresh)', addFresh, ROUNDS * opsPerPass)
         report('add (overwrite)', addOver, ROUNDS * opsPerPass)
         report('remove', remove, ROUNDS * opsPerPass)
+        report('network drain (est)', drainTime, ROUNDS * 4 * NUM_ENTITIES) -- 4 drains per round
     end)
 
     it(string.format('tick (%d entities x %d effects, %d ticks)', NUM_ENTITIES, #EFFECTS, NUM_TICKS), function()
         removeAll()
         addAll()
+        drain()
 
-        local t0 = os.clock()
+        local elapsed = 0
+        drainTime     = 0
         for _ = 1, NUM_TICKS do
+            local t0 = os.clock()
             xi.test.world:tick(xi.tick.EFFECT)
+            elapsed = elapsed + (os.clock() - t0)
+            drain() -- network tick
         end
-        local elapsed = os.clock() - t0
 
         removeAll()
 
         report('tick', elapsed, NUM_TICKS * opsPerPass)
+        report('network drain (est)', drainTime, NUM_TICKS * NUM_ENTITIES)
     end)
 end)

--- a/scripts/tests/benchmarks/status_effects.lua
+++ b/scripts/tests/benchmarks/status_effects.lua
@@ -93,6 +93,7 @@ describe('#benchmark Status Effect Container', function()
         while os.clock() < target do
             -- busy-wait: model the network tick occupying the main thread
         end
+
         drainTime = drainTime + (kNumEntities * kDrainMicrosPerEntity) / 1e6
     end
 

--- a/scripts/tests/benchmarks/status_effects.lua
+++ b/scripts/tests/benchmarks/status_effects.lua
@@ -1,0 +1,129 @@
+-- -----------------------------------------------------------------------------
+-- Status effect container benchmark.
+--
+-- OFF BY DEFAULT. This file registers no tests unless the environment variable
+-- XI_RUN_BENCHMARKS=1 is set, so it never runs in the normal suite / CI.
+--
+-- Two ways to read the results:
+--
+--  * Self-reported breakdown: each test times its sub-operations with os.clock
+--    and prints "[BENCH] ..." lines (works anywhere, no profiler needed).
+--
+--  * Tracy: configure with TRACY_ENABLE (xi_test_tracy) and connect the Tracy
+--    profiler GUI (tracy-profiler.exe) while running. The hot C++ zones
+--    (AddStatusEffect, TickEffects, TickRegen, DeleteStatusEffects) show up
+--    under the per-test zones.
+--
+-- Workload sizes are tunable from the environment:
+--   XI_BENCH_ENTITIES  entities to spread effects across (default 50)
+--   XI_BENCH_TICKS     effect ticks to advance in the tick test (default 100)
+--   XI_BENCH_ROUNDS    repeat count for add/remove timing (default 30)
+-- -----------------------------------------------------------------------------
+
+if os.getenv('XI_RUN_BENCHMARKS') ~= '1' then
+    return
+end
+
+local function envNumber(name, default)
+    local value = tonumber(os.getenv(name) or '')
+    return (value and value > 0) and math.floor(value) or default
+end
+
+local NUM_ENTITIES = envNumber('XI_BENCH_ENTITIES', 50)
+local NUM_TICKS    = envNumber('XI_BENCH_TICKS', 100)
+local ROUNDS       = envNumber('XI_BENCH_ROUNDS', 30)
+
+local EFFECTS = {
+    xi.effect.PROTECT,       xi.effect.SHELL,         xi.effect.REGEN,
+    xi.effect.REFRESH,       xi.effect.HASTE,         xi.effect.BLINK,
+    xi.effect.STONESKIN,     xi.effect.AQUAVEIL,      xi.effect.STR_BOOST,
+    xi.effect.DEX_BOOST,     xi.effect.VIT_BOOST,     xi.effect.AGI_BOOST,
+    xi.effect.INT_BOOST,     xi.effect.MND_BOOST,     xi.effect.CHR_BOOST,
+    xi.effect.MAX_HP_BOOST,  xi.effect.MAX_MP_BOOST,  xi.effect.ACCURACY_BOOST,
+    xi.effect.ATTACK_BOOST,  xi.effect.EVASION_BOOST, xi.effect.DEFENSE_BOOST,
+}
+
+describe('#benchmark Status Effect Container', function()
+    ---@type CClientEntityPair[]
+    local entities = {}
+
+    -- effect-operations performed by one addAll()/removeAll() pass
+    local opsPerPass = NUM_ENTITIES * #EFFECTS
+
+    setup(function()
+        xi.test.world:tick()
+        for i = 1, NUM_ENTITIES do
+            entities[i] = xi.test.world:spawnPlayer({
+                zone  = xi.zone.WEST_RONFAURE,
+                job   = xi.job.WHM,
+                level = 99,
+            })
+            entities[i]:setUnkillable(true)
+        end
+    end)
+
+    local function addAll()
+        for _, entity in ipairs(entities) do
+            for _, effect in ipairs(EFFECTS) do
+                entity:addStatusEffect(effect, { power = 10, tick = 3, duration = 7200, origin = entity })
+            end
+        end
+    end
+
+    local function removeAll()
+        for _, entity in ipairs(entities) do
+            for _, effect in ipairs(EFFECTS) do
+                entity:delStatusEffect(effect)
+            end
+        end
+    end
+
+    -- Report wall-clock for a measured region, normalised per effect-operation.
+    local function report(label, seconds, ops)
+        print(string.format('[BENCH] %-22s %9.2f ms total | %8.3f us/op | %d ops',
+            label, seconds * 1000, (seconds * 1e6) / ops, ops))
+    end
+
+    it(string.format('add / overwrite / remove (%d entities x %d effects, %d rounds)', NUM_ENTITIES, #EFFECTS, ROUNDS), function()
+        local addFresh, addOver, remove = 0, 0, 0
+
+        for _ = 1, ROUNDS do
+            -- Clear, then tick once (untimed) to force DeleteStatusEffects to actually
+            -- erase the tombstones delStatusEffect leaves behind, so the timed addAll
+            -- below inserts into a clean container instead of one full of dead entries.
+            removeAll()
+            xi.test.world:tick(xi.tick.EFFECT)
+
+            local t0 = os.clock()
+            addAll() -- fresh insert path
+            addFresh = addFresh + (os.clock() - t0)
+
+            t0 = os.clock()
+            addAll() -- effect already present: overwrite/refresh path
+            addOver = addOver + (os.clock() - t0)
+
+            t0 = os.clock()
+            removeAll()
+            remove = remove + (os.clock() - t0)
+        end
+
+        report('add (fresh)', addFresh, ROUNDS * opsPerPass)
+        report('add (overwrite)', addOver, ROUNDS * opsPerPass)
+        report('remove', remove, ROUNDS * opsPerPass)
+    end)
+
+    it(string.format('tick (%d entities x %d effects, %d ticks)', NUM_ENTITIES, #EFFECTS, NUM_TICKS), function()
+        removeAll()
+        addAll()
+
+        local t0 = os.clock()
+        for _ = 1, NUM_TICKS do
+            xi.test.world:tick(xi.tick.EFFECT)
+        end
+        local elapsed = os.clock() - t0
+
+        removeAll()
+
+        report('tick', elapsed, NUM_TICKS * opsPerPass)
+    end)
+end)

--- a/scripts/tests/benchmarks/status_effects.lua
+++ b/scripts/tests/benchmarks/status_effects.lua
@@ -30,12 +30,12 @@ local function envNumber(name, default)
     return (value and value > 0) and math.floor(value) or default
 end
 
-local NUM_ENTITIES        = envNumber('XI_BENCH_ENTITIES', 50)
-local NUM_TICKS           = envNumber('XI_BENCH_TICKS', 100)
-local ROUNDS              = envNumber('XI_BENCH_ROUNDS', 30)
-local DRAIN_US_PER_ENTITY = envNumber('XI_BENCH_DRAIN_US', 25)
+local kNumEntities          = envNumber('XI_BENCH_ENTITIES', 50)
+local kNumTicks             = envNumber('XI_BENCH_TICKS', 100)
+local kRounds               = envNumber('XI_BENCH_ROUNDS', 30)
+local kDrainMicrosPerEntity = envNumber('XI_BENCH_DRAIN_US', 25)
 
-local EFFECTS = {
+local effects = {
     xi.effect.PROTECT,       xi.effect.SHELL,         xi.effect.REGEN,
     xi.effect.REFRESH,       xi.effect.HASTE,         xi.effect.BLINK,
     xi.effect.STONESKIN,     xi.effect.AQUAVEIL,      xi.effect.STR_BOOST,
@@ -50,14 +50,14 @@ describe('#benchmark Status Effect Container', function()
     local entities = {}
 
     -- effect-operations performed by one addAll()/removeAll() pass
-    local opsPerPass = NUM_ENTITIES * #EFFECTS
+    local opsPerPass = kNumEntities * #effects
 
     -- accumulated wall-clock spent in the modelled network drain
     local drainTime = 0
 
     setup(function()
         xi.test.world:tick()
-        for i = 1, NUM_ENTITIES do
+        for i = 1, kNumEntities do
             entities[i] = xi.test.world:spawnPlayer({
                 zone  = xi.zone.WEST_RONFAURE,
                 job   = xi.job.WHM,
@@ -69,7 +69,7 @@ describe('#benchmark Status Effect Container', function()
 
     local function addAll()
         for _, entity in ipairs(entities) do
-            for _, effect in ipairs(EFFECTS) do
+            for _, effect in ipairs(effects) do
                 entity:addStatusEffect(effect, { power = 10, tick = 3, duration = 7200, origin = entity })
             end
         end
@@ -77,7 +77,7 @@ describe('#benchmark Status Effect Container', function()
 
     local function removeAll()
         for _, entity in ipairs(entities) do
-            for _, effect in ipairs(EFFECTS) do
+            for _, effect in ipairs(effects) do
                 entity:delStatusEffect(effect)
             end
         end
@@ -89,11 +89,11 @@ describe('#benchmark Status Effect Container', function()
             entity.packets:clear()
         end
 
-        local target = os.clock() + (NUM_ENTITIES * DRAIN_US_PER_ENTITY) / 1e6
+        local target = os.clock() + (kNumEntities * kDrainMicrosPerEntity) / 1e6
         while os.clock() < target do
             -- busy-wait: model the network tick occupying the main thread
         end
-        drainTime = drainTime + (NUM_ENTITIES * DRAIN_US_PER_ENTITY) / 1e6
+        drainTime = drainTime + (kNumEntities * kDrainMicrosPerEntity) / 1e6
     end
 
     -- Report wall-clock for a measured region, normalised per effect-operation.
@@ -102,11 +102,11 @@ describe('#benchmark Status Effect Container', function()
             label, seconds * 1000, (seconds * 1e6) / ops, ops))
     end
 
-    it(string.format('add / overwrite / remove (%d entities x %d effects, %d rounds)', NUM_ENTITIES, #EFFECTS, ROUNDS), function()
+    it(string.format('add / overwrite / remove (%d entities x %d effects, %d rounds)', kNumEntities, #effects, kRounds), function()
         local addFresh, addOver, remove = 0, 0, 0
         drainTime = 0
 
-        for _ = 1, ROUNDS do
+        for _ = 1, kRounds do
             -- Clear, then tick once (untimed) to force DeleteStatusEffects to actually
             -- erase the tombstones delStatusEffect leaves behind, so the timed addAll
             -- below inserts into a clean container instead of one full of dead entries.
@@ -130,20 +130,20 @@ describe('#benchmark Status Effect Container', function()
             drain() -- network tick
         end
 
-        report('add (fresh)', addFresh, ROUNDS * opsPerPass)
-        report('add (overwrite)', addOver, ROUNDS * opsPerPass)
-        report('remove', remove, ROUNDS * opsPerPass)
-        report('network drain (est)', drainTime, ROUNDS * 4 * NUM_ENTITIES) -- 4 drains per round
+        report('add (fresh)', addFresh, kRounds * opsPerPass)
+        report('add (overwrite)', addOver, kRounds * opsPerPass)
+        report('remove', remove, kRounds * opsPerPass)
+        report('network drain (est)', drainTime, kRounds * 4 * kNumEntities) -- 4 drains per round
     end)
 
-    it(string.format('tick (%d entities x %d effects, %d ticks)', NUM_ENTITIES, #EFFECTS, NUM_TICKS), function()
+    it(string.format('tick (%d entities x %d effects, %d ticks)', kNumEntities, #effects, kNumTicks), function()
         removeAll()
         addAll()
         drain()
 
         local elapsed = 0
         drainTime     = 0
-        for _ = 1, NUM_TICKS do
+        for _ = 1, kNumTicks do
             local t0 = os.clock()
             xi.test.world:tick(xi.tick.EFFECT)
             elapsed = elapsed + (os.clock() - t0)
@@ -152,7 +152,7 @@ describe('#benchmark Status Effect Container', function()
 
         removeAll()
 
-        report('tick', elapsed, NUM_TICKS * opsPerPass)
-        report('network drain (est)', drainTime, NUM_TICKS * NUM_ENTITIES)
+        report('tick', elapsed, kNumTicks * opsPerPass)
+        report('network drain (est)', drainTime, kNumTicks * kNumEntities)
     end)
 end)

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -324,6 +324,7 @@ set_target_output_directory(xi_map)
 set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT xi_map)
 
 if(TRACY_ENABLE)
+    target_link_libraries(xi_map PRIVATE TracyClient)
     set_target_properties(xi_map PROPERTIES OUTPUT_NAME xi_map_tracy)
     message(STATUS "TRACY_ENABLE: xi_map will be output as xi_map_tracy")
 endif(TRACY_ENABLE)

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -730,19 +730,18 @@ auto CAutomatonController::TryEnfeeble(const CurrentManeuvers& maneuvers) -> boo
         case AutomatonHead::Stormwaker:
         {
             bool dispel = false;
-            // clang-format off
-            PTarget->StatusEffectContainer->ForEachEffect([&dispel](CStatusEffect* PStatus)
-            {
-                if (!dispel && PStatus->GetDuration() > 0s)
+            PTarget->StatusEffectContainer->ForEachEffect(
+                [&dispel](CStatusEffect& PStatus)
                 {
-                    if (PStatus->HasEffectFlag(xi::StatusEffectFlag::Dispelable))
+                    if (!dispel && PStatus.GetDuration() > 0s)
                     {
-                        dispel = true;
-                        return;
+                        if (PStatus.HasEffectFlag(xi::StatusEffectFlag::Dispelable))
+                        {
+                            dispel = true;
+                            return;
+                        }
                     }
-                }
-            });
-            // clang-format on
+                });
             if (dispel)
             {
                 castPriority.emplace_back(SpellID::Dispel);
@@ -1094,11 +1093,11 @@ auto CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers) -
     std::vector<SpellID> castPriority;
 
     PAutomaton->PMaster->StatusEffectContainer->ForEachEffect(
-        [&castPriority](CStatusEffect* PStatus)
+        [&castPriority](CStatusEffect& PStatus)
         {
-            if (PStatus->GetDuration() > 0s)
+            if (PStatus.GetDuration() > 0s)
             {
-                auto id = automaton::FindNaSpell(PStatus);
+                auto id = automaton::FindNaSpell(&PStatus);
                 if (id.has_value())
                 {
                     castPriority.emplace_back(id.value());
@@ -1117,11 +1116,11 @@ auto CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers) -
     castPriority.clear();
 
     PAutomaton->StatusEffectContainer->ForEachEffect(
-        [&castPriority](CStatusEffect* PStatus)
+        [&castPriority](CStatusEffect& PStatus)
         {
-            if (PStatus->GetDuration() > 0s)
+            if (PStatus.GetDuration() > 0s)
             {
-                auto id = automaton::FindNaSpell(PStatus);
+                auto id = automaton::FindNaSpell(&PStatus);
                 if (id.has_value())
                 {
                     castPriority.emplace_back(id.value());
@@ -1146,11 +1145,11 @@ auto CAutomatonController::TryStatusRemoval(const CurrentManeuvers& maneuvers) -
                 castPriority.clear();
 
                 member->StatusEffectContainer->ForEachEffect(
-                    [&castPriority](CStatusEffect* PStatus)
+                    [&castPriority](CStatusEffect& PStatus)
                     {
-                        if (PStatus->GetDuration() > 0s)
+                        if (PStatus.GetDuration() > 0s)
                         {
-                            auto id = automaton::FindNaSpell(PStatus);
+                            auto id = automaton::FindNaSpell(&PStatus);
                             if (id.has_value())
                             {
                                 castPriority.emplace_back(id.value());
@@ -1225,33 +1224,33 @@ auto CAutomatonController::TryEnhance() -> bool
         }
 
         PAutomaton->PMaster->StatusEffectContainer->ForEachEffect(
-            [&protect, &protectcount, &shell, &shellcount, &haste, &stoneskin, &phalanx](CStatusEffect* PStatus)
+            [&protect, &protectcount, &shell, &shellcount, &haste, &stoneskin, &phalanx](CStatusEffect& PStatus)
             {
-                if (PStatus->GetDuration() > 0s)
+                if (PStatus.GetDuration() > 0s)
                 {
-                    if (PStatus->GetStatusID() == xi::StatusEffect::Protect)
+                    if (PStatus.GetStatusID() == xi::StatusEffect::Protect)
                     {
                         protect = true;
                         ++protectcount;
                     }
 
-                    if (PStatus->GetStatusID() == xi::StatusEffect::Shell)
+                    if (PStatus.GetStatusID() == xi::StatusEffect::Shell)
                     {
                         shell = true;
                         ++shellcount;
                     }
 
-                    if (PStatus->GetStatusID() == xi::StatusEffect::Haste || PStatus->GetStatusID() == xi::StatusEffect::GeoHaste)
+                    if (PStatus.GetStatusID() == xi::StatusEffect::Haste || PStatus.GetStatusID() == xi::StatusEffect::GeoHaste)
                     {
                         haste = true;
                     }
 
-                    if (PStatus->GetStatusID() == xi::StatusEffect::Stoneskin)
+                    if (PStatus.GetStatusID() == xi::StatusEffect::Stoneskin)
                     {
                         stoneskin = true;
                     }
 
-                    if (PStatus->GetStatusID() == xi::StatusEffect::Phalanx)
+                    if (PStatus.GetStatusID() == xi::StatusEffect::Phalanx)
                     {
                         phalanx = true;
                     }
@@ -1305,21 +1304,21 @@ auto CAutomatonController::TryEnhance() -> bool
     }
 
     PAutomaton->StatusEffectContainer->ForEachEffect(
-        [&protect, &shell, &haste](CStatusEffect* PStatus)
+        [&protect, &shell, &haste](CStatusEffect& PStatus)
         {
-            if (PStatus->GetDuration() > 0s)
+            if (PStatus.GetDuration() > 0s)
             {
-                if (PStatus->GetStatusID() == xi::StatusEffect::Protect)
+                if (PStatus.GetStatusID() == xi::StatusEffect::Protect)
                 {
                     protect = true;
                 }
 
-                if (PStatus->GetStatusID() == xi::StatusEffect::Shell)
+                if (PStatus.GetStatusID() == xi::StatusEffect::Shell)
                 {
                     shell = true;
                 }
 
-                if (PStatus->GetStatusID() == xi::StatusEffect::Haste || PStatus->GetStatusID() == xi::StatusEffect::GeoHaste)
+                if (PStatus.GetStatusID() == xi::StatusEffect::Haste || PStatus.GetStatusID() == xi::StatusEffect::GeoHaste)
                 {
                     haste = true;
                 }
@@ -1377,23 +1376,23 @@ auto CAutomatonController::TryEnhance() -> bool
                     isEngaged = true; // Assume everyone is engaged if the target isn't a mob
                 }
 
-                PMember->StatusEffectContainer->ForEachEffect([&protect, &protectcount, &shell, &shellcount, &haste](CStatusEffect* PStatus)
+                PMember->StatusEffectContainer->ForEachEffect([&protect, &protectcount, &shell, &shellcount, &haste](CStatusEffect& PStatus)
                 {
-                    if (PStatus->GetDuration() > 0s)
+                    if (PStatus.GetDuration() > 0s)
                     {
-                        if (PStatus->GetStatusID() == xi::StatusEffect::Protect)
+                        if (PStatus.GetStatusID() == xi::StatusEffect::Protect)
                         {
                             protect = true;
                             ++protectcount;
                         }
 
-                        if (PStatus->GetStatusID() == xi::StatusEffect::Shell)
+                        if (PStatus.GetStatusID() == xi::StatusEffect::Shell)
                         {
                             shell = true;
                             ++shellcount;
                         }
 
-                        if (PStatus->GetStatusID() == xi::StatusEffect::Haste || PStatus->GetStatusID() == xi::StatusEffect::GeoHaste)
+                        if (PStatus.GetStatusID() == xi::StatusEffect::Haste || PStatus.GetStatusID() == xi::StatusEffect::GeoHaste)
                         {
                             haste = true;
                         }

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -185,7 +185,7 @@ bool CPetController::PetIsHealing()
     {
         // Animation down
         PPet->animation = ANIMATION_HEALING;
-        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Healing, 0, 0, std::chrono::seconds(settings::get<uint8>("map.HEALING_TICK_DELAY")), 0s));
+        PPet->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Healing, 0, 0, std::chrono::seconds(settings::get<uint8>("map.HEALING_TICK_DELAY")), 0s);
         PPet->updatemask |= UPDATE_HP;
         return true;
     }

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -284,7 +284,7 @@ void CBattlefield::ApplyLevelRestrictions(CCharEntity* PChar) const
 
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable, EffectNotice::Silent);
         PChar->StatusEffectContainer->DelStatusEffectSilent(xi::StatusEffect::Reraise);
-        PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), cap, 0s, 0s));
+        PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), cap, 0s, 0s);
     }
     else
     {
@@ -294,7 +294,7 @@ void CBattlefield::ApplyLevelRestrictions(CCharEntity* PChar) const
     // Check if we should remove SJ, whether or not there is a lv cap.
     if (!(m_Rules & BCRULES::RULES_ALLOW_SUBJOBS))
     {
-        PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::SjRestriction, static_cast<uint16>(xi::StatusEffect::SjRestriction), 0, 0s, 0s));
+        PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::SjRestriction, static_cast<uint16>(xi::StatusEffect::SjRestriction), 0, 0s, 0s);
     }
 }
 
@@ -430,8 +430,8 @@ bool CBattlefield::InsertEntity(CBaseEntity* PEntity, bool enter, BATTLEFIELDMOB
         }
         else
         {
-            entity->StatusEffectContainer->AddStatusEffect(
-                new CStatusEffect(xi::StatusEffect::Battlefield, static_cast<uint16>(xi::StatusEffect::Battlefield), this->GetID(), 0s, 0s, m_Initiator.id, this->GetArea()), EffectNotice::Silent);
+            entity->StatusEffectContainer->AddStatusEffectSilent(
+                xi::StatusEffect::Battlefield, static_cast<uint16>(xi::StatusEffect::Battlefield), this->GetID(), 0s, 0s, m_Initiator.id, this->GetArea());
         }
     }
 

--- a/src/map/battlefield_handler.cpp
+++ b/src/map/battlefield_handler.cpp
@@ -155,8 +155,8 @@ uint8 CBattlefieldHandler::LoadBattlefield(CCharEntity* PChar, const Battlefield
 
     if (!PChar->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Battlefield))
     {
-        PChar->StatusEffectContainer->AddStatusEffect(
-            new CStatusEffect(xi::StatusEffect::Battlefield, static_cast<uint16>(xi::StatusEffect::Battlefield), PBattlefield->GetID(), 0s, 0s, PChar->id, PBattlefield->GetArea()), EffectNotice::Silent);
+        PChar->StatusEffectContainer->AddStatusEffectSilent(
+            xi::StatusEffect::Battlefield, static_cast<uint16>(xi::StatusEffect::Battlefield), PBattlefield->GetID(), 0s, 0s, PChar->id, PBattlefield->GetArea());
     }
 
     luautils::OnBattlefieldRegister(PChar, PBattlefield);

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -3714,7 +3714,7 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
                 // Apply Feint
                 if (CStatusEffect* PFeintEffect = StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Feint))
                 {
-                    if (PTarget->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::EvasionDown, static_cast<uint16>(xi::StatusEffect::EvasionDown), PFeintEffect->GetPower(), 3s, 30s)))
+                    if (PTarget->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::EvasionDown, static_cast<uint16>(xi::StatusEffect::EvasionDown), PFeintEffect->GetPower(), 3s, 30s))
                     {
                         auto PEffect = PTarget->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::EvasionDown);
 

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2144,8 +2144,7 @@ void CCharEntity::OnRaise()
                 weaknessTime = 3min;
             }
 
-            CStatusEffect* PWeaknessEffect = new CStatusEffect(xi::StatusEffect::Weakness, static_cast<uint16>(xi::StatusEffect::Weakness), m_weaknessLvl, 0s, weaknessTime);
-            StatusEffectContainer->AddStatusEffect(PWeaknessEffect);
+            StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Weakness, static_cast<uint16>(xi::StatusEffect::Weakness), m_weaknessLvl, 0s, weaknessTime);
         }
 
         double ratioReturned = 0.0f;
@@ -2209,8 +2208,7 @@ void CCharEntity::OnRaise()
         // If Arise was used then apply a reraise 3 effect on the target
         if (m_hasArise)
         {
-            CStatusEffect* PReraiseEffect = new CStatusEffect(xi::StatusEffect::Reraise, static_cast<uint16>(xi::StatusEffect::Reraise), 3, 0s, 1h);
-            StatusEffectContainer->AddStatusEffect(PReraiseEffect);
+            StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Reraise, static_cast<uint16>(xi::StatusEffect::Reraise), 3, 0s, 1h);
         }
 
         SetLocalVar("MijinGakure", 0);

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -11744,17 +11744,13 @@ void CLuaBaseEntity::addPartyEffect(sol::variadic_args va)
         args[idx++] = v.get<uint16>();
     }
 
-    CStatusEffect* PEffect =
-        new CStatusEffect(static_cast<xi::StatusEffect>(args[0]), args[1], args[2], std::chrono::seconds(args[3]), std::chrono::seconds(args[4]), args[5], args[6]);
-
     CBattleEntity* PEntity = ((CBattleEntity*)m_PBaseEntity);
 
-    // clang-format off
-    PEntity->ForParty([PEffect](CBattleEntity* PMember)
-    {
-        PMember->StatusEffectContainer->AddStatusEffect(PEffect);
-    });
-    // clang-format on
+    PEntity->ForParty(
+        [&](CBattleEntity* PMember)
+        {
+            PMember->StatusEffectContainer->AddStatusEffect(static_cast<xi::StatusEffect>(args[0]), args[1], args[2], std::chrono::seconds(args[3]), std::chrono::seconds(args[4]), args[5], args[6]);
+        });
 }
 
 /************************************************************************
@@ -13967,34 +13963,26 @@ auto CLuaBaseEntity::addStatusEffect(const xi::StatusEffect effectId, sol::table
     const auto sourceTypeParam = params["sourceTypeParam"].get_or(0u);
     const auto silent          = params["silent"].get_or(false);
 
-    auto* PEffect = new CStatusEffect(
-        effectId,
-        icon,
-        power,
-        std::chrono::seconds(tick),
-        std::chrono::milliseconds(static_cast<uint64>(duration * 1000)),
-        subType,
-        subPower,
-        subIcon,
-        tier,
-        static_cast<xi::StatusEffectFlag>(flag));
-
-    if (sourceType != EffectSourceType::SOURCE_NONE && sourceTypeParam > 0)
-    {
-        PEffect->SetSource(sourceType, sourceTypeParam);
-    }
-
-    PEffect->SetOriginID(originEntity.getID());
+    auto effectDuration = std::chrono::milliseconds(static_cast<uint64>(duration * 1000));
 
     if (effectId == xi::StatusEffect::Food)
     {
         if (const auto durationModifier = PBattleEntity->getMod(Mod::FOOD_DURATION))
         {
-            PEffect->SetDuration(PEffect->GetDuration() + std::chrono::floor<std::chrono::milliseconds>(PEffect->GetDuration() * (durationModifier / 100.0f)));
+            effectDuration += std::chrono::floor<std::chrono::milliseconds>(effectDuration * (durationModifier / 100.0f));
         }
     }
 
-    return PBattleEntity->StatusEffectContainer->AddStatusEffect(PEffect, silent ? EffectNotice::Silent : EffectNotice::ShowMessage);
+    auto& PSEC = PBattleEntity->StatusEffectContainer;
+
+    // The CStatusEffect constructor takes sourceType/sourceTypeParam/originID directly, so the
+    // previous SetSource/SetOriginID post-construction steps fold into the call.
+    if (silent)
+    {
+        return PSEC->AddStatusEffectSilent(effectId, icon, power, std::chrono::seconds(tick), effectDuration, subType, subPower, subIcon, tier, static_cast<xi::StatusEffectFlag>(flag), sourceType, sourceTypeParam, originEntity.getID());
+    }
+
+    return PSEC->AddStatusEffect(effectId, icon, power, std::chrono::seconds(tick), effectDuration, subType, subPower, subIcon, tier, static_cast<xi::StatusEffectFlag>(flag), sourceType, sourceTypeParam, originEntity.getID());
 }
 
 /************************************************************************
@@ -14022,7 +14010,7 @@ auto CLuaBaseEntity::copyStatusEffect(const CLuaStatusEffect* PStatusEffect) con
         remainingDuration   = std::max(remainingDuration, 0s);
     }
 
-    auto* PNewEffect = new CStatusEffect(
+    return PBattleEntity->StatusEffectContainer->AddStatusEffect(
         POriginal->GetStatusID(),
         POriginal->GetIcon(),
         POriginal->GetPower(),
@@ -14036,8 +14024,6 @@ auto CLuaBaseEntity::copyStatusEffect(const CLuaStatusEffect* PStatusEffect) con
         POriginal->GetSourceType(),
         POriginal->GetSourceTypeParam(),
         POriginal->GetOriginID());
-
-    return PBattleEntity->StatusEffectContainer->AddStatusEffect(PNewEffect);
 }
 
 /************************************************************************
@@ -14135,13 +14121,13 @@ sol::table CLuaBaseEntity::getStatusEffects()
     }
 
     auto table = lua.create_table();
-    // clang-format off
-    static_cast<CBattleEntity*>(m_PBaseEntity)->StatusEffectContainer->ForEachEffect(
-    [&table](CStatusEffect* PEffect)
+
+    auto func = [&table](CStatusEffect& PEffect)
     {
-        table.add(CLuaStatusEffect(PEffect));
-    });
-    // clang-format on
+        table.add(CLuaStatusEffect(&PEffect));
+    };
+
+    static_cast<CBattleEntity*>(m_PBaseEntity)->StatusEffectContainer->ForEachEffect(func);
 
     return table;
 }
@@ -14557,10 +14543,26 @@ uint16 CLuaBaseEntity::stealStatusEffect(CLuaBaseEntity* PTargetEntity, const so
     uint32 flag          = flagObj.is<uint32>() ? flagObj.as<uint32>() : (uint32)xi::StatusEffectFlag::Dispelable;
     auto   removalNotice = (silentObj.is<bool>() && silentObj.as<bool>()) ? EffectNotice::Silent : EffectNotice::ShowMessage;
 
-    if (CStatusEffect* PStatusEffect = PTargetBattleEntity->StatusEffectContainer->StealStatusEffect(static_cast<xi::StatusEffectFlag>(flag), removalNotice))
+    if (auto PStatusEffect = PTargetBattleEntity->StatusEffectContainer->StealStatusEffect(static_cast<xi::StatusEffectFlag>(flag), removalNotice))
     {
-        PBattleEntity->StatusEffectContainer->AddStatusEffect(PStatusEffect);
-        return static_cast<uint16>(PStatusEffect->GetStatusID());
+        const auto stolenId = static_cast<uint16>(PStatusEffect->GetStatusID());
+
+        PBattleEntity->StatusEffectContainer->AddStatusEffect(
+            PStatusEffect->GetStatusID(),
+            PStatusEffect->GetIcon(),
+            PStatusEffect->GetPower(),
+            PStatusEffect->GetTickTime(),
+            PStatusEffect->GetDuration(),
+            PStatusEffect->GetSubID(),
+            PStatusEffect->GetSubPower(),
+            PStatusEffect->GetSubIcon(),
+            PStatusEffect->GetTier(),
+            PStatusEffect->GetEffectFlags(),
+            PStatusEffect->GetSourceType(),
+            PStatusEffect->GetSourceTypeParam(),
+            PStatusEffect->GetOriginID());
+
+        return stolenId;
     }
     else
     {

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -144,21 +144,24 @@ std::unordered_map<uint32, sol::table> customMenuContext;
 namespace detail
 {
 
-// std::unordered_map<std::string, sol::reference> cachedObjects;
+// Object lookup cache. Currently only populated for status effect script lookups
+// (see getCachedEffectTable); fully cleared on any Lua file reload (see TryReloadFilewatchList).
+std::unordered_map<std::string, sol::reference> cachedObjects;
 
-// auto findCachedObject(const std::string& objName) -> sol::reference
-// {
-//     if (auto it = cachedObjects.find(objName); it != cachedObjects.end())
-//     {
-//         return it->second;
-//     }
-//     return sol::lua_nil;
-// }
+auto findCachedObject(const std::string& objName) -> sol::reference
+{
+    if (auto it = cachedObjects.find(objName); it != cachedObjects.end())
+    {
+        return it->second;
+    }
 
-// void cacheObject(const std::string& objName, sol::reference obj)
-// {
-//     cachedObjects[objName] = obj;
-// }
+    return sol::lua_nil;
+}
+
+void cacheObject(const std::string& objName, sol::reference obj)
+{
+    cachedObjects[objName] = std::move(obj);
+}
 
 // NOTE: Will crash if any intermediate keys look up nil tables
 auto lookupByKeysFast(const std::vector<std::string>& keys) -> sol::object
@@ -219,6 +222,18 @@ auto findGlobalLuaFunction(const std::string& funcName) -> sol::function
     // }
 
     return lookupByKeysSafe(split(funcName, "."));
+}
+
+auto getCachedEffectTable(const std::string& effectName) -> sol::table
+{
+    if (auto cached = findCachedObject(effectName); cached.valid())
+    {
+        return cached;
+    }
+
+    sol::table entry = GetCacheEntryFromFilename(fmt::format("./scripts/{}.lua", effectName));
+    cacheObject(effectName, entry);
+    return entry;
 }
 
 } // namespace detail
@@ -544,6 +559,8 @@ void init(IPP mapIPP, bool isRunningInCI)
 
 void cleanup()
 {
+    detail::cachedObjects.clear();
+
     moduleutils::CleanupLuaModules();
 }
 
@@ -588,9 +605,9 @@ void TryReloadFilewatchList()
         return;
     }
 
-    // For coherency between looking things up by filename and by Lua global
-    // name we need to nuke the whole lookup cache on any file changes.
-    // detail::cachedObjects.clear();
+    // The object cache holds Lua references resolved before the reload (currently status effect
+    // script tables); drop them all so changed scripts take effect immediately.
+    detail::cachedObjects.clear();
 
     for (const auto& [filename, action] : changedFiles)
     {
@@ -2741,9 +2758,7 @@ void OnEffectGain(CBattleEntity* PEntity, CStatusEffect* PStatusEffect)
 {
     TracyZoneScoped;
 
-    std::string filename = fmt::format("./scripts/{}.lua", PStatusEffect->GetName());
-
-    sol::function onEffectGain = GetCacheEntryFromFilename(filename)["onEffectGain"].get<sol::function>();
+    sol::function onEffectGain = detail::getCachedEffectTable(PStatusEffect->GetName())["onEffectGain"].get<sol::function>();
     if (!onEffectGain.valid())
     {
         return;
@@ -2762,9 +2777,7 @@ void OnEffectTick(CBattleEntity* PEntity, CStatusEffect* PStatusEffect)
 {
     TracyZoneScoped;
 
-    std::string filename = fmt::format("./scripts/{}.lua", PStatusEffect->GetName());
-
-    sol::function onEffectTick = GetCacheEntryFromFilename(filename)["onEffectTick"].get<sol::function>();
+    sol::function onEffectTick = detail::getCachedEffectTable(PStatusEffect->GetName())["onEffectTick"].get<sol::function>();
     if (!onEffectTick.valid())
     {
         return;
@@ -2783,9 +2796,7 @@ void OnEffectLose(CBattleEntity* PEntity, CStatusEffect* PStatusEffect)
 {
     TracyZoneScoped;
 
-    std::string filename = fmt::format("./scripts/{}.lua", PStatusEffect->GetName());
-
-    sol::function onEffectLose = GetCacheEntryFromFilename(filename)["onEffectLose"].get<sol::function>();
+    sol::function onEffectLose = detail::getCachedEffectTable(PStatusEffect->GetName())["onEffectLose"].get<sol::function>();
     if (!onEffectLose.valid())
     {
         return;

--- a/src/map/monstrosity.cpp
+++ b/src/map/monstrosity.cpp
@@ -332,22 +332,26 @@ void monstrosity::HandleZoneIn(CCharEntity* PChar)
     {
         auto duration = PChar->m_PMonstrosity->Belligerency ? 1min : 18h;
 
-        CStatusEffect* PEffect = new CStatusEffect(xi::StatusEffect::Gestation, static_cast<uint16>(xi::StatusEffect::Gestation), 0, 0s, duration);
+        // TODO: Move these flags into the db
+        const auto gestationFlags = xi::StatusEffectFlag::Invisible |
+                                    xi::StatusEffectFlag::Death |
+                                    xi::StatusEffectFlag::Attack |
+                                    xi::StatusEffectFlag::MagicBegin |
+                                    xi::StatusEffectFlag::Detectable |
+                                    xi::StatusEffectFlag::OnZone;
+        // NOTE: It DOES say the effect wears off, so Logout / NoLossMessage are intentionally not set.
 
-        // TODO: Move these into the db
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::Invisible);
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::Death);
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::Attack);
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::MagicBegin);
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::Detectable);
-        PEffect->AddEffectFlag(xi::StatusEffectFlag::OnZone);
-
-        // PEffect->AddEffectFlag(xi::StatusEffectFlag::Logout);
-
-        // NOTE: It DOES say the effect wears off
-        // PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
-
-        PChar->StatusEffectContainer->AddStatusEffect(PEffect, EffectNotice::Silent);
+        PChar->StatusEffectContainer->AddStatusEffectSilent(
+            xi::StatusEffect::Gestation,
+            static_cast<uint16>(xi::StatusEffect::Gestation),
+            0,
+            0s,
+            duration,
+            0,
+            0,
+            0,
+            0,
+            gestationFlags);
     }
 
     SendFullMonstrosityUpdate(PChar);

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -559,15 +559,14 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
                 }
 
                 PChar->m_mountId = this->Mount.MountId ? this->Mount.MountId + 1 : 0;
-                PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(
-                                                                  xi::StatusEffect::Mounted,
-                                                                  static_cast<uint16>(xi::StatusEffect::Mounted),
-                                                                  this->Mount.MountId ? this->Mount.MountId + 1 : 0,
-                                                                  0s,
-                                                                  30min,
-                                                                  0,
-                                                                  0x40), // previously known as nameflag "FLAG_CHOCOBO"
-                                                              EffectNotice::Silent);
+                PChar->StatusEffectContainer->AddStatusEffectSilent(
+                    xi::StatusEffect::Mounted,
+                    static_cast<uint16>(xi::StatusEffect::Mounted),
+                    this->Mount.MountId ? this->Mount.MountId + 1 : 0,
+                    0s,
+                    30min,
+                    0,
+                    0x40); // previously known as nameflag "FLAG_CHOCOBO"
 
                 PChar->PRecastContainer->Add(RECAST_ABILITY, Recast::Mount, 60s);
                 PChar->pushPacket<GP_SERV_COMMAND_ABIL_RECAST>(PChar);

--- a/src/map/packets/c2s/0x0e7_reqlogout.cpp
+++ b/src/map/packets/c2s/0x0e7_reqlogout.cpp
@@ -47,8 +47,7 @@ void GP_CLI_COMMAND_REQLOGOUT::process(MapSession* PSession, CCharEntity* PChar)
         else
         {
             // Apply new LeaveGame and store the kind as the power.
-            const auto leaveEffect = new CStatusEffect(xi::StatusEffect::Leavegame, 0, static_cast<uint16>(kind), 5s, 0s);
-            PChar->StatusEffectContainer->AddStatusEffect(leaveEffect);
+            PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Leavegame, 0, static_cast<uint16>(kind), 5s, 0s);
         }
     };
 

--- a/src/map/packets/c2s/0x0e8_camp.cpp
+++ b/src/map/packets/c2s/0x0e8_camp.cpp
@@ -53,7 +53,8 @@ void GP_CLI_COMMAND_CAMP::process(MapSession* PSession, CCharEntity* PChar) cons
             PChar->PPet->PAI->Disengage();
         }
 
-        PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Healing, 0, 0, std::chrono::seconds(settings::get<uint8>("map.HEALING_TICK_DELAY")), 0s));
+        const auto healingTickDelay = std::chrono::seconds(settings::get<uint8>("map.HEALING_TICK_DELAY"));
+        PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Healing, 0, 0, healingTickDelay, 0s);
     };
 
     auto disableHealing = [&]()

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -214,8 +214,8 @@ CCharStatusPacket::CCharStatusPacket(CCharEntity* PChar)
     packet->id   = 0x037;
     packet->size = roundUpToNearestFour(sizeof(GP_SERV_SERVERSTATUS)) / 4;
 
-    std::memcpy(packet->BufStatus, PChar->StatusEffectContainer->m_StatusIcons, 32);
-    std::memcpy(&packet->BufStatusBits, &PChar->StatusEffectContainer->m_Flags, sizeof(status_bits_t));
+    std::memcpy(packet->BufStatus, PChar->StatusEffectContainer->statusIcons(), 32);
+    std::memcpy(&packet->BufStatusBits, &PChar->StatusEffectContainer->statusBits(), sizeof(status_bits_t));
 
     packet->UniqueNo      = PChar->id;
     packet->server_status = PChar->animation;

--- a/src/map/packets/s2c/0x063_miscdata_status_icons.cpp
+++ b/src/map/packets/s2c/0x063_miscdata_status_icons.cpp
@@ -37,21 +37,22 @@ GP_SERV_COMMAND_MISCDATA::STATUS_ICONS::STATUS_ICONS(const CCharEntity* PChar)
     std::ranges::fill(packet.icons, 0x00FF);
 
     constexpr uint32 NO_TIMER = 0x7FFFFFFF;
-    int              i        = 0;
+
+    int i = 0;
     PChar->StatusEffectContainer->ForEachEffect(
-        [&packet, &i](CStatusEffect* PEffect)
+        [&packet, &i](CStatusEffect& PEffect)
         {
-            if (PEffect->GetIcon() != 0)
+            if (PEffect.GetIcon() != 0)
             {
                 uint32 timestamp = NO_TIMER;
-                if (PEffect->GetDuration() > 0s && !PEffect->HasEffectFlag(xi::StatusEffectFlag::HideTimer))
+                if (PEffect.GetDuration() > 0s && !PEffect.HasEffectFlag(xi::StatusEffectFlag::HideTimer))
                 {
                     // this value overflows, but the client expects the overflowed timestamp and corrects it
-                    uint32 seconds = timer::count_seconds(PEffect->GetStartTime() - timer::now() + PEffect->GetDuration());
+                    uint32 seconds = timer::count_seconds(PEffect.GetStartTime() - timer::now() + PEffect.GetDuration());
                     seconds += earth_time::vanadiel_timestamp();
                     timestamp = seconds * 60;
                 }
-                packet.icons[i]      = PEffect->GetIcon();
+                packet.icons[i]      = PEffect.GetIcon();
                 packet.timestamps[i] = timestamp;
                 ++i;
             }

--- a/src/map/packets/s2c/0x076_group_effects.cpp
+++ b/src/map/packets/s2c/0x076_group_effects.cpp
@@ -39,8 +39,8 @@ GP_SERV_COMMAND_GROUP_EFFECTS::GP_SERV_COMMAND_GROUP_EFFECTS(const std::vector<C
 
         packet.Members[idx].UniqueNo = PMember->id;
         packet.Members[idx].ActIndex = PMember->targid;
-        packet.Members[idx].Bits     = PMember->StatusEffectContainer->m_Flags;
+        packet.Members[idx].Bits     = PMember->StatusEffectContainer->statusBits();
 
-        std::memcpy(packet.Members[idx].Buffs, PMember->StatusEffectContainer->m_StatusIcons, sizeof(packet.Members[idx].Buffs));
+        std::memcpy(packet.Members[idx].Buffs, PMember->StatusEffectContainer->statusIcons(), sizeof(packet.Members[idx].Buffs));
     }
 }

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -685,7 +685,7 @@ void CParty::AddMember(CBattleEntity* PEntity)
             {
                 PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), MsgStd::LevelSyncActivated);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable | xi::StatusEffectFlag::OnZone);
-                PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), m_PSyncTarget->GetMLevel(), 0s, 0s), EffectNotice::Silent);
+                PChar->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), m_PSyncTarget->GetMLevel(), 0s, 0s);
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(PChar));
             }
         }
@@ -1160,7 +1160,7 @@ void CParty::SetSyncTarget(const std::string& MemberName, MsgStd message)
                     {
                         member->pushPacket<GP_SERV_COMMAND_MESSAGE>(PChar->GetMLevel(), 0, 0, 0, message);
                         member->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable | xi::StatusEffectFlag::OnZone);
-                        member->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), PChar->GetMLevel(), 0s, 0s), EffectNotice::Silent);
+                        member->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), PChar->GetMLevel(), 0s, 0s);
                         member->loc.zone->PushPacket(member, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(member));
                     }
                 }

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -28,243 +28,261 @@
 #include <utility>
 
 CStatusEffect::CStatusEffect(xi::StatusEffect id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid, uint16 subPower, uint16 subIcon, uint16 tier, xi::StatusEffectFlag flags, uint16 sourceType, uint32 sourceTypeParam, uint32 originID)
-: m_StatusID(id)
-, m_SubID(subid)
-, m_Icon(icon)
-, m_Power(power)
-, m_SubPower(subPower)
-, m_SubIcon(subIcon)
-, m_Tier(tier)
-, m_Flags(flags)
-, m_OriginID(originID)
-, m_SourceType(sourceType)
-, m_SourceTypeParam(sourceTypeParam)
-, m_TickTime(tick)
-, m_Duration(duration)
+: statusID_(id)
+, subID_(subid)
+, icon_(icon)
+, power_(power)
+, subPower_(subPower)
+, subIcon_(subIcon)
+, tier_(tier)
+, flags_(flags)
+, originID_(originID)
+, sourceType_(sourceType)
+, sourceTypeParam_(sourceTypeParam)
+, tickTime_(tick)
+, duration_(duration)
 {
-    if (m_TickTime < 3s && m_TickTime != 0s)
+    if (tickTime_ < 3s && tickTime_ != 0s)
     {
         ShowWarning("Status Effect tick time less than 3s is no longer supported.  Effect ID: %d", static_cast<uint16>(id));
     }
+
+    // Reserve space in the modlist so we don't risk it growing
+    modList_.reserve(8);
 }
 
 CStatusEffect::~CStatusEffect() = default;
 
-const std::string& CStatusEffect::GetName()
+auto CStatusEffect::modList() -> std::vector<CModifier>&
 {
-    return m_Name;
+    return modList_;
 }
 
-void CStatusEffect::SetOwner(CBattleEntity* Owner)
+auto CStatusEffect::isDeleted() const -> bool
 {
-    m_POwner = Owner;
+    return deleted_;
 }
 
-auto CStatusEffect::GetStatusID() -> xi::StatusEffect
+auto CStatusEffect::markDeleted() -> void
 {
-    return m_StatusID;
+    deleted_ = true;
 }
 
-CBattleEntity* CStatusEffect::GetOwner()
+auto CStatusEffect::GetName() const -> const std::string&
 {
-    return m_POwner;
+    return name_;
 }
 
-uint32 CStatusEffect::GetSubID() const
+auto CStatusEffect::SetOwner(CBattleEntity* owner) -> void
 {
-    return m_SubID;
+    owner_ = owner;
+}
+
+auto CStatusEffect::GetStatusID() const -> xi::StatusEffect
+{
+    return statusID_;
+}
+
+auto CStatusEffect::GetOwner() const -> CBattleEntity*
+{
+    return owner_;
+}
+
+auto CStatusEffect::GetSubID() const -> uint32
+{
+    return subID_;
 }
 
 auto CStatusEffect::GetSourceType() const -> uint16
 {
-    return m_SourceType;
+    return sourceType_;
 }
 
 auto CStatusEffect::GetSourceTypeParam() const -> uint32
 {
-    return m_SourceTypeParam;
+    return sourceTypeParam_;
 }
 
 auto CStatusEffect::GetOriginID() const -> uint32
 {
-    return m_OriginID;
+    return originID_;
 }
 
-uint16 CStatusEffect::GetEffectType() const
+auto CStatusEffect::GetEffectType() const -> uint16
 {
-    return m_Type;
+    return type_;
 }
 
-uint8 CStatusEffect::GetEffectSlot() const
+auto CStatusEffect::GetEffectSlot() const -> uint8
 {
-    return m_Slot;
+    return slot_;
 }
 
-uint16 CStatusEffect::GetIcon() const
+auto CStatusEffect::GetIcon() const -> uint16
 {
-    return m_Icon;
+    return icon_;
 }
 
-uint16 CStatusEffect::GetPower() const
+auto CStatusEffect::GetPower() const -> uint16
 {
-    return m_Power;
+    return power_;
 }
 
-uint16 CStatusEffect::GetSubPower() const
+auto CStatusEffect::GetSubPower() const -> uint16
 {
-    return m_SubPower;
+    return subPower_;
 }
 
-uint16 CStatusEffect::GetSubIcon() const
+auto CStatusEffect::GetSubIcon() const -> uint16
 {
-    return m_SubIcon;
+    return subIcon_;
 }
 
-uint16 CStatusEffect::GetTier() const
+auto CStatusEffect::GetTier() const -> uint16
 {
-    return m_Tier;
+    return tier_;
 }
 
 auto CStatusEffect::GetEffectFlags() const -> xi::StatusEffectFlag
 {
-    return m_Flags;
+    return flags_;
 }
 
-timer::duration CStatusEffect::GetTickTime() const
+auto CStatusEffect::GetTickTime() const -> timer::duration
 {
-    return m_TickTime;
+    return tickTime_;
 }
 
-timer::duration CStatusEffect::GetDuration() const
+auto CStatusEffect::GetDuration() const -> timer::duration
 {
-    return m_Duration;
+    return duration_;
 }
 
-int CStatusEffect::GetElapsedTickCount() const
+auto CStatusEffect::GetElapsedTickCount() const -> int
 {
-    return m_tickCount;
+    return tickCount_;
 }
 
-timer::time_point CStatusEffect::GetStartTime()
+auto CStatusEffect::GetStartTime() const -> timer::time_point
 {
-    return m_StartTime;
+    return startTime_;
 }
 
-void CStatusEffect::SetEffectFlags(xi::StatusEffectFlag Flags)
+auto CStatusEffect::SetEffectFlags(xi::StatusEffectFlag flags) -> void
 {
-    m_Flags = Flags;
+    flags_ = flags;
 }
 
-void CStatusEffect::AddEffectFlag(xi::StatusEffectFlag Flag)
+auto CStatusEffect::AddEffectFlag(xi::StatusEffectFlag flag) -> void
 {
-    m_Flags |= Flag;
+    flags_ |= flag;
 }
 
-void CStatusEffect::DelEffectFlag(xi::StatusEffectFlag flag)
+auto CStatusEffect::DelEffectFlag(xi::StatusEffectFlag flag) -> void
 {
-    m_Flags &= ~flag;
+    flags_ &= ~flag;
 }
 
-auto CStatusEffect::HasEffectFlag(xi::StatusEffectFlag Flag) -> bool
+auto CStatusEffect::HasEffectFlag(xi::StatusEffectFlag flag) const -> bool
 {
-    return (m_Flags & Flag) != xi::StatusEffectFlag::None;
+    return (flags_ & flag) != xi::StatusEffectFlag::None;
 }
 
-void CStatusEffect::SetIcon(uint16 Icon)
+auto CStatusEffect::SetIcon(uint16 icon) -> void
 {
-    if (m_POwner == nullptr)
+    if (owner_ == nullptr)
     {
-        ShowWarning("m_POwner was null.");
+        ShowWarning("owner_ was null.");
         return;
     }
 
-    m_Icon = Icon;
-    m_POwner->StatusEffectContainer->UpdateStatusIcons();
+    icon_ = icon;
+    owner_->StatusEffectContainer->UpdateStatusIcons();
 }
 
-void CStatusEffect::SetSubIcon(uint16 subIcon)
+auto CStatusEffect::SetSubIcon(uint16 subIcon) -> void
 {
-    if (m_POwner == nullptr)
+    if (owner_ == nullptr)
     {
-        ShowWarning("m_POwner was null.");
+        ShowWarning("owner_ was null.");
         return;
     }
-    m_SubIcon = subIcon;
-    m_POwner->StatusEffectContainer->UpdateStatusIcons();
+    subIcon_ = subIcon;
+    owner_->StatusEffectContainer->UpdateStatusIcons();
 }
 
 auto CStatusEffect::SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void
 {
-    m_SourceType      = sourceType;
-    m_SourceTypeParam = sourceTypeParam;
+    sourceType_      = sourceType;
+    sourceTypeParam_ = sourceTypeParam;
 }
 
 auto CStatusEffect::SetOriginID(uint32 originID) -> void
 {
-    m_OriginID = originID;
+    originID_ = originID;
 }
 
-void CStatusEffect::SetEffectType(uint16 Type)
+auto CStatusEffect::SetEffectType(uint16 type) -> void
 {
-    m_Type = Type;
+    type_ = type;
 }
 
-void CStatusEffect::SetEffectSlot(uint8 Slot)
+auto CStatusEffect::SetEffectSlot(uint8 slot) -> void
 {
-    m_Slot = Slot;
+    slot_ = slot;
 }
 
-void CStatusEffect::SetPower(uint16 Power)
+auto CStatusEffect::SetPower(uint16 power) -> void
 {
-    m_Power = Power;
+    power_ = power;
 }
 
-void CStatusEffect::SetSubPower(uint16 subPower)
+auto CStatusEffect::SetSubPower(uint16 subPower) -> void
 {
-    m_SubPower = subPower;
+    subPower_ = subPower;
 }
 
-void CStatusEffect::SetTier(uint16 tier)
+auto CStatusEffect::SetTier(uint16 tier) -> void
 {
-    m_Tier = tier;
+    tier_ = tier;
 }
 
-void CStatusEffect::SetDuration(timer::duration Duration)
+auto CStatusEffect::SetDuration(timer::duration duration) -> void
 {
-    m_Duration = Duration;
+    duration_ = duration;
 }
 
-void CStatusEffect::SetStartTime(timer::time_point StartTime)
+auto CStatusEffect::SetStartTime(timer::time_point startTime) -> void
 {
-    m_tickCount = 0;
-    m_StartTime = StartTime;
+    tickCount_ = 0;
+    startTime_ = startTime;
 }
 
-void CStatusEffect::SetTickTime(timer::duration tick)
+auto CStatusEffect::SetTickTime(timer::duration tick) -> void
 {
-    m_TickTime = tick;
+    tickTime_ = tick;
 }
 
-void CStatusEffect::IncrementElapsedTickCount()
+auto CStatusEffect::IncrementElapsedTickCount() -> void
 {
-    ++m_tickCount;
+    ++tickCount_;
 }
 
-void CStatusEffect::SetEffectName(std::string name)
+auto CStatusEffect::SetEffectName(std::string name) -> void
 {
-    m_Name = std::move(name);
+    name_ = std::move(name);
 }
 
-void CStatusEffect::addMod(Mod modType, int16 amount)
+auto CStatusEffect::addMod(Mod modType, int16 amount) -> void
 {
     // Since an effect's mod list is only applied to entity when adding the effect
     // we need to add the mod to the entity manually if the effect is already applied
-    if (m_POwner)
+    if (owner_)
     {
-        m_POwner->addModifier(modType, amount);
+        owner_->addModifier(modType, amount);
     }
 
-    for (auto& i : modList)
+    for (auto& i : modList_)
     {
         if (i.getModID() == modType)
         {
@@ -272,32 +290,32 @@ void CStatusEffect::addMod(Mod modType, int16 amount)
             return;
         }
     }
-    modList.emplace_back(modType, amount);
+    modList_.emplace_back(modType, amount);
 }
 
-void CStatusEffect::setMod(Mod modType, int16 value)
+auto CStatusEffect::setMod(Mod modType, int16 value) -> void
 {
-    for (auto& i : modList)
+    for (auto& i : modList_)
     {
         if (i.getModID() == modType)
         {
             // Since an effect's mod list is only applied to entity when adding the effect
             // we need to add the mod to the entity manually if the effect is already applied
-            if (m_POwner)
+            if (owner_)
             {
-                m_POwner->addModifier(modType, value - i.getModAmount());
+                owner_->addModifier(modType, value - i.getModAmount());
             }
 
             i.setModAmount(value);
             return;
         }
     }
-    modList.emplace_back(modType, value);
+    modList_.emplace_back(modType, value);
 
     // Since an effect's mod list is only applied to entity when adding the effect
     // we need to add the mod to the entity manually if the effect is already applied
-    if (m_POwner)
+    if (owner_)
     {
-        m_POwner->addModifier(modType, value);
+        owner_->addModifier(modType, value);
     }
 }

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -35,7 +35,7 @@
 
 /************************************************************************
  *                                                                       *
- *  Unsolved problems:                                                   *
+ *  TODO: (?) Unsolved problems:                                         *
  *                                                                       *
  *  - updating the effect (e.g., rewriting Protect I to Protect II)      *
  *                                                                       *
@@ -53,84 +53,87 @@ enum EffectSourceType : uint8_t
     SOURCE_CORSAIR_ROLL   = 5,
 };
 
-class CStatusEffect
+class CStatusEffect final
 {
 public:
-    auto   GetStatusID() -> xi::StatusEffect;
-    uint32 GetSubID() const;
-    auto   GetSourceType() const -> uint16;
-    auto   GetSourceTypeParam() const -> uint32;
-    auto   GetOriginID() const -> uint32;
-    uint16 GetIcon() const;
-    uint16 GetPower() const;
-    uint16 GetSubPower() const;
-    uint16 GetSubIcon() const;
-    uint16 GetTier() const;
-    auto   GetEffectFlags() const -> xi::StatusEffectFlag;
-    uint16 GetEffectType() const;
-    uint8  GetEffectSlot() const;
-
-    timer::duration   GetTickTime() const;
-    timer::duration   GetDuration() const;
-    int               GetElapsedTickCount() const;
-    timer::time_point GetStartTime();
-    CBattleEntity*    GetOwner();
-
-    void SetEffectFlags(xi::StatusEffectFlag Flags);
-    void AddEffectFlag(xi::StatusEffectFlag Flag);
-    void DelEffectFlag(xi::StatusEffectFlag Flag);
-    auto HasEffectFlag(xi::StatusEffectFlag Flag) -> bool;
-    void SetEffectType(uint16 Type);
-    void SetEffectSlot(uint8 Slot);
-    void SetIcon(uint16 Icon);
-    auto SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void;
-    void SetPower(uint16 Power);
-    void SetSubPower(uint16 subPower);
-    void SetSubIcon(uint16 subIcon);
-    void SetTier(uint16 tier);
-    void SetDuration(timer::duration Duration);
-    void SetOwner(CBattleEntity* Owner);
-    void SetTickTime(timer::duration tick);
-    auto SetOriginID(uint32 originID) -> void;
-
-    void IncrementElapsedTickCount();
-    void SetStartTime(timer::time_point StartTime);
-
-    void addMod(Mod modType, int16 amount);
-    void setMod(Mod modType, int16 value);
-
-    void SetEffectName(std::string name);
-
-    const std::string& GetName();
-
-    std::vector<CModifier> modList; // List of modifiers
-    bool                   deleted{ false };
-
     CStatusEffect(xi::StatusEffect id, uint16 icon, uint16 power, timer::duration tick, timer::duration duration, uint32 subid = 0, uint16 subPower = 0, uint16 subIcon = 0, uint16 tier = 0, xi::StatusEffectFlag flags = xi::StatusEffectFlag::None, uint16 sourceType = EffectSourceType::SOURCE_NONE, uint32 sourceTypeParam = 0, uint32 originID = 0);
-
     ~CStatusEffect();
 
+    auto GetStatusID() const -> xi::StatusEffect;
+    auto GetSubID() const -> uint32;
+    auto GetSourceType() const -> uint16;
+    auto GetSourceTypeParam() const -> uint32;
+    auto GetOriginID() const -> uint32;
+    auto GetIcon() const -> uint16;
+    auto GetPower() const -> uint16;
+    auto GetSubPower() const -> uint16;
+    auto GetSubIcon() const -> uint16;
+    auto GetTier() const -> uint16;
+    auto GetEffectFlags() const -> xi::StatusEffectFlag;
+    auto GetEffectType() const -> uint16;
+    auto GetEffectSlot() const -> uint8;
+
+    auto GetTickTime() const -> timer::duration;
+    auto GetDuration() const -> timer::duration;
+    auto GetElapsedTickCount() const -> int;
+    auto GetStartTime() const -> timer::time_point;
+    auto GetOwner() const -> CBattleEntity*;
+
+    auto SetEffectFlags(xi::StatusEffectFlag flags) -> void;
+    auto AddEffectFlag(xi::StatusEffectFlag flag) -> void;
+    auto DelEffectFlag(xi::StatusEffectFlag flag) -> void;
+    auto HasEffectFlag(xi::StatusEffectFlag flag) const -> bool;
+    auto SetEffectType(uint16 type) -> void;
+    auto SetEffectSlot(uint8 slot) -> void;
+    auto SetIcon(uint16 icon) -> void;
+    auto SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void;
+    auto SetPower(uint16 power) -> void;
+    auto SetSubPower(uint16 subPower) -> void;
+    auto SetSubIcon(uint16 subIcon) -> void;
+    auto SetTier(uint16 tier) -> void;
+    auto SetDuration(timer::duration duration) -> void;
+    auto SetOwner(CBattleEntity* owner) -> void;
+    auto SetTickTime(timer::duration tick) -> void;
+    auto SetOriginID(uint32 originID) -> void;
+
+    auto IncrementElapsedTickCount() -> void;
+    auto SetStartTime(timer::time_point startTime) -> void;
+
+    auto addMod(Mod modType, int16 amount) -> void;
+    auto setMod(Mod modType, int16 value) -> void;
+
+    auto SetEffectName(std::string name) -> void;
+    auto GetName() const -> const std::string&;
+
+    auto modList() -> std::vector<CModifier>&;
+
+    auto markDeleted() -> void;
+    auto isDeleted() const -> bool;
+
 private:
-    CBattleEntity* m_POwner{ nullptr };
+    CBattleEntity* owner_{ nullptr };
 
-    xi::StatusEffect     m_StatusID{ xi::StatusEffect::None };  // Main effect type
-    uint32               m_SubID{ 0 };                          // Additional effect type
-    uint16               m_Icon{ 0 };                           // Effect icon
-    uint16               m_Power{ 0 };                          // Strength of effect
-    uint16               m_SubPower{ 0 };                       // Secondary power of the effect
-    uint16               m_SubIcon{ 0 };                        // Secondary icon for the sub effect (used for things like setting an Aura sub effect icon)
-    uint16               m_Tier{ 0 };                           // Tier of the effect
-    xi::StatusEffectFlag m_Flags{ xi::StatusEffectFlag::None }; // Effect flags (conditions for its disappearance)
-    uint32               m_OriginID{ 0 };                       // The effect's origin ID. (This is usually the ID of the entity that created the effect)
-    uint16               m_SourceType{ 0 };                     // The effect's source type
-    uint32               m_SourceTypeParam{ 0 };                // The effect's source ID
-    uint16               m_Type{ 0 };                           // Used to enforce only one
-    uint8                m_Slot{ 0 };                           // Used to determine slot order for songs/rolls
+    std::vector<CModifier> modList_;          // List of modifiers
+    bool                   deleted_{ false }; // Pending-removal flag, swept by CStatusEffectContainer
 
-    timer::duration   m_TickTime{ 0ms }; // Effect repetition time
-    timer::duration   m_Duration{ 0ms }; // Duration of effect
-    timer::time_point m_StartTime;       // Time to obtain effect
-    int               m_tickCount{ 0 };  // Elapsed ticks
+    xi::StatusEffect     statusID_{ xi::StatusEffect::None };  // Main effect type
+    uint32               subID_{ 0 };                          // Additional effect type
+    uint16               icon_{ 0 };                           // Effect icon
+    uint16               power_{ 0 };                          // Strength of effect
+    uint16               subPower_{ 0 };                       // Secondary power of the effect
+    uint16               subIcon_{ 0 };                        // Secondary icon for the sub effect (used for things like setting an Aura sub effect icon)
+    uint16               tier_{ 0 };                           // Tier of the effect
+    xi::StatusEffectFlag flags_{ xi::StatusEffectFlag::None }; // Effect flags (conditions for its disappearance)
+    uint32               originID_{ 0 };                       // The effect's origin ID. (This is usually the ID of the entity that created the effect)
+    uint16               sourceType_{ 0 };                     // The effect's source type
+    uint32               sourceTypeParam_{ 0 };                // The effect's source ID
+    uint16               type_{ 0 };                           // Used to enforce only one
+    uint8                slot_{ 0 };                           // Used to determine slot order for songs/rolls
 
-    std::string m_Name; // Effect name for scripts
+    timer::duration   tickTime_{ 0ms }; // Effect repetition time
+    timer::duration   duration_{ 0ms }; // Duration of effect
+    timer::time_point startTime_;       // Time to obtain effect
+    int               tickCount_{ 0 };  // Elapsed ticks
+
+    std::string name_; // Effect name for scripts
 };

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -131,7 +131,7 @@ bool isSortedByStartTime(uint16 effectId)
     return static_cast<uint16>(effectId) >= static_cast<uint16>(xi::StatusEffect::FireManeuver) && static_cast<uint16>(effectId) <= static_cast<uint16>(xi::StatusEffect::DarkManeuver);
 }
 
-bool statusOrdering(CStatusEffect* AStatus, CStatusEffect* BStatus)
+bool statusOrdering(const std::unique_ptr<CStatusEffect>& AStatus, const std::unique_ptr<CStatusEffect>& BStatus)
 {
     // Sort by overall status effect ordering, if they have different sort keys
     uint16 ASortKey = effects::EffectsParams[static_cast<uint16>(AStatus->GetStatusID())].SortKey;
@@ -177,19 +177,16 @@ CStatusEffectContainer::CStatusEffectContainer(CBattleEntity* PEntity)
 
 CStatusEffectContainer::~CStatusEffectContainer()
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
-    {
-        destroy(PStatusEffect);
-    }
+    // The owned unique_ptrs in m_StatusEffectSet free their effects automatically.
 }
 
 auto CStatusEffectContainer::GetEffectsCount(xi::StatusEffect ID) -> uint8
 {
     uint8 count = 0;
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == ID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == ID && !PStatusEffect->isDeleted())
         {
             count++;
         }
@@ -200,9 +197,9 @@ auto CStatusEffectContainer::GetEffectsCount(xi::StatusEffect ID) -> uint8
 auto CStatusEffectContainer::GetEffectsCountWithFlag(xi::StatusEffectFlag flag) -> uint8
 {
     uint8 count = 0;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
             count++;
         }
@@ -214,9 +211,9 @@ uint8 CStatusEffectContainer::GetLowestFreeSlot()
 {
     uint8 lowestFreeSlot = 1;
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetEffectSlot() == lowestFreeSlot && !PStatusEffect->deleted)
+        if (PStatusEffect->GetEffectSlot() == lowestFreeSlot && !PStatusEffect->isDeleted())
         {
             lowestFreeSlot++;
         }
@@ -461,13 +458,17 @@ void CStatusEffectContainer::OverwriteStatusEffect(CStatusEffect* StatusEffect)
  *                                                                         *
  **************************************************************************/
 
-bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, EffectNotice notice)
+bool CStatusEffectContainer::AddStatusEffect(std::unique_ptr<CStatusEffect> PStatusEffectPtr, EffectNotice notice)
 {
-    if (PStatusEffect == nullptr)
+    if (PStatusEffectPtr == nullptr)
     {
         ShowWarning("status_effect_container::AddStatusEffect Status effect given was nullptr!");
         return false;
     }
+
+    // Observing pointer into the owned effect; the container takes ownership on insert below.
+    // If the effect is not gained, PStatusEffectPtr frees it when this function returns.
+    CStatusEffect* PStatusEffect = PStatusEffectPtr.get();
 
     uint16 statusId = static_cast<uint16>(PStatusEffect->GetStatusID());
 
@@ -495,7 +496,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, Effec
 
         PStatusEffect->SetStartTime(timer::now());
 
-        m_StatusEffectSet.insert(PStatusEffect);
+        m_StatusEffectSet.insert(std::move(PStatusEffectPtr));
 
         ApplyStateAlteringEffects(PStatusEffect);
 
@@ -505,7 +506,7 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, Effec
         // Set owner after triggering all "effect gain" lua actions, to ensure effect:addMod() doesn't double up mod powers on the entity
         PStatusEffect->SetOwner(m_POwner);
 
-        m_POwner->addModifiers(&PStatusEffect->modList);
+        m_POwner->addModifiers(&PStatusEffect->modList());
 
         if (PStatusEffect->GetStatusID() >= xi::StatusEffect::FireManeuver && PStatusEffect->GetStatusID() <= xi::StatusEffect::DarkManeuver && m_POwner->objtype == TYPE_PC)
         {
@@ -539,10 +540,6 @@ bool CStatusEffectContainer::AddStatusEffect(CStatusEffect* PStatusEffect, Effec
 
         return true;
     }
-    else
-    {
-        destroy(PStatusEffect);
-    }
 
     return false;
 }
@@ -563,15 +560,15 @@ void CStatusEffectContainer::DeleteStatusEffects()
     bool effects_removed = false;
     for (auto effect_iter = m_StatusEffectSet.begin(); effect_iter != m_StatusEffectSet.end();)
     {
-        CStatusEffect* PStatusEffect = *effect_iter;
-        if (PStatusEffect->deleted)
+        CStatusEffect* PStatusEffect = effect_iter->get();
+        if (PStatusEffect->isDeleted())
         {
             if (PStatusEffect->GetIcon() != 0)
             {
                 update_icons = true;
             }
-            effect_iter = m_StatusEffectSet.erase(effect_iter);
-            destroy(PStatusEffect);
+            // erase() frees the owned effect.
+            effect_iter     = m_StatusEffectSet.erase(effect_iter);
             effects_removed = true;
         }
         else
@@ -602,13 +599,13 @@ void CStatusEffectContainer::DeleteStatusEffects()
 
 void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, const EffectNotice notice)
 {
-    if (!PStatusEffect->deleted)
+    if (!PStatusEffect->isDeleted())
     {
-        PStatusEffect->deleted = true;
+        PStatusEffect->markDeleted();
         luautils::OnEffectLose(m_POwner, PStatusEffect);
         m_POwner->PAI->EventHandler.triggerListener("EFFECT_LOSE", m_POwner, PStatusEffect);
 
-        m_POwner->delModifiers(&PStatusEffect->modList);
+        m_POwner->delModifiers(&PStatusEffect->modList());
         if (m_POwner->objtype == TYPE_PC)
         {
             auto* PChar = static_cast<CCharEntity*>(m_POwner);
@@ -668,11 +665,11 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, co
 
 auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect);
+            RemoveStatusEffect(PStatusEffect.get());
             return true;
         }
     }
@@ -681,11 +678,11 @@ auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID) -> bool
 
 auto CStatusEffectContainer::DelStatusEffectSilent(xi::StatusEffect StatusID) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
             return true;
         }
     }
@@ -694,11 +691,11 @@ auto CStatusEffectContainer::DelStatusEffectSilent(xi::StatusEffect StatusID) ->
 
 auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID, uint16 SubID) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect);
+            RemoveStatusEffect(PStatusEffect.get());
             return true;
         }
     }
@@ -707,11 +704,11 @@ auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID, uint16 S
 
 auto CStatusEffectContainer::DelStatusEffectBySource(xi::StatusEffect StatusID, EffectSourceType sourceType, uint16 sourceTypeParam) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSourceType() == sourceType && PStatusEffect->GetSourceTypeParam() == sourceTypeParam && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSourceType() == sourceType && PStatusEffect->GetSourceTypeParam() == sourceTypeParam && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect);
+            RemoveStatusEffect(PStatusEffect.get());
             return true;
         }
     }
@@ -720,11 +717,11 @@ auto CStatusEffectContainer::DelStatusEffectBySource(xi::StatusEffect StatusID, 
 
 auto CStatusEffectContainer::DelStatusEffectByTier(xi::StatusEffect StatusID, uint16 tier) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetTier() == tier && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetTier() == tier && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
             return true;
         }
     }
@@ -740,16 +737,15 @@ void CStatusEffectContainer::KillAllStatusEffect()
 {
     for (auto effect_iter = m_StatusEffectSet.begin(); effect_iter != m_StatusEffectSet.end();)
     {
-        CStatusEffect* PStatusEffect = *effect_iter;
+        CStatusEffect* PStatusEffect = effect_iter->get();
         if (PStatusEffect->GetDuration() != 0s)
         {
             luautils::OnEffectLose(m_POwner, PStatusEffect);
 
-            m_POwner->delModifiers(&PStatusEffect->modList);
+            m_POwner->delModifiers(&PStatusEffect->modList());
 
+            // erase() frees the owned effect.
             effect_iter = m_StatusEffectSet.erase(effect_iter);
-
-            destroy(PStatusEffect);
         }
         else
         {
@@ -796,14 +792,14 @@ void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffe
 
 void CStatusEffectContainer::DelStatusEffectsByIcon(const uint16 BuffNo)
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetIcon() == BuffNo)
         {
             // This covers all effects that client can remove. Function not used for anything the server removes.
             if (!(PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::NoCancel)))
             {
-                RemoveStatusEffect(PStatusEffect);
+                RemoveStatusEffect(PStatusEffect.get());
             }
         }
     }
@@ -816,18 +812,18 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
         return;
     }
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetEffectType() == Type)
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
         }
     }
 }
 
 void CStatusEffectContainer::DelStatusEffectsByFlag(xi::StatusEffectFlag flag, EffectNotice notice)
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->HasEffectFlag(flag))
         {
@@ -841,7 +837,7 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(xi::StatusEffectFlag flag, E
                 continue;
             }
 
-            RemoveStatusEffect(PStatusEffect, notice);
+            RemoveStatusEffect(PStatusEffect.get(), notice);
         }
     }
 }
@@ -855,11 +851,11 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(xi::StatusEffectFlag flag, E
 auto CStatusEffectContainer::EraseStatusEffect() -> xi::StatusEffect
 {
     std::vector<CStatusEffect*> erasableList;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Erasable) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Erasable) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
-            erasableList.emplace_back(PStatusEffect);
+            erasableList.emplace_back(PStatusEffect.get());
         }
     }
     if (!erasableList.empty())
@@ -875,14 +871,14 @@ auto CStatusEffectContainer::EraseStatusEffect() -> xi::StatusEffect
 auto CStatusEffectContainer::HealingWaltz() -> xi::StatusEffect
 {
     std::vector<CStatusEffect*> waltzableList;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Waltzable) ||
              PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Erasable)) &&
             PStatusEffect->GetDuration() > 0s &&
-            !PStatusEffect->deleted)
+            !PStatusEffect->isDeleted())
         {
-            waltzableList.emplace_back(PStatusEffect);
+            waltzableList.emplace_back(PStatusEffect.get());
         }
     }
     if (!waltzableList.empty())
@@ -902,11 +898,11 @@ returns number of erased effects
 uint8 CStatusEffectContainer::EraseAllStatusEffect()
 {
     uint8 count = 0;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Erasable) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Erasable) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect);
+            RemoveStatusEffect(PStatusEffect.get());
             count++;
         }
     }
@@ -922,11 +918,11 @@ uint8 CStatusEffectContainer::EraseAllStatusEffect()
 auto CStatusEffectContainer::DispelStatusEffect(xi::StatusEffectFlag flag) -> xi::StatusEffect
 {
     std::vector<CStatusEffect*> dispelableList;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
-            dispelableList.emplace_back(PStatusEffect);
+            dispelableList.emplace_back(PStatusEffect.get());
         }
     }
     if (!dispelableList.empty())
@@ -946,11 +942,11 @@ returns number of dispelled effects
 auto CStatusEffectContainer::DispelAllStatusEffect(xi::StatusEffectFlag flag) -> uint8
 {
     uint8 count = 0;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
             count++;
         }
     }
@@ -965,9 +961,9 @@ auto CStatusEffectContainer::DispelAllStatusEffect(xi::StatusEffectFlag flag) ->
 
 auto CStatusEffectContainer::HasStatusEffect(xi::StatusEffect StatusID) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
         {
             return true;
         }
@@ -977,9 +973,9 @@ auto CStatusEffectContainer::HasStatusEffect(xi::StatusEffect StatusID) -> bool
 
 auto CStatusEffectContainer::HasStatusEffectByFlag(xi::StatusEffectFlag flag) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(flag) && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(flag) && !PStatusEffect->isDeleted())
         {
             return true;
         }
@@ -1004,7 +1000,7 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
 
     uint8          numOfEffects = 0;
     CStatusEffect* oldestSong   = nullptr;
-    for (CStatusEffect* ExistingStatusEffect : m_StatusEffectSet)
+    for (const auto& ExistingStatusEffect : m_StatusEffectSet)
     {
         if (ExistingStatusEffect->GetStatusID() >= xi::StatusEffect::Requiem && ExistingStatusEffect->GetStatusID() <= xi::StatusEffect::Nocturne) // is an active brd effect
         {
@@ -1019,12 +1015,12 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
                 numOfEffects++;
                 if (!oldestSong)
                 {
-                    oldestSong = ExistingStatusEffect;
+                    oldestSong = ExistingStatusEffect.get();
                 }
                 else if (ExistingStatusEffect->GetStartTime() + ExistingStatusEffect->GetDuration() <
                          oldestSong->GetStartTime() + oldestSong->GetDuration())
                 {
-                    oldestSong = ExistingStatusEffect;
+                    oldestSong = ExistingStatusEffect.get();
                 }
             }
         }
@@ -1037,7 +1033,7 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
             // use lowest available slot, unless it's replacing an existing song
             PStatusEffect->SetEffectSlot(GetLowestFreeSlot());
         }
-        AddStatusEffect(PStatusEffect);
+        AddStatusEffect(std::unique_ptr<CStatusEffect>(PStatusEffect));
         return true;
     }
     else if (oldestSong)
@@ -1045,7 +1041,7 @@ bool CStatusEffectContainer::ApplyBardEffect(CStatusEffect* PStatusEffect, uint8
         // overwrite oldest
         PStatusEffect->SetEffectSlot(oldestSong->GetEffectSlot());
         DelStatusEffectByTier(oldestSong->GetStatusID(), oldestSong->GetTier());
-        AddStatusEffect(PStatusEffect);
+        AddStatusEffect(std::unique_ptr<CStatusEffect>(PStatusEffect));
         return true;
     }
 
@@ -1088,7 +1084,7 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
                     PStatusEffect->SetDuration(PEffect->GetDuration());
                     PStatusEffect->SetEffectSlot(PEffect->GetEffectSlot());
                     DelStatusEffectSilent(PStatusEffect->GetStatusID());
-                    AddStatusEffect(PStatusEffect, EffectNotice::Silent);
+                    AddStatusEffect(std::unique_ptr<CStatusEffect>(PStatusEffect), EffectNotice::Silent);
                     return true;
                 }
                 else // We rolled over 12 and busted.
@@ -1113,7 +1109,7 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
                             bustEffect->SetSource(PEffect->GetSourceType(), PEffect->GetSourceTypeParam());
                             bustEffect->SetOriginID(PEffect->GetOriginID());
 
-                            AddStatusEffect(bustEffect, EffectNotice::Silent);
+                            AddStatusEffect(std::unique_ptr<CStatusEffect>(bustEffect), EffectNotice::Silent);
                             DelStatusEffectSilent(xi::StatusEffect::DoubleUpChance);
                         }
                     }
@@ -1138,12 +1134,12 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
                 {
                     if (oldestRoll == nullptr)
                     {
-                        oldestRoll = PEffect;
+                        oldestRoll = PEffect.get();
                     }
                     else if (PEffect->GetStartTime() + PEffect->GetDuration() <
                              oldestRoll->GetStartTime() + oldestRoll->GetDuration())
                     {
-                        oldestRoll = PEffect;
+                        oldestRoll = PEffect.get();
                     }
                 }
             }
@@ -1153,7 +1149,7 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
     if (numOfEffects < maxRolls)
     {
         PStatusEffect->SetEffectSlot(GetLowestFreeSlot());
-        AddStatusEffect(PStatusEffect, EffectNotice::Silent);
+        AddStatusEffect(std::unique_ptr<CStatusEffect>(PStatusEffect), EffectNotice::Silent);
         return true;
     }
     else if (oldestRoll != nullptr)
@@ -1161,7 +1157,7 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
         // Overwrite the oldest roll
         PStatusEffect->SetEffectSlot(oldestRoll->GetEffectSlot());
         DelStatusEffect(oldestRoll->GetStatusID());
-        AddStatusEffect(PStatusEffect);
+        AddStatusEffect(std::unique_ptr<CStatusEffect>(PStatusEffect));
         return true;
     }
     else
@@ -1174,7 +1170,7 @@ auto CStatusEffectContainer::ApplyCorsairEffect(CStatusEffect* PStatusEffect, ui
 
 bool CStatusEffectContainer::HasCorsairEffect(uint32 charid)
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((PStatusEffect->GetStatusID() >= xi::StatusEffect::FightersRoll && PStatusEffect->GetStatusID() <= xi::StatusEffect::NaturalistsRoll) ||
             PStatusEffect->GetStatusID() == xi::StatusEffect::RuneistsRoll || PStatusEffect->GetStatusID() == xi::StatusEffect::Bust) // is a cor effect
@@ -1191,7 +1187,7 @@ bool CStatusEffectContainer::HasCorsairEffect(uint32 charid)
 void CStatusEffectContainer::Fold(uint32 charid)
 {
     CStatusEffect* oldestRoll = nullptr;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((PStatusEffect->GetStatusID() >= xi::StatusEffect::FightersRoll && PStatusEffect->GetStatusID() <= xi::StatusEffect::NaturalistsRoll) ||
             PStatusEffect->GetStatusID() == xi::StatusEffect::RuneistsRoll || PStatusEffect->GetStatusID() == xi::StatusEffect::Bust) // is a cor effect
@@ -1200,22 +1196,22 @@ void CStatusEffectContainer::Fold(uint32 charid)
             {
                 if (oldestRoll == nullptr)
                 {
-                    oldestRoll = PStatusEffect;
+                    oldestRoll = PStatusEffect.get();
                 }
                 else if (PStatusEffect->GetStatusID() == xi::StatusEffect::Bust)
                 {
                     if (oldestRoll->GetStatusID() == xi::StatusEffect::Bust)
                     {
-                        oldestRoll = PStatusEffect->GetStartTime() > oldestRoll->GetStartTime() ? PStatusEffect : oldestRoll;
+                        oldestRoll = PStatusEffect->GetStartTime() > oldestRoll->GetStartTime() ? PStatusEffect.get() : oldestRoll;
                     }
                     else
                     {
-                        oldestRoll = PStatusEffect;
+                        oldestRoll = PStatusEffect.get();
                     }
                 }
                 else if (oldestRoll->GetStatusID() != xi::StatusEffect::Bust && PStatusEffect->GetStartTime() > oldestRoll->GetStartTime())
                 {
-                    oldestRoll = PStatusEffect;
+                    oldestRoll = PStatusEffect.get();
                 }
             }
         }
@@ -1256,9 +1252,9 @@ auto CStatusEffectContainer::GetHighestRuneEffect() -> xi::StatusEffect
 {
     std::unordered_map<xi::StatusEffect, uint8> runeEffects;
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= xi::StatusEffect::Ignis && PStatusEffect->GetStatusID() <= xi::StatusEffect::Tenebrae && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= xi::StatusEffect::Ignis && PStatusEffect->GetStatusID() <= xi::StatusEffect::Tenebrae && !PStatusEffect->isDeleted())
         {
             if (runeEffects.count(PStatusEffect->GetStatusID()) == 0)
             {
@@ -1315,9 +1311,9 @@ void CStatusEffectContainer::RemoveAllRunes()
 
 auto CStatusEffectContainer::HasStatusEffect(xi::StatusEffect StatusID, uint16 SubID) -> bool
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->isDeleted())
         {
             return true;
         }
@@ -1329,7 +1325,7 @@ auto CStatusEffectContainer::HasStatusEffect(std::initializer_list<xi::StatusEff
 {
     for (auto&& effect_from_set : m_StatusEffectSet)
     {
-        if (!effect_from_set->deleted)
+        if (!effect_from_set->isDeleted())
         {
             for (auto&& effect_to_check : effects)
             {
@@ -1345,11 +1341,11 @@ auto CStatusEffectContainer::HasStatusEffect(std::initializer_list<xi::StatusEff
 
 auto CStatusEffectContainer::GetStatusEffect(xi::StatusEffect StatusID) -> CStatusEffect*
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
         {
-            return PStatusEffect;
+            return PStatusEffect.get();
         }
     }
     return nullptr;
@@ -1357,11 +1353,11 @@ auto CStatusEffectContainer::GetStatusEffect(xi::StatusEffect StatusID) -> CStat
 
 auto CStatusEffectContainer::GetStatusEffect(xi::StatusEffect StatusID, uint32 SubID) -> CStatusEffect*
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->isDeleted())
         {
-            return PStatusEffect;
+            return PStatusEffect.get();
         }
     }
     return nullptr;
@@ -1369,11 +1365,11 @@ auto CStatusEffectContainer::GetStatusEffect(xi::StatusEffect StatusID, uint32 S
 
 auto CStatusEffectContainer::GetStatusEffectBySource(xi::StatusEffect StatusID, EffectSourceType SourceType, uint16 SourceTypeParam) -> CStatusEffect*
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSourceType() == SourceType && PStatusEffect->GetSourceTypeParam() == SourceTypeParam && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSourceType() == SourceType && PStatusEffect->GetSourceTypeParam() == SourceTypeParam && !PStatusEffect->isDeleted())
         {
-            return PStatusEffect;
+            return PStatusEffect.get();
         }
     }
     return nullptr;
@@ -1385,14 +1381,14 @@ auto CStatusEffectContainer::GetStatusEffectBySource(xi::StatusEffect StatusID, 
  *                                                                       *
  ************************************************************************/
 
-auto CStatusEffectContainer::StealStatusEffect(xi::StatusEffectFlag flag, EffectNotice notice) -> CStatusEffect*
+auto CStatusEffectContainer::StealStatusEffect(xi::StatusEffectFlag flag, EffectNotice notice) -> std::unique_ptr<CStatusEffect>
 {
     std::vector<CStatusEffect*> dispelableList;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->deleted)
+        if (PStatusEffect->HasEffectFlag(flag) && PStatusEffect->GetDuration() > 0s && !PStatusEffect->isDeleted())
         {
-            dispelableList.emplace_back(PStatusEffect);
+            dispelableList.emplace_back(PStatusEffect.get());
         }
     }
     if (!dispelableList.empty())
@@ -1401,8 +1397,8 @@ auto CStatusEffectContainer::StealStatusEffect(xi::StatusEffectFlag flag, Effect
 
         CStatusEffect* oldEffect = dispelableList.at(rndIdx);
 
-        // make a copy
-        CStatusEffect* EffectCopy = new CStatusEffect(
+        // make a copy the caller takes ownership of
+        auto EffectCopy = std::make_unique<CStatusEffect>(
             oldEffect->GetStatusID(),
             oldEffect->GetIcon(),
             oldEffect->GetPower(),
@@ -1444,7 +1440,7 @@ void CStatusEffectContainer::UpdateStatusIcons()
 
     uint8 count = 0;
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         uint16 icon = PStatusEffect->GetIcon();
 
@@ -1480,9 +1476,9 @@ auto CStatusEffectContainer::GetStatusEffectsInIDRange(xi::StatusEffect start, x
 {
     std::vector<xi::StatusEffect> effectList;
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->isDeleted())
         {
             effectList.emplace_back(PStatusEffect->GetStatusID());
         }
@@ -1493,9 +1489,9 @@ auto CStatusEffectContainer::GetStatusEffectsInIDRange(xi::StatusEffect start, x
 auto CStatusEffectContainer::GetStatusEffectCountInIDRange(xi::StatusEffect start, xi::StatusEffect end) -> uint8
 {
     uint8 count = 0;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->isDeleted())
         {
             count++;
         }
@@ -1506,13 +1502,13 @@ auto CStatusEffectContainer::GetStatusEffectCountInIDRange(xi::StatusEffect star
 auto CStatusEffectContainer::GetNewestStatusEffectInIDRange(xi::StatusEffect start, xi::StatusEffect end) -> xi::StatusEffect
 {
     CStatusEffect* newest = nullptr;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->isDeleted())
         {
             if (!newest || PStatusEffect->GetStartTime() > newest->GetStartTime())
             {
-                newest = PStatusEffect;
+                newest = PStatusEffect.get();
             }
         }
     }
@@ -1526,13 +1522,13 @@ auto CStatusEffectContainer::GetNewestStatusEffectInIDRange(xi::StatusEffect sta
 void CStatusEffectContainer::RemoveOldestStatusEffectInIDRange(xi::StatusEffect start, xi::StatusEffect end)
 {
     CStatusEffect* oldest = nullptr;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->isDeleted())
         {
             if (!oldest || PStatusEffect->GetStartTime() < oldest->GetStartTime())
             {
-                oldest = PStatusEffect;
+                oldest = PStatusEffect.get();
             }
         }
     }
@@ -1545,13 +1541,13 @@ void CStatusEffectContainer::RemoveOldestStatusEffectInIDRange(xi::StatusEffect 
 void CStatusEffectContainer::RemoveNewestStatusEffectInIDRange(xi::StatusEffect start, xi::StatusEffect end)
 {
     CStatusEffect* newest = nullptr;
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
-        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->deleted)
+        if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end && !PStatusEffect->isDeleted())
         {
             if (!newest || PStatusEffect->GetStartTime() > newest->GetStartTime())
             {
-                newest = PStatusEffect;
+                newest = PStatusEffect.get();
             }
         }
     }
@@ -1563,11 +1559,11 @@ void CStatusEffectContainer::RemoveNewestStatusEffectInIDRange(xi::StatusEffect 
 
 void CStatusEffectContainer::RemoveAllStatusEffectsInIDRange(xi::StatusEffect start, xi::StatusEffect end)
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() >= start && PStatusEffect->GetStatusID() <= end)
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
         }
     }
 }
@@ -1695,7 +1691,7 @@ void CStatusEffectContainer::LoadStatusEffects()
     TracyZoneScoped;
     TracyZoneString(m_POwner->getName());
 
-    std::vector<CStatusEffect*> PEffectList;
+    std::vector<std::unique_ptr<CStatusEffect>> PEffectList;
 
     const auto rset = db::preparedStmt("SELECT effectid, icon, power, tick, "
                                        "duration, subid, subpower, tier, "
@@ -1730,22 +1726,20 @@ void CStatusEffectContainer::LoadStatusEffects()
                 continue;
             }
         }
-        auto* PStatusEffect =
-            new CStatusEffect(effectID,
-                              rset->get<uint16>("icon"),
-                              rset->get<uint16>("power"),
-                              std::chrono::seconds(rset->get<uint16>("tick")),
-                              duration,
-                              rset->get<uint16>("subid"),
-                              rset->get<uint16>("subpower"),
-                              0, // SubIcon (not persisted in char_effects)
-                              rset->get<uint16>("tier"),
-                              static_cast<xi::StatusEffectFlag>(flags),
-                              rset->get<uint16>("sourcetype"),
-                              rset->get<uint32>("sourcetypeparam"),
-                              rset->get<uint32>("originid"));
-
-        PEffectList.emplace_back(PStatusEffect);
+        auto PStatusEffect =
+            std::make_unique<CStatusEffect>(effectID,
+                                            rset->get<uint16>("icon"),
+                                            rset->get<uint16>("power"),
+                                            std::chrono::seconds(rset->get<uint16>("tick")),
+                                            duration,
+                                            rset->get<uint16>("subid"),
+                                            rset->get<uint16>("subpower"),
+                                            0, // SubIcon (not persisted in char_effects)
+                                            rset->get<uint16>("tier"),
+                                            static_cast<xi::StatusEffectFlag>(flags),
+                                            rset->get<uint16>("sourcetype"),
+                                            rset->get<uint32>("sourcetypeparam"),
+                                            rset->get<uint32>("originid"));
 
         // load shadows left
         if (PStatusEffect->GetStatusID() == xi::StatusEffect::CopyImage)
@@ -1756,11 +1750,13 @@ void CStatusEffectContainer::LoadStatusEffects()
         {
             m_POwner->setModifier(Mod::BLINK, PStatusEffect->GetPower());
         }
+
+        PEffectList.emplace_back(std::move(PStatusEffect));
     }
 
     for (auto&& PStatusEffect : PEffectList)
     {
-        AddStatusEffect(PStatusEffect);
+        AddStatusEffect(std::move(PStatusEffect));
     }
 
     m_POwner->UpdateHealth(); // after loading the effects, recalculate the maximum amount of HP/MP
@@ -1784,15 +1780,15 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
 
     db::preparedStmt("DELETE FROM char_effects WHERE charid = ?", m_POwner->id);
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Logout)) || (!logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::OnZone)))
         {
-            RemoveStatusEffect(PStatusEffect, EffectNotice::Silent);
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
             continue;
         }
 
-        if (PStatusEffect->deleted)
+        if (PStatusEffect->isDeleted())
         {
             continue;
         }
@@ -1878,11 +1874,11 @@ void CStatusEffectContainer::CheckEffectsExpiry(timer::time_point tick)
     TracyZoneScoped;
     TracyZoneString(m_POwner->getName());
 
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetDuration() != 0s && PStatusEffect->GetStartTime() + PStatusEffect->GetDuration() <= tick)
         {
-            RemoveStatusEffect(PStatusEffect);
+            RemoveStatusEffect(PStatusEffect.get());
         }
     }
     DeleteStatusEffects();
@@ -1907,49 +1903,48 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
         auto* PChar = static_cast<CCharEntity*>(PEntity);
         if (auraTarget == AURA_TARGET::ALLIES)
         {
-            // clang-format off
-            PChar->ForPartyWithTrusts([&](CBattleEntity* PMember)
-            {
-                if (PMember != nullptr &&
-                    m_POwner->loc.zone &&
-                    PMember->loc.zone &&
-                    m_POwner->loc.zone->GetID() == PMember->loc.zone->GetID() &&
-                    distance(m_POwner->loc.p, PMember->loc.p) <= aura_range + PMember->modelHitboxSize &&
-                    !PMember->isDead())
+            PChar->ForPartyWithTrusts(
+                [&](CBattleEntity* PMember)
                 {
-                    CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()));
-
-                    if (PEffect && (PEffect->GetEffectFlags() & xi::StatusEffectFlag::AlwaysExpiring) != xi::StatusEffectFlag::None)
+                    if (PMember != nullptr &&
+                        m_POwner->loc.zone &&
+                        PMember->loc.zone &&
+                        m_POwner->loc.zone->GetID() == PMember->loc.zone->GetID() &&
+                        distance(m_POwner->loc.p, PMember->loc.p) <= aura_range + PMember->modelHitboxSize &&
+                        !PMember->isDead())
                     {
-                        PEffect->SetStartTime(timer::now());
+                        CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()));
 
-                        // Effect updated, probably from Ecliptic Attrition
-                        // Update status effect with new potency.
-                        // Take care to design your "owning" effects such as the xi::StatusEffect::ColureActive to control the subpower, rather than the resulting effect ticking down.
-                        // Otherwise odd things may happen
-                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        if (PEffect && (PEffect->GetEffectFlags() & xi::StatusEffectFlag::AlwaysExpiring) != xi::StatusEffectFlag::None)
                         {
-                            luautils::OnEffectLose(PMember, PEffect);
-                            PEffect->SetPower(PStatusEffect->GetSubPower());
-                            luautils::OnEffectGain(PMember, PEffect);
+                            PEffect->SetStartTime(timer::now());
+
+                            // Effect updated, probably from Ecliptic Attrition
+                            // Update status effect with new potency.
+                            // Take care to design your "owning" effects such as the xi::StatusEffect::ColureActive to control the subpower, rather than the resulting effect ticking down.
+                            // Otherwise odd things may happen
+                            if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                            {
+                                luautils::OnEffectLose(PMember, PEffect);
+                                PEffect->SetPower(PStatusEffect->GetSubPower());
+                                luautils::OnEffectGain(PMember, PEffect);
+                            }
+                        }
+                        else
+                        {
+                            uint16 icon = PStatusEffect->GetSubIcon() > 0 ? PStatusEffect->GetSubIcon() : PStatusEffect->GetSubID();
+
+                            PEffect = new CStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()), // Effect ID
+                                                        icon,                                                     // Effect Icon
+                                                        PStatusEffect->GetSubPower(),                             // Power
+                                                        3s,                                                       // Tick
+                                                        4s);                                                      // Duration
+                            PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
+                            PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
+                            PMember->StatusEffectContainer->AddStatusEffect(std::unique_ptr<CStatusEffect>(PEffect), EffectNotice::Silent);
                         }
                     }
-                    else
-                    {
-                        uint16 icon = PStatusEffect->GetSubIcon() > 0 ? PStatusEffect->GetSubIcon() : PStatusEffect->GetSubID();
-
-                        PEffect = new CStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()), // Effect ID
-                                                    icon,                                           // Effect Icon
-                                                    PStatusEffect->GetSubPower(),                   // Power
-                                                    3s,                                              // Tick
-                                                    4s);                                             // Duration
-                        PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
-                        PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
-                        PMember->StatusEffectContainer->AddStatusEffect(PEffect, EffectNotice::Silent);
-                    }
-                }
-            });
-            // clang-format on
+                });
         }
         else if (auraTarget == AURA_TARGET::ENEMIES)
         {
@@ -1989,7 +1984,7 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                                                     4s);                                                      // Duration
                         PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
                         PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
-                        PTarget->StatusEffectContainer->AddStatusEffect(PEffect, EffectNotice::Silent);
+                        PTarget->StatusEffectContainer->AddStatusEffect(std::unique_ptr<CStatusEffect>(PEffect), EffectNotice::Silent);
                     }
                 }
             }
@@ -1999,48 +1994,47 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
     {
         if (auraTarget == AURA_TARGET::ALLIES)
         {
-            // clang-format off
-            PEntity->ForParty([&](CBattleEntity* PMember)
-            {
-                if (PMember != nullptr &&
-                    m_POwner->loc.zone &&
-                    PMember->loc.zone &&
-                    PEntity->loc.zone->GetID() == PMember->loc.zone->GetID() && distance(m_POwner->loc.p, PMember->loc.p) <= aura_range + PMember->modelHitboxSize &&
-                    !PMember->isDead())
+            PEntity->ForParty(
+                [&](CBattleEntity* PMember)
                 {
-                    CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()));
-
-                    if (PEffect && (PEffect->GetEffectFlags() & xi::StatusEffectFlag::AlwaysExpiring) != xi::StatusEffectFlag::None)
+                    if (PMember != nullptr &&
+                        m_POwner->loc.zone &&
+                        PMember->loc.zone &&
+                        PEntity->loc.zone->GetID() == PMember->loc.zone->GetID() && distance(m_POwner->loc.p, PMember->loc.p) <= aura_range + PMember->modelHitboxSize &&
+                        !PMember->isDead())
                     {
-                        PEffect->SetStartTime(timer::now());
+                        CStatusEffect* PEffect = PMember->StatusEffectContainer->GetStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()));
 
-                        // Effect updated, probably from Ecliptic Attrition
-                        // Update status effect with new potency.
-                        // Take care to design your "owning" effects such as the xi::StatusEffect::ColureActive to control the subpower, rather than the resulting effect ticking down.
-                        // Otherwise odd things may happen
-                        if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                        if (PEffect && (PEffect->GetEffectFlags() & xi::StatusEffectFlag::AlwaysExpiring) != xi::StatusEffectFlag::None)
                         {
-                            luautils::OnEffectLose(PMember, PEffect);
-                            PEffect->SetPower(PStatusEffect->GetSubPower());
-                            luautils::OnEffectGain(PMember, PEffect);
+                            PEffect->SetStartTime(timer::now());
+
+                            // Effect updated, probably from Ecliptic Attrition
+                            // Update status effect with new potency.
+                            // Take care to design your "owning" effects such as the xi::StatusEffect::ColureActive to control the subpower, rather than the resulting effect ticking down.
+                            // Otherwise odd things may happen
+                            if (PEffect->GetPower() != PStatusEffect->GetSubPower())
+                            {
+                                luautils::OnEffectLose(PMember, PEffect);
+                                PEffect->SetPower(PStatusEffect->GetSubPower());
+                                luautils::OnEffectGain(PMember, PEffect);
+                            }
+                        }
+                        else
+                        {
+                            uint16 icon = PStatusEffect->GetSubIcon() > 0 ? PStatusEffect->GetSubIcon() : PStatusEffect->GetSubID();
+
+                            PEffect = new CStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()), // Effect ID
+                                                        icon,                                                     // Effect Icon
+                                                        PStatusEffect->GetSubPower(),                             // Power
+                                                        3s,                                                       // Tick
+                                                        4s);                                                      // Duration
+                            PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
+                            PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
+                            PMember->StatusEffectContainer->AddStatusEffect(std::unique_ptr<CStatusEffect>(PEffect), EffectNotice::Silent);
                         }
                     }
-                    else
-                    {
-                        uint16 icon = PStatusEffect->GetSubIcon() > 0 ? PStatusEffect->GetSubIcon() : PStatusEffect->GetSubID();
-
-                        PEffect = new CStatusEffect(static_cast<xi::StatusEffect>(PStatusEffect->GetSubID()), // Effect ID
-                                                    icon,                                           // Effect Icon
-                                                    PStatusEffect->GetSubPower(),                   // Power
-                                                    3s,                                              // Tick
-                                                    4s);                                             // Duration
-                        PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
-                        PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
-                        PMember->StatusEffectContainer->AddStatusEffect(PEffect, EffectNotice::Silent);
-                    }
-                }
-            });
-            // clang-format on
+                });
         }
         else if (auraTarget == AURA_TARGET::ENEMIES)
         {
@@ -2083,7 +2077,7 @@ void CStatusEffectContainer::HandleAura(CStatusEffect* PStatusEffect)
                                                     4s);                                                      // Duration
                         PEffect->AddEffectFlag(xi::StatusEffectFlag::NoLossMessage);
                         PEffect->AddEffectFlag(xi::StatusEffectFlag::AlwaysExpiring);
-                        PTarget->StatusEffectContainer->AddStatusEffect(PEffect, EffectNotice::Silent);
+                        PTarget->StatusEffectContainer->AddStatusEffect(std::unique_ptr<CStatusEffect>(PEffect), EffectNotice::Silent);
                     }
                 }
             }
@@ -2117,10 +2111,10 @@ void CStatusEffectContainer::TickEffects(timer::time_point tick)
             {
                 if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Aura))
                 {
-                    HandleAura(PStatusEffect);
+                    HandleAura(PStatusEffect.get());
                 }
                 PStatusEffect->IncrementElapsedTickCount();
-                luautils::OnEffectTick(m_POwner, PStatusEffect);
+                luautils::OnEffectTick(m_POwner, PStatusEffect.get());
             }
         }
     }
@@ -2300,13 +2294,14 @@ bool CStatusEffectContainer::HasPreventActionEffect(bool ignoreCharm)
         return HasStatusEffect(
             { xi::StatusEffect::SleepI, xi::StatusEffect::SleepIi, xi::StatusEffect::Petrification, xi::StatusEffect::Lullaby, xi::StatusEffect::Penalty, xi::StatusEffect::Stun, xi::StatusEffect::Terror });
     }
+
     return HasStatusEffect(
         { xi::StatusEffect::SleepI, xi::StatusEffect::SleepIi, xi::StatusEffect::Petrification, xi::StatusEffect::Lullaby, xi::StatusEffect::CharmI, xi::StatusEffect::CharmIi, xi::StatusEffect::Penalty, xi::StatusEffect::Stun, xi::StatusEffect::Terror });
 }
 
 uint16 CStatusEffectContainer::GetConfrontationEffect()
 {
-    for (auto* PEffect : m_StatusEffectSet)
+    for (const auto& PEffect : m_StatusEffectSet)
     {
         if (PEffect->HasEffectFlag(xi::StatusEffectFlag::Confrontation))
         {
@@ -2318,18 +2313,18 @@ uint16 CStatusEffectContainer::GetConfrontationEffect()
 
 void CStatusEffectContainer::CopyConfrontationEffect(CBattleEntity* PEntity)
 {
-    for (auto* PEffect : m_StatusEffectSet)
+    for (const auto& PEffect : m_StatusEffectSet)
     {
         if (PEffect->HasEffectFlag(xi::StatusEffectFlag::Confrontation))
         {
-            PEntity->StatusEffectContainer->AddStatusEffect(new CStatusEffect(*PEffect));
+            PEntity->StatusEffectContainer->AddStatusEffect(*PEffect);
         }
     }
 }
 
 bool CStatusEffectContainer::CheckForElevenRoll()
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((PStatusEffect->GetStatusID() >= xi::StatusEffect::FightersRoll && PStatusEffect->GetStatusID() <= xi::StatusEffect::NaturalistsRoll &&
              PStatusEffect->GetSubPower() == 11) ||
@@ -2355,7 +2350,7 @@ void CStatusEffectContainer::WakeUp()
 
 bool CStatusEffectContainer::HasBustEffect(uint16 id)
 {
-    for (CStatusEffect* PStatusEffect : m_StatusEffectSet)
+    for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == xi::StatusEffect::Bust && PStatusEffect->GetSubPower() == id)
         {
@@ -2363,4 +2358,14 @@ bool CStatusEffectContainer::HasBustEffect(uint16 id)
         }
     }
     return false;
+}
+
+auto CStatusEffectContainer::statusIcons() const -> const uint8*
+{
+    return m_StatusIcons;
+}
+
+auto CStatusEffectContainer::statusBits() const -> const uint64&
+{
+    return m_Flags;
 }

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -428,6 +428,8 @@ bool CStatusEffectContainer::CanGainStatusEffect(CStatusEffect* PStatusEffect)
 
 void CStatusEffectContainer::OverwriteStatusEffect(CStatusEffect* StatusEffect)
 {
+    TracyZoneScoped;
+
     xi::StatusEffect statusEffect = StatusEffect->GetStatusID();
     // remove effect
     xi::EffectOverwrite overwrite = effects::EffectsParams[static_cast<uint16>(statusEffect)].Overwrite;
@@ -465,6 +467,8 @@ bool CStatusEffectContainer::AddStatusEffect(std::unique_ptr<CStatusEffect> PSta
         ShowWarning("status_effect_container::AddStatusEffect Status effect given was nullptr!");
         return false;
     }
+
+    TracyZoneScoped;
 
     // Observing pointer into the owned effect; the container takes ownership on insert below.
     // If the effect is not gained, PStatusEffectPtr frees it when this function returns.
@@ -599,6 +603,8 @@ void CStatusEffectContainer::DeleteStatusEffects()
 
 void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, const EffectNotice notice)
 {
+    TracyZoneScoped;
+
     if (!PStatusEffect->isDeleted())
     {
         PStatusEffect->markDeleted();
@@ -665,6 +671,8 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, co
 
 auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID) -> bool
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
@@ -678,6 +686,8 @@ auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID) -> bool
 
 auto CStatusEffectContainer::DelStatusEffectSilent(xi::StatusEffect StatusID) -> bool
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && !PStatusEffect->isDeleted())
@@ -691,6 +701,8 @@ auto CStatusEffectContainer::DelStatusEffectSilent(xi::StatusEffect StatusID) ->
 
 auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID, uint16 SubID) -> bool
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSubID() == SubID && !PStatusEffect->isDeleted())
@@ -704,6 +716,8 @@ auto CStatusEffectContainer::DelStatusEffect(xi::StatusEffect StatusID, uint16 S
 
 auto CStatusEffectContainer::DelStatusEffectBySource(xi::StatusEffect StatusID, EffectSourceType sourceType, uint16 sourceTypeParam) -> bool
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetSourceType() == sourceType && PStatusEffect->GetSourceTypeParam() == sourceTypeParam && !PStatusEffect->isDeleted())
@@ -717,6 +731,8 @@ auto CStatusEffectContainer::DelStatusEffectBySource(xi::StatusEffect StatusID, 
 
 auto CStatusEffectContainer::DelStatusEffectByTier(xi::StatusEffect StatusID, uint16 tier) -> bool
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetStatusID() == StatusID && PStatusEffect->GetTier() == tier && !PStatusEffect->isDeleted())
@@ -735,6 +751,8 @@ auto CStatusEffectContainer::DelStatusEffectByTier(xi::StatusEffect StatusID, ui
  ************************************************************************/
 void CStatusEffectContainer::KillAllStatusEffect()
 {
+    TracyZoneScoped;
+
     for (auto effect_iter = m_StatusEffectSet.begin(); effect_iter != m_StatusEffectSet.end();)
     {
         CStatusEffect* PStatusEffect = effect_iter->get();
@@ -758,6 +776,8 @@ void CStatusEffectContainer::KillAllStatusEffect()
 // Apply any state alterations for the effect if applicable.
 void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffect)
 {
+    TracyZoneScoped;
+
     xi::StatusEffect effect = StatusEffect->GetStatusID();
 
     if (m_POwner->isAlive())
@@ -792,6 +812,8 @@ void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffe
 
 void CStatusEffectContainer::DelStatusEffectsByIcon(const uint16 BuffNo)
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetIcon() == BuffNo)
@@ -812,6 +834,8 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
         return;
     }
 
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->GetEffectType() == Type)
@@ -823,6 +847,8 @@ void CStatusEffectContainer::DelStatusEffectsByType(uint16 Type)
 
 void CStatusEffectContainer::DelStatusEffectsByFlag(xi::StatusEffectFlag flag, EffectNotice notice)
 {
+    TracyZoneScoped;
+
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if (PStatusEffect->HasEffectFlag(flag))
@@ -850,6 +876,8 @@ void CStatusEffectContainer::DelStatusEffectsByFlag(xi::StatusEffectFlag flag, E
 
 auto CStatusEffectContainer::EraseStatusEffect() -> xi::StatusEffect
 {
+    TracyZoneScoped;
+
     std::vector<CStatusEffect*> erasableList;
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
@@ -870,6 +898,8 @@ auto CStatusEffectContainer::EraseStatusEffect() -> xi::StatusEffect
 
 auto CStatusEffectContainer::HealingWaltz() -> xi::StatusEffect
 {
+    TracyZoneScoped;
+
     std::vector<CStatusEffect*> waltzableList;
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
@@ -891,12 +921,13 @@ auto CStatusEffectContainer::HealingWaltz() -> xi::StatusEffect
     return xi::StatusEffect::None;
 }
 
-/*
-Erases all negative status effects
-returns number of erased effects
-*/
+// Erases all negative status effects
+// returns number of erased effects
+
 uint8 CStatusEffectContainer::EraseAllStatusEffect()
 {
+    TracyZoneScoped;
+
     uint8 count = 0;
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
@@ -917,6 +948,8 @@ uint8 CStatusEffectContainer::EraseAllStatusEffect()
 
 auto CStatusEffectContainer::DispelStatusEffect(xi::StatusEffectFlag flag) -> xi::StatusEffect
 {
+    TracyZoneScoped;
+
     std::vector<CStatusEffect*> dispelableList;
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -167,6 +167,8 @@ private:
 template <typename T, typename... Args>
 bool CStatusEffectContainer::AddStatusEffect(Args&&... args)
 {
+    TracyZoneScoped;
+
     return AddStatusEffect(std::make_unique<T>(std::forward<Args>(args)...), EffectNotice::ShowMessage);
 }
 
@@ -174,12 +176,16 @@ bool CStatusEffectContainer::AddStatusEffect(Args&&... args)
 template <typename T, typename... Args>
 bool CStatusEffectContainer::AddStatusEffectSilent(Args&&... args)
 {
+    TracyZoneScoped;
+
     return AddStatusEffect(std::make_unique<T>(std::forward<Args>(args)...), EffectNotice::Silent);
 }
 
 template <typename F, typename... Args>
 void CStatusEffectContainer::ForEachEffect(F func, Args&&... args)
 {
+    TracyZoneScoped;
+
     // The container owns each effect; hand callers a reference to the underlying effect.
     for (auto&& PEffect : m_StatusEffectSet)
     {

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -23,7 +23,9 @@
 
 #include "common/cbasetypes.h"
 
+#include <memory>
 #include <set>
+#include <utility>
 
 #include "status_effect.h"
 
@@ -41,15 +43,24 @@ enum class EffectNotice : uint8
     Silent      = 1, // Suppress the message entirely
 };
 
-class CStatusEffectContainer
+class CStatusEffectContainer final
 {
 public:
-    uint64 m_Flags{ 0 };        // Bits of overflow of bytes m_statusicons (two battles for each effect)
-    uint8  m_StatusIcons[32]{}; // Icons status effects
+    CStatusEffectContainer(CBattleEntity* PEntity);
+    ~CStatusEffectContainer();
+
+    template <typename T = CStatusEffect, typename... Args>
+    bool AddStatusEffect(Args&&... args);
+
+    template <typename T = CStatusEffect, typename... Args>
+    bool AddStatusEffectSilent(Args&&... args);
+
+    template <typename F, typename... Args>
+    void ForEachEffect(F func, Args&&... args);
 
     bool ApplyBardEffect(CStatusEffect* PStatusEffect, uint8 maxSongs);
     bool CanGainStatusEffect(CStatusEffect* PStatusEffect); // returns true if the status effect will take effect
-    bool AddStatusEffect(CStatusEffect* StatusEffect, EffectNotice = EffectNotice::ShowMessage);
+
     auto DelStatusEffect(xi::StatusEffect StatusID) -> bool;
     auto DelStatusEffectSilent(xi::StatusEffect StatusID) -> bool;
     auto DelStatusEffect(xi::StatusEffect StatusID, uint16 SubID) -> bool;
@@ -66,12 +77,12 @@ public:
     auto HasStatusEffect(std::initializer_list<xi::StatusEffect>) -> bool;
     auto HasStatusEffectByFlag(xi::StatusEffectFlag flag) -> bool;
 
-    auto  EraseStatusEffect() -> xi::StatusEffect;                                             // We delete the first negative effect
-    auto  HealingWaltz() -> xi::StatusEffect;                                                  // dancers healing waltz
-    uint8 EraseAllStatusEffect();                                                              // erases all status effects
-    auto  DispelStatusEffect(xi::StatusEffectFlag flag) -> xi::StatusEffect;                   // We delete the first positive effect
-    auto  DispelAllStatusEffect(xi::StatusEffectFlag flag) -> uint8;                           // dispels all status effects
-    auto  StealStatusEffect(xi::StatusEffectFlag flag, EffectNotice notice) -> CStatusEffect*; // dispels one effect and returns it
+    auto  EraseStatusEffect() -> xi::StatusEffect;                                                             // We delete the first negative effect
+    auto  HealingWaltz() -> xi::StatusEffect;                                                                  // dancers healing waltz
+    uint8 EraseAllStatusEffect();                                                                              // erases all status effects
+    auto  DispelStatusEffect(xi::StatusEffectFlag flag) -> xi::StatusEffect;                                   // We delete the first positive effect
+    auto  DispelAllStatusEffect(xi::StatusEffectFlag flag) -> uint8;                                           // dispels all status effects
+    auto  StealStatusEffect(xi::StatusEffectFlag flag, EffectNotice notice) -> std::unique_ptr<CStatusEffect>; // dispels one effect and hands ownership to the caller
 
     auto GetStatusEffect(xi::StatusEffect StatusID) -> CStatusEffect*;
     auto GetStatusEffect(xi::StatusEffect StatusID, uint32 SubID) -> CStatusEffect*;
@@ -123,20 +134,16 @@ public:
     uint16 GetConfrontationEffect();                        // gets confrontation number (bcnm, confrontation, campaign, reive mark)
     void   CopyConfrontationEffect(CBattleEntity* PEntity); // copies confrontation status (pet summoning, etc)
 
-    template <typename F, typename... Args>
-    void ForEachEffect(F func, Args&&... args)
-    {
-        for (auto&& PEffect : m_StatusEffectSet)
-        {
-            func(PEffect, std::forward<Args>(args)...);
-        }
-    }
-
-    CStatusEffectContainer(CBattleEntity* PEntity);
-    ~CStatusEffectContainer();
+    [[nodiscard]] auto statusIcons() const -> const uint8*;
+    [[nodiscard]] auto statusBits() const -> const uint64&;
 
 private:
     CBattleEntity* m_POwner = nullptr;
+
+    uint64 m_Flags{ 0 };        // Bits of overflow of bytes m_statusicons (two battles for each effect)
+    uint8  m_StatusIcons[32]{}; // Icons status effects
+
+    bool AddStatusEffect(std::unique_ptr<CStatusEffect> StatusEffect, EffectNotice = EffectNotice::ShowMessage);
 
     // void ReplaceStatusEffect(xi::StatusEffect effect); //this needs to be implemented
     void RemoveStatusEffect(CStatusEffect* PStatusEffect, EffectNotice notice = EffectNotice::ShowMessage); // We remove the effect by its number in the container
@@ -146,14 +153,43 @@ private:
 
     void OverwriteStatusEffect(CStatusEffect* StatusEffect);
 
-    std::multiset<CStatusEffect*, bool (*)(CStatusEffect* AStatus, CStatusEffect* BStatus)> m_StatusEffectSet{};
+    // The container owns the lifetime of its status effects. External access is handed out as
+    // observing CStatusEffect* (nullable lookups) or CStatusEffect& (iteration via ForEachEffect).
+    std::multiset<std::unique_ptr<CStatusEffect>, bool (*)(const std::unique_ptr<CStatusEffect>&, const std::unique_ptr<CStatusEffect>&)> m_StatusEffectSet;
 };
 
-/************************************************************************
- *                                                                       *
- *                                                                       *
- *                                                                       *
- ************************************************************************/
+//
+// Inline impls
+//
+
+// TODO: Now that we've extracted these into helpers, we can pre-allocate or pool these allocations
+
+template <typename T, typename... Args>
+bool CStatusEffectContainer::AddStatusEffect(Args&&... args)
+{
+    return AddStatusEffect(std::make_unique<T>(std::forward<Args>(args)...), EffectNotice::ShowMessage);
+}
+
+// As above, but suppresses the gain/loss messages (the EffectNotice::Silent path).
+template <typename T, typename... Args>
+bool CStatusEffectContainer::AddStatusEffectSilent(Args&&... args)
+{
+    return AddStatusEffect(std::make_unique<T>(std::forward<Args>(args)...), EffectNotice::Silent);
+}
+
+template <typename F, typename... Args>
+void CStatusEffectContainer::ForEachEffect(F func, Args&&... args)
+{
+    // The container owns each effect; hand callers a reference to the underlying effect.
+    for (auto&& PEffect : m_StatusEffectSet)
+    {
+        func(*PEffect, std::forward<Args>(args)...);
+    }
+}
+
+//
+// Helpers
+//
 
 namespace effects
 {

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1183,7 +1183,7 @@ void HandleSpikesStatusEffect(const CBattleEntity* PAttacker, const CBattleEntit
         {
             if (!PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::CurseI))
             {
-                PAttacker->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::CurseI, static_cast<uint16>(xi::StatusEffect::CurseI), 15, 0s, 3min));
+                PAttacker->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::CurseI, static_cast<uint16>(xi::StatusEffect::CurseI), 15, 0s, 3min);
             }
             break;
         }
@@ -1191,7 +1191,7 @@ void HandleSpikesStatusEffect(const CBattleEntity* PAttacker, const CBattleEntit
         {
             if (xirand::GetRandomNumber(100) < 20 + lvlDiff && !PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Paralysis))
             {
-                PAttacker->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Paralysis, static_cast<uint16>(xi::StatusEffect::Paralysis), 20, 0s, 30s));
+                PAttacker->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Paralysis, static_cast<uint16>(xi::StatusEffect::Paralysis), 20, 0s, 30s);
             }
             break;
         }
@@ -1199,7 +1199,7 @@ void HandleSpikesStatusEffect(const CBattleEntity* PAttacker, const CBattleEntit
         {
             if (xirand::GetRandomNumber(100) < 30 + lvlDiff && !PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Stun))
             {
-                PAttacker->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Stun, static_cast<uint16>(xi::StatusEffect::Stun), 1, 0s, 3s));
+                PAttacker->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Stun, static_cast<uint16>(xi::StatusEffect::Stun), 1, 0s, 3s);
             }
             break;
         }
@@ -1348,17 +1348,17 @@ void HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, action_re
         }
         if (PDefender->objtype == TYPE_PC)
         {
-            PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(previous_daze, 0, previous_daze_power, 0s, 10s, PAttacker->id), EffectNotice::Silent);
+            PDefender->StatusEffectContainer->AddStatusEffectSilent(previous_daze, 0, previous_daze_power, 0s, 10s, PAttacker->id);
         }
         else
         {
             if (previous_daze == xi::StatusEffect::DrainDaze && PDefender->m_EcoSystem != xi::Ecosystem::Undead)
             {
-                PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::DrainDaze, 0, previous_daze_power, 0s, 10s, PAttacker->id), EffectNotice::Silent);
+                PDefender->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::DrainDaze, 0, previous_daze_power, 0s, 10s, PAttacker->id);
             }
             else
             {
-                PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(previous_daze, 0, previous_daze_power, 0s, 10s, PAttacker->id), EffectNotice::Silent);
+                PDefender->StatusEffectContainer->AddStatusEffectSilent(previous_daze, 0, previous_daze_power, 0s, 10s, PAttacker->id);
             }
         }
     }
@@ -1702,7 +1702,7 @@ void HandleEnspell(CBattleEntity* PAttacker, CBattleEntity* PDefender, action_re
             {
                 Action->additionalEffect = ActionProcAddEffect::Haste;
                 // Ability haste added in scripts\globals\effects\haste_samba_haste_effect.lua
-                PAttacker->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::HasteSambaHaste, 0, power, 0s, 10s));
+                PAttacker->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::HasteSambaHaste, 0, power, 0s, 10s);
                 // Status effect removed in CAttackRound constructor (i.e. after next attack round is calculated)
             }
         }
@@ -3356,7 +3356,7 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
     if (PSCEffect == nullptr && PCBEffect == nullptr)
     {
         // No effect exists, apply an effect using the weaponskill ID as the power with a tier of 0.
-        PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Skillchain, 0, combined_properties, 0s, 10s, 0, 0, 0));
+        PDefender->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Skillchain, 0, combined_properties, 0s, 10s, 0, 0, 0);
         return ActionProcSkillChain::None;
     }
 
@@ -3386,7 +3386,7 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
 
             skillchain = FormSkillchain(resonanceProperties, skillProperties);
         }
-        PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Skillchain, 0, combined_properties, 0s, 10s, 0, 0, 0));
+        PDefender->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Skillchain, 0, combined_properties, 0s, 10s, 0, 0, 0);
         PDefender->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Chainbound);
         PSCEffect = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Skillchain, 0);
     }
@@ -4943,7 +4943,7 @@ void HandleScarletDelirium(CBattleEntity* PDefender, int32 damage)
 
         // Convert status effect from "Absorb damage" mode to "Provide damage bonus" mode
         PDefender->StatusEffectContainer->DelStatusEffectSilent(xi::StatusEffect::ScarletDelirium);
-        PDefender->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::ScarletDelirium1, static_cast<uint16>(xi::StatusEffect::ScarletDelirium1), power, 0s, duration), EffectNotice::Silent);
+        PDefender->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::ScarletDelirium1, static_cast<uint16>(xi::StatusEffect::ScarletDelirium1), power, 0s, duration);
     }
 }
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7110,7 +7110,7 @@ void ReloadParty(CCharEntity* PChar)
         {
             PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, PSyncTarget->GetMLevel(), MsgBasic::LevelSyncActivated);
             PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable);
-            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), PSyncTarget->GetMLevel(), 0s, 0s), EffectNotice::Silent);
+            PChar->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), PSyncTarget->GetMLevel(), 0s, 0s);
         }
 
         if (allianceid != 0)

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1242,15 +1242,15 @@ void SetupPetWithMaster(CBattleEntity* PMaster, CPetEntity* PPet)
 
     if (PMaster->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Debilitation))
     {
-        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Debilitation, static_cast<uint16>(xi::StatusEffect::Debilitation), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Debilitation)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Debilitation)->GetDuration()), EffectNotice::Silent);
+        PPet->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::Debilitation, static_cast<uint16>(xi::StatusEffect::Debilitation), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Debilitation)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Debilitation)->GetDuration());
     }
     if (PMaster->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Omerta))
     {
-        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Omerta, static_cast<uint16>(xi::StatusEffect::Omerta), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Omerta)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Omerta)->GetDuration()), EffectNotice::Silent);
+        PPet->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::Omerta, static_cast<uint16>(xi::StatusEffect::Omerta), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Omerta)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Omerta)->GetDuration());
     }
     if (PMaster->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Impairment))
     {
-        PPet->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::Impairment, static_cast<uint16>(xi::StatusEffect::Impairment), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Impairment)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Impairment)->GetDuration()), EffectNotice::Silent);
+        PPet->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::Impairment, static_cast<uint16>(xi::StatusEffect::Impairment), PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Impairment)->GetPower(), 0s, PMaster->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Impairment)->GetDuration());
     }
 }
 

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -664,7 +664,7 @@ void CZone::updateCharLevelRestriction(CCharEntity* PChar)
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::SynthSupport, EffectNotice::Silent);
         PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Bloodpact, EffectNotice::Silent);
         PChar->StatusEffectContainer->DelStatusEffectSilent(xi::StatusEffect::Reraise);
-        PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), m_levelRestriction, 0s, 0s));
+        PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), m_levelRestriction, 0s, 0s);
     }
 }
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -228,7 +228,7 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
 
         if (PChar->PInstance->GetLevelCap() > 0)
         {
-            PChar->StatusEffectContainer->AddStatusEffect(new CStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), PChar->PInstance->GetLevelCap(), 0s, 0s));
+            PChar->StatusEffectContainer->AddStatusEffect(xi::StatusEffect::LevelRestriction, static_cast<uint16>(xi::StatusEffect::LevelRestriction), PChar->PInstance->GetLevelCap(), 0s, 0s);
         }
 
         if (PChar->PInstance->CheckFirstEntry(PChar->id))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Continuing to tidy: hiding public members, removing public `new`, etc.

This includes a rough benchmark for status effect application and ticking, I'm experimenting with some special Lua caching in another branch that might make use of this once it's in.

This should have no logical changes, we're still allocating/deallocating all the time, but it's behind `unique_ptr`. This is a good candidate for pooling later on.

EDIT:
Also adds second-level caching for status effect scripts:
<img width="731" height="137" alt="image" src="https://github.com/user-attachments/assets/84fb89c8-9ac0-45b7-a33a-70d11626bd80" />
