### PR TITLE
Core: Logging improvements

### DIFF
--- a/src/common/circular_buffer.h
+++ b/src/common/circular_buffer.h
@@ -23,59 +23,97 @@
 
 #include <memory>
 #include <mutex>
+#include <stdexcept>
+#include <utility>
 
 // https://gist.github.com/edwintcloud/d547a4f9ccaf7245b06f0e8782acefaa
+//
+// Fixed-capacity, thread-safe ring buffer. Capacity must be a power of two so the
+// hot enqueue path can wrap indices with a cheap mask instead of a modulo.
 template <class T>
 class CircularBuffer final
 {
 private:
     std::unique_ptr<T[]> buffer;
 
-    std::size_t head = 0;
-    std::size_t tail = 0;
-    std::size_t max_size;
+    std::size_t head{};
+    std::size_t tail{};
+    std::size_t max_size{};
+    std::size_t mask{};
     bool        full = false;
-    T           empty_item;
 
-    std::recursive_mutex mutex;
+    T empty_item{};
+
+    std::mutex mutex;
+
+    // Unlocked; callers must already hold `mutex`.
+    bool is_empty_unlocked() const
+    {
+        return (!full && (head == tail));
+    }
+
+    // Advance an index by one with wraparound. Capacity is a power of two, so this
+    // is a single AND rather than a (much more expensive) modulo on the hot path.
+    std::size_t advance(std::size_t index) const
+    {
+        return (index + 1) & mask;
+    }
+
+    // Shared, unlocked enqueue body. The forwarding reference lets callers pass an
+    // lvalue (copied into the slot) or an rvalue (moved, no allocation).
+    template <class U>
+    void push_unlocked(U&& item)
+    {
+        buffer[tail] = std::forward<U>(item);
+
+        if (full)
+        {
+            head = advance(head);
+        }
+
+        tail = advance(tail);
+
+        full = tail == head;
+    }
 
 public:
     CircularBuffer(std::size_t max_size)
-    : buffer(std::unique_ptr<T[]>(new T[max_size]))
+    : buffer(std::make_unique<T[]>(max_size))
     , max_size(max_size)
+    , mask(max_size - 1)
     {
+        if (max_size == 0 || (max_size & (max_size - 1)) != 0)
+        {
+            throw std::invalid_argument("CircularBuffer capacity must be a power of two");
+        }
     }
 
     void enqueue(const T& item)
     {
         std::lock_guard lock(mutex);
+        push_unlocked(item);
+    }
 
-        buffer[tail] = item;
-
-        if (full)
-        {
-            head = (head + 1) % max_size;
-        }
-
-        tail = (tail + 1) % max_size;
-
-        full = tail == head;
+    void enqueue(T&& item)
+    {
+        std::lock_guard lock(mutex);
+        push_unlocked(std::move(item));
     }
 
     T dequeue()
     {
         std::lock_guard lock(mutex);
 
-        if (is_empty())
+        if (is_empty_unlocked())
         {
             throw std::runtime_error("buffer is empty");
         }
 
-        T item = buffer[head];
+        T item = std::move(buffer[head]);
 
         buffer[head] = empty_item;
 
-        head = (head + 1) % max_size;
+        head = advance(head);
 
         full = false;
 
@@ -86,7 +124,7 @@ public:
     {
         std::lock_guard lock(mutex);
 
-        if (is_empty())
+        if (is_empty_unlocked())
         {
             throw std::runtime_error("buffer is empty");
         }
@@ -98,7 +136,7 @@ public:
     {
         std::lock_guard lock(mutex);
 
-        return (!full && (head == tail));
+        return is_empty_unlocked();
     }
 
     bool is_full()

--- a/src/common/circular_buffer.h
+++ b/src/common/circular_buffer.h
@@ -40,7 +40,7 @@ private:
     std::size_t tail{};
     std::size_t max_size{};
     std::size_t mask{};
-    bool        full = false;
+    bool        full{};
 
     T empty_item{};
 

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -172,8 +172,9 @@ void logging::InitializeLog(const std::string& serverName, const std::string& lo
     {
         auto logger = std::make_shared<spdlog::async_logger>(std::string(logNames[i]), sinks.begin(), sinks.end(), spdlog::thread_pool());
         spdlog::register_logger(logger);
-        logPointers[i] = logger.get();
     }
+
+    logging::RefreshLoggerCache();
 
     spdlog::set_level(spdlog::level::debug);
 }
@@ -201,6 +202,15 @@ void logging::SetPattern(const std::string& str)
     formatter->add_flag<q_formatter_flag>('q');
     formatter->set_pattern(str);
     spdlog::set_formatter(std::move(formatter));
+}
+
+void logging::RefreshLoggerCache()
+{
+    for (std::size_t i = 0; i < logNames.size(); ++i)
+    {
+        const auto logger = spdlog::get(std::string(logNames[i]));
+        logPointers[i]    = logger.get();
+    }
 }
 
 auto logging::loggerFor(std::string_view name) -> spdlog::logger*

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -36,12 +36,15 @@
 #include "spdlog/sinks/daily_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 
+#include <array>
+#include <cctype>
+
 namespace
 {
 
 std::string ServerName;
 
-CircularBuffer<std::string> BacktraceBuffer(16);
+CircularBuffer<std::string> BacktraceBuffer(32);
 
 bool gSeenWarningOrError = false;
 
@@ -56,9 +59,10 @@ public:
         // on the right, so we have to do it by hand.
         // If longer than length, we pad, if less, then we build a new string of size length.
         // https://fmt.dev/latest/syntax.html
-        std::size_t length      = 32;
-        std::string locationStr = fmt::format("{}:{}", msg.source.funcname, msg.source.line);
-        std::string outStr      = locationStr.size() > length ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
+        static constexpr std::size_t length = 32;
+
+        const std::string locationStr = fmt::format("{}:{}", msg.source.funcname, msg.source.line);
+        const std::string outStr      = locationStr.size() > length ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
         dest.append(outStr.data(), outStr.data() + outStr.size());
     }
 
@@ -73,8 +77,8 @@ class ampersand_formatter_flag : public spdlog::custom_flag_formatter
 public:
     void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
     {
-        std::string outStr = ServerName;
-        dest.append(outStr.data(), outStr.data() + outStr.size());
+        // Append directly; no need to copy ServerName into a temporary first.
+        dest.append(ServerName.data(), ServerName.data() + ServerName.size());
     }
 
     std::unique_ptr<custom_flag_formatter> clone() const override
@@ -88,9 +92,13 @@ class underscore_formatter_flag : public spdlog::custom_flag_formatter
 public:
     void format(const spdlog::details::log_msg&, const std::tm&, spdlog::memory_buf_t& dest) override
     {
-        std::string firstChar = std::string(1, ServerName[0]);
-        std::string outStr    = to_upper(firstChar);
-        dest.append(outStr.data(), outStr.data() + outStr.size());
+        if (ServerName.empty())
+        {
+            return;
+        }
+
+        const char initial = static_cast<char>(std::toupper(static_cast<unsigned char>(ServerName[0])));
+        dest.append(&initial, &initial + 1);
     }
 
     std::unique_ptr<custom_flag_formatter> clone() const override
@@ -108,9 +116,10 @@ public:
         // on the right, so we have to do it by hand.
         // If longer than length, we pad, if less, then we build a new string of size length.
         // https://fmt.dev/latest/syntax.html
-        std::size_t length      = 32;
-        std::string locationStr = fmt::format("{}:{}", msg.source.filename, msg.source.line);
-        std::string outStr      = locationStr.size() > 12 ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
+        static constexpr std::size_t length = 32;
+
+        const std::string locationStr = fmt::format("{}:{}", msg.source.filename, msg.source.line);
+        const std::string outStr      = locationStr.size() > length ? std::string(locationStr.end() - length, locationStr.end()) : fmt::format("{:>{}}", locationStr, length);
         dest.append(outStr.data(), outStr.data() + outStr.size());
     }
 
@@ -120,7 +129,7 @@ public:
     }
 };
 
