### PR TITLE
[lua] Route quick draw logic through corsair job util

### DIFF
--- a/scripts/actions/abilities/dark_shot.lua
+++ b/scripts/actions/abilities/dark_shot.lua
@@ -7,89 +7,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.DARK_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local duration = 60
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.DARK, 0, 0, bonusAcc)
-
-    if resist < 0.25 then
-        ability:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
-        return 0
-    end
-
-    duration = duration * resist
-
-    local effects = {}
-
-    local bio = target:getStatusEffect(xi.effect.BIO)
-    if bio ~= nil then
-        table.insert(effects, bio)
-    end
-
-    local blind = target:getStatusEffect(xi.effect.BLINDNESS)
-    if blind ~= nil then
-        table.insert(effects, blind)
-    end
-
-    local threnody = target:getStatusEffect(xi.effect.THRENODY)
-    if threnody ~= nil and threnody:getSubPower() == xi.mod.LIGHT_MEVA then
-        table.insert(effects, threnody)
-    end
-
-    if #effects > 0 then
-        local effect = effects[math.random(1, #effects)]
-        -- TODO: duration here overwrites all previous values, this logic needs to be verified
-        duration = effect:getDuration()
-        local startTime = effect:getStartTime()
-        local tick      = effect:getTick()
-        local power     = effect:getPower()
-        local subpower  = effect:getSubPower()
-        local tier      = effect:getTier()
-        local effectId  = effect:getEffectType()
-        local subId     = effect:getSubType()
-        power    = power * 1.5
-        subpower = subpower * 1.5
-        target:delStatusEffectSilent(effectId)
-        target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-        local newEffect = target:getStatusEffect(effectId)
-
-        if newEffect then
-            newEffect:setStartTime(startTime)
-        end
-    end
-
-    ability:setMsg(xi.msg.basic.JA_REMOVE_EFFECT_2)
-
-    local dispelledEffect = target:dispelStatusEffect()
-    if dispelledEffect == xi.effect.NONE then
-        -- no effect
-        ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
-    end
-
-    local _ = player:delItem(xi.item.DARK_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dispelledEffect
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/earth_shot.lua
+++ b/scripts/actions/abilities/earth_shot.lua
@@ -1,91 +1,17 @@
 -----------------------------------
 -- Ability: Earth Shot
--- Consumes a Earth Card to enhance earth-based debuffs. Deals earth-based magic damage
+-- Consumes an Earth Card to enhance earth-based debuffs. Deals earth-based magic damage
 -- Rasp Effect: Enhanced DoT and DEX-, Slow Effect +10%
 -----------------------------------
 ---@type TAbility
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.EARTH_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.EARTH, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.EARTH, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.EARTH, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.EARTH, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.EARTH, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local rasp = target:getStatusEffect(xi.effect.RASP)
-        if rasp ~= nil then
-            table.insert(effects, rasp)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.THUNDER_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        local slow = target:getStatusEffect(xi.effect.SLOW)
-        if slow ~= nil then
-            table.insert(effects, slow)
-        end
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-            local newEffect = target:getStatusEffect(effectId)
-
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.EARTH_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/fire_shot.lua
+++ b/scripts/actions/abilities/fire_shot.lua
@@ -7,81 +7,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.FIRE_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.FIRE, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.FIRE, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.FIRE, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.FIRE, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.FIRE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local burn = target:getStatusEffect(xi.effect.BURN)
-        if burn ~= nil then
-            table.insert(effects, burn)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.ICE_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-
-            local newEffect = target:getStatusEffect(effectId)
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.FIRE_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/ice_shot.lua
+++ b/scripts/actions/abilities/ice_shot.lua
@@ -1,92 +1,17 @@
 -----------------------------------
 -- Ability: Ice Shot
--- Consumes a Ice Card to enhance ice-based debuffs. Deals ice-based magic damage
+-- Consumes an Ice Card to enhance ice-based debuffs. Deals ice-based magic damage
 -- Frost Effect: Enhanced DoT and AGI-
 -----------------------------------
 ---@type TAbility
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.ICE_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.ICE, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.ICE, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.ICE, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.ICE, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.ICE, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local frost = target:getStatusEffect(xi.effect.FROST)
-        if frost ~= nil then
-            table.insert(effects, frost)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.WIND_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        local paralyze = target:getStatusEffect(xi.effect.PARALYSIS)
-        if paralyze ~= nil then
-            table.insert(effects, paralyze)
-        end
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-
-            local newEffect = target:getStatusEffect(effectId)
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.ICE_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/light_shot.lua
+++ b/scripts/actions/abilities/light_shot.lua
@@ -6,85 +6,12 @@
 ---@type TAbility
 local abilityObject = {}
 
-local diaInfo =
-{
-    [1] = 10,
-    [3] = 15,
-    [5] = 20,
-    [7] = 25,
-    [9] = 30,
-}
-
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.LIGHT_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local duration = 60
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.LIGHT, 0, 0, bonusAcc)
-
-    if resist < 0.5 then
-        ability:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
-        return xi.effect.SLEEP_I
-    end
-
-    if target:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = math.floor(duration * resist), origin = player }) then
-        ability:setMsg(xi.msg.basic.JA_ENFEEB_IS)
-    else
-        ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
-    end
-
-    local _ = player:delItem(xi.item.LIGHT_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    -- Boost dia effect
-    local dia = target:getStatusEffect(xi.effect.DIA)
-    if not dia then
-        return xi.effect.SLEEP_I
-    end
-
-    local diaOwner    = dia:getOriginID()
-    local diaPower    = dia:getPower()
-    local diaSubpower = dia:getSubPower()
-    local diaTier     = dia:getTier()
-    local startTime   = dia:getStartTime()
-
-    -- Already boosted
-    if diaSubpower > diaInfo[diaTier] then
-        return xi.effect.SLEEP_I
-    end
-
-    diaPower    = diaPower + 1
-    diaSubpower = diaSubpower + math.floor(100 * 28 / 1024) -- TODO: Change ATTP, DEFP and similar mods from base 100 to base 10k
-
-    target:delStatusEffectSilent(xi.effect.DIA)
-    target:addStatusEffect(xi.effect.DIA, { power = diaPower, duration = dia:getDuration(), origin = player, tick = dia:getTick(), subType = dia:getSubType(), subPower = diaSubpower, tier = diaTier })
-
-    local newEffect = target:getStatusEffect(xi.effect.DIA)
-    if newEffect then
-        newEffect:setStartTime(startTime)
-        newEffect:setOriginID(diaOwner)
-    end
-
-    return xi.effect.SLEEP_I
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/thunder_shot.lua
+++ b/scripts/actions/abilities/thunder_shot.lua
@@ -7,83 +7,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.THUNDER_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.THUNDER, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.THUNDER, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.THUNDER, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.THUNDER, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.THUNDER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local shock = target:getStatusEffect(xi.effect.SHOCK)
-
-        if shock ~= nil then
-            table.insert(effects, shock)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.WATER_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-
-            local newEffect = target:getStatusEffect(effectId)
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.THUNDER_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/water_shot.lua
+++ b/scripts/actions/abilities/water_shot.lua
@@ -7,86 +7,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.WATER_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.WATER, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WATER, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.WATER, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.WATER, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WATER, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local drown = target:getStatusEffect(xi.effect.DROWN)
-        if drown ~= nil then
-            table.insert(effects, drown)
-        end
-
-        local poison = target:getStatusEffect(xi.effect.POISON)
-        if poison ~= nil then
-            table.insert(effects, poison)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.FIRE_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-
-            local newEffect = target:getStatusEffect(effectId)
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.WATER_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/wind_shot.lua
+++ b/scripts/actions/abilities/wind_shot.lua
@@ -7,90 +7,11 @@
 local abilityObject = {}
 
 abilityObject.onAbilityCheck = function(player, target, ability)
-    --ranged weapon/ammo: You do not have an appropriate ranged weapon equipped.
-    --no card: <name> cannot perform that action.
-    if
-        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
-        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
-    then
-        return 216, 0
-    end
-
-    if
-        player:hasItem(xi.item.WIND_CARD, 0) or
-        player:hasItem(xi.item.TRUMP_CARD, 0)
-    then
-        return 0, 0
-    else
-        return 71, 0
-    end
+    return xi.job_utils.corsair.checkQuickDraw(player, ability)
 end
 
 abilityObject.onUseAbility = function(player, target, ability, action)
-    action:setRecast(math.max(0, action:getRecast() - player:getMod(xi.mod.QUICK_DRAW_RECAST)))
-    local params = {}
-    params.includemab = true
-
-    local dmg = (2 * (player:getRangedDmg() + player:getAmmoDmg()) + player:getMod(xi.mod.QUICK_DRAW_DMG)) * (1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100)
-    dmg       = dmg + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT)
-    dmg       = addBonusesAbility(player, xi.element.WIND, target, dmg, params)
-
-    local bonusAcc = player:getStat(xi.mod.AGI) / 2 + player:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + player:getMod(xi.mod.QUICK_DRAW_MACC)
-    dmg            = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.WIND, 0, 0, bonusAcc))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateAbsorption(target, xi.element.WIND, false))
-    dmg            = math.floor(dmg * xi.spells.damage.calculateNullification(target, xi.element.WIND, false, false))
-
-    params.targetTPMult = 0 -- Quick Draw does not feed TP
-    dmg                 = xi.ability.takeDamage(target, player, params, true, dmg, xi.attackType.MAGICAL, xi.damageType.WIND, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    if dmg > 0 then
-        local effects = {}
-
-        local choke = target:getStatusEffect(xi.effect.CHOKE)
-
-        if choke ~= nil then
-            table.insert(effects, choke)
-        end
-
-        local threnody = target:getStatusEffect(xi.effect.THRENODY)
-
-        if threnody ~= nil and threnody:getSubPower() == xi.mod.EARTH_MEVA then
-            table.insert(effects, threnody)
-        end
-
-        --TODO: Frightful Roar
-        --[[local frightfulRoar = target:getStatusEffect(xi.effect.)
-        if (frightfulRoar ~= nil) then
-            effects[counter] = frightfulRoar
-            counter = counter + 1
-        end]]
-
-        if #effects > 0 then
-            local effect    = effects[math.random(1, #effects)]
-            local duration  = effect:getDuration()
-            local startTime = effect:getStartTime()
-            local tick      = effect:getTick()
-            local power     = effect:getPower()
-            local subpower  = effect:getSubPower()
-            local tier      = effect:getTier()
-            local effectId  = effect:getEffectType()
-            local subId     = effect:getSubType()
-
-            power = power * 1.2
-            target:delStatusEffectSilent(effectId)
-            target:addStatusEffect(effectId, { power = power, duration = duration, origin = player, tick = tick, subType = subId, subPower = subpower, tier = tier })
-
-            local newEffect = target:getStatusEffect(effectId)
-            if newEffect then
-                newEffect:setStartTime(startTime)
-            end
-        end
-    end
-
-    local _ = player:delItem(xi.item.WIND_CARD, 1) or player:delItem(xi.item.TRUMP_CARD, 1)
-    target:updateClaim(player)
-
-    return dmg
+    return xi.job_utils.corsair.useElementalShot(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -355,6 +355,64 @@ local rollData =
     },
 }
 
+local quickDrawDataTable =
+{
+    [xi.jobAbility.FIRE_SHOT   ] = { cardAmmo = xi.item.FIRE_CARD,    element = xi.element.FIRE,    multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.ICE_SHOT    ] = { cardAmmo = xi.item.ICE_CARD,     element = xi.element.ICE,     multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.WIND_SHOT   ] = { cardAmmo = xi.item.WIND_CARD,    element = xi.element.WIND,    multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.EARTH_SHOT  ] = { cardAmmo = xi.item.EARTH_CARD,   element = xi.element.EARTH,   multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.THUNDER_SHOT] = { cardAmmo = xi.item.THUNDER_CARD, element = xi.element.THUNDER, multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.WATER_SHOT  ] = { cardAmmo = xi.item.WATER_CARD,   element = xi.element.WATER,   multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
+    [xi.jobAbility.LIGHT_SHOT  ] = { cardAmmo = xi.item.LIGHT_CARD,   element = xi.element.LIGHT,   multiplier = 1.0, canDamage = false, applyEffectId = xi.effect.SLEEP_I },
+    [xi.jobAbility.DARK_SHOT   ] = { cardAmmo = xi.item.DARK_CARD,    element = xi.element.DARK,    multiplier = 1.5, canDamage = false, applyEffectId = xi.effect.NONE    }, -- Dispel
+}
+
+local quickDrawEffectBoostTable =
+{
+    [xi.jobAbility.FIRE_SHOT] =
+    {
+        { effectId = xi.effect.BURN, capGlobal = 8 },
+    },
+
+    [xi.jobAbility.ICE_SHOT] =
+    {
+        { effectId = xi.effect.FROST,     capGlobal =  8 },
+        { effectId = xi.effect.PARALYSIS, capGlobal = 30 },
+    },
+
+    [xi.jobAbility.WIND_SHOT] =
+    {
+        { effectId = xi.effect.CHOKE, capGlobal = 8 }, -- TODO: Determine if Wind Shot effects Defense Down
+    },
+
+    [xi.jobAbility.EARTH_SHOT] =
+    {
+        { effectId = xi.effect.RASP, capGlobal =    8 },
+        { effectId = xi.effect.SLOW, capGlobal = 3300 },
+    },
+
+    [xi.jobAbility.THUNDER_SHOT] =
+    {
+        { effectId = xi.effect.SHOCK, capGlobal = 8 },
+    },
+
+    [xi.jobAbility.WATER_SHOT] =
+    {
+        { effectId = xi.effect.DROWN, capGlobal = 8 },
+    },
+
+    [xi.jobAbility.LIGHT_SHOT] =
+    {
+        { effectId = xi.effect.DIA, capByTier = { [1] = 10, [3] = 15, [5] = 20, [7] = 25, [9] = 30 } },
+    },
+
+    [xi.jobAbility.DARK_SHOT] =
+    {
+        { effectId = xi.effect.BIO,       capByTier = { [2] = 10, [4] = 15, [6] = 20, [8] = 25, [10] = 30 } },
+        { effectId = xi.effect.BLINDNESS, capGlobal = 30                                                    },
+    },
+}
+
 local rollEnhanceMods =
 {
     [xi.jobAbility.CASTERS_ROLL   ] = xi.mod.ENHANCES_CASTERS_ROLL,
@@ -604,6 +662,135 @@ local function applyRoll(caster, target, inAbility, total, isDoubleup, currentAb
     return total
 end
 
+local function handleQuickDrawDamage(player, target, action, element, resist)
+    -- Calculate Quick Draw damage - https://wiki.ffo.jp/html/3349.html TODO: QUICK_DRAW_TRIPLE_DAMAGE gear mod needs research
+    local damage                 = 2 * player:getRangedDmg() + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT) + player:getMod(xi.mod.QUICK_DRAW_DMG)
+    local deathPenaltyMultiplier = 1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100
+    local damageAdditiveBonus    = player:getMod(xi.mod.MAGIC_DAMAGE)
+    local elementalStaffBonus    = xi.spells.damage.calculateElementalStaffBonus(player, element)
+    local affinityMultiplier     = xi.spells.damage.calculateElementalAffinityBonus(player, element)
+    local dayWeatherMultiplier   = xi.spells.damage.calculateDayAndWeather(player, element, false)
+    local magicBonusDiff         = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element, 0)
+
+    -- Unconfirmed order.
+    local sdtMultiplier          = xi.combat.damage.magicalElementSDT(target, element)
+    local additionalResistTier   = xi.spells.damage.calculateAdditionalResistTier(player, target, element)
+    local elementalAbsorption    = xi.spells.damage.calculateAbsorption(target, element, false)
+    local elementalNullification = xi.spells.damage.calculateNullification(target, element, false, false)
+
+    -- Apply multipliers and bonuses.
+    damage = math.floor(damage * deathPenaltyMultiplier)
+    damage = math.floor(damage + damageAdditiveBonus)
+    damage = math.floor(damage * elementalStaffBonus)
+    damage = math.floor(damage * affinityMultiplier)
+    damage = math.floor(damage * dayWeatherMultiplier)
+    damage = math.floor(damage * magicBonusDiff)
+    damage = math.floor(damage * sdtMultiplier)
+    damage = math.floor(damage * resist)
+    damage = math.floor(damage * additionalResistTier)
+    damage = math.floor(damage * elementalAbsorption)
+    damage = math.floor(damage * elementalNullification)
+
+    -- TODO: Investigate. Whats actually needed from this?
+    damage = xi.ability.takeDamage(target, player, { targetTPMult = 0 }, true, damage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + element, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
+
+    return damage
+end
+
+local function handleQuickDrawEffectBoost(player, target, abilityId, multiplier)
+    local effectData = quickDrawEffectBoostTable[abilityId]
+    if not effectData then
+        return
+    end
+
+    -- Gather eligible effects that are below the power cap.
+    local effects = {}
+    for _, entryTable in ipairs(effectData) do
+        local effectChecked = target:getStatusEffect(entryTable.effectId)
+
+        if effectChecked then
+            local eligible = false
+
+            -- Check for Dia/Bio.
+            if entryTable.capByTier then
+                local basePower = entryTable.capByTier[effectChecked:getTier()]
+                eligible        = basePower and basePower < effectChecked:getSubPower()
+
+            -- Check for all other eligible effects
+            else
+                eligible = effectChecked:getPower() < entryTable.capGlobal
+            end
+
+            if eligible then
+                table.insert(effects, { effect = effectChecked, entry = entryTable })
+            end
+        end
+    end
+
+    -- Early return: No effect can be boosted, either because it's capped or isn't present.
+    if #effects <= 0 then
+        return
+    end
+
+    -- Select effect entry from table and fetch it's content.
+    local selected = effects[math.random(1, #effects)]
+    local effect   = selected.effect
+    local entry    = selected.entry
+
+    -- Fetch effect data.
+    local effectId        = effect:getEffectType()
+    local effectPower     = effect:getPower()
+    local effectTick      = effect:getTick() / 1000
+    local effectDuration  = effect:getDuration() / 1000
+    local effectSubPower  = effect:getSubPower()
+    local effectSubType   = effect:getSubType()
+    local effectTier      = effect:getTier()
+    local effectStartTime = effect:getStartTime()
+    local effectOriginID  = effect:getOriginID()
+
+    -- Apply boost to Dia or Bio effects. They can only be boosted once. "Cannot be stacked."
+    if entry.capByTier then
+        -- TODO: Determine power effect of Bio. Current retail bug with Dark Shot removes the DoT effect from Bio currently.
+        if effectId == xi.effect.DIA then
+            effectPower = effectPower + 1
+        end
+
+        -- If subPower exceeds cap, clamp it.
+        effectSubPower = effectSubPower + math.floor(100 * 28 / 1024) -- TODO: Change ATTP, DEFP and similar mods from base 100 to base 10k
+
+    -- Apply boost to all other eligible effects.
+    else
+        if effectId >= xi.effect.BURN and effectId <= xi.effect.DROWN then
+            effectPower = math.min(effectPower + 2, entry.capGlobal)
+        else
+            effectPower = math.min(effectPower * multiplier, entry.capGlobal)
+        end
+    end
+
+    -- Remove the existing effect and reapply it with the new power/subPower values.
+    target:delStatusEffectSilent(effectId)
+
+    local params =
+    {
+        power    = effectPower,
+        tick     = effectTick,
+        duration = effectDuration,
+        subPower = effectSubPower,
+        subType  = effectSubType,
+        tier     = effectTier,
+        origin   = player,
+    }
+
+    target:addStatusEffect(effectId, params)
+
+    -- Update the start time and origin ID of the new effect to match the original effect.
+    local newEffect = target:getStatusEffect(effectId)
+    if newEffect then
+        newEffect:setStartTime(effectStartTime)
+        newEffect:setOriginID(effectOriginID)
+    end
+end
+
 -----------------------------------
 -- Global helper functions
 -----------------------------------
@@ -686,6 +873,29 @@ xi.job_utils.corsair.checkFold = function(player)
     end
 
     return xi.msg.basic.CANNOT_PERFORM, 0
+end
+
+xi.job_utils.corsair.checkQuickDraw = function(player, ability)
+    local data = quickDrawDataTable[ability:getID()]
+    if not data then
+        return xi.msg.basic.CANNOT_PERFORM, 0
+    end
+
+    if
+        player:getWeaponSkillType(xi.slot.RANGED) ~= xi.skill.MARKSMANSHIP or
+        player:getWeaponSkillType(xi.slot.AMMO) ~= xi.skill.MARKSMANSHIP
+    then
+        return xi.msg.basic.NO_RANGED_WEAPON, 0
+    end
+
+    if
+        not player:hasItem(data.cardAmmo, xi.inventoryLocation.INVENTORY) and
+        not player:hasItem(xi.item.TRUMP_CARD, xi.inventoryLocation.INVENTORY)
+    then
+        return xi.msg.basic.CANNOT_PERFORM, 0
+    end
+
+    return 0, 0
 end
 
 -----------------------------------
@@ -778,8 +988,83 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
     end
 end
 
+xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
+    local abilityId = ability:getID()
+
+    -- Fetch specific ability data.
+    local data = quickDrawDataTable[abilityId]
+    if not data then
+        return
+    end
+
+    -- Handle card consumption.
+    if not actor:delItem(data.cardAmmo, 1) then
+        actor:delItem(xi.item.TRUMP_CARD, 1)
+    end
+
+    -- Handle recast.
+    action:setRecast(math.max(0, action:getRecast() - actor:getMod(xi.mod.QUICK_DRAW_RECAST)))
+
+    -- Handle claim.
+    target:updateClaim(actor)
+
+    -- Calculate resist rate.
+    local bonusAcc = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC)
+    local resist   = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.MARKSMANSHIP, 0,  data.element, xi.mod.AGI, 0, bonusAcc)
+
+    -- Handle damage.
+    local damage = 0
+    if data.canDamage then
+        damage = handleQuickDrawDamage(actor, target, action, data.element, resist)
+    end
+
+    if damage > 0 then
+        actor:addTP(xi.combat.tp.getSingleRangedHitTPReturn(actor))
+        actor:trySkillUp(xi.skill.MARKSMANSHIP, target:getMainLvl())
+    end
+
+    -- Handle effect boost.
+    handleQuickDrawEffectBoost(actor, target, abilityId, data.multiplier)
+
+    -- Handle effect application.
+    if data.applyEffectId > 0 then
+        if
+            xi.data.statusEffect.isTargetImmune(target, data.applyEffectId, data.element) or
+            xi.data.statusEffect.isTargetResistant(actor, target, data.applyEffectId) or
+            not xi.data.statusEffect.isResistRateSuccessfull(data.applyEffectId, resist, 0)
+        then
+            ability:setMsg(xi.msg.basic.JA_MISS_2)
+            return data.applyEffectId
+        end
+
+        -- Light shot.
+        if data.applyEffectId == xi.effect.SLEEP_I then
+            if target:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = math.floor(90 * resist), subPower = data.element, origin = actor }) then
+                ability:setMsg(xi.msg.basic.JA_ENFEEB_IS)
+            else
+                ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
+            end
+
+            return xi.effect.SLEEP_I
+
+        -- Dark shot.
+        else
+            ability:setMsg(xi.msg.basic.JA_REMOVE_EFFECT_2)
+
+            local dispelledEffect = target:dispelStatusEffect()
+            if dispelledEffect == xi.effect.NONE then
+                ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
+            end
+
+            return dispelledEffect
+        end
+    end
+
+    return damage
+end
+
 xi.job_utils.corsair.useSnakeEye = function(player, action)
-    player:addStatusEffect(xi.effect.SNAKE_EYE, { power = (player:getMerit(xi.merit.SNAKE_EYE) - 10), duration = 60, origin = player })
+    player:addStatusEffect(xi.effect.SNAKE_EYE, { power = player:getMerit(xi.merit.SNAKE_EYE) - 10, duration = 60, origin = player })
 
     return xi.effect.SNAKE_EYE
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes the logic from individual Quick Draw shots and instead routes all shot logic through the corsair job util
- Corrects the Quick Draw damage formula. Replicated JP wiki formula and confirmed against numbers reported on retail. https://wiki.ffo.jp/html/3349.html
  - Adds in bonus magic damage mod
  - Ammo damage was being added twice since getRangedDmg() already adds it in
- Boost effects are now routed through a single function, with unique increases and caps per effect.
  - Confirmed poison does not get boosted. With this, Sruon discovered there's a bug on retail where dark shot makes it so Bio doesn't tick damage anymore!

## Steps to test these changes

- Use slow or bio on a target mob
- Use a matching element quick draw shot on the mob
- See the mob takes expected damage along with the relevant status effect getting boosted as expected