### PR TITLE
[C++] [lua] Removed nested buffing logic from doRoamTick, add doBuffTick

### DIFF
--- a/scripts/globals/summon.lua
+++ b/scripts/globals/summon.lua
@@ -13,6 +13,15 @@ local trialSizeBattles = set{
     xi.battlefield.id.TRIAL_SIZE_TRIAL_BY_WATER,
 }
 
+-- TODO: Determine if this is the correct way of calculating this.
+xi.summon.getSummoningSkillOverCap = function(avatar)
+    local summoner       = avatar:getMaster()
+    local summoningSkill = summoner:getSkillLevel(xi.skill.SUMMONING_MAGIC)
+    local maxSkill       = summoner:getMaxSkillLevel(avatar:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC)
+
+    return math.max(summoningSkill - maxSkill, 0)
+end
+
 -- Checks if the summoner is in a Trial Size Avatar Mini Fight (only carbuncle is allowed)
 xi.summon.avatarMiniFightCheck = function(caster, spellID)
     local result = 0

--- a/scripts/tests/packets/s2c/0x028_battle2/mobskills.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/mobskills.lua
@@ -314,7 +314,7 @@ local packets =
     {
         test = function(player, mob)
             player:gotoZone(xi.zone.DYNAMIS_WINDURST)
-            local yagudo = player.entities:moveTo('Vanguard_Chanter')
+            local yagudo = player.entities:moveTo('Vanguard_Sentinel')
             yagudo:updateEnmity(player)
             yagudo:addTP(3000)
             yagudo:useMobAbility(xi.mobSkill.SWEEP, player, 5, true)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -79,11 +79,33 @@ auto CMobController::Tick(const timer::time_point tick) -> Task<void>
         }
         else if (!PMob->isDead())
         {
+            if (PMob->SpellContainer->HasSpells() && DoBuffTick())
+            {
+                co_return;
+            }
+
             co_await DoRoamTick(tick);
         }
     }
 
     co_return;
+}
+
+auto CMobController::DoBuffTick() -> bool
+{
+    TracyZoneScoped;
+
+    if (PMob->PAI->IsCurrentState<CMagicState>())
+    {
+        return true;
+    }
+
+    if (!IsSpellReady(0, 0) || !PMob->SpellContainer->HasBuffSpells())
+    {
+        return false;
+    }
+
+    return TryCastSpell();
 }
 
 auto CMobController::TryDeaggro() -> bool
@@ -1196,21 +1218,6 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
                 {
                     // I spawned a pet
                 }