-const std::vector<std::string> logNames = {
+constexpr std::array<std::string_view, 7> logNames = {
     "critical",
     "error",
     "lua",
@@ -129,6 +138,11 @@ const std::vector<std::string> logNames = {
     "debug",
     "trace",
 };
+
+// Non-owning pointers to the loggers registered under logNames, in the same order.
+// Populated once in InitializeLog (before any worker threads exist) and only read
+// afterward, so loggerFor() needs no synchronization. The registry owns the loggers.
+std::array<spdlog::logger*, logNames.size()> logPointers{};
 
 void logging::InitializeLog(const std::string& serverName, const std::string& logFile, bool appendDate)
 {
@@ -154,15 +168,14 @@ void logging::InitializeLog(const std::string& serverName, const std::string& lo
         sinks.emplace_back(std::make_shared<spdlog::sinks::basic_file_sink_mt>(logFile));
     }
 
-    for (auto& name : logNames)
+    for (std::size_t i = 0; i < logNames.size(); ++i)
     {
-        auto logger = std::make_shared<spdlog::async_logger>(name, sinks.begin(), sinks.end(), spdlog::thread_pool());
+        auto logger = std::make_shared<spdlog::async_logger>(std::string(logNames[i]), sinks.begin(), sinks.end(), spdlog::thread_pool());
         spdlog::register_logger(logger);
+        logPointers[i] = logger.get();
     }
 
     spdlog::set_level(spdlog::level::debug);
-
-    spdlog::enable_backtrace(16);
 }
 
 void logging::ShutDown()
@@ -190,9 +203,29 @@ void logging::SetPattern(const std::string& str)
     spdlog::set_formatter(std::move(formatter));
 }
 
+auto logging::loggerFor(std::string_view name) -> spdlog::logger*
+{
+    for (std::size_t i = 0; i < logNames.size(); ++i)
+    {
+        if (logNames[i] == name)
+        {
+            return logPointers[i];
+        }
+    }
+
+    // Fallback for the (pre-init) edge case: pay the one-off registry lookup.
+    const auto logger = spdlog::get(std::string(name));
+    return logger.get();
+}
+
 void logging::AddBacktrace(const std::string& str)
 {
     BacktraceBuffer.enqueue(str);
+}
+
+void logging::AddBacktrace(std::string&& str)
+{
+    BacktraceBuffer.enqueue(std::move(str));
 }
 
 auto logging::GetBacktrace() -> std::vector<std::string>

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include "cbasetypes.h"
-#include "logging_context.h"
-#include "macros.h"
-#include "tracy.h"
+#include <common/cbasetypes.h>
+#include <common/logging_context.h>
+#include <common/macros.h>
+#include <common/tracy.h>
 
 #include <string>
 #include <string_view>
@@ -38,12 +38,15 @@
 
 #include <spdlog/spdlog.h>
 
+//
 // Forward declaration
+//
+
 namespace settings
 {
 
 template <typename T>
-T get(std::string);
+T get(std::string_view);
 
 } // namespace settings
 
@@ -56,7 +59,13 @@ void ShutDown();
 void SetPattern(const std::string& str);
 
 void AddBacktrace(const std::string& str);
+void AddBacktrace(std::string&& str);
 auto GetBacktrace() -> std::vector<std::string>;
+
+// Returns the logger registered under `name` ("debug", "info", "error", ...).
+// Resolved once during InitializeLog and read lock-free afterward, so emit paths avoid
+// spdlog's registry mutex on every log call. Non-owning; valid until ShutDown.
+auto loggerFor(std::string_view name) -> spdlog::logger*;
 
 void tapWarningOrError();
 
@@ -146,13 +155,13 @@ inline auto format_as(type v) \
 #define LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, MsgVar)                                  \
     if (!::logging::detail::gJsonMode)                                                                  \
     {                                                                                                   \
-        LOG_TYPE_MACRO(spdlog::get(LogStringName), MsgVar);                                             \
+        LOG_TYPE_MACRO(::logging::loggerFor(LogStringName), MsgVar);                                    \
     }                                                                                                   \
     else                                                                                                \
     {                                                                                                   \
         fmt::memory_buffer _jbuf;                                                                       \
         ::logging::detail::renderJsonLine(_jbuf, { LogStringName, File, Line, __FUNCTION__, MsgVar }); \
-        LOG_TYPE_MACRO(spdlog::get(LogStringName), std::string_view{ _jbuf.data(), _jbuf.size() });     \
+        LOG_TYPE_MACRO(::logging::loggerFor(LogStringName), std::string_view{ _jbuf.data(), _jbuf.size() }); \
     }                                                                                                   \
     STATEMENT_CLOSE
 
@@ -160,13 +169,13 @@ inline auto format_as(type v) \
     BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_CONDITIONAL(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER if (settings::get<bool>(LogConditionStr)) { const auto _msgStr = fmt::sprintf(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_FMT(LOG_TYPE_MACRO, LogStringName, File, Line, ...) \
     BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); END_CATCH_HANDLER(File, Line)
 
 #define LOGGER_BODY_CONDITIONAL_FMT(LOG_TYPE_MACRO, LogStringName, LogConditionStr, File, Line, ...) \
-    BEGIN_CATCH_HANDLER const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); if (settings::get<bool>(LogConditionStr)) { LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
+    BEGIN_CATCH_HANDLER if (settings::get<bool>(LogConditionStr)) { const auto _msgStr = fmt::format(__VA_ARGS__); TracyZoneScoped; TracyMessageStr(_msgStr); logging::AddBacktrace(_msgStr); LOGGER_EMIT(LOG_TYPE_MACRO, LogStringName, File, Line, _msgStr); } END_CATCH_HANDLER(File, Line)
 
 // Regular Loggers
 // NOTE 1: Trace is not for logging to screen or file; it's for filling the backtrace buffer and reporting to Tracy.

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -63,9 +63,14 @@ void AddBacktrace(std::string&& str);
 auto GetBacktrace() -> std::vector<std::string>;
 
 // Returns the logger registered under `name` ("debug", "info", "error", ...).
-// Resolved once during InitializeLog and read lock-free afterward, so emit paths avoid
-// spdlog's registry mutex on every log call. Non-owning; valid until ShutDown.
+// Resolved during InitializeLog and read lock-free afterward, so emit paths avoid
+// spdlog's registry mutex on every log call. Non-owning; valid until the next refresh.
 auto loggerFor(std::string_view name) -> spdlog::logger*;
+
+// Re-resolves the lock-free loggerFor cache from the spdlog registry. MUST be called after
+// anything that drops/re-registers loggers (e.g. spdlog::shutdown + re-register), otherwise
+// loggerFor would return dangling pointers. Call when no other thread is logging.
+void RefreshLoggerCache();
 
 void tapWarningOrError();
 

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -34,7 +34,14 @@
 namespace settings
 {
 
-std::unordered_map<std::string, SettingsVariant> settingsMap;
+SettingsMap settingsMap;
+
+namespace detail
+{
+
+std::atomic<uint64_t> generation{ 0 };
+
+} // namespace detail
 
 // We need this to figure out which environment variables are numbers
 // so we can pass them to the lua settings properly typed.
@@ -51,11 +58,11 @@ bool isNumber(const std::string& stringValue)
     return true;
 }
 
-/**
- * @brief
- * Load the settings Lua files found in <root>/settings/. Default settings are loaded first from <root>/settings/default/,
- * and are then replaced by the settings found in <root>/settings/, if any.
- */
+//
+// @brief
+// Load the settings Lua files found in <root>/settings/. Default settings are loaded first from <root>/settings/default/,
+// and are then replaced by the settings found in <root>/settings/, if any.
+//
 void init()
 {
     // Load defaults
@@ -104,7 +111,9 @@ void init()
         for (const auto& [innerKeyObj, innerValObj] : outerValObj.as<sol::table>())
         {
             auto innerKey = innerKeyObj.as<std::string>();
-            auto key      = to_upper(fmt::format("{}.{}", outerKey, innerKey));
+            // Stored verbatim: settings::get is case-sensitive, and call sites use the
+            // conventional "<file>.<SETTING_NAME>" casing, so the key must match exactly.
+            auto key = fmt::format("{}.{}", outerKey, innerKey);
 
             if (innerValObj.is<bool>())
             {
@@ -169,7 +178,9 @@ void init()
         for (const auto& [innerKeyObj, innerValObj] : outerValObj.as<sol::table>())
         {
             auto innerKey = innerKeyObj.as<std::string>();
-            auto key      = to_upper(fmt::format("{}.{}", outerKey, innerKey));
+            // Stored verbatim: settings::get is case-sensitive, and call sites use the
+            // conventional "<file>.<SETTING_NAME>" casing, so the key must match exactly.
+            auto key = fmt::format("{}.{}", outerKey, innerKey);
 
             if (innerValObj.is<bool>())
             {
@@ -218,6 +229,8 @@ void init()
         auto inner                          = to_upper(parts[1]);
         lua["xi"]["settings"][outer][inner] = value;
     }
+
+    detail::generation.fetch_add(1, std::memory_order_release);
 
     logging::SetPattern(get<std::string>("logging.PATTERN"));
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -21,46 +21,76 @@
 
 #pragma once
 
-#include "logging.h"
-#include "utils.h"
-#include "xi.h"
+#include <common/logging.h>
+#include <common/utils.h>
+#include <common/xi.h>
 
+#include <atomic>
+#include <cstdint>
+#include <functional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 #include <variant>
 
 namespace settings
 {
 
 using SettingsVariant = std::variant<bool, double, std::string>;
-extern std::unordered_map<std::string, SettingsVariant> settingsMap;
+
+namespace detail
+{
+
+// Bumped every time the settings are (re)loaded (settings::init) or mutated (settings::set).
+// Cached reads compare against this with a single atomic load to detect staleness, so a
+// hot-reload transparently invalidates every per-thread read cache.
+extern std::atomic<uint64_t> generation;
+
+// Transparent hash so both settingsMap and the read cache can be probed with a std::string_view
+// without allocating a std::string on the hot path (the map's key_equal must be transparent too,
+// hence std::equal_to<>).
+struct TransparentStringHash
+{
+    using is_transparent = void;
+
+    [[nodiscard]] std::size_t operator()(std::string_view sv) const noexcept
+    {
+        return std::hash<std::string_view>{}(sv);
+    }
+};
+
+} // namespace detail
+
+// Transparent map: lookups accept a std::string_view directly, no temporary std::string.
+using SettingsMap = std::unordered_map<std::string, SettingsVariant, detail::TransparentStringHash, std::equal_to<>>;
+extern SettingsMap settingsMap;
 
 void init();
 
-/**
- * @brief
- * Get the value of a setting, based on a string key.
- *
- * @tparam T
- * The value type being requested. If not the original type, it will be gracefully converted.
- *
- * @param name
- * The name of the key being requested. It must be prefixed with the filename the setting is from.
- * For example: "settings/main.lua" contains "ENABLE_COP". You would request: "main.ENABLE_COP".
- * Therefore: bool val = settings::get<bool>("map.ENABLE_COP");
- * NOTE: These names are NOT case-sensitive.
- */
+//
+// @brief
+// Get the value of a setting, based on a string key.
+//
+// @tparam T
+// The value type being requested. If not the original type, it will be gracefully converted.
+//
+// @param key
+// The name of the key being requested. It must be prefixed with the filename the setting is from.
+// For example: "settings/main.lua" contains "ENABLE_COP". You would request: "main.ENABLE_COP".
+// Therefore: bool val = settings::get<bool>("map.ENABLE_COP");
+// NOTE: These names ARE case-sensitive.
+//
 template <typename T>
-T get(std::string name)
+T getUncached(std::string_view key)
 {
     // out = type being requested
     T out{};
 
-    auto key = to_upper(name);
-    if (auto maybeResult = settingsMap.find(key); maybeResult != settingsMap.end())
+    if (const auto maybeResult = settingsMap.find(key); maybeResult != settingsMap.end())
     {
-        auto& variant = (*maybeResult).second;
+        const auto& variant = maybeResult->second;
 
         // arg = type held inside the variant
         std::visit(
@@ -142,8 +172,36 @@ T get(std::string name)
         return out;
     }
 
-    ShowError(fmt::format("Settings: Failed to look up key: {}, using default value: \"{}\"", name, out));
+    ShowError(fmt::format("Settings: Failed to look up key: {}, using default value: \"{}\"", key, out));
     return T();
+}
+
+template <typename T>
+T get(std::string_view key)
+{
+    // One memo per (T, thread). Bounded by the number of distinct setting keys, so it never
+    // grows unbounded. thread_local also means no locking and no contention with the reload thread
+    // on a cache hit.
+    static thread_local std::unordered_map<std::string, std::pair<uint64_t, T>, detail::TransparentStringHash, std::equal_to<>> cache;
+
+    const uint64_t gen = detail::generation.load(std::memory_order_acquire);
+
+    if (const auto it = cache.find(key); it != cache.end())
+    {
+        if (it->second.first == gen)
+        {
+            return it->second.second;
+        }
+
+        // Stale entry (settings were reloaded/mutated): refresh it in place.
+        it->second.first  = gen;
+        it->second.second = getUncached<T>(key);
+        return it->second.second;
+    }
+
+    T value = getUncached<T>(key);
+    cache.emplace(std::string(key), std::pair<uint64_t, T>{ gen, value });
+    return value;
 }
 
 // A partial, core-only way to set settings.
@@ -151,10 +209,12 @@ T get(std::string name)
 //
 // TODO: Gracefully convert like-types into types for the variant
 // TODO: Publish back up into Lua
-void set(const auto& name, const auto& value)
+void set(const auto& key, const auto& value)
 {
-    const auto key   = to_upper(name);
     settingsMap[key] = SettingsVariant(value);
+
+    // Invalidate every per-thread read cache (see detail::generation).
+    detail::generation.fetch_add(1, std::memory_order_release);
 }
 
 void visit(const xi::Fn<void(std::string, SettingsVariant)>& visitor);

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -729,30 +729,32 @@ std::vector<std::string> split(const std::string& s, const std::string& delimite
 
 std::string to_lower(const std::string& s)
 {
+    // Branchless ASCII uppercase. Avoids the locale-aware std::tolower (a non-inlined,
+    // table-indirected call per character); all keys/names this is used on are ASCII.
     std::string data = s;
-    std::transform(
-        data.begin(),
-        data.end(),
-        data.begin(),
-        [](unsigned char c)
+    for (char& c : data)
+    {
+        if (c >= 'A' && c <= 'Z')
         {
-            return std::tolower(c);
-        });
+            c += ('a' - 'A');
+        }
+    }
 
     return data;
 }
 
 std::string to_upper(const std::string& s)
 {
+    // Branchless ASCII uppercase. Avoids the locale-aware std::toupper (a non-inlined,
+    // table-indirected call per character); all keys/names this is used on are ASCII.
     std::string data = s;
-    std::transform(
-        data.begin(),
-        data.end(),
-        data.begin(),
-        [](unsigned char c)
+    for (char& c : data)
+    {
+        if (c >= 'a' && c <= 'z')
         {
-            return std::toupper(c);
-        });
+            c -= ('a' - 'A');
+        }
+    }
 
     return data;
 }

--- a/src/test/test_application.cpp
+++ b/src/test/test_application.cpp
@@ -206,5 +206,9 @@ void TestApplication::captureLogger() const
         spdlog::register_logger(logger);
     }
 
+    // The loggers were just dropped and re-created, so the lock-free loggerFor cache now holds
+    // dangling pointers. Re-resolve it before anything logs again.
+    logging::RefreshLoggerCache();
+
     logging::SetPattern(settings::get<std::string>("test.PATTERN"));
 }

--- a/src/world/http_server.cpp
+++ b/src/world/http_server.cpp
@@ -133,10 +133,12 @@ HTTPServer::HTTPServer(Scheduler& scheduler)
                     settings::visit(
                         [&](const auto& key, const auto& variant)
                         {
+                            // Keys are stored verbatim (mixed case), and the omit list is lowercase,
+                            // so match case-insensitively to still catch e.g. "...PASSWORD".
+                            const auto lowerKey = to_lower(key);
                             for (const auto& text : textToOmit)
                             {
-                                // NOTE: Remember that keys are stored as uppercase
-                                if (key.find(to_upper(text)) != std::string::npos)
+                                if (lowerKey.find(text) != std::string::npos)
                                 {
                                     return;
                                 }

--- a/tools/run_clang_format.py
+++ b/tools/run_clang_format.py
@@ -25,6 +25,7 @@ def find_clang_format():
         "/usr/bin/clang-format",
         "/usr/local/bin/clang-format",
         "/opt/homebrew/bin/clang-format",
+        "C:\\Program Files\\LLVM\\bin\\clang-format.exe",
     ]
 
     for path in paths:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Invert settings/string building checks
- Improve backtrace circular buffer
- Improve custom formatters
- Cache loggers for quick lookup
- Memoize settings access and results
