### PR TITLE
Core: Add basic level of Lua empty-handler elision

### DIFF
--- a/scripts/tests/modules/test_npcs_in_gm_home.lua
+++ b/scripts/tests/modules/test_npcs_in_gm_home.lua
@@ -1,0 +1,72 @@
+-----------------------------------
+-- Verifies the default 'test_npcs_in_gm_home' module (listed in modules/init.txt)
+-- still inserts its example NPC into GM_Home, and that triggering it prints
+-- the expected message back to the player.
+--
+-- See: modules/custom/lua/test_npcs_in_gm_home.lua
+-----------------------------------
+describe('Module: test_npcs_in_gm_home', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.GM_HOME })
+    end)
+
+    -- Dynamic entities are stored internally with a 'DE_' prefix, and entity name
+    -- lookups are full-match (std::regex_match), so we query the prefixed name.
+    local horroName = 'DE_Horro'
+
+    -- Pull every CHAT_STD (0x017) message the server pushed to the player and
+    -- decode the sender name + message text out of the raw packet bytes.
+    local function chatMessages()
+        local function readStr(pkt, startIdx, maxLen)
+            local s = ''
+            for i = 0, maxLen - 1 do
+                local byte = pkt.data[startIdx + i]
+                if byte == nil or byte == 0 then
+                    break
+                end
+
+                s = string.format('%s%s', s, string.char(byte))
+            end
+
+            return s
+        end
+
+        local messages = {}
+        for _, pkt in pairs(player.packets:getIncoming()) do
+            if pkt.type == 0x017 then
+                table.insert(messages,
+                    {
+                        name = readStr(pkt, 8, 15),
+                        text = readStr(pkt, 23, pkt.size - 23),
+                    })
+            end
+        end
+
+        return messages
+    end
+
+    it('inserts Horro into GM_Home', function()
+        local horro = player.entities:get(horroName)
+        assert(horro, 'Horro NPC was not found in GM_Home')
+    end)
+
+    it('prints its greeting when triggered', function()
+        player.packets:clear()
+        player.entities:gotoAndTrigger(horroName)
+
+        local found = false
+        for _, msg in ipairs(chatMessages()) do
+            if msg.text == 'Welcome to GM Home!' then
+                -- packetName is set to '<STAR_LARGE icon>Horro', so just check the suffix
+                assert(string.find(msg.name, 'Horro', 1, true), string.format('greeting came from an unexpected sender: %s', msg.name))
+                found = true
+                break
+            end
+        end
+
+        assert(found, 'Did not receive Horro\'s "Welcome to GM Home!" greeting')
+    end)
+end)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -153,8 +153,11 @@ namespace detail
 {
 
 // NOTE: Is safe to call on invalid tables, will ultimately return nil
-auto lookupByKeysSafe(const std::vector<std::string>& keys) -> sol::object
+// NOTE: Intentionally NOT cached - would break Mocking/Spy etc.
+auto findGlobalLuaFunction(const std::string& funcName) -> sol::function
 {
+    const auto keys = split(funcName, ".");
+
     sol::table table = lua["_G"];
     for (size_t i = 0; i < keys.size(); ++i)
     {
@@ -175,17 +178,117 @@ auto lookupByKeysSafe(const std::vector<std::string>& keys) -> sol::object
     return sol::lua_nil;
 }
 
-auto findGlobalLuaFunction(const std::string& funcName) -> sol::function
+// Use LuaJIT's debug modules to look at the bytecode representation of a function. If it's a single
+// RET0 then it's a stub/empty handler. We can use this information to cache more aggressively.
+// TODO: We could also use this information to Warn on startup, or silently strip these functions
+// to streamline the Lua state size.
+bool isEmptyLuaFunction(const sol::function& fn)
 {
-    // NOTE: Intentionally NOT cached - would break Mocking/Spy etc.
-    return lookupByKeysSafe(split(funcName, "."));
+    if (!fn.valid())
+    {
+        return false;
+    }
+
+    static const sol::function checker = []() -> sol::function
+    {
+        const auto result = lua.safe_script(
+            R"Lua(
+            local ok1, util  = pcall(require, "jit.util")
+            local ok2, vmdef = pcall(require, "jit.vmdef")
+            if not (ok1 and ok2 and util and vmdef) then
+                return function() return false end
+            end
+            local bcnames = vmdef.bcnames
+            local band    = bit.band
+            local function opname(ins)
+                local op = band(ins, 0xff)
+                return (bcnames:sub(op * 6 + 1, op * 6 + 6):gsub("%s+$", ""))
+            end
+            return function(f)
+                if type(f) ~= "function" then
+                    return false
+                end
+                local bodyCount, lastOp = 0, nil
+                for pc = 0, 4 do
+                    local ins = util.funcbc(f, pc)
+                    if not ins then
+                        break
+                    end
+                    local name = opname(ins)
+                    if name:sub(1, 4) ~= "FUNC" then -- skip the FUNCF/FUNCV/FUNCC header
+                        bodyCount = bodyCount + 1
+                        lastOp    = name
+                        if bodyCount > 1 then
+                            return false
+                        end
+                    end
+                end
+                return bodyCount == 1 and lastOp == "RET0"
+            end
+            )Lua",
+            sol::script_pass_on_error);
+
+        if (result.valid())
+        {
+            return result;
+        }
+
+        sol::error err = result;
+        ShowErrorFmt("Failed to create nil function checker: {}", err.what());
+
+        return sol::function(sol::lua_nil);
+    }();
+
+    if (!checker.valid())
+    {
+        return false;
+    }
+
+    const auto res = checker(fn);
+    return res.valid() && res.get<bool>();
+}
+
+sol::function nonEmptyOrNil(const std::string& funcName, sol::function fn)
+{
+    // NOTE: Interaction Framework relies on these functions existing and being valid for them to
+    // hook, so we can't mark them for replacement!
+    static constexpr std::string_view frameworkFallbacks[] = {
+        "onTrigger",
+        "onTrade",
+        "onSteal",
+        "onZoneIn",
+        "onZoneOut",
+        "afterZoneIn",
+        "onEventFinish",
+        "onEventUpdate",
+        "onTriggerAreaEnter",
+        "onTriggerAreaLeave",
+    };
+
+    for (const auto fallback : frameworkFallbacks)
+    {
+        if (funcName == fallback)
+        {
+            return fn;
+        }
+    }
+
+    return [&]()
+    {
+        if (!isEmptyLuaFunction(fn))
+        {
+            return fn;
+        }
+
+        return sol::function(sol::lua_nil);
+    }();
 }
 
 } // namespace detail
 
