### PR TITLE
[lua, cpp] Pulling the Plug fixes; OnSpellCastStart fix

### DIFF
--- a/scripts/zones/Spire_of_Vahzl/mobs/Memory_Receptacle_Red.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Memory_Receptacle_Red.lua
@@ -22,10 +22,10 @@ end
 entity.onMobSpawn = function(mob)
     mob:setModelId(1105)
     mob:setAutoAttackEnabled(false)
+    mob:setMobAbilityEnabled(false)
     mob:setAggressive(true)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 15)
     mob:setMobMod(xi.mobMod.DETECTION, xi.detects.HEARING)
-    mob:setMod(xi.mod.REGAIN, 550)
 
     -- Red receptacle starts with all damage immunities, which are removed when a respective shield receptacle dies
     mob:setMod(xi.mod.UDMGPHYS, -10000)
@@ -46,7 +46,9 @@ entity.onMobEngage = function(mob, target)
         return
     end
 
-    mob:setLocalVar('drawInTimer', GetSystemTime() + 20)
+    local currentTime = GetSystemTime()
+    mob:setLocalVar('drawInTimer', currentTime + 20)
+    mob:setLocalVar('seedTimer', currentTime + 15)
 
     -- Select a random position for shield receptacles to spawn at
     local area      = mob:getBattlefield():getArea()
@@ -56,7 +58,7 @@ entity.onMobEngage = function(mob, target)
     local position  = math.random(1, #positions[area][1])
 
     battlefield:setLocalVar('position', position)
-    battlefield:setLocalVar('moveTimer', GetSystemTime() + 30)
+    battlefield:setLocalVar('moveTimer', currentTime + 30)
 
     for i = 0, 2 do
         local shieldMob = GetMobByID(ID.mob.MEMORY_RECEPTACLE_SHIELD + offset + i)
@@ -70,34 +72,38 @@ end
 
 entity.onMobFight = function(mob, target)
     -- Every 20 seconds, memory receptacles draws in a random member in the battlefield
+    local currentTime = GetSystemTime()
     local drawInTimer = mob:getLocalVar('drawInTimer')
-    if GetSystemTime() > drawInTimer then
+    if currentTime > drawInTimer then
         local players = mob:getBattlefield():getPlayers()
 
         utils.drawIn(players[math.random(#players)], { position = mob:getPos() })
 
-        mob:setLocalVar('drawInTimer', GetSystemTime() + 20)
+        mob:setLocalVar('drawInTimer', currentTime + 20)
     end
-end
 
-entity.onMobMobskillChoose = function(mob, target, skillId)
-    -- Every three moves, all shield receptacles simultaneously use Empty Seed
-    local skillCount = mob:getLocalVar('skillCount') + 1
-    if skillCount == 3 then
-        local offset = (mob:getBattlefield():getArea() - 1) * 10
-        for i = 0, 2 do
-            local shieldMob = GetMobByID(ID.mob.MEMORY_RECEPTACLE_SHIELD + offset + i)
-            if shieldMob and shieldMob:isAlive() then
-                shieldMob:setLocalVar('useEmptySeed', 1)
+    -- Every 15 seconds, Memory Receptacle uses Empty Seed
+    local seedTimer = mob:getLocalVar('seedTimer')
+    if currentTime > seedTimer then
+        mob:useMobAbility(xi.mobSkill.EMPTY_SEED)
+        mob:setLocalVar('seedTimer', currentTime + 15)
+
+        -- Every three moves, all shield receptacles simultaneously use Empty Seed
+        local skillCount = mob:getLocalVar('skillCount') + 1
+        if skillCount == 3 then
+            local offset = (mob:getBattlefield():getArea() - 1) * 10
+            for i = 0, 2 do
+                local shieldMob = GetMobByID(ID.mob.MEMORY_RECEPTACLE_SHIELD + offset + i)
+                if shieldMob and shieldMob:isAlive() then
+                    shieldMob:setLocalVar('useEmptySeed', 1)
+                end
             end
+
+            mob:setLocalVar('skillCount', 0)
+        else
+            mob:setLocalVar('skillCount', skillCount)
         end
-
-        mob:setLocalVar('skillCount', 0)
-    else
-        mob:setLocalVar('skillCount', skillCount)
     end
-
-    return xi.mobSkill.EMPTY_SEED
 end
 
 entity.onMobDeath = function(mob, player, optParams)
@@ -107,7 +113,9 @@ entity.onMobDeath = function(mob, player, optParams)
             return
         end
 
-        for _, mobEntity in pairs(battlefield:getMobs()) do
+        battlefield:setLocalVar('endingBattlefield', 1)
+
+        for _, mobEntity in pairs(battlefield:getMobs(true, true)) do
             if mobEntity:getID() ~= mob:getID() and mobEntity:isAlive() then
                 mobEntity:setHP(0)
             end

--- a/scripts/zones/Spire_of_Vahzl/mobs/Memory_Receptacle_Shield.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Memory_Receptacle_Shield.lua
@@ -78,6 +78,12 @@ entity.onMobDeath = function(mob, player, optParams)
             end
         end
 
+        -- Skip NM spawn if the Red Receptacle already died and is ending the battlefield
+        local battlefield = mob:getBattlefield()
+        if not battlefield or battlefield:getLocalVar('endingBattlefield') == 1 then
+            return
+        end
+
         -- Spawn the corresponding Promyvion Mob (Contemplator/Ingurgitator/Repiner)
         local nmMob = GetMobByID(mob:getID() + 3)
         if nmMob and not nmMob:isSpawned() then

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3120,13 +3120,13 @@ void OnSpellCastStart(CBattleEntity* PCaster, CBattleEntity* PTarget, CSpell* PS
         return;
     }
 
-    sol::function onSpellInterrupted = getEntityCachedFunction(PCaster, "onSpellCastStart");
-    if (!onSpellInterrupted.valid())
+    sol::function onSpellCastStart = getEntityCachedFunction(PCaster, "onSpellCastStart");
+    if (!onSpellCastStart.valid())
     {
         return;
     }
 
-    auto result = onSpellInterrupted(PCaster, PSpell);
+    auto result = onSpellCastStart(PCaster, PTarget, PSpell);
     if (!result.valid())
     {
         sol::error err = result;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixed a few issues that were coming up with battlefields during testing:
  - Pulling the Plug: Using Empty Seed too often after a fix to when mobs decide to use TP. Corrected to be on a set 15 second interval to match up with retail. Also correctly kills mobs on battlefield win without spawning their respective summons.
  - onSpellCastStart was erroring on Ajido-Marujido in final Windurst mission battlefield due to a missing param on the result of the binding.

## Steps to test these changes

- Load up Pulling the Plug, see that mobs clean up properly on battlefield and the mob
- Load up Moon Reading battlefield, see that no error appears when Ajido-Marujido casts a spell
