### PR TITLE
[lua] Additional Maat Adjustments

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/Maat_smn.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Maat_smn.lua
@@ -39,6 +39,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Maat_whm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Maat_whm.lua
@@ -31,6 +31,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 6)
 
     -- Reset mob.

--- a/scripts/zones/Chamber_of_Oracles/mobs/Maat_sam.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Maat_sam.lua
@@ -26,7 +26,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
 

--- a/scripts/zones/Horlais_Peak/mobs/Maat_blm.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Maat_blm.lua
@@ -31,6 +31,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Horlais_Peak/mobs/Maat_rng.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Maat_rng.lua
@@ -30,6 +30,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setMod(xi.mod.RATT, 100)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setBaseSpeed(60)
 
     -- Reset mob.

--- a/scripts/zones/Horlais_Peak/mobs/Maat_war.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Maat_war.lua
@@ -18,12 +18,16 @@ entity.onMobInitialize = function(mob)
         if damage >= 292 then
             mobArg:messageText(mobArg, ID.text.THAT_LL_HURT_IN_THE_MORNING)
         end
+
+        if damage >= 584 then
+            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+        end
     end)
 end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setBaseSpeed(60)
 
     -- Reset mob.

--- a/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
+++ b/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
@@ -35,6 +35,7 @@ entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setMod(xi.mod.DMGMAGIC, -1250) -- Observed at 99 and the skillchain damage in under level 71 vods
     mob:setMod(xi.mod.UFASTCAST, 70)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setMobMod(xi.mobMod.ROAM_COOL, 8)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 18)
 

--- a/scripts/zones/QuBia_Arena/mobs/Maat_drk.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maat_drk.lua
@@ -30,7 +30,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/QuBia_Arena/mobs/Maat_pld.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maat_pld.lua
@@ -27,7 +27,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Talacca_Cove/mobs/Qultada.lua
+++ b/scripts/zones/Talacca_Cove/mobs/Qultada.lua
@@ -30,6 +30,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Waughroon_Shrine/mobs/Maat_rdm.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Maat_rdm.lua
@@ -29,12 +29,12 @@ entity.onMobInitialize = function(mob)
     end)
 end
 
--- RDM Maat needs Grav Res Rank 7
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 7)
+    mob:setMod(xi.mod.GRAVITY_MEVA, 100) -- RDM Maat needs Grav Res Rank 7
     mob:setMod(xi.mod.DARK_SLEEP_RES_RANK, 3)
 
     -- Reset mob.

--- a/scripts/zones/Waughroon_Shrine/mobs/Maat_thf.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Maat_thf.lua
@@ -33,7 +33,7 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Maats damage to be more in line with 66-70 engagement of the fight.

It turns out when you enter the fight at level 99 it can skew his base damage and make it difficult to test what his base setting should be.

Skold helped me out be entering at a lower level Warrior to get a more accurate reading.
It seems most Maat's resting base damage multiplier is 1.25x, then is further enhanced by damage received, or the level of the player (which is honestly a mechanic I can't even begin to understand as its not very intuitive).

I originally set many Maat's base damage to 1.5x as it was very clear that it wasn't 1.0x.  It seems it was somewhere in the middle.

https://www.youtube.com/watch?v=eAjPhC-szuw
https://www.youtube.com/watch?v=GDLgAl0Gz14
https://www.youtube.com/watch?v=p-P-VwEihEM

## Steps to test these changes

Fight Maat, get smacked.