-/**
- * @brief Initialization of Lua user classes and global functions.
- */
+//
+// @brief Initialization of Lua user classes and global functions.
+//
 void init(IPP mapIPP, bool isRunningInCI)
 {
     TracyZoneScoped;
@@ -650,25 +753,25 @@ sol::function getEntityCachedFunction(CBaseEntity* PEntity, const std::string& f
                 case TYPE_NPC:
                     if (auto f = lua["xi"]["zones"][PEntity->loc.zone->getName()]["npcs"][PEntity->getName()][funcName]; f.valid())
                     {
-                        return f.get<sol::function>();
+                        return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                     }
                     break;
                 case TYPE_MOB:
                     if (auto f = lua["xi"]["zones"][PEntity->loc.zone->getName()]["mobs"][PEntity->getName()][funcName]; f.valid())
                     {
-                        return f.get<sol::function>();
+                        return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                     }
                     break;
                 case TYPE_PET:
                     if (auto f = lua["xi"]["pets"][static_cast<CPetEntity*>(PEntity)->GetScriptName()][funcName]; f.valid())
                     {
-                        return f.get<sol::function>();
+                        return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                     }
                     break;
                 case TYPE_TRUST:
                     if (auto f = lua["xi"]["actions"]["spells"]["trust"][PEntity->getName()][funcName]; f.valid())
                     {
-                        return f.get<sol::function>();
+                        return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                     }
                     break;
                 default:
@@ -751,7 +854,7 @@ sol::function getSpellCachedFunction(CSpell* PSpell, std::string funcName)
         {
             if (auto f = lua["xi"]["actions"]["spells"][switchKey][name][funcName]; f.valid())
             {
-                return f.get<sol::function>();
+                return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
             }
             return sol::lua_nil;
         });
@@ -775,7 +878,7 @@ auto getEffectCachedFunction(const std::string& effectName, const std::string& f
             {
                 if (auto f = effectTable[funcName]; f.valid())
                 {
-                    return f.get<sol::function>();
+                    return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                 }
             }
             return sol::lua_nil;
@@ -1052,7 +1155,7 @@ sol::function getCachedFileFunction(const std::string& filename, const std::stri
             {
                 if (auto f = table[funcName]; f.valid())
                 {
-                    return f.get<sol::function>();
+                    return detail::nonEmptyOrNil(funcName, f.get<sol::function>());
                 }
             }
             return sol::lua_nil;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -189,8 +189,20 @@ bool isEmptyLuaFunction(const sol::function& fn)
         return false;
     }
 
-    static const sol::function checker = []() -> sol::function
+    // Compile the checker once and cache it inside the Lua state itself (in the registry),
+    // rather than in a C++ static. A function-local static sol::function would be destroyed
+    // during static destruction at process exit - after lua_cleanup() has already closed the
+    // Lua state - causing luaL_unref to run against a freed lua_State (crash). Caching in the
+    // registry ties the checker's lifetime to the state, so it is torn down cleanly with it.
+    static constexpr auto checkerKey = "isEmptyLuaFunctionChecker";
+
+    const sol::function checker = [&]() -> sol::function
     {
+        if (const sol::function cached = lua.registry()[checkerKey]; cached.valid())
+        {
+            return cached;
+        }
+
         const auto result = lua.safe_script(
             R"Lua(
             local ok1, util  = pcall(require, "jit.util")
@@ -228,15 +240,16 @@ bool isEmptyLuaFunction(const sol::function& fn)
             )Lua",
             sol::script_pass_on_error);
 
-        if (result.valid())
+        if (!result.valid())
         {
-            return result;
+            const sol::error err = result;
+            ShowErrorFmt("Failed to create nil function checker: {}", err.what());
+            return sol::function(sol::lua_nil);
         }
 
-        sol::error err = result;
-        ShowErrorFmt("Failed to create nil function checker: {}", err.what());
-
-        return sol::function(sol::lua_nil);
+        const sol::function created = result;
+        lua.registry()[checkerKey]  = created;
+        return created;
     }();
 
     if (!checker.valid())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

```cpp
// Use LuaJIT's debug modules to look at the bytecode representation of a function. If it's a single
// RET0 then it's a stub/empty handler. We can use this information to cache more aggressively.
// TODO: We could also use this information to Warn on startup, or silently strip these functions
// to streamline the Lua state size.

...

    // NOTE: Interaction Framework relies on these functions existing and being valid for them to
    // hook, so we can't mark them for replacement!
    static constexpr std::string_view frameworkFallbacks[] = {
        "onTrigger",
        "onTrade",
        "onSteal",
        "onZoneIn",
        "onZoneOut",
        "afterZoneIn",
        "onEventFinish",
        "onEventUpdate",
        "onTriggerAreaEnter",
        "onTriggerAreaLeave",
    };
```

This is not a crutch to start being lazy with how we lay out our Lua files and what we put into the Lua state!
