### PR TITLE
[C++] Core: Fix map server shutdown crash on SIGINT/SIGTERM

### DIFF
--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -43,29 +43,6 @@
 namespace
 {
 
-void handleSignal(const std::error_code& error, int signal)
-{
-    switch (signal)
-    {
-#ifdef _WIN32
-        case SIGBREAK:
-#endif // _WIN32
-        case SIGINT:
-        case SIGTERM:
-            std::exit(0);
-#ifndef _WIN32
-        case SIGABRT:
-        case SIGSEGV:
-        case SIGFPE:
-        case SIGILL:
-            break;
-#endif
-        default:
-            std::cerr << fmt::format("Unhandled signal: {}\n", signal);
-            break;
-    }
-}
-
 #ifdef _WIN32
 unsigned long prevQuickEditMode;
 #endif // _WIN32
@@ -120,6 +97,31 @@ void Application::trySetConsoleTitle()
 #endif
 }
 
+void Application::handleSignal(const std::error_code& error, int signal)
+{
+    switch (signal)
+    {
+#ifdef _WIN32
+        case SIGBREAK:
+#endif // _WIN32
+        case SIGINT:
+        case SIGTERM:
+            // Shut down gracefully so main() unwinds and the engine's destructor runs.
+            requestExit();
+            break;
+#ifndef _WIN32
+        case SIGABRT:
+        case SIGSEGV:
+        case SIGFPE:
+        case SIGILL:
+            break;
+#endif
+        default:
+            std::cerr << fmt::format("Unhandled signal: {}\n", signal);
+            break;
+    }
+}
+
 void Application::registerSignalHandlers()
 {
     signals_.add(SIGINT);
@@ -133,7 +135,11 @@ void Application::registerSignalHandlers()
     signals_.add(SIGXFSZ);
     signals_.add(SIGPIPE);
 #endif
-    signals_.async_wait(&handleSignal);
+    signals_.async_wait(
+        [this](const std::error_code& error, int signal)
+        {
+            handleSignal(error, signal);
+        });
 }
 
 void Application::usercheck() const

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -66,6 +66,7 @@ public:
 
     void trySetConsoleTitle();
     void registerSignalHandlers();
+    void handleSignal(const std::error_code& error, int signal);
     void usercheck() const;
     void tryIncreaseRLimits();
     void tryDisableQuickEditMode() const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a crash on server shutdown when the process is stopped with `SIGINT` (Ctrl+C) or `SIGTERM`. On Linux, with the map server fully loaded, this was happening to me every time and resulted in a heap corruption that reports `corrupted double-linked list`, or a `SIGSEGV` in `Override::~Override` under a debugger.

Fixed by routing `SIGINT` and `SIGTERM` through `requestExit()` instead of `std::exit(0)` so that it uses the same path as the `exit` command.

## Steps to test these changes

1. Build and start the map server, then wait for it to fully load.
2. Press `Ctrl+C`. Before, this would crash on exit. After these changes it should shutdown cleanly.

