### PR TITLE
Core: Add LosCache to CanSeeTarget

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -80,6 +80,8 @@ set(MAP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/latent_effect.h
     ${CMAKE_CURRENT_SOURCE_DIR}/linkshell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/linkshell.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/los_cache.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/los_cache.h
     ${CMAKE_CURRENT_SOURCE_DIR}/map_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/map_application.h
     ${CMAKE_CURRENT_SOURCE_DIR}/map_engine.cpp

--- a/src/map/entities/base_entity.cpp
+++ b/src/map/entities/base_entity.cpp
@@ -181,6 +181,8 @@ bool CBaseEntity::CanSeeTarget(CBaseEntity* target)
 
 bool CBaseEntity::CanSeeTarget(const position_t& targetPointBase)
 {
+    TracyZoneScoped;
+
     constexpr float ENTITY_HEIGHT = 2.0f;
 
     // TODO: Handle:
@@ -189,7 +191,17 @@ bool CBaseEntity::CanSeeTarget(const position_t& targetPointBase)
 
     const auto src = Vector3{ loc.p.x, loc.p.y - ENTITY_HEIGHT, loc.p.z };
     const auto dst = Vector3{ targetPointBase.x, targetPointBase.y - ENTITY_HEIGHT, targetPointBase.z };
-    return !this->loc.zone->xiMesh()->rayIntersect(src, dst);
+
+    const auto now    = timer::now();
+    const auto zoneId = static_cast<uint16>(this->loc.zone->GetID());
+    if (const auto cached = losCache_.get(src, dst, zoneId, now))
+    {
+        return *cached;
+    }
+
+    const bool canSee = !this->loc.zone->xiMesh()->rayIntersect(src, dst);
+    losCache_.put(src, dst, zoneId, canSee, now);
+    return canSee;
 }
 
 CBaseEntity* CBaseEntity::GetEntity(uint16 targid, uint8 filter) const

--- a/src/map/entities/base_entity.h
+++ b/src/map/entities/base_entity.h
@@ -25,6 +25,7 @@
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
 #include "common/timer.h"
+#include "los_cache.h"
 #include "packets/basic.h"
 
 #include <map>
@@ -343,6 +344,8 @@ public:
 protected:
     std::map<std::string, uint32> localVars_;
     uint8                         speed; // speed of movement
+
+    LineOfSightCache losCache_;
 };
 
 #endif // _BASEENTITY_H

--- a/src/map/los_cache.cpp
+++ b/src/map/los_cache.cpp
@@ -1,0 +1,103 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <map/los_cache.h>
+
+auto LineOfSightCache::get(const Vector3& src, const Vector3& dst, uint16 zoneId, timer::time_point now) -> std::optional<bool>
+{
+    const Key key = makeKey(src, dst, zoneId);
+
+    for (std::size_t i = 0; i < size_; ++i)
+    {
+        if (entries_[i].key == key)
+        {
+            if (now >= entries_[i].expiry)
+            {
+                return std::nullopt;
+            }
+
+            const bool result = entries_[i].result;
+            moveToFront(i);
+            return result;
+        }
+    }
+
+    return std::nullopt;
+}
+
+void LineOfSightCache::put(const Vector3& src, const Vector3& dst, uint16 zoneId, bool result, timer::time_point now)
+{
+    const Key  key    = makeKey(src, dst, zoneId);
+    const auto expiry = now + kTTL;
+
+    for (std::size_t i = 0; i < size_; ++i)
+    {
+        if (entries_[i].key == key)
+        {
+            entries_[i].result = result;
+            entries_[i].expiry = expiry;
+            moveToFront(i);
+            return;
+        }
+    }
+
+    if (size_ < kCapacity)
+    {
+        ++size_;
+    }
+
+    for (std::size_t i = size_ - 1; i > 0; --i) // shift down, dropping the LRU entry if full
+    {
+        entries_[i] = entries_[i - 1];
+    }
+
+    entries_[0] = Entry{ key, result, expiry };
+}
+
+auto LineOfSightCache::makeKey(const Vector3& src, const Vector3& dst, uint16 zoneId) -> Key
+{
+    return Key{
+        zoneId,
+        static_cast<int16>(src.x / kYalmsPerCell),
+        static_cast<int16>(src.y / kYalmsPerCell),
+        static_cast<int16>(src.z / kYalmsPerCell),
+        static_cast<int16>(dst.x / kYalmsPerCell),
+        static_cast<int16>(dst.y / kYalmsPerCell),
+        static_cast<int16>(dst.z / kYalmsPerCell),
+    };
+}
+
+void LineOfSightCache::moveToFront(std::size_t i)
+{
+    if (i == 0)
+    {
+        return;
+    }
+
+    const Entry tmp = entries_[i];
+
+    for (std::size_t j = i; j > 0; --j)
+    {
+        entries_[j] = entries_[j - 1];
+    }
+
+    entries_[0] = tmp;
+}

--- a/src/map/los_cache.h
+++ b/src/map/los_cache.h
@@ -1,0 +1,72 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+#include <common/timer.h>
+
+#include <map/ximesh/vector3.h>
+
+#include <array>
+#include <chrono>
+#include <optional>
+
+class LineOfSightCache
+{
+public:
+    auto get(const Vector3& src, const Vector3& dst, uint16 zoneId, timer::time_point now) -> std::optional<bool>;
+    void put(const Vector3& src, const Vector3& dst, uint16 zoneId, bool result, timer::time_point now);
+
+private:
+    static constexpr std::size_t               kCapacity = 8;
+    static constexpr std::chrono::milliseconds kTTL{ 2500 };
+    static constexpr float                     kYalmsPerCell = 2.0f;
+
+    struct Key
+    {
+        uint16 zone{};
+
+        int16 sx{};
+        int16 sy{};
+        int16 sz{};
+
+        int16 dx{};
+        int16 dy{};
+        int16 dz{};
+
+        auto operator==(const Key&) const -> bool = default;
+    };
+
+    struct Entry
+    {
+        Key               key{};
+        bool              result{};
+        timer::time_point expiry{};
+    };
+
+    static auto makeKey(const Vector3& src, const Vector3& dst, uint16 zoneId) -> Key;
+
+    void moveToFront(std::size_t i);
+
+    std::array<Entry, kCapacity> entries_{};
+    std::size_t                  size_{ 0 };
+};


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We love to cache expensive things.

LOS checks are quite expensive, but a large use-case of ours is for people to be standing static, and for the mobs to be standing stactic, with everyone wailing on eachother. In these cases, we don't need to be constantly checking LOS. 

So, I've put in a configurable cache, with a 2-yalm cell width, and a 2s TTL. This has about a 30% hit rate in my Dynamis-!provokeall tests, which is a significant saving:

<img width="722" height="209" alt="image" src="https://github.com/user-attachments/assets/40cc6183-37de-4763-95c9-1df24da9393a" />
