### PR TITLE
Strip comment that has not aged well

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -1,19 +1,6 @@
 -----------------------------------
 -- This global is intended to handle additional effects from item sources of:
 -- melee attacks, ranged attacks, auto-spikes
--- Notes:
--- Ranged versions get bonus from int/mnd, melee does NOT.
--- No matter how much INT you stack that fire sword doesn't hit any harder.
--- No matter how much MND you stack that holy mace doesn't hit any harder.
--- But Ice Arrows and Bloody Bolts will gain damage from INT and Holy bolts will gain damage from MND.
--- Melee weapon proc also do not appear to adjust for level, only resistance.
--- In testing my fire sword had the same damage ranges no matter my level vs same mob.
--- Weakness/resistance to element would swing damage range a lot
--- For status effects is it possible to land on highly resistant mobs because of flooring.
--- Ranged throwing items have weird cases that don't fully fit in the above,
--- and a handfull of weapons have seem to scale up the more magic accuracy you have
--- Yes accuracy, not attack. More research needed. Not adding them till we know how they work.
--- (And then these comments get cleaned up)
 -----------------------------------
 require('scripts/globals/teleports') -- For warp weapon proc.
 require('scripts/globals/magic') -- For resist functions


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Back when I wrote these comments, they were easy to prove true. Most of it even still applies in many cases. But more and more exceptions have piled up after the level cap increased and new gear was added. Individual items can have different behaviors in regard to proc rate, damage values, and base stats being used in their math. Back in the old 75 cap era no amount  of MND affected my Holy Mauls. No Amount of INT affected my fire sword. Today there are very definitely melee weapons that use these stats, and more. Even a dagger or 2 using AGI in their math.

## Steps to test these changes

N/A comment removal only
