### PR TITLE
Core: Add mockable socket interface

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -129,6 +129,7 @@ set(MAP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/recast_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/socket.h
     ${CMAKE_CURRENT_SOURCE_DIR}/spell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/spell.h
     ${CMAKE_CURRENT_SOURCE_DIR}/status_effect_container.cpp

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -69,7 +69,7 @@ MapNetworking::MapNetworking(Scheduler& scheduler, MapStatistics& mapStatistics,
     try
     {
         const auto udpPort = mapIPP_.getPort() == 0 ? settings::get<uint16>("network.MAP_PORT") : mapIPP_.getPort();
-        mapSocket_         = std::make_unique<MapSocket>(scheduler_, udpPort, std::bind(&MapNetworking::handle_incoming_packet, this, std::placeholders::_1, std::placeholders::_2));
+        socket_            = std::make_unique<MapSocket>(scheduler_, udpPort, std::bind(&MapNetworking::handle_incoming_packet, this, std::placeholders::_1, std::placeholders::_2));
     }
     catch (const std::exception& e)
     {
@@ -151,7 +151,7 @@ void MapNetworking::handle_incoming_packet(ByteSpan buffer, const IPP& ipp)
             PSession->server_packet_id += 1;
         }
 
-        mapSocket_->send(ipp, { PBuff.data(), size });
+        socket_->send(ipp, { PBuff.data(), size });
 
         std::swap(PBuff, PSession->server_packet_data);
         std::swap(size, PSession->server_packet_size);
@@ -771,9 +771,9 @@ auto MapNetworking::scheduler() -> Scheduler&
     return scheduler_;
 }
 
-auto MapNetworking::socket() -> MapSocket&
+auto MapNetworking::socket() -> Socket&
 {
-    return *mapSocket_;
+    return *socket_;
 }
 
 auto MapNetworking::packetSystem() -> PacketSystem&

--- a/src/map/map_networking.h
+++ b/src/map/map_networking.h
@@ -26,17 +26,18 @@
 #include <common/ipp.h>
 #include <common/scheduler.h>
 
-#include "map_config.h"
-#include "map_constants.h"
-#include "map_session.h"
-#include "map_session_container.h"
-#include "map_socket.h"
-#include "map_statistics.h"
-#include "packet_system.h"
+#include <map/map_config.h>
+#include <map/map_constants.h>
+#include <map/map_session.h>
+#include <map/map_session_container.h>
+#include <map/map_socket.h>
+#include <map/map_statistics.h>
+#include <map/packet_system.h>
+#include <map/socket.h>
 
 class CBasicPacket;
 
-class MapNetworking
+class MapNetworking final
 {
 public:
     using UsePreviousKey = xi::Flag<struct UsePreviousKeyTag>;
@@ -93,16 +94,16 @@ public:
     auto ipp() const -> IPP;
     auto sessions() -> MapSessionContainer&;
     auto scheduler() -> Scheduler&;
-    auto socket() -> MapSocket&;
+    auto socket() -> Socket&;
     auto packetSystem() -> PacketSystem&;
 
 private:
-    Scheduler&                 scheduler_;
-    MapStatistics&             mapStatistics_;
-    IPP                        mapIPP_;
-    MapSessionContainer        mapSessions_;
-    std::unique_ptr<MapSocket> mapSocket_;
-    MapConfig                  config_;
+    Scheduler&              scheduler_;
+    MapStatistics&          mapStatistics_;
+    IPP                     mapIPP_;
+    MapSessionContainer     mapSessions_;
+    std::unique_ptr<Socket> socket_;
+    MapConfig               config_;
 
     // TODO: We can probably dedupe these and move the main buffer into MapSocket, passing a span
     //     : to it back into here when we've got our buffer of network data.

--- a/src/map/socket.h
+++ b/src/map/socket.h
@@ -1,7 +1,7 @@
-﻿/*
+/*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,35 +21,20 @@
 
 #pragma once
 
-#include <common/blowfish.h>
 #include <common/cbasetypes.h>
 #include <common/ipp.h>
-#include <common/scheduler.h>
 
-#include <map/map_constants.h>
-#include <map/socket.h>
+#include <functional>
 
-#include <asio/ip/network_v4.hpp>
-#include <asio/ip/udp.hpp>
-#include <asio/ts/buffer.hpp>
-#include <asio/ts/internet.hpp>
-
-class MapSocket final : public Socket
+class Socket
 {
 public:
-    MapSocket(Scheduler& scheduler, uint16 port, ReceiveFn onReceiveFn);
-    ~MapSocket() override;
+    // Called when bytes are received from a client, with the sender's address.
+    using ReceiveFn = std::function<void(ByteSpan, const IPP&)>;
 
-    void send(const IPP& ipp, ByteSpan buffer) override;
+    virtual ~Socket() = default;
 
-private:
-    void receive();
+    virtual void send(const IPP& ipp, ByteSpan buffer) = 0;
 
-    Scheduler&              scheduler_;
-    uint16                  port_;
-    asio::ip::udp::socket   socket_;
-    NetworkBuffer           buffer_; // TODO: Pass in the global buffer, or only use this one
-    asio::ip::udp::endpoint remoteEndpoint_;
-
-    ReceiveFn onReceiveFn_;
+    // TODO: Mockable receive()
 };

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     in_memory_sink.h
     mock_manager.cpp
     mock_manager.h
+    mock_socket.h
     test_application.h
     test_application.cpp
     test_case.h

--- a/src/test/mock_socket.h
+++ b/src/test/mock_socket.h
@@ -1,7 +1,7 @@
-﻿/*
+/*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,35 +21,45 @@
 
 #pragma once
 
-#include <common/blowfish.h>
 #include <common/cbasetypes.h>
 #include <common/ipp.h>
-#include <common/scheduler.h>
 
-#include <map/map_constants.h>
 #include <map/socket.h>
 
-#include <asio/ip/network_v4.hpp>
-#include <asio/ip/udp.hpp>
-#include <asio/ts/buffer.hpp>
-#include <asio/ts/internet.hpp>
+#include <cstring>
+#include <utility>
+#include <vector>
 
-class MapSocket final : public Socket
+// In-memory Socket for tests/benchmarks.
+class MockSocket final : public Socket
 {
 public:
-    MapSocket(Scheduler& scheduler, uint16 port, ReceiveFn onReceiveFn);
-    ~MapSocket() override;
+    struct Datagram
+    {
+        IPP                ipp;
+        std::vector<uint8> bytes;
+    };
 
-    void send(const IPP& ipp, ByteSpan buffer) override;
+    MockSocket() = default;
+
+    explicit MockSocket(ReceiveFn onReceiveFn)
+    : onReceiveFn_(std::move(onReceiveFn))
+    {
+    }
+
+    void send(const IPP& ipp, ByteSpan buffer) override
+    {
+        auto& datagram = sent.emplace_back();
+        datagram.ipp   = ipp;
+        datagram.bytes.assign(buffer.begin(), buffer.end());
+
+        ++sendCount;
+    }
+
+    // Every datagram passed to send(), in order.
+    std::vector<Datagram> sent;
+    std::size_t           sendCount = 0;
 
 private:
-    void receive();
-
-    Scheduler&              scheduler_;
-    uint16                  port_;
-    asio::ip::udp::socket   socket_;
-    NetworkBuffer           buffer_; // TODO: Pass in the global buffer, or only use this one
-    asio::ip::udp::endpoint remoteEndpoint_;
-
     ReceiveFn onReceiveFn_;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Doesn't do anything yet. Just adds an interface and a very basic mock, and then doesn't use them.

We eventually want to construct xi_test with a mock socket (a mocket, if you will) so we can simulate traffic in and traffic out, and the performance cost those have associated with them. Even if we're simulating them as memcpys into arrays that we throw away, it's adding work that we're currently skipping and will be _incredibly useful_ for benchmarking. 