### PR TITLE
Set DEBUGGER_WORKING_DIRECTORY for Ninja debug sessions

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -98,7 +98,10 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_AND_DEFINES_STR}")
 
 function(set_target_output_directory target)
     # Run from the repo root: data, scripts, settings and the runtime DLLs all live there.
+    # DEBUGGER_WORKING_DIRECTORY (CMake 4.0+): Ninja and other non-VS generators.
+    # VS_DEBUGGER_WORKING_DIRECTORY: Visual Studio generator (takes precedence there).
     set_target_properties(${target} PROPERTIES
+        DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
     message(STATUS "${target}: staging build artifact to ${CMAKE_SOURCE_DIR} after build")


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Server binaries expect to run from the repo root (`./settings/`, `./scripts/`, `./data/`). We already copy executables there after build, but running debug still launches the build-tree binary. With the Ninja generator, `VS_DEBUGGER_WORKING_DIRECTORY` is ignored, so the debugger CWD stays under `build/` and startup fails in `settings::init()` when iterating `./settings/default/`.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Run xi_map and other processes with VS debugger and confirm processes are started successfully
<!-- Clear and detailed steps to test your changes here -->
