### PR TITLE
DB: Extract out interface, implement C-connector backend

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -17,8 +17,40 @@ set(COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/cbasetypes.h
     ${CMAKE_CURRENT_SOURCE_DIR}/console_service.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/console_service.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/database.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/database.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/active_database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/binding.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/blob.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/blob.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/bound_value.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/caching_database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/caching_database.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/connection.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/database.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/prepared_statement.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/query_validation.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/result_set.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/result_set.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/traits.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_include.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_connection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_connection.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_database.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_prepared_statement.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_prepared_statement.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_result_set.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/mariadb_cpp/mariadb_cpp_result_set.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_connection.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_connection.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_include.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_database.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_prepared_statement.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_prepared_statement.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_result_set.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/database/libmariadb/libmariadb_result_set.h
     ${CMAKE_CURRENT_SOURCE_DIR}/debug.h
     $<$<PLATFORM_ID:Linux>:${CMAKE_CURRENT_SOURCE_DIR}/debug_linux.cpp>
     $<$<PLATFORM_ID:Darwin>:${CMAKE_CURRENT_SOURCE_DIR}/debug_osx.cpp>

--- a/src/common/database/active_database.cpp
+++ b/src/common/database/active_database.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,16 +19,30 @@
 ===========================================================================
 */
 
-#pragma once
-
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
-
 #include <common/database/database.h>
+
+#include <common/database/libmariadb/libmariadb_database.h>
+
+namespace
+{
+
+db::Database* gActiveDatabase = nullptr;
+
+} // namespace
+
+auto db::getDatabase() -> Database&
+{
+    if (gActiveDatabase == nullptr)
+    {
+        // Default backend for all apps: the MariaDB Connector/C (libmariadb) backend.
+        static LibMariaDBDatabase defaultDatabase;
+        gActiveDatabase = &defaultDatabase;
+    }
+
+    return *gActiveDatabase;
+}
+
+auto db::setDatabase(Database* database) -> void
+{
+    gActiveDatabase = database;
+}

--- a/src/common/database/binding.h
+++ b/src/common/database/binding.h
@@ -1,0 +1,129 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+
+#include <common/database/blob.h>
+#include <common/database/bound_value.h>
+#include <common/database/traits.h>
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace db::detail
+{
+
+// Lower a single C++ argument into a type-erased BoundValue, appending it to the parameter list.
+template <typename T>
+auto lowerBoundValue(std::vector<BoundValue>& params, T&& value) -> void;
+
+// Lower a full argument pack into a parameter list, preserving left-to-right order.
+template <typename... Args>
+auto lowerBoundValues(Args&&... args) -> std::vector<BoundValue>;
+
+} // namespace db::detail
+
+//
+// Out-of-line template definitions
+//
+
+namespace db::detail
+{
+
+template <typename T>
+auto lowerBoundValue(std::vector<BoundValue>& params, T&& value) -> void
+{
+    using U = enum_decay_t<std::remove_cvref_t<T>>;
+
+    if constexpr (std::is_same_v<U, int32>)
+    {
+        params.emplace_back(std::in_place_type<int32>, static_cast<int32>(value));
+    }
+    else if constexpr (std::is_same_v<U, uint32>)
+    {
+        params.emplace_back(std::in_place_type<uint32>, static_cast<uint32>(value));
+    }
+    else if constexpr (std::is_same_v<U, int16>)
+    {
+        params.emplace_back(std::in_place_type<int16>, static_cast<int16>(value));
+    }
+    else if constexpr (std::is_same_v<U, uint16>)
+    {
+        params.emplace_back(std::in_place_type<uint16>, static_cast<uint16>(value));
+    }
+    else if constexpr (std::is_same_v<U, int8>)
+    {
+        params.emplace_back(std::in_place_type<int8>, static_cast<int8>(value));
+    }
+    else if constexpr (std::is_same_v<U, uint8>)
+    {
+        params.emplace_back(std::in_place_type<uint8>, static_cast<uint8>(value));
+    }
+    else if constexpr (std::is_same_v<U, bool>)
+    {
+        params.emplace_back(std::in_place_type<bool>, static_cast<bool>(value));
+    }
+    else if constexpr (std::is_same_v<U, double>)
+    {
+        params.emplace_back(std::in_place_type<double>, static_cast<double>(value));
+    }
+    else if constexpr (std::is_same_v<U, float>)
+    {
+        params.emplace_back(std::in_place_type<float>, static_cast<float>(value));
+    }
+    else if constexpr (std::is_same_v<U, std::string>)
+    {
+        params.emplace_back(std::in_place_type<std::string>, value);
+    }
+    else if constexpr (std::is_same_v<U, const char*> || std::is_same_v<U, char*>)
+    {
+        params.emplace_back(std::in_place_type<std::string>, value);
+    }
+    else if constexpr (std::is_same_v<U, size_t>)
+    {
+        // NOTE: Preserves legacy behaviour of binding size_t via a 32-bit unsigned. TODO: widen.
+        params.emplace_back(std::in_place_type<uint32>, static_cast<uint32>(value));
+    }
+    else if constexpr (is_blob_v<U>)
+    {
+        params.emplace_back(std::in_place_type<std::shared_ptr<BlobWrapper>>, BlobWrapper::create(value));
+    }
+    else
+    {
+        static_assert(always_false_v<T>, "Unsupported type in binder");
+    }
+}
+
+template <typename... Args>
+auto lowerBoundValues(Args&&... args) -> std::vector<BoundValue>
+{
+    std::vector<BoundValue> params;
+    params.reserve(sizeof...(Args));
+    (lowerBoundValue(params, std::forward<Args>(args)), ...);
+    return params;
+}
+
+} // namespace db::detail

--- a/src/common/database/blob.cpp
+++ b/src/common/database/blob.cpp
@@ -1,0 +1,91 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/blob.h>
+
+#include <cstring>
+#include <string_view>
+
+db::BlobWrapper::blobstream::blobstream(char* buffer, std::size_t size)
+{
+    setg(buffer, buffer, buffer + size);
+}
+
+db::BlobWrapper::BlobWrapper(char* data, std::size_t size)
+: data(std::make_unique<char[]>(size))
+, size(size)
+, blobStream(data, size)
+, istream(&blobStream)
+{
+    // TODO: Do we really need to guarantee that the underlying data
+    //     : will outlive the original callsite? We could just get rid of
+    //     : data and size and use the two streams.
+    std::memcpy(this->data.get(), data, size);
+}
+
+auto db::BlobWrapper::toString() const -> std::string
+{
+    // Escape characters in the blob
+    std::string result;
+    result.reserve(size * 2); // Reserving space for maximum possible expansion
+
+    for (const char ch : std::string_view(data.get(), size))
+    {
+        switch (ch)
+        {
+            case '\0': // Null character
+                result += "\\0";
+                break;
+            case '\'': // Single quote
+                result += "\\'";
+                break;
+            case '\"': // Double quote
+                result += "\\\"";
+                break;
+            case '\b': // Backspace
+                result += "\\b";
+                break;
+            case '\n': // Newline
+                result += "\\n";
+                break;
+            case '\r': // Carriage return
+                result += "\\r";
+                break;
+            case '\t': // Tab
+                result += "\\t";
+                break;
+            case '\x1A': // Ctrl-Z
+                result += "\\Z";
+                break;
+            case '\\': // Backslash
+                result += "\\\\";
+                break;
+            case '%': // Percent (reserved by sprintf, etc.)
+                result += "%%";
+                break;
+            default:
+                result += ch;
+                break;
+        }
+    }
+
+    return result;
+}

--- a/src/common/database/blob.h
+++ b/src/common/database/blob.h
@@ -1,0 +1,70 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <istream>
+#include <memory>
+#include <streambuf>
+#include <string>
+#include <type_traits>
+
+namespace db
+{
+
+// A wrapper to ensure the underlying data, the blobstream, and the istream are all alive
+// and valid as long as they need to be.
+struct BlobWrapper
+{
+    std::unique_ptr<char[]> data;
+    std::size_t             size;
+
+    // https://stackoverflow.com/a/1449527
+    class blobstream : public std::streambuf
+    {
+    public:
+        blobstream(char* buffer, std::size_t size);
+    };
+
+    blobstream   blobStream;
+    std::istream istream;
+
+    template <typename T>
+    static auto create(T& source) -> std::shared_ptr<BlobWrapper>;
+
+    BlobWrapper(char* data, std::size_t size);
+
+    auto toString() const -> std::string;
+};
+
+//
+// Out-of-line template definitions
+//
+
+template <typename T>
+auto BlobWrapper::create(T& source) -> std::shared_ptr<BlobWrapper>
+{
+    static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+    return std::make_shared<BlobWrapper>(reinterpret_cast<char*>(&source), sizeof(T));
+}
+
+} // namespace db

--- a/src/common/database/bound_value.h
+++ b/src/common/database/bound_value.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,29 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/cbasetypes.h>
 
-#include <common/database/database.h>
+#include <common/database/blob.h>
+
+#include <memory>
+#include <string>
+#include <variant>
+
+namespace db
+{
+
+// A single, type-erased prepared-statement parameter.
+using BoundValue = std::variant<
+    int8,
+    uint8,
+    int16,
+    uint16,
+    int32,
+    uint32,
+    bool,
+    float,
+    double,
+    std::string,
+    std::shared_ptr<BlobWrapper>>;
+
+} // namespace db

--- a/src/common/database/caching_database.cpp
+++ b/src/common/database/caching_database.cpp
@@ -1,0 +1,185 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/caching_database.h>
+
+#include <common/database/query_validation.h>
+
+#include <common/logging.h>
+#include <common/settings.h>
+#include <common/timer.h>
+#include <common/tracy.h>
+#include <common/xi.h>
+
+#include <chrono>
+#include <functional>
+#include <thread>
+#include <unordered_map>
+using namespace std::chrono_literals;
+
+namespace
+{
+
+// Per-(thread, backend instance) connection state. thread_local keeps each worker thread on its own
+// connection; keying by the backend pointer lets multiple backends coexist in one process.
+thread_local std::unordered_map<const db::CachingDatabase*, db::detail::ConnectionState> tlsStates;
+
+bool timersEnabled = false;
+
+// Emit a slow-query log line on scope exit if the query exceeded the configured thresholds.
+auto makeQueryTimer(const std::string& query) -> xi::final_action<std::function<void()>>
+{
+    const auto start = timer::now();
+    return xi::finally<std::function<void()>>(
+        [query, start]() -> void
+        {
+            if (!timersEnabled || !settings::get<bool>("logging.SQL_SLOW_QUERY_LOG_ENABLE"))
+            {
+                return;
+            }
+
+            const auto duration = timer::count_milliseconds(timer::now() - start);
+            if (duration > settings::get<uint32>("logging.SQL_SLOW_QUERY_ERROR_TIME"))
+            {
+                ShowError(fmt::format("SQL query took {}ms: {}", duration, query));
+            }
+            else if (duration > settings::get<uint32>("logging.SQL_SLOW_QUERY_WARNING_TIME"))
+            {
+                ShowWarning(fmt::format("SQL query took {}ms: {}", duration, query));
+            }
+        });
+}
+
+} // namespace
+
+auto db::CachingDatabase::getState() -> detail::ConnectionState&
+{
+    TracyZoneScoped;
+
+    auto& state = tlsStates[this];
+    if (state.connection == nullptr)
+    {
+        state.connection = createConnection();
+        state.statements.clear();
+    }
+
+    return state;
+}
+
+auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet>
+{
+    TracyZoneScoped;
+    TracyZoneString(rawQuery);
+
+    const auto queryType = detail::validateQueryLeadingKeyword(rawQuery);
+    if (queryType == ResultSetType::Invalid)
+    {
+        ShowErrorFmt("Invalid query: {}", rawQuery);
+        return nullptr;
+    }
+
+    if (!detail::validateQueryContent(rawQuery))
+    {
+        ShowErrorFmt("Invalid query content: {}", rawQuery);
+        return nullptr;
+    }
+
+    auto& state = getState();
+
+    const auto operation = [&](detail::ConnectionState& connState) -> std::unique_ptr<ResultSet>
+    {
+        // Lazily prepare-and-cache the statement for this query.
+        auto it = connState.statements.find(rawQuery);
+        if (it == connState.statements.end())
+        {
+            it = connState.statements.emplace(rawQuery, connState.connection->prepare(rawQuery)).first;
+        }
+
+        DebugSQLFmt("preparedStmt: {}", rawQuery);
+
+        const auto& stmt = it->second;
+
+        // NOTE: Everything is 1-indexed.
+        int counter = 0;
+        for (const auto& param : params)
+        {
+            stmt->bind(++counter, param);
+        }
+
+        const auto queryTimer = makeQueryTimer(rawQuery);
+
+        return (queryType == ResultSetType::Select) ? stmt->executeQuery(rawQuery) : stmt->executeUpdate(rawQuery);
+    };
+
+    const auto queryRetryCount = 1 + settings::get<uint32>("network.SQL_QUERY_RETRY_COUNT");
+    for (auto i = 0U; i < queryRetryCount; ++i)
+    {
+        try
+        {
+            if (i > 0)
+            {
+                ShowInfo("Connection lost, re-establishing connection and retrying query (attempt %d)", i);
+                state.statements.clear();
+                state.connection = createConnection();
+            }
+            return operation(state);
+        }
+        catch (const std::exception& e)
+        {
+            if (state.connection == nullptr || !state.connection->isConnectionError(e))
+            {
+                ShowErrorFmt("Query Failed: {}", rawQuery);
+                ShowErrorFmt("{}", e.what());
+                return nullptr;
+            }
+        }
+    }
+
+    ShowCritical("Query Failed after %d retries: %s", queryRetryCount, rawQuery.c_str());
+    std::this_thread::sleep_for(1s);
+    std::terminate();
+}
+
+auto db::CachingDatabase::getSchema() -> std::string
+{
+    TracyZoneScoped;
+
+    return getState().connection->schema();
+}
+
+auto db::CachingDatabase::getVersion() -> std::string
+{
+    TracyZoneScoped;
+
+    return getState().connection->version();
+}
+
+auto db::CachingDatabase::getDriverVersion() -> std::string
+{
+    TracyZoneScoped;
+
+    return getState().connection->driverVersion();
+}
+
+auto db::enableTimers() -> void
+{
+    timersEnabled = true;
+}

--- a/src/common/database/caching_database.h
+++ b/src/common/database/caching_database.h
@@ -1,0 +1,67 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/database/bound_value.h>
+#include <common/database/connection.h>
+#include <common/database/database.h>
+#include <common/database/prepared_statement.h>
+#include <common/database/result_set.h>
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace db
+{
+
+namespace detail
+{
+
+// Per-(thread, backend) connection state: the live connection plus its prepared-statement cache.
+struct ConnectionState
+{
+    std::unique_ptr<Connection>                                         connection;
+    std::unordered_map<std::string, std::unique_ptr<PreparedStatement>> statements;
+};
+
+} // namespace detail
+
+class CachingDatabase : public Database
+{
+public:
+    auto execute(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
+
+    auto getSchema() -> std::string override;
+    auto getVersion() -> std::string override;
+    auto getDriverVersion() -> std::string override;
+
+protected:
+    virtual auto createConnection() -> std::unique_ptr<Connection> = 0;
+
+private:
+    // The calling thread's connection state for this backend, connecting lazily on first use.
+    auto getState() -> detail::ConnectionState&;
+};
+
+} // namespace db

--- a/src/common/database/connection.h
+++ b/src/common/database/connection.h
@@ -1,0 +1,55 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/database/prepared_statement.h>
+
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class Connection
+{
+public:
+    virtual ~Connection() = default;
+
+    // Prepare (or fail) a statement for this connection.
+    virtual auto prepare(const std::string& query) -> std::unique_ptr<PreparedStatement> = 0;
+
+    // The connected database/schema name, ie. xidb.
+    virtual auto schema() -> std::string = 0;
+
+    // The database server version, ie. MariaDB 10.6.12-MariaDB.
+    virtual auto version() -> std::string = 0;
+
+    // The client driver version, ie. MariaDB Connector/C 3.2.8.
+    virtual auto driverVersion() -> std::string = 0;
+
+    // Whether the given exception (thrown by prepare/bind/execute) indicates a lost or broken
+    // connection that warrants reconnecting and retrying, rather than a genuine query failure.
+    virtual auto isConnectionError(const std::exception& e) const -> bool = 0;
+};
+
+} // namespace db

--- a/src/common/database/database.cpp
+++ b/src/common/database/database.cpp
@@ -1,7 +1,7 @@
-﻿/*
+/*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,73 +19,18 @@
 ===========================================================================
 */
 
-#include "database.h"
+#include <common/database/database.h>
 
-#include "application.h"
-#include "logging.h"
-#include "macros.h"
-#include "settings.h"
-#include "timer.h"
-#include "utils.h"
+#include <common/database/query_validation.h>
+
+#include <common/logging.h>
+#include <common/macros.h>
+#include <common/utils.h>
 
 #include <chrono>
+#include <thread>
+#include <unordered_map>
 using namespace std::chrono_literals;
-
-namespace
-{
-
-// TODO: Manual checkout and pooling of state
-// Each thread gets its own connection, so we don't need to worry about thread safety.
-thread_local Synchronized<db::detail::State> state;
-
-const std::vector<std::string> connectionIssues = {
-    "Lost connection",
-    "Server has gone away",
-    "Connection refused",
-    "Can't connect to server",
-};
-
-bool timersEnabled = false;
-
-} // namespace
-
-auto db::getConnection() -> std::unique_ptr<sql::Connection>
-{
-    try
-    {
-        const auto login  = settings::get<std::string>("network.SQL_LOGIN");
-        const auto passwd = settings::get<std::string>("network.SQL_PASSWORD");
-        const auto host   = settings::get<std::string>("network.SQL_HOST");
-        const auto port   = settings::get<uint16>("network.SQL_PORT");
-        const auto schema = settings::get<std::string>("network.SQL_DATABASE");
-        const auto url    = fmt::format("tcp://{}:{}/{}", host, port, schema);
-
-        return std::unique_ptr<sql::Connection>(sql::mariadb::get_driver_instance()->connect(url.c_str(), login.c_str(), passwd.c_str()));
-    }
-    catch (const std::exception& e)
-    {
-        // If we can't establish a connection to the database we can't do anything.
-        // Time to die!
-        ShowCritical("!!! Failed to connect to database, terminating server !!!");
-        ShowCritical(e.what());
-        std::this_thread::sleep_for(1s);
-        std::terminate();
-    }
-}
-
-auto db::detail::isConnectionIssue(const std::exception& e) -> bool
-{
-    const auto str = fmt::format("{}", e.what());
-    for (const auto& issue : connectionIssues)
-    {
-        if (str.find(issue) != std::string::npos)
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
 
 auto db::detail::validateQueryLeadingKeyword(const std::string& query) -> ResultSetType
 {
@@ -186,56 +131,6 @@ auto db::detail::validateQueryContent(const std::string& query) -> bool
     return true;
 }
 
-Synchronized<db::detail::State>& db::detail::getState()
-{
-    TracyZoneScoped;
-
-    // NOTE: mariadb-connector-cpp doesn't seem to make any guarantees about whether or not isValid()
-    //     : is const. So we're going to have to wrap calls to it as though they aren't.
-
-    if (state.read(
-            [&](auto& state)
-            {
-                return state.connection != nullptr;
-            }))
-    {
-        return state;
-    }
-
-    // Otherwise, create a new connection. Writing it to the state.connection unique_ptr will release any previous connection
-    // that might be there.
-
-    state.write(
-        [&](auto& state)
-        {
-            state.reset();
-        });
-
-    return state;
-}
-
-auto db::detail::timer(const std::string& query) -> xi::final_action<std::function<void()>>
-{
-    const auto start = timer::now();
-    return xi::finally<std::function<void()>>(
-        [query, start]() -> void
-        {
-            const auto end      = timer::now();
-            const auto duration = timer::count_milliseconds(end - start);
-            if (timersEnabled && settings::get<bool>("logging.SQL_SLOW_QUERY_LOG_ENABLE"))
-            {
-                if (duration > settings::get<uint32>("logging.SQL_SLOW_QUERY_ERROR_TIME"))
-                {
-                    ShowError(fmt::format("SQL query took {}ms: {}", duration, query));
-                }
-                else if (duration > settings::get<uint32>("logging.SQL_SLOW_QUERY_WARNING_TIME"))
-                {
-                    ShowWarning(fmt::format("SQL query took {}ms: {}", duration, query));
-                }
-            }
-        });
-}
-
 auto db::escapeString(std::string_view str) -> std::string
 {
     static const std::unordered_map<char, std::string> replacements = {
@@ -305,38 +200,24 @@ auto db::getDatabaseSchema() -> std::string
 {
     TracyZoneScoped;
 
-    return detail::getState().write(
-        [&](detail::State& state) -> std::string
-        {
-            return state.connection->getSchema().c_str();
-        });
+    return db::getDatabase().getSchema();
 }
 
 auto db::getDatabaseVersion() -> std::string
 {
     TracyZoneScoped;
 
-    return detail::getState().write(
-        [&](detail::State& state) -> std::string
-        {
-            const std::unique_ptr<sql::DatabaseMetaData> metadata(state.connection->getMetaData());
-            return fmt::format("{} {}", metadata->getDatabaseProductName().c_str(), metadata->getDatabaseProductVersion().c_str());
-        });
+    return db::getDatabase().getVersion();
 }
 
 auto db::getDriverVersion() -> std::string
 {
     TracyZoneScoped;
 
-    return detail::getState().write(
-        [&](detail::State& state) -> std::string
-        {
-            const std::unique_ptr<sql::DatabaseMetaData> metadata(state.connection->getMetaData());
-            return fmt::format("{} {}", metadata->getDriverName().c_str(), metadata->getDriverVersion().c_str());
-        });
+    return db::getDatabase().getDriverVersion();
 }
 
-void db::checkCharset()
+auto db::checkCharset() -> void
 {
     TracyZoneScoped;
 
@@ -369,7 +250,7 @@ void db::checkCharset()
     }
 }
 
-void db::checkTriggers()
+auto db::checkTriggers() -> void
 {
     const auto triggerQuery = "SHOW TRIGGERS WHERE `Trigger` LIKE ?";
 
@@ -405,7 +286,7 @@ void db::checkTriggers()
     }
 }
 
-bool db::setAutoCommit(bool value)
+auto db::setAutoCommit(bool value) -> bool
 {
     TracyZoneScoped;
 
@@ -418,7 +299,7 @@ bool db::setAutoCommit(bool value)
     return true;
 }
 
-bool db::getAutoCommit()
+auto db::getAutoCommit() -> bool
 {
     TracyZoneScoped;
 
@@ -433,7 +314,7 @@ bool db::getAutoCommit()
     return false;
 }
 
-bool db::transactionStart()
+auto db::transactionStart() -> bool
 {
     TracyZoneScoped;
 
@@ -446,7 +327,7 @@ bool db::transactionStart()
     return true;
 }
 
-bool db::transactionCommit()
+auto db::transactionCommit() -> bool
 {
     TracyZoneScoped;
 
@@ -459,7 +340,7 @@ bool db::transactionCommit()
     return true;
 }
 
-bool db::transactionRollback()
+auto db::transactionRollback() -> bool
 {
     TracyZoneScoped;
 
@@ -472,12 +353,7 @@ bool db::transactionRollback()
     return true;
 }
 
-void db::enableTimers()
-{
-    timersEnabled = true;
-}
-
-bool db::transaction(const std::function<void()>& transactionFn)
+auto db::transaction(const std::function<void()>& transactionFn) -> bool
 {
     TracyZoneScoped;
 

--- a/src/common/database/database.h
+++ b/src/common/database/database.h
@@ -1,0 +1,140 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+#include <common/scheduler.h>
+#include <common/tracy.h>
+
+#include <common/database/binding.h>
+#include <common/database/blob.h>
+#include <common/database/bound_value.h>
+#include <common/database/prepared_statement.h>
+#include <common/database/result_set.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+// @note Everything in sql:: database-land is 1-indexed, not 0-indexed.
+namespace db
+{
+
+class Database
+{
+public:
+    virtual ~Database() = default;
+
+    // Execute a query with the given pre-lowered parameters.
+    // Returns a queryable result set for SELECT-like queries, a rows-affected result set for
+    // UPDATE-like queries, or nullptr if the query is invalid.
+    virtual auto execute(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> = 0;
+
+    // The database name, ie. xidb.
+    virtual auto getSchema() -> std::string = 0;
+
+    // The version of the database software, ie. MariaDB 10.6.12-MariaDB.
+    virtual auto getVersion() -> std::string = 0;
+
+    // The version of the database driver, ie. MariaDB Connector/C++ 1.0.3.
+    virtual auto getDriverVersion() -> std::string = 0;
+};
+
+// Get the active database backend.
+auto getDatabase() -> Database&;
+
+// Override the active database backend (intended for tests/benchmarks). Pass nullptr to restore the
+// default backend.
+auto setDatabase(Database* database) -> void;
+
+// @brief Execute a prepared statement with the given query string and arguments.
+// @param query The query string to execute.
+// @param args The arguments to bind to the prepared statement.
+// @return A unique pointer to the result set of the query.
+// @note If the query hasn't been seen before it will generate a prepared statement for it to be used immediately and in the future.
+// @note Everything in database-land is 1-indexed, not 0-indexed.
+template <typename... Args>
+auto preparedStmt(const std::string& rawQuery, Args&&... args) -> std::unique_ptr<ResultSet>;
+
+template <typename... Args>
+auto preparedStmt(Scheduler& scheduler, const std::string& rawQuery, Args&&... args) -> Task<std::unique_ptr<ResultSet>>;
+
+auto escapeString(std::string_view str) -> std::string;
+auto escapeString(const std::string& str) -> std::string;
+auto escapeString(const char* str) -> std::string;
+
+auto getDatabaseSchema() -> std::string;
+
+auto getDatabaseVersion() -> std::string;
+
+auto getDriverVersion() -> std::string;
+
+auto checkCharset() -> void;
+auto checkTriggers() -> void;
+
+auto setAutoCommit(bool value) -> bool;
+auto getAutoCommit() -> bool;
+
+auto transactionStart() -> bool;
+auto transactionCommit() -> bool;
+auto transactionRollback() -> bool;
+
+auto enableTimers() -> void;
+
+// Execute a transaction with the given transaction function.
+//
+// Will handle maintenance of the autocommit state and rollback the transaction if the transaction
+// function throws. Otherwise will commit the transaction on successful completion of the function.
+//
+// Returns true if the transaction was successful and committed or false if it was rolled back.
+auto transaction(const std::function<void()>& transactionFn) -> bool;
+
+auto getTableColumnNames(const std::string& tableName) -> std::vector<std::string>;
+
+//
+// Out-of-line template definitions
+//
+
+template <typename... Args>
+auto preparedStmt(const std::string& rawQuery, Args&&... args) -> std::unique_ptr<ResultSet>
+{
+    TracyZoneScoped;
+    TracyZoneString(rawQuery);
+
+    const auto params = detail::lowerBoundValues(std::forward<Args>(args)...);
+    return getDatabase().execute(rawQuery, params);
+}
+
+template <typename... Args>
+auto preparedStmt(Scheduler& scheduler, const std::string& rawQuery, Args&&... args) -> Task<std::unique_ptr<ResultSet>>
+{
+    co_return scheduler.spawnOnWorkerThread(
+        [rawQuery, ... capturedArgs = std::forward<Args>(args)]() mutable
+        {
+            return db::preparedStmt(rawQuery, std::forward<Args>(capturedArgs)...);
+        });
+}
+
+} // namespace db

--- a/src/common/database/libmariadb/libmariadb_connection.cpp
+++ b/src/common/database/libmariadb/libmariadb_connection.cpp
@@ -1,0 +1,135 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/libmariadb/libmariadb_connection.h>
+
+#include <common/database/libmariadb/libmariadb_prepared_statement.h>
+
+#include <common/logging.h>
+#include <common/settings.h>
+
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <chrono>
+using namespace std::chrono_literals;
+
+db::LibMariaDBConnection::LibMariaDBConnection(MYSQL* connection)
+: connection_(connection)
+{
+}
+
+db::LibMariaDBConnection::~LibMariaDBConnection()
+{
+    if (connection_ != nullptr)
+    {
+        mysql_close(connection_);
+    }
+}
+
+auto db::LibMariaDBConnection::prepare(const std::string& query) -> std::unique_ptr<PreparedStatement>
+{
+    MYSQL_STMT* stmt = mysql_stmt_init(connection_);
+    if (stmt == nullptr)
+    {
+        throw detail::libmariadb::Error(mysql_errno(connection_), mysql_error(connection_));
+    }
+
+    if (mysql_stmt_prepare(stmt, query.c_str(), static_cast<unsigned long>(query.size())) != 0)
+    {
+        const auto        errnum  = mysql_stmt_errno(stmt);
+        const std::string message = mysql_stmt_error(stmt);
+        mysql_stmt_close(stmt);
+        throw detail::libmariadb::Error(errnum, message);
+    }
+
+    return std::make_unique<LibMariaDBPreparedStatement>(stmt);
+}
+
+auto db::LibMariaDBConnection::schema() -> std::string
+{
+    return settings::get<std::string>("network.SQL_DATABASE");
+}
+
+auto db::LibMariaDBConnection::version() -> std::string
+{
+    return fmt::format("MariaDB {}", mysql_get_server_info(connection_));
+}
+
+auto db::LibMariaDBConnection::driverVersion() -> std::string
+{
+    return fmt::format("MariaDB Connector/C {}", mysql_get_client_info());
+}
+
+auto db::LibMariaDBConnection::isConnectionError(const std::exception& e) const -> bool
+{
+    if (const auto* error = dynamic_cast<const detail::libmariadb::Error*>(&e))
+    {
+        return detail::libmariadb::isConnectionLost(error->errnum);
+    }
+
+    return false;
+}
+
+auto db::LibMariaDBConnection::connect() -> std::unique_ptr<Connection>
+{
+    static std::once_flag libraryInitFlag;
+    std::call_once(
+        libraryInitFlag,
+        []()
+        {
+            mysql_library_init(0, nullptr, nullptr);
+        });
+
+    // Initialize per-thread connector state. Paired thread cleanup is a known TODO; the connection
+    // is thread-local for the life of the worker thread.
+    mysql_thread_init();
+
+    MYSQL* connection = mysql_init(nullptr);
+    if (connection == nullptr)
+    {
+        ShowCritical("!!! Failed to allocate database handle, terminating server !!!");
+        std::this_thread::sleep_for(1s);
+        std::terminate();
+    }
+
+    const auto login  = settings::get<std::string>("network.SQL_LOGIN");
+    const auto passwd = settings::get<std::string>("network.SQL_PASSWORD");
+    const auto host   = settings::get<std::string>("network.SQL_HOST");
+    const auto port   = settings::get<uint16>("network.SQL_PORT");
+    const auto schema = settings::get<std::string>("network.SQL_DATABASE");
+
+    if (mysql_real_connect(connection, host.c_str(), login.c_str(), passwd.c_str(), schema.c_str(), port, nullptr, 0) == nullptr)
+    {
+        // If we can't establish a connection to the database we can't do anything.
+        // Time to die!
+        ShowCritical("!!! Failed to connect to database, terminating server !!!");
+        ShowCritical(mysql_error(connection));
+        mysql_close(connection);
+        std::this_thread::sleep_for(1s);
+        std::terminate();
+    }
+
+    mysql_set_character_set(connection, "utf8mb4");
+
+    return std::make_unique<LibMariaDBConnection>(connection);
+}

--- a/src/common/database/libmariadb/libmariadb_connection.h
+++ b/src/common/database/libmariadb/libmariadb_connection.h
@@ -1,0 +1,56 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/database/libmariadb/libmariadb_include.h>
+
+#include <common/database/connection.h>
+
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class LibMariaDBConnection final : public Connection
+{
+public:
+    explicit LibMariaDBConnection(MYSQL* connection);
+    ~LibMariaDBConnection() override;
+
+    LibMariaDBConnection(const LibMariaDBConnection&)            = delete;
+    LibMariaDBConnection& operator=(const LibMariaDBConnection&) = delete;
+
+    auto prepare(const std::string& query) -> std::unique_ptr<PreparedStatement> override;
+    auto schema() -> std::string override;
+    auto version() -> std::string override;
+    auto driverVersion() -> std::string override;
+    auto isConnectionError(const std::exception& e) const -> bool override;
+
+    static auto connect() -> std::unique_ptr<Connection>;
+
+private:
+    MYSQL* connection_;
+};
+
+} // namespace db

--- a/src/common/database/libmariadb/libmariadb_database.cpp
+++ b/src/common/database/libmariadb/libmariadb_database.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,16 +19,11 @@
 ===========================================================================
 */
 
-#pragma once
+#include <common/database/libmariadb/libmariadb_database.h>
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/libmariadb/libmariadb_connection.h>
 
-#include <common/database/database.h>
+auto db::LibMariaDBDatabase::createConnection() -> std::unique_ptr<Connection>
+{
+    return LibMariaDBConnection::connect();
+}

--- a/src/common/database/libmariadb/libmariadb_database.h
+++ b/src/common/database/libmariadb/libmariadb_database.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,18 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/caching_database.h>
+#include <common/database/connection.h>
 
-#include <common/database/database.h>
+#include <memory>
+
+namespace db
+{
+
+class LibMariaDBDatabase final : public CachingDatabase
+{
+protected:
+    auto createConnection() -> std::unique_ptr<Connection> override;
+};
+
+} // namespace db

--- a/src/common/database/libmariadb/libmariadb_include.h
+++ b/src/common/database/libmariadb/libmariadb_include.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,13 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#endif
 
-#include <common/database/database.h>
+#include <mysql.h>

--- a/src/common/database/libmariadb/libmariadb_prepared_statement.cpp
+++ b/src/common/database/libmariadb/libmariadb_prepared_statement.cpp
@@ -1,0 +1,400 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/libmariadb/libmariadb_prepared_statement.h>
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace
+{
+
+// Initial per-column fetch buffer for text columns. Larger values (blobs, long strings) are pulled
+// in full with a follow-up mysql_stmt_fetch_column once the real length is known.
+constexpr unsigned long kInitialColumnBuffer = 256;
+
+} // namespace
+
+db::detail::libmariadb::Error::Error(unsigned int errnum, const std::string& message)
+: std::runtime_error(message)
+, errnum(errnum)
+{
+}
+
+auto db::detail::libmariadb::isConnectionLost(unsigned int errnum) -> bool
+{
+    switch (errnum)
+    {
+        case 2002: // CR_CONNECTION_ERROR
+        case 2003: // CR_CONN_HOST_ERROR
+        case 2006: // CR_SERVER_GONE_ERROR
+        case 2013: // CR_SERVER_LOST
+        case 2055: // CR_SERVER_LOST_EXTENDED
+            return true;
+        default:
+            return false;
+    }
+}
+
+db::LibMariaDBPreparedStatement::LibMariaDBPreparedStatement(MYSQL_STMT* stmt)
+: stmt_(stmt)
+{
+}
+
+db::LibMariaDBPreparedStatement::~LibMariaDBPreparedStatement()
+{
+    if (stmt_ != nullptr)
+    {
+        mysql_stmt_close(stmt_);
+    }
+}
+
+auto db::LibMariaDBPreparedStatement::bind(int index, const BoundValue& value) -> void
+{
+    if (static_cast<int>(paramBinds_.size()) < index)
+    {
+        paramBinds_.resize(index);
+    }
+
+    MYSQL_BIND& b = paramBinds_[index - 1];
+    std::memset(&b, 0, sizeof(b));
+
+    std::visit(
+        [&](const auto& v)
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::shared_ptr<BlobWrapper>>)
+            {
+                auto& buffer = paramBuffers_.emplace_back(v->data.get(), v->data.get() + v->size);
+                // Guarantee a non-null data() pointer: libmariadb binds a null buffer as SQL NULL,
+                // so an empty blob must still point at valid (zero-length) storage to bind as ''.
+                buffer.reserve(1);
+                auto& length    = paramLengths_.emplace_back(static_cast<unsigned long>(v->size));
+                b.buffer_type   = MYSQL_TYPE_BLOB;
+                b.buffer        = buffer.data();
+                b.buffer_length = static_cast<unsigned long>(buffer.size());
+                b.length        = &length;
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                auto& buffer = paramBuffers_.emplace_back(v.begin(), v.end());
+                // See above: an empty string must bind as '' (non-null buffer), not SQL NULL.
+                buffer.reserve(1);
+                auto& length    = paramLengths_.emplace_back(static_cast<unsigned long>(v.size()));
+                b.buffer_type   = MYSQL_TYPE_STRING;
+                b.buffer        = buffer.data();
+                b.buffer_length = static_cast<unsigned long>(buffer.size());
+                b.length        = &length;
+            }
+            else
+            {
+                // Arithmetic and bool: copy the value bytes into stable storage.
+                auto& buffer = paramBuffers_.emplace_back(sizeof(U));
+                std::memcpy(buffer.data(), &v, sizeof(U));
+                b.buffer = buffer.data();
+
+                if constexpr (std::is_same_v<U, int8> || std::is_same_v<U, uint8> || std::is_same_v<U, bool>)
+                {
+                    b.buffer_type = MYSQL_TYPE_TINY;
+                }
+                else if constexpr (std::is_same_v<U, int16> || std::is_same_v<U, uint16>)
+                {
+                    b.buffer_type = MYSQL_TYPE_SHORT;
+                }
+                else if constexpr (std::is_same_v<U, int32> || std::is_same_v<U, uint32>)
+                {
+                    b.buffer_type = MYSQL_TYPE_LONG;
+                }
+                else if constexpr (std::is_same_v<U, float>)
+                {
+                    b.buffer_type = MYSQL_TYPE_FLOAT;
+                }
+                else if constexpr (std::is_same_v<U, double>)
+                {
+                    b.buffer_type = MYSQL_TYPE_DOUBLE;
+                }
+
+                b.is_unsigned = std::is_unsigned_v<U> ? 1 : 0;
+            }
+        },
+        value);
+}
+
+auto db::LibMariaDBPreparedStatement::applyBindings() -> void
+{
+    if (!paramBinds_.empty())
+    {
+        if (mysql_stmt_bind_param(stmt_, paramBinds_.data()) != 0)
+        {
+            throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+        }
+    }
+}
+
+auto db::LibMariaDBPreparedStatement::resetBindings() -> void
+{
+    paramBinds_.clear();
+    paramBuffers_.clear();
+    paramLengths_.clear();
+}
+
+auto db::LibMariaDBPreparedStatement::ensureSchema() -> void
+{
+    if (schemaInitialized_)
+    {
+        return;
+    }
+
+    auto schema = std::make_shared<ColumnSchema>();
+    kinds_.clear();
+
+    const std::unique_ptr<MYSQL_RES, decltype(&mysql_free_result)> meta(mysql_stmt_result_metadata(stmt_), &mysql_free_result);
+    if (meta != nullptr)
+    {
+        const unsigned int ncol   = mysql_num_fields(meta.get());
+        MYSQL_FIELD*       fields = mysql_fetch_fields(meta.get());
+
+        schema->names.reserve(ncol);
+        kinds_.reserve(ncol);
+        for (unsigned int i = 0; i < ncol; ++i)
+        {
+            std::string name(fields[i].name, fields[i].name_length);
+            schema->index[name] = i;
+            schema->names.push_back(std::move(name));
+
+            switch (fields[i].type)
+            {
+                case MYSQL_TYPE_TINY:
+                case MYSQL_TYPE_SHORT:
+                case MYSQL_TYPE_LONG:
+                case MYSQL_TYPE_INT24:
+                case MYSQL_TYPE_LONGLONG:
+                case MYSQL_TYPE_YEAR:
+                    kinds_.push_back((fields[i].flags & UNSIGNED_FLAG) ? CellKind::UInt64 : CellKind::Int64);
+                    break;
+                case MYSQL_TYPE_FLOAT:
+                case MYSQL_TYPE_DOUBLE:
+                    kinds_.push_back(CellKind::Double);
+                    break;
+                default:
+                    // DECIMAL/NEWDECIMAL, dates/times, CHAR/VARCHAR, BLOB, etc. are kept as text.
+                    kinds_.push_back(CellKind::Text);
+                    break;
+            }
+        }
+    }
+
+    schema_            = std::move(schema);
+    schemaInitialized_ = true;
+}
+
+auto db::LibMariaDBPreparedStatement::fetchRows() -> std::vector<LibMariaDBResultSet::Row>
+{
+    const std::size_t ncol = kinds_.size();
+    if (ncol == 0)
+    {
+        return {};
+    }
+
+    // Bind each column in its native form (8-byte numerics, a scratch buffer for text).
+    std::vector<std::vector<char>> buffers(ncol);
+    std::vector<unsigned long>     lengths(ncol, 0);
+    std::vector<my_bool>           nulls(ncol, 0);
+    std::vector<my_bool>           errors(ncol, 0);
+    std::vector<MYSQL_BIND>        outBinds(ncol);
+    for (std::size_t i = 0; i < ncol; ++i)
+    {
+        std::memset(&outBinds[i], 0, sizeof(MYSQL_BIND));
+        outBinds[i].is_null = &nulls[i];
+        outBinds[i].error   = &errors[i];
+        outBinds[i].length  = &lengths[i];
+
+        switch (kinds_[i])
+        {
+            case CellKind::Int64:
+            case CellKind::UInt64:
+                buffers[i].resize(sizeof(int64));
+                outBinds[i].buffer_type = MYSQL_TYPE_LONGLONG;
+                outBinds[i].is_unsigned = (kinds_[i] == CellKind::UInt64) ? 1 : 0;
+                break;
+            case CellKind::Double:
+                buffers[i].resize(sizeof(double));
+                outBinds[i].buffer_type = MYSQL_TYPE_DOUBLE;
+                break;
+            case CellKind::Text:
+                buffers[i].resize(kInitialColumnBuffer);
+                outBinds[i].buffer_type   = MYSQL_TYPE_STRING;
+                outBinds[i].buffer_length = kInitialColumnBuffer;
+                break;
+        }
+
+        outBinds[i].buffer = buffers[i].data();
+    }
+
+    if (mysql_stmt_bind_result(stmt_, outBinds.data()) != 0)
+    {
+        throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+    }
+
+    if (mysql_stmt_store_result(stmt_) != 0)
+    {
+        throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+    }
+
+    std::vector<LibMariaDBResultSet::Row> rows;
+    rows.reserve(static_cast<std::size_t>(mysql_stmt_num_rows(stmt_)));
+
+    for (;;)
+    {
+        const int rc = mysql_stmt_fetch(stmt_);
+        if (rc == MYSQL_NO_DATA)
+        {
+            break;
+        }
+        if (rc == 1)
+        {
+            throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+        }
+
+        // rc == 0 (success) or MYSQL_DATA_TRUNCATED
+        LibMariaDBResultSet::Row row(ncol);
+        for (std::size_t i = 0; i < ncol; ++i)
+        {
+            if (nulls[i] != 0)
+            {
+                row[i] = std::monostate{};
+                continue;
+            }
+
+            switch (kinds_[i])
+            {
+                case CellKind::Int64:
+                {
+                    int64 value = 0;
+                    std::memcpy(&value, buffers[i].data(), sizeof(value));
+                    row[i] = value;
+                    break;
+                }
+                case CellKind::UInt64:
+                {
+                    uint64 value = 0;
+                    std::memcpy(&value, buffers[i].data(), sizeof(value));
+                    row[i] = value;
+                    break;
+                }
+                case CellKind::Double:
+                {
+                    double value = 0.0;
+                    std::memcpy(&value, buffers[i].data(), sizeof(value));
+                    row[i] = value;
+                    break;
+                }
+                case CellKind::Text:
+                {
+                    const unsigned long actualLen = lengths[i];
+                    if (actualLen > buffers[i].size())
+                    {
+                        // Value truncated into the fixed buffer; fetch the full column.
+                        std::vector<char> big(actualLen);
+                        MYSQL_BIND        colBind;
+                        std::memset(&colBind, 0, sizeof(colBind));
+                        unsigned long colLen  = 0;
+                        my_bool       colNull = 0;
+                        my_bool       colErr  = 0;
+                        colBind.buffer_type   = MYSQL_TYPE_STRING;
+                        colBind.buffer        = big.data();
+                        colBind.buffer_length = actualLen;
+                        colBind.length        = &colLen;
+                        colBind.is_null       = &colNull;
+                        colBind.error         = &colErr;
+
+                        if (mysql_stmt_fetch_column(stmt_, &colBind, static_cast<unsigned int>(i), 0) != 0)
+                        {
+                            throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+                        }
+
+                        row[i] = std::string(big.data(), actualLen);
+                    }
+                    else
+                    {
+                        row[i] = std::string(buffers[i].data(), actualLen);
+                    }
+                    break;
+                }
+            }
+        }
+
+        rows.push_back(std::move(row));
+    }
+
+    return rows;
+}
+
+auto db::LibMariaDBPreparedStatement::executeQuery(const std::string& query) -> std::unique_ptr<ResultSet>
+{
+    try
+    {
+        applyBindings();
+
+        if (mysql_stmt_execute(stmt_) != 0)
+        {
+            throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+        }
+
+        ensureSchema();
+        auto rows = fetchRows();
+
+        resetBindings();
+        return std::make_unique<LibMariaDBResultSet>(query, schema_, std::move(rows));
+    }
+    catch (...)
+    {
+        resetBindings();
+        throw;
+    }
+}
+
+auto db::LibMariaDBPreparedStatement::executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet>
+{
+    try
+    {
+        applyBindings();
+
+        if (mysql_stmt_execute(stmt_) != 0)
+        {
+            throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+        }
+
+        const auto affected = mysql_stmt_affected_rows(stmt_);
+        resetBindings();
+        return std::make_unique<LibMariaDBResultSet>(static_cast<std::size_t>(affected), query);
+    }
+    catch (...)
+    {
+        resetBindings();
+        throw;
+    }
+}

--- a/src/common/database/libmariadb/libmariadb_prepared_statement.h
+++ b/src/common/database/libmariadb/libmariadb_prepared_statement.h
@@ -1,0 +1,95 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+// Must precede any project header that could transitively include <windows.h>.
+#include <common/database/libmariadb/libmariadb_include.h>
+
+#include <common/database/bound_value.h>
+#include <common/database/libmariadb/libmariadb_result_set.h>
+#include <common/database/prepared_statement.h>
+#include <common/database/result_set.h>
+
+#include <deque>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace db::detail::libmariadb
+{
+
+// Error raised by the libmariadb backend. Carries the connector errno so the connection can
+// distinguish a recoverable connection drop from a genuine query failure.
+struct Error final : std::runtime_error
+{
+    Error(unsigned int errnum, const std::string& message);
+
+    unsigned int errnum;
+};
+
+auto isConnectionLost(unsigned int errnum) -> bool;
+
+} // namespace db::detail::libmariadb
+
+namespace db
+{
+
+class LibMariaDBPreparedStatement final : public PreparedStatement
+{
+public:
+    explicit LibMariaDBPreparedStatement(MYSQL_STMT* stmt);
+    ~LibMariaDBPreparedStatement() override;
+
+    LibMariaDBPreparedStatement(const LibMariaDBPreparedStatement&)            = delete;
+    LibMariaDBPreparedStatement& operator=(const LibMariaDBPreparedStatement&) = delete;
+
+    auto bind(int index, const BoundValue& value) -> void override;
+    auto executeQuery(const std::string& query) -> std::unique_ptr<ResultSet> override;
+    auto executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet> override;
+
+private:
+    enum class CellKind
+    {
+        Int64,
+        UInt64,
+        Double,
+        Text,
+    };
+
+    auto applyBindings() -> void;
+    auto resetBindings() -> void;
+    auto ensureSchema() -> void;
+    auto fetchRows() -> std::vector<LibMariaDBResultSet::Row>;
+
+    MYSQL_STMT* stmt_;
+
+    std::vector<MYSQL_BIND>       paramBinds_;
+    std::deque<std::vector<char>> paramBuffers_;
+    std::deque<unsigned long>     paramLengths_;
+
+    std::shared_ptr<const ColumnSchema> schema_;
+    std::vector<CellKind>               kinds_;
+    bool                                schemaInitialized_ = false;
+};
+
+} // namespace db

--- a/src/common/database/libmariadb/libmariadb_result_set.cpp
+++ b/src/common/database/libmariadb/libmariadb_result_set.cpp
@@ -1,0 +1,246 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/libmariadb/libmariadb_result_set.h>
+
+#include <cstdlib>
+#include <type_traits>
+#include <utility>
+
+db::LibMariaDBResultSet::LibMariaDBResultSet(const std::string& query, std::shared_ptr<const ColumnSchema> schema, std::vector<Row> rows)
+: ResultSet(query, ResultSetType::Select)
+, schema_(std::move(schema))
+, rows_(std::move(rows))
+{
+}
+
+db::LibMariaDBResultSet::LibMariaDBResultSet(std::size_t rowsAffected, const std::string& query)
+: ResultSet(query, ResultSetType::Update, rowsAffected)
+{
+}
+
+auto db::LibMariaDBResultSet::rawNext() -> bool
+{
+    ++cursor_;
+    return cursor_ >= 0 && static_cast<std::size_t>(cursor_) < rows_.size();
+}
+
+auto db::LibMariaDBResultSet::rawRowsCount() const -> std::size_t
+{
+    return rows_.size();
+}
+
+auto db::LibMariaDBResultSet::rawColumnCount() const -> std::size_t
+{
+    return schema_ ? schema_->names.size() : 0;
+}
+
+auto db::LibMariaDBResultSet::rawIsNull(const std::string& key) const -> bool
+{
+    return std::holds_alternative<std::monostate>(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::rawColumnLabel(uint32 index) const -> std::string
+{
+    // index is 1-based.
+    if (schema_ && index >= 1 && static_cast<std::size_t>(index) <= schema_->names.size())
+    {
+        return schema_->names[index - 1];
+    }
+    return {};
+}
+
+auto db::LibMariaDBResultSet::rawGetInt64(const std::string& key) const -> int64
+{
+    return toInt64(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::rawGetUInt64(const std::string& key) const -> uint64
+{
+    return toUInt64(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::rawGetInt32(const std::string& key) const -> int32
+{
+    return static_cast<int32>(toInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetUInt32(const std::string& key) const -> uint32
+{
+    return static_cast<uint32>(toUInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetInt16(const std::string& key) const -> int16
+{
+    return static_cast<int16>(toInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetUInt16(const std::string& key) const -> uint16
+{
+    return static_cast<uint16>(toUInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetInt8(const std::string& key) const -> int8
+{
+    return static_cast<int8>(toInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetUInt8(const std::string& key) const -> uint8
+{
+    return static_cast<uint8>(toUInt64(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetBool(const std::string& key) const -> bool
+{
+    return toInt64(cellAt(key)) != 0;
+}
+
+auto db::LibMariaDBResultSet::rawGetFloat(const std::string& key) const -> float
+{
+    return static_cast<float>(toDouble(cellAt(key)));
+}
+
+auto db::LibMariaDBResultSet::rawGetDouble(const std::string& key) const -> double
+{
+    return toDouble(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::rawGetString(const std::string& key) const -> std::string
+{
+    return toText(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::rawGetBlobBytes(const std::string& key) const -> std::string
+{
+    // Blob/text columns are stored as a std::string holding the full bytes.
+    return toText(cellAt(key));
+}
+
+auto db::LibMariaDBResultSet::cellAt(const std::string& key) const -> const Cell&
+{
+    static const Cell nullCell{};
+
+    if (!schema_)
+    {
+        return nullCell;
+    }
+
+    const auto it = schema_->index.find(key);
+    if (it == schema_->index.end())
+    {
+        return nullCell;
+    }
+
+    if (cursor_ < 0 || static_cast<std::size_t>(cursor_) >= rows_.size())
+    {
+        return nullCell;
+    }
+
+    return rows_[cursor_][it->second];
+}
+
+auto db::LibMariaDBResultSet::toInt64(const Cell& cell) -> int64
+{
+    return std::visit(
+        [](const auto& v) -> int64
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::monostate>)
+            {
+                return 0;
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                return std::strtoll(v.c_str(), nullptr, 10);
+            }
+            else
+            {
+                return static_cast<int64>(v);
+            }
+        },
+        cell);
+}
+
+auto db::LibMariaDBResultSet::toUInt64(const Cell& cell) -> uint64
+{
+    return std::visit(
+        [](const auto& v) -> uint64
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::monostate>)
+            {
+                return 0;
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                return std::strtoull(v.c_str(), nullptr, 10);
+            }
+            else
+            {
+                return static_cast<uint64>(v);
+            }
+        },
+        cell);
+}
+
+auto db::LibMariaDBResultSet::toDouble(const Cell& cell) -> double
+{
+    return std::visit(
+        [](const auto& v) -> double
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::monostate>)
+            {
+                return 0.0;
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                return std::strtod(v.c_str(), nullptr);
+            }
+            else
+            {
+                return static_cast<double>(v);
+            }
+        },
+        cell);
+}
+
+auto db::LibMariaDBResultSet::toText(const Cell& cell) -> std::string
+{
+    return std::visit(
+        [](const auto& v) -> std::string
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::monostate>)
+            {
+                return {};
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                return v;
+            }
+            else
+            {
+                return std::to_string(v);
+            }
+        },
+        cell);
+}

--- a/src/common/database/libmariadb/libmariadb_result_set.h
+++ b/src/common/database/libmariadb/libmariadb_result_set.h
@@ -1,0 +1,90 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+
+#include <common/database/result_set.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace db
+{
+
+struct ColumnSchema
+{
+    std::vector<std::string>                     names;
+    std::unordered_map<std::string, std::size_t> index;
+};
+
+class LibMariaDBResultSet final : public ResultSet
+{
+public:
+    using Cell = std::variant<std::monostate, int64, uint64, double, std::string>;
+    using Row  = std::vector<Cell>;
+
+    // SELECT-like result. The schema is shared (and owned) across all result sets of one statement.
+    LibMariaDBResultSet(const std::string& query, std::shared_ptr<const ColumnSchema> schema, std::vector<Row> rows);
+
+    // UPDATE-like result.
+    LibMariaDBResultSet(std::size_t rowsAffected, const std::string& query);
+
+protected:
+    auto rawNext() -> bool override;
+    auto rawRowsCount() const -> std::size_t override;
+    auto rawColumnCount() const -> std::size_t override;
+    auto rawIsNull(const std::string& key) const -> bool override;
+    auto rawColumnLabel(uint32 index) const -> std::string override;
+
+    auto rawGetInt64(const std::string& key) const -> int64 override;
+    auto rawGetUInt64(const std::string& key) const -> uint64 override;
+    auto rawGetInt32(const std::string& key) const -> int32 override;
+    auto rawGetUInt32(const std::string& key) const -> uint32 override;
+    auto rawGetInt16(const std::string& key) const -> int16 override;
+    auto rawGetUInt16(const std::string& key) const -> uint16 override;
+    auto rawGetInt8(const std::string& key) const -> int8 override;
+    auto rawGetUInt8(const std::string& key) const -> uint8 override;
+    auto rawGetBool(const std::string& key) const -> bool override;
+    auto rawGetFloat(const std::string& key) const -> float override;
+    auto rawGetDouble(const std::string& key) const -> double override;
+    auto rawGetString(const std::string& key) const -> std::string override;
+    auto rawGetBlobBytes(const std::string& key) const -> std::string override;
+
+private:
+    auto cellAt(const std::string& key) const -> const Cell&;
+
+    static auto toInt64(const Cell& cell) -> int64;
+    static auto toUInt64(const Cell& cell) -> uint64;
+    static auto toDouble(const Cell& cell) -> double;
+    static auto toText(const Cell& cell) -> std::string;
+
+    std::shared_ptr<const ColumnSchema> schema_;
+    std::vector<Row>                    rows_;
+    std::ptrdiff_t                      cursor_ = -1;
+};
+
+} // namespace db

--- a/src/common/database/mariadb_cpp/mariadb_cpp_connection.cpp
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_connection.cpp
@@ -1,0 +1,114 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/mariadb_cpp/mariadb_cpp_connection.h>
+
+#include <common/database/mariadb_cpp/mariadb_cpp_prepared_statement.h>
+
+#include <common/logging.h>
+#include <common/settings.h>
+
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <chrono>
+using namespace std::chrono_literals;
+
+namespace
+{
+
+const std::vector<std::string> connectionIssues = {
+    "Lost connection",
+    "Server has gone away",
+    "Connection refused",
+    "Can't connect to server",
+};
+
+} // namespace
+
+db::MariaDBCppConnection::MariaDBCppConnection(std::unique_ptr<sql::Connection> connection)
+: connection_(std::move(connection))
+{
+}
+
+auto db::MariaDBCppConnection::prepare(const std::string& query) -> std::unique_ptr<PreparedStatement>
+{
+    return std::make_unique<MariaDBCppPreparedStatement>(connection_->prepareStatement(query.c_str()));
+}
+
+auto db::MariaDBCppConnection::schema() -> std::string
+{
+    return connection_->getSchema().c_str();
+}
+
+auto db::MariaDBCppConnection::version() -> std::string
+{
+    const std::unique_ptr<sql::DatabaseMetaData> metadata(connection_->getMetaData());
+    return fmt::format("{} {}", metadata->getDatabaseProductName().c_str(), metadata->getDatabaseProductVersion().c_str());
+}
+
+auto db::MariaDBCppConnection::driverVersion() -> std::string
+{
+    const std::unique_ptr<sql::DatabaseMetaData> metadata(connection_->getMetaData());
+    return fmt::format("{} {}", metadata->getDriverName().c_str(), metadata->getDriverVersion().c_str());
+}
+
+auto db::MariaDBCppConnection::isConnectionError(const std::exception& e) const -> bool
+{
+    const auto message = fmt::format("{}", e.what());
+    for (const auto& issue : connectionIssues)
+    {
+        if (message.find(issue) != std::string::npos)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+auto db::MariaDBCppConnection::connect() -> std::unique_ptr<Connection>
+{
+    try
+    {
+        const auto login  = settings::get<std::string>("network.SQL_LOGIN");
+        const auto passwd = settings::get<std::string>("network.SQL_PASSWORD");
+        const auto host   = settings::get<std::string>("network.SQL_HOST");
+        const auto port   = settings::get<uint16>("network.SQL_PORT");
+        const auto schema = settings::get<std::string>("network.SQL_DATABASE");
+        const auto url    = fmt::format("tcp://{}:{}/{}", host, port, schema);
+
+        auto connection = std::unique_ptr<sql::Connection>(
+            sql::mariadb::get_driver_instance()->connect(url.c_str(), login.c_str(), passwd.c_str()));
+
+        return std::make_unique<MariaDBCppConnection>(std::move(connection));
+    }
+    catch (const std::exception& e)
+    {
+        // If we can't establish a connection to the database we can't do anything.
+        // Time to die!
+        ShowCritical("!!! Failed to connect to database, terminating server !!!");
+        ShowCritical(e.what());
+        std::this_thread::sleep_for(1s);
+        std::terminate();
+    }
+}

--- a/src/common/database/mariadb_cpp/mariadb_cpp_connection.h
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_connection.h
@@ -1,0 +1,52 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/database/connection.h>
+
+#include <common/database/mariadb_cpp/mariadb_cpp_include.h>
+
+#include <exception>
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class MariaDBCppConnection final : public Connection
+{
+public:
+    explicit MariaDBCppConnection(std::unique_ptr<sql::Connection> connection);
+
+    auto prepare(const std::string& query) -> std::unique_ptr<PreparedStatement> override;
+    auto schema() -> std::string override;
+    auto version() -> std::string override;
+    auto driverVersion() -> std::string override;
+    auto isConnectionError(const std::exception& e) const -> bool override;
+
+    static auto connect() -> std::unique_ptr<Connection>;
+
+private:
+    std::unique_ptr<sql::Connection> connection_;
+};
+
+} // namespace db

--- a/src/common/database/mariadb_cpp/mariadb_cpp_database.cpp
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_database.cpp
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -19,16 +19,11 @@
 ===========================================================================
 */
 
-#pragma once
+#include <common/database/mariadb_cpp/mariadb_cpp_database.h>
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/mariadb_cpp/mariadb_cpp_connection.h>
 
-#include <common/database/database.h>
+auto db::MariaDBCppDatabase::createConnection() -> std::unique_ptr<Connection>
+{
+    return MariaDBCppConnection::connect();
+}

--- a/src/common/database/mariadb_cpp/mariadb_cpp_database.h
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_database.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,18 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/caching_database.h>
+#include <common/database/connection.h>
 
-#include <common/database/database.h>
+#include <memory>
+
+namespace db
+{
+
+class MariaDBCppDatabase final : public CachingDatabase
+{
+protected:
+    auto createConnection() -> std::unique_ptr<Connection> override;
+};
+
+} // namespace db

--- a/src/common/database/mariadb_cpp/mariadb_cpp_include.h
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_include.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,15 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+// TODO: mariadb-connector-cpp triggers this. Remove once they fix it.
+// 4263 'function': member function does not override any base class member functions
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4263)
+#endif
 
-#include <common/database/database.h>
+#include <conncpp.hpp>
+
+#ifdef _WIN32
+#pragma warning(pop)
+#endif

--- a/src/common/database/mariadb_cpp/mariadb_cpp_prepared_statement.cpp
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_prepared_statement.cpp
@@ -1,0 +1,105 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/mariadb_cpp/mariadb_cpp_prepared_statement.h>
+
+#include <common/database/mariadb_cpp/mariadb_cpp_result_set.h>
+
+#include <common/logging.h>
+#include <common/tracy.h>
+
+#include <memory>
+#include <type_traits>
+#include <variant>
+
+auto db::MariaDBCppPreparedStatement::bind(int index, const BoundValue& value) -> void
+{
+    TracyZoneScoped;
+
+    std::visit(
+        [&](const auto& v)
+        {
+            using U = std::remove_cvref_t<decltype(v)>;
+            if constexpr (std::is_same_v<U, std::shared_ptr<BlobWrapper>>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v->toString());
+                stmt_->setBlob(index, &v->istream);
+            }
+            else if constexpr (std::is_same_v<U, std::string>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setString(index, v.c_str());
+            }
+            else if constexpr (std::is_same_v<U, int8> || std::is_same_v<U, uint8>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setByte(index, v);
+            }
+            else if constexpr (std::is_same_v<U, int16>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setShort(index, v);
+            }
+            else if constexpr (std::is_same_v<U, uint16>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setUInt(index, v);
+            }
+            else if constexpr (std::is_same_v<U, int32>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setInt(index, v);
+            }
+            else if constexpr (std::is_same_v<U, uint32>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setUInt(index, v);
+            }
+            else if constexpr (std::is_same_v<U, bool>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setBoolean(index, v);
+            }
+            else if constexpr (std::is_same_v<U, float>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setFloat(index, v);
+            }
+            else if constexpr (std::is_same_v<U, double>)
+            {
+                DebugSQLFmt("binding {}: {}", index, v);
+                stmt_->setDouble(index, v);
+            }
+        },
+        value);
+}
+
+auto db::MariaDBCppPreparedStatement::executeQuery(const std::string& query) -> std::unique_ptr<ResultSet>
+{
+    auto rset = std::unique_ptr<sql::ResultSet>(stmt_->executeQuery());
+    return std::make_unique<MariaDBCppResultSet>(std::move(rset), query);
+}
+
+auto db::MariaDBCppPreparedStatement::executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet>
+{
+    const auto rowsAffected = stmt_->executeUpdate();
+    return std::make_unique<MariaDBCppResultSet>(static_cast<std::size_t>(rowsAffected), query);
+}

--- a/src/common/database/mariadb_cpp/mariadb_cpp_prepared_statement.h
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_prepared_statement.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,32 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/bound_value.h>
+#include <common/database/prepared_statement.h>
+#include <common/database/result_set.h>
 
-#include <common/database/database.h>
+#include <common/database/mariadb_cpp/mariadb_cpp_include.h>
+
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class MariaDBCppPreparedStatement final : public PreparedStatement
+{
+public:
+    explicit MariaDBCppPreparedStatement(sql::PreparedStatement* stmt)
+    : stmt_(stmt)
+    {
+    }
+
+    auto bind(int index, const BoundValue& value) -> void override;
+    auto executeQuery(const std::string& query) -> std::unique_ptr<ResultSet> override;
+    auto executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet> override;
+
+private:
+    std::unique_ptr<sql::PreparedStatement> stmt_;
+};
+
+} // namespace db

--- a/src/common/database/mariadb_cpp/mariadb_cpp_result_set.cpp
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_result_set.cpp
@@ -1,0 +1,132 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/mariadb_cpp/mariadb_cpp_result_set.h>
+
+#include <utility>
+
+db::MariaDBCppResultSet::MariaDBCppResultSet(std::unique_ptr<sql::ResultSet>&& resultSet, const std::string& query)
+: ResultSet(query, ResultSetType::Select)
+, resultSet_(std::move(resultSet))
+{
+}
+
+db::MariaDBCppResultSet::MariaDBCppResultSet(std::size_t rowsAffected, const std::string& query)
+: ResultSet(query, ResultSetType::Update, rowsAffected)
+{
+}
+
+auto db::MariaDBCppResultSet::rawNext() -> bool
+{
+    return resultSet_->next();
+}
+
+auto db::MariaDBCppResultSet::rawRowsCount() const -> std::size_t
+{
+    return resultSet_->rowsCount();
+}
+
+auto db::MariaDBCppResultSet::rawColumnCount() const -> std::size_t
+{
+    const std::unique_ptr<sql::ResultSetMetaData> metadata(resultSet_->getMetaData());
+    return static_cast<std::size_t>(metadata->getColumnCount());
+}
+
+auto db::MariaDBCppResultSet::rawIsNull(const std::string& key) const -> bool
+{
+    return resultSet_->isNull(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawColumnLabel(uint32 index) const -> std::string
+{
+    const std::unique_ptr<sql::ResultSetMetaData> metadata(resultSet_->getMetaData());
+    return metadata->getColumnLabel(index).c_str();
+}
+
+auto db::MariaDBCppResultSet::rawGetInt64(const std::string& key) const -> int64
+{
+    return resultSet_->getInt64(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetUInt64(const std::string& key) const -> uint64
+{
+    return resultSet_->getUInt64(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetInt32(const std::string& key) const -> int32
+{
+    return resultSet_->getInt(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetUInt32(const std::string& key) const -> uint32
+{
+    return resultSet_->getUInt(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetInt16(const std::string& key) const -> int16
+{
+    return static_cast<int16>(resultSet_->getInt(key.c_str()));
+}
+
+auto db::MariaDBCppResultSet::rawGetUInt16(const std::string& key) const -> uint16
+{
+    return static_cast<uint16>(resultSet_->getUInt(key.c_str()));
+}
+
+auto db::MariaDBCppResultSet::rawGetInt8(const std::string& key) const -> int8
+{
+    // There is only a signed byte accessor
+    return static_cast<int8>(resultSet_->getByte(key.c_str()));
+}
+
+auto db::MariaDBCppResultSet::rawGetUInt8(const std::string& key) const -> uint8
+{
+    // There isn't an unsigned byte accessor, so we'll just use getUInt
+    return static_cast<uint8>(resultSet_->getUInt(key.c_str()));
+}
+
+auto db::MariaDBCppResultSet::rawGetBool(const std::string& key) const -> bool
+{
+    return resultSet_->getBoolean(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetFloat(const std::string& key) const -> float
+{
+    return resultSet_->getFloat(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetDouble(const std::string& key) const -> double
+{
+    return resultSet_->getDouble(key.c_str());
+}
+
+auto db::MariaDBCppResultSet::rawGetString(const std::string& key) const -> std::string
+{
+    return resultSet_->getString(key.c_str()).c_str();
+}
+
+auto db::MariaDBCppResultSet::rawGetBlobBytes(const std::string& key) const -> std::string
+{
+    // Preserve the full blob length, including embedded nulls, rather than truncating at the first
+    // null the way a c_str()-based conversion would.
+    const auto blob = resultSet_->getString(key.c_str());
+    return std::string(blob.c_str(), blob.length());
+}

--- a/src/common/database/mariadb_cpp/mariadb_cpp_result_set.h
+++ b/src/common/database/mariadb_cpp/mariadb_cpp_result_set.h
@@ -1,0 +1,67 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+
+#include <common/database/result_set.h>
+
+#include <common/database/mariadb_cpp/mariadb_cpp_include.h>
+
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class MariaDBCppResultSet final : public ResultSet
+{
+public:
+    MariaDBCppResultSet(std::unique_ptr<sql::ResultSet>&& resultSet, const std::string& query);
+    MariaDBCppResultSet(std::size_t rowsAffected, const std::string& query);
+
+protected:
+    auto rawNext() -> bool override;
+    auto rawRowsCount() const -> std::size_t override;
+    auto rawColumnCount() const -> std::size_t override;
+    auto rawIsNull(const std::string& key) const -> bool override;
+    auto rawColumnLabel(uint32 index) const -> std::string override;
+
+    auto rawGetInt64(const std::string& key) const -> int64 override;
+    auto rawGetUInt64(const std::string& key) const -> uint64 override;
+    auto rawGetInt32(const std::string& key) const -> int32 override;
+    auto rawGetUInt32(const std::string& key) const -> uint32 override;
+    auto rawGetInt16(const std::string& key) const -> int16 override;
+    auto rawGetUInt16(const std::string& key) const -> uint16 override;
+    auto rawGetInt8(const std::string& key) const -> int8 override;
+    auto rawGetUInt8(const std::string& key) const -> uint8 override;
+    auto rawGetBool(const std::string& key) const -> bool override;
+    auto rawGetFloat(const std::string& key) const -> float override;
+    auto rawGetDouble(const std::string& key) const -> double override;
+    auto rawGetString(const std::string& key) const -> std::string override;
+    auto rawGetBlobBytes(const std::string& key) const -> std::string override;
+
+private:
+    std::unique_ptr<sql::ResultSet> resultSet_;
+};
+
+} // namespace db

--- a/src/common/database/prepared_statement.h
+++ b/src/common/database/prepared_statement.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,28 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/bound_value.h>
+#include <common/database/result_set.h>
 
-#include <common/database/database.h>
+#include <memory>
+#include <string>
+
+namespace db
+{
+
+class PreparedStatement
+{
+public:
+    virtual ~PreparedStatement() = default;
+
+    // Bind a single value to the given (1-indexed) parameter slot.
+    virtual auto bind(int index, const BoundValue& value) -> void = 0;
+
+    // Execute as a SELECT-like query, returning a queryable result set.
+    virtual auto executeQuery(const std::string& query) -> std::unique_ptr<ResultSet> = 0;
+
+    // Execute as an UPDATE-like query, returning a rows-affected result set.
+    virtual auto executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet> = 0;
+};
+
+} // namespace db

--- a/src/common/database/query_validation.h
+++ b/src/common/database/query_validation.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2024 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,14 +21,18 @@
 
 #pragma once
 
-// Umbrella header for the database layer.
-//
-// The real implementations live under common/database/. Consumers should keep including
-// <common/database.h>; this pulls in the connector-agnostic public interface: the abstract
-// Database/ResultSet/PreparedStatement, the templated preparedStmt/get<T> binding, the blob
-// helpers and the free functions.
-//
-// The concrete MariaDB Connector/C++ backend is deliberately NOT included here, so the
-// connector header (and its warning workaround) no longer leaks into every translation unit.
+#include <common/database/result_set.h>
 
-#include <common/database/database.h>
+#include <string>
+
+namespace db::detail
+{
+
+// Inspect the leading keyword of a query to classify it as a Select (queryable),
+// Update (rows-affected only), or Invalid query.
+auto validateQueryLeadingKeyword(const std::string& query) -> ResultSetType;
+
+// Sanity-check the body of a query (e.g. reject stray "{}" format holes and ';').
+auto validateQueryContent(const std::string& query) -> bool;
+
+} // namespace db::detail

--- a/src/common/database/result_set.cpp
+++ b/src/common/database/result_set.cpp
@@ -1,0 +1,129 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <common/database/result_set.h>
+
+#include <common/logging.h>
+
+#include <utility>
+
+db::ResultSet::ResultSet(std::string query, ResultSetType type, std::size_t rowsAffected)
+: query_(std::move(query))
+, type_(type)
+, rowsAffected_(rowsAffected)
+{
+}
+
+auto db::ResultSet::type() const -> ResultSetType
+{
+    return type_;
+}
+
+auto db::ResultSet::query() const -> const std::string&
+{
+    return query_;
+}
+
+auto db::ResultSet::next() -> bool
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::next: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return false;
+    }
+
+    return rawNext();
+}
+
+auto db::ResultSet::rowsCount() const -> uint32
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::rowsCount: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return 0;
+    }
+
+    DebugSQLFmt("rowsCount: {}", rawRowsCount());
+    return static_cast<uint32>(rawRowsCount());
+}
+
+auto db::ResultSet::rowsAffected() const -> uint32
+{
+    if (type_ != ResultSetType::Update)
+    {
+        ShowErrorFmt("ResultSet::rowsAffected: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return 0;
+    }
+
+    DebugSQLFmt("rowsAffected: {}", rowsAffected_);
+    return static_cast<uint32>(rowsAffected_);
+}
+
+auto db::ResultSet::columnCount() const -> uint32
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::columnCount: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return 0;
+    }
+
+    return static_cast<uint32>(rawColumnCount());
+}
+
+auto db::ResultSet::columnName(uint32 index) const -> std::string
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::columnName: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return {};
+    }
+
+    return rawColumnLabel(index + 1);
+}
+
+auto db::ResultSet::isNull(const std::string& key) const -> bool
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::isNull: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return false;
+    }
+
+    return rawIsNull(key);
+}
+
+auto db::ResultSet::getBlobBytes(const std::string& key) const -> std::string
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::getBlobBytes: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return {};
+    }
+
+    return rawGetBlobBytes(key);
+}

--- a/src/common/database/result_set.h
+++ b/src/common/database/result_set.h
@@ -1,0 +1,338 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+#include <common/logging.h>
+#include <common/tracy.h>
+
+#include <common/database/traits.h>
+
+#include <algorithm>
+#include <cstring>
+#include <exception>
+#include <iterator>
+#include <string>
+#include <type_traits>
+
+// @note Everything in database-land is 1-indexed, not 0-indexed.
+namespace db
+{
+
+enum class ResultSetType
+{
+    Select,  // We can query the rset for data
+    Update,  // The rset only has rowsCount()/rowsAffected() populated
+    Invalid, // The query is invalid and we can't do anything with it
+};
+
+// Forward declaration so ResultSet::get<T>() can reference it.
+template <typename WrapperPtrT, typename T>
+auto extractFromBlob(const WrapperPtrT& rset, const std::string& blobKey, T& destination) -> void;
+
+class ResultSet
+{
+public:
+    ResultSet(std::string query, ResultSetType type, std::size_t rowsAffected = 0);
+    virtual ~ResultSet() = default;
+
+    ResultSet(const ResultSet&)            = delete;
+    ResultSet& operator=(const ResultSet&) = delete;
+
+    auto type() const -> ResultSetType;
+    auto query() const -> const std::string&;
+
+    auto next() -> bool;
+
+    auto rowsCount() const -> uint32;
+    auto rowsAffected() const -> uint32;
+    auto columnCount() const -> uint32;
+
+    auto columnName(uint32 index) const -> std::string;
+
+    auto isNull(const std::string& key) const -> bool;
+
+    // Get the raw, untruncated bytes of a blob column.
+    // Unlike get<std::string>, this preserves embedded nulls and the full length.
+    auto getBlobBytes(const std::string& key) const -> std::string;
+
+    // Get the value of the associated key.
+    template <typename T>
+    auto get(const std::string& key) const -> T;
+
+    // Get the value of the 0-indexed column.
+    template <typename T>
+    auto get(uint32 index) const -> T;
+
+    // Get the value of the associated key, or the default value if it is null/not-populated.
+    template <typename T>
+    auto getOrDefault(const std::string& key, T defaultValue) const -> T;
+
+    // Get the value of the 0-indexed column, or the default value if it is null/not-populated.
+    template <typename T>
+    auto getOrDefault(uint32 index, T defaultValue) const -> T;
+
+protected:
+    virtual auto rawNext() -> bool                                 = 0;
+    virtual auto rawRowsCount() const -> std::size_t               = 0;
+    virtual auto rawColumnCount() const -> std::size_t             = 0;
+    virtual auto rawIsNull(const std::string& key) const -> bool   = 0;
+    virtual auto rawColumnLabel(uint32 index) const -> std::string = 0;
+
+    virtual auto rawGetInt64(const std::string& key) const -> int64           = 0;
+    virtual auto rawGetUInt64(const std::string& key) const -> uint64         = 0;
+    virtual auto rawGetInt32(const std::string& key) const -> int32           = 0;
+    virtual auto rawGetUInt32(const std::string& key) const -> uint32         = 0;
+    virtual auto rawGetInt16(const std::string& key) const -> int16           = 0;
+    virtual auto rawGetUInt16(const std::string& key) const -> uint16         = 0;
+    virtual auto rawGetInt8(const std::string& key) const -> int8             = 0;
+    virtual auto rawGetUInt8(const std::string& key) const -> uint8           = 0;
+    virtual auto rawGetBool(const std::string& key) const -> bool             = 0;
+    virtual auto rawGetFloat(const std::string& key) const -> float           = 0;
+    virtual auto rawGetDouble(const std::string& key) const -> double         = 0;
+    virtual auto rawGetString(const std::string& key) const -> std::string    = 0;
+    virtual auto rawGetBlobBytes(const std::string& key) const -> std::string = 0;
+
+    std::string   query_;
+    ResultSetType type_;
+    std::size_t   rowsAffected_{ 0 };
+};
+
+//
+// Out-of-line template definitions
+//
+
+template <typename T>
+auto ResultSet::get(const std::string& key) const -> T
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::get: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return T{};
+    }
+
+    // Enum support: use underlying type to select database accessor
+    using UnderlyingT = detail::enum_decay_t<T>;
+    UnderlyingT value{};
+
+    if constexpr (!detail::is_blob_v<UnderlyingT>)
+    {
+        if (rawIsNull(key))
+        {
+            // NULL is legitimate data (e.g. LEFT JOIN columns); callers wanting a fallback should
+            // use getOrDefault(). Note it at debug level rather than spamming errors.
+            DebugSQLFmt("ResultSet::get: key {} is null (Query: {})", key, query_);
+            if constexpr (std::is_enum_v<T>)
+            {
+                return static_cast<T>(value);
+            }
+            else
+            {
+                return value;
+            }
+        }
+    }
+
+    //
+    // If the backend gets an invalid, incorrectly sized, or incorrectly signed value, it will throw
+    // an exception. So we'll wrap the whole extraction step in try/catch.
+    //
+
+    try
+    {
+        if constexpr (std::is_same_v<UnderlyingT, int64>)
+        {
+            value = static_cast<UnderlyingT>(rawGetInt64(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, uint64>)
+        {
+            value = static_cast<UnderlyingT>(rawGetUInt64(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, int32>)
+        {
+            value = static_cast<UnderlyingT>(rawGetInt32(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, uint32>)
+        {
+            value = static_cast<UnderlyingT>(rawGetUInt32(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, int16>)
+        {
+            value = static_cast<UnderlyingT>(rawGetInt16(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, uint16>)
+        {
+            value = static_cast<UnderlyingT>(rawGetUInt16(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, int8>)
+        {
+            value = static_cast<UnderlyingT>(rawGetInt8(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, uint8>)
+        {
+            value = static_cast<UnderlyingT>(rawGetUInt8(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, bool>)
+        {
+            value = static_cast<UnderlyingT>(rawGetBool(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, double>)
+        {
+            value = static_cast<UnderlyingT>(rawGetDouble(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, float>)
+        {
+            value = static_cast<UnderlyingT>(rawGetFloat(key));
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, std::string>)
+        {
+            value = rawGetString(key);
+        }
+        else if constexpr (std::is_same_v<UnderlyingT, size_t>)
+        {
+            // NOTE: Preserves the historical behaviour of reading size_t as a 32-bit unsigned value.
+            value = static_cast<UnderlyingT>(rawGetUInt32(key));
+        }
+        else if constexpr (detail::is_blob_v<UnderlyingT>)
+        {
+            extractFromBlob(this, key, value);
+        }
+        else
+        {
+            static_assert(detail::always_false_v<T>, "Trying to extract unsupported type from ResultSet");
+        }
+    }
+    catch (std::exception& e)
+    {
+        ShowErrorFmt("ResultSet::get: Error: {}", e.what());
+        ShowErrorFmt("Key: {}", key);
+        ShowErrorFmt("Query: {}", query_);
+        return T{};
+    }
+    catch (...)
+    {
+        ShowErrorFmt("ResultSet::get: Unknown error");
+        ShowErrorFmt("Key: {}", key);
+        ShowErrorFmt("Query: {}", query_);
+        return T{};
+    }
+
+    if constexpr (std::is_enum_v<T>)
+    {
+        return static_cast<T>(value);
+    }
+    else
+    {
+        return value;
+    }
+}
+
+template <typename T>
+auto ResultSet::get(const uint32 index) const -> T
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::get: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return T{};
+    }
+
+    return get<T>(rawColumnLabel(index + 1));
+}
+
+template <typename T>
+auto ResultSet::getOrDefault(const std::string& key, T defaultValue) const -> T
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::getOrDefault: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return defaultValue;
+    }
+
+    if (rawIsNull(key))
+    {
+        return defaultValue;
+    }
+
+    return get<T>(key);
+}
+
+template <typename T>
+auto ResultSet::getOrDefault(const uint32 index, T defaultValue) const -> T
+{
+    if (type_ != ResultSetType::Select)
+    {
+        ShowErrorFmt("ResultSet::getOrDefault: Invalid type {}", static_cast<int>(type_));
+        ShowErrorFmt("Query: {}", query_);
+        return defaultValue;
+    }
+
+    return getOrDefault<T>(rawColumnLabel(index + 1), defaultValue);
+}
+
+// @brief Extract a struct from a blob column.
+// @param rset The result set to extract the blob from.
+// @param blobKey The key of the blob in the result set.
+// @param destination The struct to extract the blob into.
+template <typename WrapperPtrT, typename T>
+auto extractFromBlob(const WrapperPtrT& rset, const std::string& blobKey, T& destination) -> void
+{
+    TracyZoneScoped;
+
+    // TODO: static_assert(std::is_trivial_v<T>, "T must be trivial");
+    static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+
+    // If we read a null blob we will get back garbage data.
+    // This will introduce difficult to track down crashes.
+    if (!rset->isNull(blobKey))
+    {
+        // getBlobBytes preserves the full length (including embedded nulls), unlike get<std::string>,
+        // which would truncate the blob result.
+        const auto blobStr = rset->getBlobBytes(blobKey);
+
+        // Login server creates new chars with null blobs. Map server then initializes.
+        // We don't want to overwrite the initialized map data with null blobs / 0 values.
+        // See: login_helpers.cpp saveCharacter() and charutils::LoadChar
+
+        // Zero-initialize the destination object
+        if constexpr (std::is_array_v<T>)
+        {
+            using Element = std::remove_extent_t<T>;
+            std::fill(std::begin(destination), std::end(destination), Element{});
+        }
+        else if constexpr (std::is_assignable_v<T&, T>)
+        {
+            destination = T{};
+        }
+        else
+        {
+            std::fill_n(reinterpret_cast<uint8_t*>(&destination), sizeof(T), 0);
+        }
+
+        // Copy the blob into the destination object
+        std::memcpy(&destination, blobStr.data(), std::min(sizeof(T), blobStr.size()));
+    }
+}
+
+} // namespace db

--- a/src/common/database/traits.h
+++ b/src/common/database/traits.h
@@ -1,0 +1,80 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <array>
+#include <type_traits>
+
+namespace db::detail
+{
+
+template <typename T>
+struct always_false : std::false_type
+{
+};
+
+template <typename T>
+inline constexpr bool always_false_v = always_false<T>::value;
+
+template <typename T>
+struct is_std_array : std::false_type
+{
+};
+
+template <typename T, std::size_t N>
+struct is_std_array<std::array<T, N>> : std::true_type
+{
+};
+
+template <typename T>
+inline constexpr bool is_std_array_v = is_std_array<T>::value;
+
+template <typename T>
+struct is_standard_trivial : std::bool_constant<std::is_standard_layout_v<T> && std::is_trivial_v<T>>
+{
+};
+
+template <typename T>
+inline constexpr bool is_standard_trivial_v = is_standard_trivial<T>::value;
+
+template <typename T>
+inline constexpr bool is_blob = (is_std_array_v<T> || std::is_array_v<T> || is_standard_trivial_v<T>) && !std::is_fundamental_v<T>;
+
+template <typename T>
+inline constexpr bool is_blob_v = is_blob<T>;
+
+template <typename T, bool = std::is_enum_v<T>>
+struct enum_decay_impl
+{
+    using type = std::decay_t<T>;
+};
+
+template <typename T>
+struct enum_decay_impl<T, true>
+{
+    using type = std::underlying_type_t<T>;
+};
+
+template <typename T>
+using enum_decay_t = typename enum_decay_impl<T>::type;
+
+} // namespace db::detail

--- a/src/map/campaign_handler.cpp
+++ b/src/map/campaign_handler.cpp
@@ -227,7 +227,7 @@ void CCampaignHandler::SetInfluence(CampaignArmy army, int16 amount)
 {
     const auto current = std::clamp<int16>(amount, 0, 250);
 
-    std::unique_ptr<db::detail::ResultSetWrapper> rset = nullptr;
+    std::unique_ptr<db::ResultSet> rset = nullptr;
     switch (army)
     {
         case CampaignArmy::Sandoria:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Ohhhh boy, what a happy accident this was.

In my quest to inject sane interface boundaries into important code, and to improve areas (that I wrote 😎) that already have pretty well-defined boundaries, I wandered into the db code and started investigating.

It was pretty reasonable to extract out the interfaces for Database, Connection, ResultSet, etc. and to make our mariadb-cpp-connector backend adhere to them. It was also fine to extract out the logic that I built on top to cache prepared statement objects, sanity check incoming queries etc.

Then, it was somewhat apparent that I had put in enough safety layers when I built on top of the cpp connector (because I've never trusted it) that all the historic threading and access problems with the c connector were now no longer relevant.

So now there's a c-connector backend, which provides the same API, threading guarantees, and better performance:

<img width="1465" height="372" alt="image" src="https://github.com/user-attachments/assets/5faa2c00-e206-4c46-94cb-7d2a0d32267d" />

This also opens the door for a (nearly) drop-in postgress backend, whenever a certain PG expert feels like taking on a fun weekend project.

**EDIT:** This sets the C-backend to be the default, and leaves the cpp backend behind if we need to switch back to it.

This also allows us to easily mock the whole DB for xi_test, if we'd like to.

**EDIT2:** More ranting: The cpp backend does a lot of writing and backing things up to the heap, when it really doesn't need to. The speedup comes from us having our thing caching layer, skipping the cpp layer, and going straight to the C-layer.