-                else if (
-                    (!PMob->PBattlefield || PMob->PBattlefield->GetStatus() != BATTLEFIELD_STATUS_OPEN) &&
-                    PMob->GetMJob() == JOB_SMN && CanCastSpells(IgnoreRecastsAndCosts::No) &&
-                    PMob->SpellContainer->HasBuffSpells() && m_Tick >= m_nextMagicTime)
-                {
-                    // summon pet
-                    // - initial summoner-mob pets in battlefields will happen via battlefield.lua, so the first player sees the action
-                    // - Once battlefield is locked, behavior is back to normal with no rng added to pet summoning
-                    TryCastSpell();
-                }
-                else if (CanCastSpells(IgnoreRecastsAndCosts::No) && xirand::GetRandomNumber(10) < 3 && PMob->SpellContainer->HasBuffSpells())
-                {
-                    // cast buff
-                    TryCastSpell();
-                }
                 else if (PMob->m_roamFlags & ROAMFLAG_SCRIPTED)
                 {
                     // allow custom event action
@@ -1368,7 +1375,7 @@ void CMobController::Reset()
 {
     TracyZoneScoped;
 
-    // Wait a little before roaming / casting spell / spawning pet
+    // Wait a little while before roaming again.
     m_LastActionTime = m_Tick - std::chrono::seconds(xirand::GetRandomNumber(PMob->getMobMod(MOBMOD_ROAM_COOL)));
 
     // Don't attack player right off of spawn

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -73,6 +73,7 @@ protected:
     virtual void Move();
 
     virtual auto DoCombatTick(timer::time_point tick) -> Task<void>;
+    virtual auto DoBuffTick() -> bool;
     void         FaceTarget(uint16 targid = 0) const;
     virtual void HandleEnmity();
 

--- a/src/map/ai/controllers/pet_controller.cpp
+++ b/src/map/ai/controllers/pet_controller.cpp
@@ -79,6 +79,18 @@ auto CPetController::Tick(timer::time_point tick) -> Task<void>
     co_await CMobController::Tick(tick);
 }
 
+// Light Spirit is the only elemental spirit that is allowed to cast out of combat.
+auto CPetController::DoBuffTick() -> bool
+{
+    const auto* PPetEntity = dynamic_cast<CPetEntity*>(PPet);
+    if (!PPetEntity || PPetEntity->petID() != PETID_LIGHTSPIRIT)
+    {
+        return false;
+    }
+
+    return CMobController::DoBuffTick();
+}
+
 auto CPetController::DoRoamTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScoped;
@@ -109,23 +121,10 @@ auto CPetController::DoRoamTick(timer::time_point tick) -> Task<void>
         {
             const auto petType             = PPetEntity->getPetType();
             const auto isWyvernOrAutomaton = petType == PET_TYPE::WYVERN || petType == PET_TYPE::AUTOMATON;
-            const auto isLightSpirit       = PPetEntity->petID() == PETID_LIGHTSPIRIT;
 
             if (isWyvernOrAutomaton)
             {
                 if (PetIsHealing())
-                {
-                    co_return;
-                }
-
-                // TODO: Other logic?
-            }
-
-            // Only Light Spirit will cast on roam tick
-            if (isLightSpirit)
-            {
-                // This will respect the pet's mob casting cooldown properties via MOBMOD_MAGIC_COOL
-                if (CMobController::IsSpellReady(0, 0) && CMobController::TryCastSpell())
                 {
                     co_return;
                 }

--- a/src/map/ai/controllers/pet_controller.h
+++ b/src/map/ai/controllers/pet_controller.h
@@ -38,6 +38,7 @@ protected:
     bool PetIsHealing();
 
     virtual auto Tick(timer::time_point tick) -> Task<void> override;
+    virtual auto DoBuffTick() -> bool override;
     virtual void HandleEnmity() override
     {
     }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As the title says, this PR removes nested logic for out of combat spell casting (buffing) and moves it into its own function that is checked before roaming. This means in general, mobs will buff themselves more often, and it will be especially obvious in BCNMs (this represents a significant challenge increase for most of them)

This now means that you can control the mobs out of combat buffing frequency simply by adjusting their spell cooldowns. 

I spot checked Ro'Meave on retail and wiped out all of the RDM weapons, on spawn, they buff every 15 seconds seconds or so, so following the mobs actual spell cooldown should be fine.  

However, this PR is only half of the fix needed - it would seem most buffs are only refreshed when they fall off. Stuff like Stoneskin, Protect, Shell etc. (The exception being Bards, they cast nonstop like clockwork.) We don't have that logic built in yet, but it could be easily added soon. Other than the increased buffing frequency, I didn't notice any negative side effects. (We also could not add this functionality and just make lua spell lists instead for every mob, which will follow this logic perfectly)

I checked...
* Mobs in BCNMs, like the bards in Prehistoric Pigeons, and RDM Maat
* Weapons in Ro'Meave
* Sahagins in SSG
* Yagudos at the top of Oztroja
* Summoner mobs, to ensure they were still summoning their spirits properly (even though thats wrong)
* Also added back a missing function to calculate spell cooldowns for Elementals, and made sure Light Spirit works okay. 

## Steps to test these changes

Check all of the stuff listed above, and any other casting edge cases you can think of. 
