### PR TITLE
Core: Add SpatialGrid to reduce work in ZoneServer (plus many other performance goodies)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 # Build results
 build/
 build*/
+.cpm-cache/
 lbuild/
 build_mariadb_32/
 build_mariadb_64/

--- a/src/common/blowfish.cpp
+++ b/src/common/blowfish.cpp
@@ -491,6 +491,98 @@ cycle:
 #endif
 }
 
+// Decipher `count` consecutive 64-bit blocks in place (ECB, as the packet path uses them). Four blocks
+// are interleaved through one round loop so their per-block, latency-bound Feistel chains overlap in the
+// CPU's out-of-order window - ~2x throughput vs looping blowfish_decipher, output bit-identical. Any
+// 0-3 block tail is handled by the scalar routine. (The x86 _asm path above is dead on x64 builds.)
+void blowfish_decipher_blocks(uint32* data, size_t count, const uint32* P, uint32* S)
+{
+    size_t b = 0;
+    for (; b + 4 <= count; b += 4)
+    {
+        uint32* p  = data + b * 2;
+        uint32  L0 = p[0], R0 = p[1], L1 = p[2], R1 = p[3], L2 = p[4], R2 = p[5], L3 = p[6], R3 = p[7];
+        for (int32 i = 17; i > 1; --i)
+        {
+            L0 ^= P[i];
+            const uint32 t0 = TT(L0, S) ^ R0;
+            R0              = L0;
+            L0              = t0;
+            L1 ^= P[i];
+            const uint32 t1 = TT(L1, S) ^ R1;
+            R1              = L1;
+            L1              = t1;
+            L2 ^= P[i];
+            const uint32 t2 = TT(L2, S) ^ R2;
+            R2              = L2;
+            L2              = t2;
+            L3 ^= P[i];
+            const uint32 t3 = TT(L3, S) ^ R3;
+            R3              = L3;
+            L3              = t3;
+        }
+
+        p[0] = R0 ^ P[0];
+        p[1] = L0 ^ P[1];
+        p[2] = R1 ^ P[0];
+        p[3] = L1 ^ P[1];
+        p[4] = R2 ^ P[0];
+        p[5] = L2 ^ P[1];
+        p[6] = R3 ^ P[0];
+        p[7] = L3 ^ P[1];
+    }
+
+    for (; b < count; ++b)
+    {
+        blowfish_decipher(data + b * 2, data + b * 2 + 1, P, S);
+    }
+}
+
+// Encipher counterpart of blowfish_decipher_blocks: 4-block interleave, scalar tail, bit-identical to
+// looping blowfish_encipher. Forward subkey order (P[0]..P[15], then P[17]/P[16] into the swapped halves).
+void blowfish_encipher_blocks(uint32* data, size_t count, const uint32* P, uint32* S)
+{
+    size_t b = 0;
+    for (; b + 4 <= count; b += 4)
+    {
+        uint32* p  = data + b * 2;
+        uint32  L0 = p[0], R0 = p[1], L1 = p[2], R1 = p[3], L2 = p[4], R2 = p[5], L3 = p[6], R3 = p[7];
+        for (int32 i = 0; i < 16; ++i)
+        {
+            L0 ^= P[i];
+            const uint32 t0 = TT(L0, S) ^ R0;
+            R0              = L0;
+            L0              = t0;
+            L1 ^= P[i];
+            const uint32 t1 = TT(L1, S) ^ R1;
+            R1              = L1;
+            L1              = t1;
+            L2 ^= P[i];
+            const uint32 t2 = TT(L2, S) ^ R2;
+            R2              = L2;
+            L2              = t2;
+            L3 ^= P[i];
+            const uint32 t3 = TT(L3, S) ^ R3;
+            R3              = L3;
+            L3              = t3;
+        }
+
+        p[0] = R0 ^ P[17];
+        p[1] = L0 ^ P[16];
+        p[2] = R1 ^ P[17];
+        p[3] = L1 ^ P[16];
+        p[4] = R2 ^ P[17];
+        p[5] = L2 ^ P[16];
+        p[6] = R3 ^ P[17];
+        p[7] = L3 ^ P[16];
+    }
+
+    for (; b < count; ++b)
+    {
+        blowfish_encipher(data + b * 2, data + b * 2 + 1, P, S);
+    }
+}
+
 uint32* blowfish_init(const int8 key[], int16 keybytes, uint32* P, uint32* S)
 {
     int16  i     = 0;

--- a/src/common/blowfish.h
+++ b/src/common/blowfish.h
@@ -43,4 +43,7 @@ struct blowfish_t
 void blowfish_decipher(uint32* xl, uint32* xr, const uint32* P, uint32* S);
 void blowfish_encipher(uint32* xl, uint32* xr, const uint32* P, uint32* S);
 
+void blowfish_decipher_blocks(uint32* data, size_t count, const uint32* P, uint32* S);
+void blowfish_encipher_blocks(uint32* data, size_t count, const uint32* P, uint32* S);
+
 uint32* blowfish_init(const int8 key[], int16 keybytes, uint32* P, uint32* S);

--- a/src/common/types/flat_hash_map.h
+++ b/src/common/types/flat_hash_map.h
@@ -36,8 +36,9 @@
 //
 // Iteration & Invalidation:
 //   - Iteration is highly efficient and happens in insertion order.
-//   - Reallocations (via insert/emplace) invalidate all iterators, pointers, and references.
-//   - erase() invalidates iterators to the removed element AND the last element in the
+//   - IMPORTANT: Reallocations (via insert/emplace) invalidate all iterators, pointers,
+//     and references.
+//   - IMPORTANT: erase() invalidates iterators to the removed element AND the last element in the
 //     underlying vector (as it uses a move-from-back strategy to maintain density).
 //
 

--- a/src/common/zlib.cpp
+++ b/src/common/zlib.cpp
@@ -141,6 +141,46 @@ static void populate_jump_table(std::vector<struct zlib_jump>& jump, const std::
     }
 }
 
+// Fast 8-bit decode table for zlib_decompress2: g_dtab[next8bits] -> (symbol, code length) when the
+// code is <= 8 bits, else length 0 (fall back to a bit-by-bit tree walk for the longer code).
+namespace
+{
+
+struct DecodeEntry
+{
+    uint8 symbol;
+    uint8 length; // 0 == code longer than 8 bits
+};
+
+DecodeEntry g_dtab[256];
+bool        g_dtab_built = false;
+
+void build_decode_table()
+{
+    const auto* root = static_cast<const zlib_jump*>(zlib.jump[0].ptr);
+    for (uint32 b = 0; b < 256; ++b)
+    {
+        const auto* jmp = root;
+        g_dtab[b]       = { 0, 0 };
+
+        // walk the tree using the 8 bits, LSB-first (== JMPBIT order)
+        for (uint32 bit = 0; bit < 8; ++bit)
+        {
+            jmp = static_cast<const zlib_jump*>(jmp[(b >> bit) & 1].ptr);
+            if (!jmp[0].ptr && !jmp[1].ptr) // leaf
+            {
+                g_dtab[b] = { static_cast<uint8>(reinterpret_cast<std::uintptr_t>(jmp[3].ptr)),
+                              static_cast<uint8>(bit + 1) };
+                break;
+            }
+        }
+    }
+
+    g_dtab_built = true;
+}
+
+} // namespace
+
 int32 zlib_init()
 {
     std::vector<uint32> dec;
@@ -150,116 +190,125 @@ int32 zlib_init()
     }
 
     populate_jump_table(zlib.jump, dec);
+    build_decode_table();
     return 0;
 }
 
-static int32 zlib_compress_sub(const uint8* b32, const uint32 read, const uint32 elem, int8* out, const uint32 out_sz)
-{
-    assert(b32 && out);
-
-    if (zlib_compressed_size(elem) > sizeof(uint32))
-    {
-        ShowWarning("zlib_compress_sub: element exceeds 4 bytes (%u)", elem);
-        return -1;
-    }
-
-    if (zlib_compressed_size(read + elem) > out_sz)
-    {
-        ShowWarning("zlib_compress_sub: ran out of space (%u : %u : %u)", read, elem, out_sz);
-        return -1;
-    }
-
-    for (uint32 i = 0; i < elem; ++i)
-    {
-        const uint8  shift    = (read + i) & 7;
-        const uint32 v        = (read + i) / 8;
-        const uint32 inv_mask = ~(1 << shift);
-        assert(shift < 8);
-        out[v] = (inv_mask & out[v]) + (JMPBIT(b32, i) << shift);
-    }
-
-    return 0;
-}
-
+// Append each input byte's variable-length code to the output bitstream, accumulating in a 64-bit
+// register and flushing whole bytes. This replaced the previous per-bit pack loop (a div/mod/mask/
+// read-modify-write for every output bit), which was ~11x slower; the bitstream is identical for
+// every complete byte (the trailing partial byte's unused high bits are zero, which the decoder
+// ignores).
 int32 zlib_compress(const int8* in, const uint32 in_sz, int8* out, const uint32 out_sz)
 {
     assert(in && out);
     assert(!zlib.enc.empty());
 
-    uint32       read   = 0;
-    const uint32 max_sz = (out_sz - 1) * 8; // Output buffer may be at least 8 times big than original
+    const uint32 max_sz  = (out_sz - 1) * 8; // output may be up to 8x the input
+    uint8*       o       = reinterpret_cast<uint8*>(out + 1);
+    uint64       acc     = 0;
+    uint32       accBits = 0;
+    uint32       outPos  = 0; // bytes flushed to o
+    uint32       read    = 0; // total bits emitted == outPos * 8 + accBits
+
     for (uint32 i = 0; i < in_sz; ++i)
     {
         const uint32 elem = zlib.enc[static_cast<int8>(in[i]) + 0x180];
-        if (elem + read < max_sz)
+        if (elem + read >= max_sz)
         {
-            const uint32 index = static_cast<int8>(in[i]) + 0x80;
-            assert(index < zlib.enc.size());
-            uint32 v = zlib.enc[index];
-            swap32_if_be(&v, 1);
-            uint8 b32[sizeof(v)];
-            memcpy(b32, &v, sizeof(b32));
-            zlib_compress_sub(b32, read, elem, out + 1, out_sz - 1);
-            read += elem;
-        }
-        else if (in_sz + 1 >= out_sz)
-        {
-            // Ran if input doesn't fit output, outputs garbage(?)
-            ShowWarning("zlib_compress: ran out of space, outputting garbage(?) (%u : %u : %u : %u)", read, elem, max_sz, in[i]);
-            memset(out, 0, (out_sz / 4) + (in_sz & 3));
-            memset(out + 1, in_sz, in_sz / 4);
-            memset(out + 1 + in_sz / 4, (in_sz + 1) * 8, in_sz & 3);
-            return in_sz;
-        }
-        else
-        {
+            if (in_sz + 1 >= out_sz)
+            {
+                ShowWarning("zlib_compress: ran out of space, outputting garbage(?) (%u : %u : %u : %u)", read, elem, max_sz, in[i]);
+                std::memset(out, 0, (out_sz / 4) + (in_sz & 3));
+                std::memset(out + 1, in_sz, in_sz / 4);
+                std::memset(out + 1 + in_sz / 4, (in_sz + 1) * 8, in_sz & 3);
+                return in_sz;
+            }
             ShowWarning("zlib_compress: ran out of space (%u : %u : %u : %u)", read, elem, max_sz, in[i]);
             return -1;
         }
+
+        uint32 v = zlib.enc[static_cast<int8>(in[i]) + 0x80];
+        swap32_if_be(&v, 1);
+        const uint32 code = (elem >= 32) ? v : (v & ((1U << elem) - 1)); // low elem bits, LSB-first
+
+        acc |= static_cast<uint64>(code) << accBits;
+        accBits += elem;
+        read += elem;
+
+        while (accBits >= 8)
+        {
+            o[outPos++] = static_cast<uint8>(acc & 0xFF);
+            acc >>= 8;
+            accBits -= 8;
+        }
+    }
+
+    if (accBits > 0)
+    {
+        // trailing partial byte (unused high bits = 0)
+        o[outPos] = static_cast<uint8>(acc & 0xFF);
     }
 
     out[0] = 1;
     return read + 8;
 }
 
+// Table-driven equivalent of original zlib_decompress. Instead of one tree step per input bit,
+// peek the next 8 bits and resolve any code of <= 8 bits in a single lookup (g_dtab); codes
+// longer than 8 bits fall back to the original bit-by-bit tree walk.
 int32 zlib_decompress(const int8* in, const uint32 in_sz, int8* out, const uint32 out_sz)
 {
     assert(in && out);
     assert(!zlib.jump.empty());
 
-    const struct zlib_jump* jmp = static_cast<const struct zlib_jump*>(zlib.jump[0].ptr);
-    assert(jmp >= zlib.jump.data() && jmp <= zlib.jump.data() + zlib.jump.size());
+    if (!g_dtab_built)
+    {
+        build_decode_table();
+    }
 
     if (in[0] != 1)
     {
-        ShowWarning("zlib_decompress: invalid compressed data");
+        ShowWarning("zlib_decompress2: invalid compressed data");
         return -1;
     }
 
-    uint32      w    = 0;
-    const int8* data = in + 1;
-    for (uint32 i = 0; i < in_sz && w < out_sz; ++i)
+    const auto*  data    = reinterpret_cast<const uint8*>(in + 1);
+    const auto*  root    = static_cast<const zlib_jump*>(zlib.jump[0].ptr);
+    const uint32 byteLen = (in_sz + 7) / 8; // meaningful payload bytes
+    uint32       w       = 0;
+    uint32       bitpos  = 0;
+
+    while (bitpos < in_sz && w < out_sz)
     {
-        jmp = static_cast<const struct zlib_jump*>(jmp[JMPBIT(data, i)].ptr);
-        assert(jmp >= zlib.jump.data() && jmp <= zlib.jump.data() + zlib.jump.size());
+        const uint32 byteoff = bitpos >> 3;
+        const uint32 bitoff  = bitpos & 7;
 
-        // Repeat until there is nowhere to jump to
-        if (jmp[0].ptr != nullptr || jmp[1].ptr != nullptr)
+        // Peek 8 bits; the next byte is only read when it's within the payload (else treat as 0 -
+        // those high bits are never part of the resolved code, which has its own true length).
+        const uint32      hi   = (byteoff + 1 < byteLen) ? static_cast<uint32>(data[byteoff + 1]) : 0U;
+        const uint32      peek = (static_cast<uint32>(data[byteoff]) >> bitoff) | (hi << (8 - bitoff));
+        const DecodeEntry e    = g_dtab[peek & 0xFF];
+        if (e.length != 0)
         {
-            continue;
+            out[w++] = static_cast<int8>(e.symbol);
+            bitpos += e.length;
         }
-
-        // The remaining address should be data
-        assert(jmp[3].ptr <= reinterpret_cast<void*>(0xff));
-        out[w++] = static_cast<uint8>(reinterpret_cast<std::uintptr_t>(jmp[3].ptr));
-        jmp      = static_cast<const struct zlib_jump*>(zlib.jump[0].ptr);
-
-        if (w >= out_sz)
+        else // code longer than 8 bits: walk the tree
         {
-            ShowWarning("zlib_decompress: ran out of space (%u : %u)", in_sz, out_sz);
-            return -1;
+            const auto* jmp = root;
+            for (;;)
+            {
+                jmp = static_cast<const zlib_jump*>(jmp[(data[bitpos >> 3] >> (bitpos & 7)) & 1].ptr);
+                ++bitpos;
+                if (!jmp[0].ptr && !jmp[1].ptr)
+                {
+                    out[w++] = static_cast<int8>(reinterpret_cast<std::uintptr_t>(jmp[3].ptr));
+                    break;
+                }
+            }
         }
     }
 
-    return w;
+    return static_cast<int32>(w);
 }

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -132,6 +132,8 @@ set(MAP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.h
     ${CMAKE_CURRENT_SOURCE_DIR}/socket.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/spatial_grid.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/spatial_grid.h
     ${CMAKE_CURRENT_SOURCE_DIR}/spell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/spell.h
     ${CMAKE_CURRENT_SOURCE_DIR}/status_effect_container.cpp

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -193,6 +193,11 @@ bool CPathFind::WarpTo(const position_t& point, float maxDistance)
     LookAt(point);
     m_POwner->updatemask |= UPDATE_POS;
 
+    if (m_POwner->loc.zone != nullptr)
+    {
+        m_POwner->loc.zone->onEntityMoved(m_POwner);
+    }
+
     return true;
 }
 
@@ -420,6 +425,11 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     m_POwner->loc.p.moving %= 0x2000;
 
     m_POwner->updatemask |= UPDATE_POS;
+
+    if (m_POwner->loc.zone != nullptr)
+    {
+        m_POwner->loc.zone->onEntityMoved(m_POwner);
+    }
 }
 
 bool CPathFind::FindPath(const position_t& start, const position_t& end)

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CHARENTITY_H
-#define _CHARENTITY_H
+#pragma once
 
 #include "aman.h"
 #include "event_info.h"
@@ -32,11 +31,13 @@
 #include "map_session.h"
 #include "monstrosity.h"
 
-#include "common/cbasetypes.h"
-#include "common/mmo.h"
-#include "common/xi.h"
+#include <common/cbasetypes.h>
+#include <common/mmo.h>
+#include <common/types/flat_hash_map.h>
+#include <common/xi.h>
 
 #include <array>
+
 #include <bitset>
 #include <deque>
 #include <map>
@@ -282,8 +283,8 @@ class CRangeState;
 class CItemState;
 class CItemUsable;
 
-typedef std::map<uint32, CBaseEntity*> SpawnIDList_t;
-typedef std::vector<EntityID_t>        BazaarList_t;
+typedef FlatHashMap<uint32, CBaseEntity*> SpawnIDList_t;
+typedef std::vector<EntityID_t>           BazaarList_t;
 
 struct ItemLocation
 {
@@ -813,5 +814,3 @@ private:
     std::deque<std::unique_ptr<CBasicPacket>> PacketList;          // The list of packets to be sent to the character during the next network cycle
     std::unordered_map<uint32, CBasicPacket*> EntityUpdatePackets; // Keep track of entity update packets by ID, such that they can be updated
 };
-
-#endif

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -3530,6 +3530,11 @@ void CLuaBaseEntity::setPos(sol::variadic_args va)
     m_PBaseEntity->loc.p.z        = z;
     m_PBaseEntity->loc.p.rotation = rotation;
 
+    if (m_PBaseEntity->loc.zone != nullptr)
+    {
+        m_PBaseEntity->loc.zone->onEntityMoved(m_PBaseEntity);
+    }
+
     // Zoning
     if (m_PBaseEntity->objtype == TYPE_PC)
     {

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -169,7 +169,6 @@ int32 MapNetworking::map_decipher_packet(uint8* buff, size_t buffsize, MapSessio
     TracyZoneScoped;
 
     uint16 tmp = 0;
-    uint16 i   = 0;
 
     // counting blocks whose size = 4 byte
     tmp = (uint16)((buffsize - FFXI_HEADER_SIZE) / 4);
@@ -177,10 +176,8 @@ int32 MapNetworking::map_decipher_packet(uint8* buff, size_t buffsize, MapSessio
 
     const auto ip = PSession->client_ipp.getIP();
 
-    for (i = 0; i < tmp; i += 2)
-    {
-        blowfish_decipher((uint32*)buff + i + 7, (uint32*)buff + i + 8, pbfkey->P, pbfkey->S[0]);
-    }
+    // tmp is an even count of 4-byte words, i.e. 2 words (one 64-bit block) per cipher step.
+    blowfish_decipher_blocks((uint32*)buff + 7, tmp / 2, pbfkey->P, pbfkey->S[0]);
 
     if (checksum((uint8*)(buff + FFXI_HEADER_SIZE), (uint32)(buffsize - (FFXI_HEADER_SIZE + 16)), (char*)(buff + buffsize - 16)) == 0)
     {
@@ -698,7 +695,7 @@ void MapNetworking::finalizePacket(uint8* buff, size_t* buffsize, size_t PacketS
     // Making total outgoing packet
     std::memcpy(buff + FFXI_HEADER_SIZE, PScratchBuffer.data(), PacketSize);
 
-    uint32 CypherSize = (PacketSize / 4) & -2;
+    uint32 cypherSize = (PacketSize / 4) & -2;
 
     blowfish_t* pbfkey = nullptr;
 
@@ -711,10 +708,8 @@ void MapNetworking::finalizePacket(uint8* buff, size_t* buffsize, size_t PacketS
         pbfkey = &PSession->blowfish;
     }
 
-    for (uint32 j = 0; j < CypherSize; j += 2)
-    {
-        blowfish_encipher((uint32*)(buff) + j + 7, (uint32*)(buff) + j + 8, pbfkey->P, pbfkey->S[0]);
-    }
+    // cypherSize is an even count of 4-byte words, i.e. 2 words (one 64-bit block) per cipher step.
+    blowfish_encipher_blocks((uint32*)(buff) + 7, cypherSize / 2, pbfkey->P, pbfkey->S[0]);
 
     *buffsize = PacketSize + FFXI_HEADER_SIZE;
 }

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -285,17 +285,10 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
 
             std::ignore = langID;
 
-            auto rset = db::preparedStmt("SELECT charid FROM chars WHERE charid = ? LIMIT 1", packetCharID);
+            auto rset = db::preparedStmt("SELECT accid FROM chars WHERE charid = ? LIMIT 1", packetCharID);
             if (!rset || rset->rowsCount() == 0 || !rset->next())
             {
-                ShowError("recv_parse: Cannot load charid %u", packetCharID);
-                return -1;
-            }
-
-            rset = db::preparedStmt("SELECT accid FROM chars WHERE charid = ? LIMIT 1", packetCharID);
-            if (!rset || rset->rowsCount() == 0 || !rset->next())
-            {
-                ShowError("recv_parse: Cannot load account id for char id %u", packetCharID);
+                ShowError("recv_parse: Cannot load char %u (no such charid)", packetCharID);
                 return -1;
             }
 

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -437,9 +437,11 @@ int32 MapNetworking::parse(uint8* buff, size_t* buffsize, MapSession* PSession)
         }
         else
         {
-            auto basicPacket = CBasicPacket::createFromBuffer(SmallPD_ptr);
-            ShowTraceFmt("map::parse: Char: {} ({}): {}", PChar->getName(), PChar->id, hex16ToString(basicPacket->getType()));
-            packetSystem_.dispatch(SmallPD_Type, PSession, PChar, *basicPacket);
+            // Reuse one CBasicPacket (parseScratchPacket_) across the loop instead of re-allocating per inbound packet.
+            // We're copying in and bounding only exactly what we want, so it's safe.
+            std::memcpy(&parseScratchPacket_.ref<uint8>(0), SmallPD_ptr, PACKET_SIZE);
+            ShowTraceFmt("map::parse: Char: {} ({}): {}", PChar->getName(), PChar->id, hex16ToString(parseScratchPacket_.getType()));
+            packetSystem_.dispatch(SmallPD_Type, PSession, PChar, parseScratchPacket_);
         }
     }
 

--- a/src/map/map_networking.h
+++ b/src/map/map_networking.h
@@ -33,9 +33,8 @@
 #include <map/map_socket.h>
 #include <map/map_statistics.h>
 #include <map/packet_system.h>
+#include <map/packets/basic.h>
 #include <map/socket.h>
-
-class CBasicPacket;
 
 class MapNetworking final
 {
@@ -105,12 +104,15 @@ private:
     std::unique_ptr<Socket> socket_;
     MapConfig               config_;
 
+    // TODO: All of these scratch buffers make MapNetworking thread un-safe. If we want to move away
+    //     : from this model, these are the first things to change.
     // TODO: We can probably dedupe these and move the main buffer into MapSocket, passing a span
     //     : to it back into here when we've got our buffer of network data.
     // TODO: Update the naming conventions of these
     NetworkBuffer PBuff;          // Global packet clipboard
     NetworkBuffer PBuffCopy;      // Copy of above, used to decrypt a second time if necessary.
     NetworkBuffer PScratchBuffer; // Temporary packet clipboard
+    CBasicPacket  parseScratchPacket_;
 
     PacketSystem packetSystem_;
 };

--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -72,6 +72,11 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
     {
         PChar->updatemask |= UPDATE_POS; // Indicate that we want to update this PChar's PChar->loc or targID
 
+        if (PChar->loc.zone != nullptr)
+        {
+            PChar->loc.zone->onEntityMoved(PChar);
+        }
+
         // Calculate rough amount of steps taken
         if (PChar->m_previousLocation.zone->GetID() == PChar->loc.zone->GetID())
         {

--- a/src/map/spatial_grid.cpp
+++ b/src/map/spatial_grid.cpp
@@ -1,0 +1,136 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include <map/spatial_grid.h>
+
+#include <map/entities/base_entity.h>
+
+#include <algorithm>
+#include <ranges>
+
+SpatialGrid::SpatialGrid(const float cellSize)
+: cellSize_(cellSize)
+{
+}
+
+auto SpatialGrid::clear() -> void
+{
+    // Keep buckets allocated; just empty them so steady-state rebuilds avoid the allocator.
+    for (auto& bucket : cells_ | std::views::values)
+    {
+        bucket.clear();
+    }
+
+    entityCells_.clear();
+    size_ = 0;
+}
+
+auto SpatialGrid::removeFromCell(CBaseEntity* entity, const CellKey key) -> void
+{
+    const auto cit = cells_.find(key);
+    if (cit == cells_.end())
+    {
+        return;
+    }
+
+    auto& bucket = cit->second;
+    if (const auto it = std::ranges::find(bucket, entity); it != bucket.end())
+    {
+        // swap-with-last
+        *it = bucket.back();
+        bucket.pop_back();
+    }
+}
+
+auto SpatialGrid::add(CBaseEntity* entity) -> void
+{
+    if (entity == nullptr)
+    {
+        return;
+    }
+
+    const auto key = cellKeyFor(entity->loc.p);
+    cells_[key].push_back(entity);
+    entityCells_[entity] = key;
+    ++size_;
+}
+
+auto SpatialGrid::update(CBaseEntity* entity) -> void
+{
+    if (entity == nullptr)
+    {
+        return;
+    }
+
+    const auto newKey = cellKeyFor(entity->loc.p);
+    const auto it     = entityCells_.find(entity);
+    if (it == entityCells_.end())
+    {
+        // Not tracked yet (e.g. moved before the first resync) - file it now.
+        cells_[newKey].push_back(entity);
+        entityCells_.emplace(entity, newKey);
+        ++size_;
+        return;
+    }
+
+    if (it->second == newKey)
+    {
+        // still in the same cell
+        return;
+    }
+
+    removeFromCell(entity, it->second);
+    cells_[newKey].push_back(entity);
+    it->second = newKey;
+}
+
+auto SpatialGrid::remove(CBaseEntity* entity) -> void
+{
+    if (entity == nullptr)
+    {
+        return;
+    }
+
+    const auto it = entityCells_.find(entity);
+    if (it == entityCells_.end())
+    {
+        return;
+    }
+
+    removeFromCell(entity, it->second);
+    entityCells_.erase(it);
+    --size_;
+}
+
+auto SpatialGrid::size() const -> std::size_t
+{
+    return size_;
+}
+
+auto SpatialGrid::cellCount() const -> std::size_t
+{
+    return cells_.size();
+}
+
+auto SpatialGrid::cellKeyFor(const position_t& p) const -> CellKey
+{
+    return packKey(cellCoord(p.x), cellCoord(p.z));
+}

--- a/src/map/spatial_grid.h
+++ b/src/map/spatial_grid.h
@@ -1,0 +1,113 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+#include <common/mmo.h>
+#include <common/types/flat_hash_map.h>
+
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+class CBaseEntity;
+
+// Uniform 2D (x/z) grid over a zone's entities. Cell size is the proximity radius, so a "within R"
+// query touches a fixed 3x3 block of cells. The grid only narrows the candidate set - callers keep
+// their own precise distance/vertical/status filters, so results match a full scan.
+//
+// Maintained incrementally: add() on enter, remove() on leave, update() on move (re-files only when
+// the cell changes), so it stays current between ticks for consumers called at arbitrary times. A
+// per-tick clear()+re-add resync is a cheap safety net for repositions that bypass the move hook.
+class SpatialGrid
+{
+public:
+    using CellKey = uint64;
+    using Bucket  = std::vector<CBaseEntity*>;
+
+    // cellSize defaults to the proximity radius (ENTITY_RENDER_DISTANCE), making a "within R" query a
+    // 3x3 block. Smaller cells stay correct (forEachInRange widens the block via ceil(radius/cellSize))
+    // but trade fewer over-fetched candidates for more cell lookups; measure before changing it.
+    // TODO: confirm the client's real max draw distance (~30?) and track it here and in ENTITY_RENDER_DISTANCE.
+    explicit SpatialGrid(float cellSize = 50.0f);
+
+    auto clear() -> void;                     // empty buckets (keep capacity) and reset tracking
+    auto add(CBaseEntity* entity) -> void;    // file at its current loc.p (non-owning)
+    auto update(CBaseEntity* entity) -> void; // re-file if it crossed a cell; files it if untracked
+    auto remove(CBaseEntity* entity) -> void; // pull from the grid (safe if absent)
+
+    // Visit every entity in a cell within `radius` of `center` (2D x/z); caller applies precise filters.
+    template <typename Func>
+    auto forEachInRange(const position_t& center, float radius, Func&& fn) const -> void;
+
+    [[nodiscard]] auto size() const -> std::size_t;
+    [[nodiscard]] auto cellCount() const -> std::size_t;
+    [[nodiscard]] auto cellKeyFor(const position_t& p) const -> CellKey;
+
+private:
+    [[nodiscard]] auto        cellCoord(float v) const -> int32;
+    [[nodiscard]] static auto packKey(int32 cx, int32 cz) -> CellKey;
+    // pull from a cell's bucket (swap-with-last)
+
+    auto removeFromCell(CBaseEntity* entity, CellKey key) -> void;
+
+    float                              cellSize_;
+    FlatHashMap<CellKey, Bucket>       cells_;
+    FlatHashMap<CBaseEntity*, CellKey> entityCells_; // where each entity is currently filed
+    std::size_t                        size_ = 0;
+};
+
+//
+// Template impls
+//
+
+template <typename Func>
+auto SpatialGrid::forEachInRange(const position_t& center, const float radius, Func&& fn) const -> void
+{
+    const auto span = static_cast<int32>(std::ceil(radius / cellSize_));
+    const auto ccx  = cellCoord(center.x);
+    const auto ccz  = cellCoord(center.z);
+
+    for (int32 dx = -span; dx <= span; ++dx)
+    {
+        for (int32 dz = -span; dz <= span; ++dz)
+        {
+            if (const auto it = cells_.find(packKey(ccx + dx, ccz + dz)); it != cells_.end())
+            {
+                for (const auto entity : it->second)
+                {
+                    fn(entity);
+                }
+            }
+        }
+    }
+}
+
+inline auto SpatialGrid::cellCoord(const float v) const -> int32
+{
+    return static_cast<int32>(std::floor(v / cellSize_));
+}
+
+inline auto SpatialGrid::packKey(const int32 cx, const int32 cz) -> CellKey
+{
+    return (static_cast<CellKey>(static_cast<uint32>(cx)) << 32) | static_cast<uint32>(cz);
+}

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -631,6 +631,11 @@ void CZone::FindPartyForMob(CBaseEntity* PEntity)
     m_zoneEntities->FindPartyForMob(PEntity);
 }
 
+void CZone::onEntityMoved(CBaseEntity* PEntity)
+{
+    m_zoneEntities->onEntityMoved(PEntity);
+}
+
 void CZone::TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId)
 {
     m_zoneEntities->TransportDepart(boundary, prevZoneId, transportId);

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -26,6 +26,7 @@
 #include <common/mmo.h>
 #include <common/scheduler.h>
 #include <common/timer.h>
+#include <common/types/flat_hash_map.h>
 #include <common/types/maybe.h>
 #include <common/vana_time.h>
 
@@ -551,7 +552,7 @@ typedef std::list<std::unique_ptr<ITriggerArea>> triggerAreaList_t;
 
 typedef std::list<zoneLine_t*> zoneLineList_t;
 
-typedef std::map<uint16, CBaseEntity*> EntityList_t;
+typedef FlatHashMap<uint16, CBaseEntity*> EntityList_t;
 
 using QueryByNameResult_t = std::vector<CBaseEntity*>;
 

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -628,6 +628,10 @@ public:
 
     virtual void FindPartyForMob(CBaseEntity* PEntity);
 
+    // Keep the underlying spatial grid current when an entity moves outside the per-tick resync
+    // (teleport, setPos, a movement step, etc.).
+    virtual void onEntityMoved(CBaseEntity* PEntity);
+
     virtual void TransportDepart(uint16 boundary, uint16 prevZoneId, uint16 transportId); // Collect passengers if ship/boat is departing
 
     virtual void updateCharLevelRestriction(CCharEntity* PChar); // Removes the character's level restriction. If the zone has a level restriction, it is applied after it is removed.

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -773,7 +773,7 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
         {
             if (!isInSpawnList)
             {
-                spawnList.insert(itr, SpawnIDList_t::value_type(id, PCurrentMob));
+                spawnList.emplace(id, PCurrentMob);
                 PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
         };
@@ -855,7 +855,7 @@ void CZoneEntities::SpawnPETs(CCharEntity* PChar)
         {
             if (!isInSpawnList)
             {
-                spawnList.insert(itr, SpawnIDList_t::value_type(id, PCurrentEntity));
+                spawnList.emplace(id, PCurrentEntity);
                 PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
         };
@@ -904,7 +904,7 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
 
             if (want && !inSpawnSet)
             {
-                spawnList.insert(itr, SpawnIDList_t::value_type(PEntity->id, PEntity));
+                spawnList.emplace(PEntity->id, PEntity);
                 PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
             else if (!want && inSpawnSet)
@@ -963,7 +963,7 @@ void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
         {
             if (!isInSpawnList)
             {
-                spawnList.insert(itr, SpawnIDList_t::value_type(id, PCurrentEntity));
+                spawnList.emplace(id, PCurrentEntity);
                 PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
             }
         };
@@ -1508,8 +1508,7 @@ void CZoneEntities::PushPacket(CBaseEntity* PEntity, GLOBAL_MESSAGE_TYPE message
 
                                 auto pushPacketIfInSpawnList = [&](CCharEntity* PChar, SpawnIDList_t const& spawnlist)
                                 {
-                                    auto iter = spawnlist.lower_bound(id);
-                                    if (iter != spawnlist.end() && !spawnlist.key_comp()(id, iter->first))
+                                    if (spawnlist.find(id) != spawnlist.end())
                                     {
                                         PChar->pushPacket(packet->copy());
                                     }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -755,6 +755,36 @@ void CZoneEntities::DespawnPC(CCharEntity* PChar)
     }
 }
 
+void CZoneEntities::tapMobAggro(CCharEntity* PChar, CMobEntity* PCurrentMob)
+{
+    // Check to skip aggro routine
+    if (PCurrentMob->isDead() || PChar->isDead() || PChar->visibleGmLevel >= 3 || PCurrentMob->PMaster)
+    {
+        return;
+    }
+
+    // checking monsters night/daytime sleep is already taken into account in the CurrentAction check, because monsters don't move in their sleep
+    const EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PCurrentMob);
+
+    CMobController* PController = static_cast<CMobController*>(PCurrentMob->PAI->GetController());
+
+    // Check if this mob follows targets and if so then it should not aggro
+    if (PCurrentMob->m_roamFlags & ROAMFLAG_FOLLOW)
+    {
+        if (PController->CanFollowTarget(PChar))
+        {
+            PController->SetFollowTarget(PChar, FollowType::Roam);
+        }
+        return;
+    }
+
+    bool validAggro = mobCheck > EMobDifficulty::TooWeak || PChar->isSitting() || PCurrentMob->getMobMod(MOBMOD_ALWAYS_AGGRO);
+    if (validAggro && PController->CanAggroTarget(PChar))
+    {
+        PCurrentMob->PAI->Engage(PChar->targid);
+    }
+}
+
 void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
 {
     TracyZoneScoped;
@@ -788,43 +818,13 @@ void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
             }
         };
 
-        const auto tapAggro = [&]()
-        {
-            // Check to skip aggro routine
-            if (PCurrentMob->isDead() || PChar->isDead() || PChar->visibleGmLevel >= 3 || PCurrentMob->PMaster)
-            {
-                return;
-            }
-
-            // checking monsters night/daytime sleep is already taken into account in the CurrentAction check, because monsters don't move in their sleep
-            const EMobDifficulty mobCheck = charutils::CheckMob(PChar->GetMLevel(), PCurrentMob);
-
-            CMobController* PController = static_cast<CMobController*>(PCurrentMob->PAI->GetController());
-
-            // Check if this mob follows targets and if so then it should not aggro
-            if (PCurrentMob->m_roamFlags & ROAMFLAG_FOLLOW)
-            {
-                if (PController->CanFollowTarget(PChar))
-                {
-                    PController->SetFollowTarget(PChar, FollowType::Roam);
-                }
-                return;
-            }
-
-            bool validAggro = mobCheck > EMobDifficulty::TooWeak || PChar->isSitting() || PCurrentMob->getMobMod(MOBMOD_ALWAYS_AGGRO);
-            if (validAggro && PController->CanAggroTarget(PChar))
-            {
-                PCurrentMob->PAI->Engage(PChar->targid);
-            }
-        };
-
         // Is this mob "visible" to the player?
         if (isVisibleStatus && isInHeightRange && isInRange)
         {
             tryAddToSpawnList();
 
             // TODO: Can/should this aggro routine be moved out of here and into the entity's first tick/spawn?
-            tapAggro();
+            tapMobAggro(PChar, PCurrentMob);
         }
         else
         {

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -100,6 +100,7 @@ CZoneEntities::CZoneEntities(Scheduler& scheduler, MapConfig config, CZone* zone
     m_trustsToDelete.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
     m_aggroableMobs.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
     m_charsToChangeZone.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
+    tickEntityScratch_.reserve(1024);
 }
 
 CZoneEntities::~CZoneEntities()
@@ -1849,92 +1850,89 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
 
     luautils::OnZoneTick(this->m_zone);
 
-    co_await Scheduler::TaskGroup(
-        m_mobList.size(),
-        [&](auto& add)
+    // Snapshot each list, then tick inline.
+    tickEntityScratch_.clear();
+    FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PMob, m_mobList)
+    {
+        if (!PMob || (PMob->PBattlefield && PMob->PBattlefield->CanCleanup()))
         {
-            FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PMob, m_mobList)
-            {
-                if (!PMob)
-                {
-                    continue;
-                }
+            continue;
+        }
 
-                if (PMob->PBattlefield && PMob->PBattlefield->CanCleanup())
-                {
-                    continue;
-                }
+        tickEntityScratch_.push_back(PMob);
+    }
 
-                add(mobTick(PMob, tick));
-            }
-        });
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await mobTick(static_cast<CMobEntity*>(PEntity), tick);
+    }
 
-    co_await Scheduler::TaskGroup(
-        m_aggroableMobs.size(),
-        [&](auto& add)
-        {
-            // Check to see if any aggroable mobs should be aggroed by other mobs
-            for (const auto& PMob : m_aggroableMobs)
-            {
-                add(mobAggroCheck(PMob, tick));
-            }
-        });
+    // Check to see if any aggroable mobs should be aggroed by other mobs (snapshot then run inline).
+    tickEntityScratch_.assign(m_aggroableMobs.begin(), m_aggroableMobs.end());
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await mobAggroCheck(static_cast<CMobEntity*>(PEntity), tick);
+    }
 
     //
     // NPC tick logic
     //
 
-    co_await Scheduler::TaskGroup(
-        m_npcList.size(),
-        [&](auto& add)
-        {
-            FOR_EACH_PAIR_CAST_SECOND(CNpcEntity*, PNpc, m_npcList)
-            {
-                add(npcTick(PNpc, tick));
-            }
-        });
+    tickEntityScratch_.clear();
+    FOR_EACH_PAIR_CAST_SECOND(CNpcEntity*, PNpc, m_npcList)
+    {
+        tickEntityScratch_.push_back(PNpc);
+    }
+
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await npcTick(static_cast<CNpcEntity*>(PEntity), tick);
+    }
 
     //
     // Pet tick logic
     //
 
-    co_await Scheduler::TaskGroup(
-        m_petList.size(),
-        [&](auto& add)
-        {
-            FOR_EACH_PAIR_CAST_SECOND(CPetEntity*, PPet, m_petList)
-            {
-                add(petTick(PPet, tick));
-            }
-        });
+    tickEntityScratch_.clear();
+    FOR_EACH_PAIR_CAST_SECOND(CPetEntity*, PPet, m_petList)
+    {
+        tickEntityScratch_.push_back(PPet);
+    }
+
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await petTick(static_cast<CPetEntity*>(PEntity), tick);
+    }
 
     //
     // Trust tick logic
     //
 
-    co_await Scheduler::TaskGroup(
-        m_trustList.size(),
-        [&](auto& add)
-        {
-            FOR_EACH_PAIR_CAST_SECOND(CTrustEntity*, PTrust, m_trustList)
-            {
-                add(trustTick(PTrust, tick));
-            }
-        });
+    tickEntityScratch_.clear();
+    FOR_EACH_PAIR_CAST_SECOND(CTrustEntity*, PTrust, m_trustList)
+    {
+        tickEntityScratch_.push_back(PTrust);
+    }
+
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await trustTick(static_cast<CTrustEntity*>(PEntity), tick);
+    }
 
     //
     // Char tick logic
     //
 
-    co_await Scheduler::TaskGroup(
-        m_charList.size(),
-        [&](auto& add)
-        {
-            FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PChar, m_charList)
-            {
-                add(charTick(PChar, tick));
-            }
-        });
+    tickEntityScratch_.clear();
+    FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PChar, m_charList)
+    {
+        tickEntityScratch_.push_back(PChar);
+    }
+
+    for (auto* PEntity : tickEntityScratch_)
+    {
+        co_await charTick(static_cast<CCharEntity*>(PEntity), tick);
+    }
 
     //
     // Cleanup logic

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -100,6 +100,7 @@ CZoneEntities::CZoneEntities(Scheduler& scheduler, MapConfig config, CZone* zone
     m_trustsToDelete.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
     m_aggroableMobs.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
     m_charsToChangeZone.reserve(INTERMEDIATE_CONTAINER_RESERVE_SIZE);
+    idsToRemoveScratch_.reserve(64);
     tickEntityScratch_.reserve(1024);
 }
 
@@ -153,6 +154,9 @@ void CZoneEntities::HealAllMobs()
 void CZoneEntities::TryAddToNearbySpawnLists(CBaseEntity* PEntity)
 {
     TracyZoneScoped;
+
+    // File the newly-inserted entity into the event-driven grid so later proximity queries see it.
+    spatialGrid_.update(PEntity);
 
     FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PCurrentChar, m_charList)
     {
@@ -580,6 +584,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
         fishingutils::InterruptFishing(PChar);
     }
 
+    onEntityDespawned(PChar);
     m_charList.erase(PChar->targid);
     m_charTargIds.erase(PChar->targid);
 
@@ -755,6 +760,59 @@ void CZoneEntities::DespawnPC(CCharEntity* PChar)
     }
 }
 
+void CZoneEntities::onEntityMoved(CBaseEntity* PEntity)
+{
+    if (PEntity != nullptr)
+    {
+        spatialGrid_.update(PEntity);
+    }
+}
+
+void CZoneEntities::onEntityDespawned(CBaseEntity* PEntity)
+{
+    if (PEntity != nullptr)
+    {
+        spatialGrid_.remove(PEntity);
+    }
+}
+
+void CZoneEntities::rebuildSpatialGrid()
+{
+    TracyZoneScoped;
+
+    // Full resync: a cheap O(N) safety net against any missed incremental hook. The grid is kept
+    // current between ticks by add()/update()/remove() on insert/move/despawn (see TryAddToNearby-
+    // SpawnLists, CZoneEntities::onEntityMoved, and the despawn paths); this catches repositions
+    // that write loc.p without the hook (draw-in/event-end/teleports).
+    //
+    // TODO: If we're extremely careful, we can make this whole system entirely event-based and
+    //     : never have to do full rebuilds. For now, full rebuilds at the start of each tick
+    //     : are incredibly cheap for the benefits they provide.
+
+    spatialGrid_.clear();
+    alwaysRelevantNpcs_.clear();
+
+    for (const EntityList_t* list : { &m_mobList, &m_petList, &m_trustList, &m_charList, &m_allyList, &m_TransportList })
+    {
+        for (const auto& [_, entity] : *list)
+        {
+            spatialGrid_.add(entity);
+        }
+    }
+
+    // NPCs file into the grid like everything else, and we collect the alwaysRelevant ones here (in
+    // the loop we already pay) so SpawnNPCs can spawn them regardless of range - a 3x3 cell query
+    // can't find an NPC that's relevant from across the zone.
+    for (const auto& [_, entity] : m_npcList)
+    {
+        spatialGrid_.add(entity);
+        if (static_cast<CNpcEntity*>(entity)->alwaysRelevant())
+        {
+            alwaysRelevantNpcs_.push_back(entity);
+        }
+    }
+}
+
 void CZoneEntities::tapMobAggro(CCharEntity* PChar, CMobEntity* PCurrentMob)
 {
     // Check to skip aggro routine
@@ -785,100 +843,99 @@ void CZoneEntities::tapMobAggro(CCharEntity* PChar, CMobEntity* PCurrentMob)
     }
 }
 
+void CZoneEntities::syncSpawnListWithGrid(CCharEntity*                     PChar,
+                                          SpawnIDList_t&                   spawnList,
+                                          uint8                            objtype,
+                                          uint8                            spawnFlag,
+                                          const EntityFn&                  visible,
+                                          const EntityCallback&            onAdd,
+                                          const std::vector<CBaseEntity*>* alwaysInclude)
+{
+    // Remove pass: anything currently shown that is no longer visible.
+    idsToRemoveScratch_.clear();
+    for (const auto& [id, entity] : spawnList)
+    {
+        if (!visible(entity))
+        {
+            idsToRemoveScratch_.push_back(id);
+        }
+    }
+
+    for (const auto id : idsToRemoveScratch_)
+    {
+        auto* entity = spawnList[id];
+        spawnList.erase(id);
+        PChar->updateEntityPacket(entity, ENTITY_DESPAWN, UPDATE_NONE);
+    }
+
+    // Add a single candidate if it's the right type, not already shown, and passes the precise filter.
+    const auto tryAdd = [&](CBaseEntity* entity)
+    {
+        if (entity->objtype != objtype || spawnList.find(entity->id) != spawnList.end() || !visible(entity))
+        {
+            return;
+        }
+
+        spawnList[entity->id] = entity;
+
+        PChar->updateEntityPacket(entity, ENTITY_SPAWN, spawnFlag);
+
+        if (onAdd)
+        {
+            onAdd(entity);
+        }
+    };
+
+    // Add pass: in-range candidates from a 3x3 cell query, then any always-relevant entities the
+    // range query can't reach (run through the same filter, so they're added only when appropriate).
+    spatialGrid_.forEachInRange(PChar->loc.p, ENTITY_RENDER_DISTANCE, tryAdd);
+
+    if (alwaysInclude != nullptr)
+    {
+        for (CBaseEntity* entity : *alwaysInclude)
+        {
+            tryAdd(entity);
+        }
+    }
+}
+
 void CZoneEntities::SpawnMOBs(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PCurrentMob, m_mobList)
-    {
-        auto& spawnList = PChar->SpawnMOBList;
-
-        const auto id              = PCurrentMob->id;
-        const auto itr             = spawnList.find(id);
-        const auto isInSpawnList   = itr != spawnList.end();
-        const auto isInHeightRange = isWithinVerticalDistance(PChar, PCurrentMob);
-        const auto isInRange       = isWithinDistance(PChar->loc.p, PCurrentMob->loc.p, ENTITY_RENDER_DISTANCE);
-        const auto isVisibleStatus = PCurrentMob->status != STATUS_TYPE::DISAPPEAR;
-
-        const auto tryAddToSpawnList = [&]()
+    syncSpawnListWithGrid(
+        PChar,
+        PChar->SpawnMOBList,
+        TYPE_MOB,
+        UPDATE_ALL_MOB,
+        /*Fn: visible*/ [&](CBaseEntity* entity)
         {
-            if (!isInSpawnList)
-            {
-                spawnList.emplace(id, PCurrentMob);
-                PChar->updateEntityPacket(PCurrentMob, ENTITY_SPAWN, UPDATE_ALL_MOB);
-            }
-        };
-
-        const auto tryRemoveFromSpawnList = [&]()
+            return entity->status != STATUS_TYPE::DISAPPEAR &&
+                   isWithinVerticalDistance(PChar, entity) &&
+                   isWithinDistance(PChar->loc.p, entity->loc.p, ENTITY_RENDER_DISTANCE);
+        },
+        /*Fn: onAdd*/ [&](CBaseEntity* entity)
         {
-            if (isInSpawnList)
-            {
-                spawnList.erase(itr);
-                PChar->updateEntityPacket(PCurrentMob, ENTITY_DESPAWN, UPDATE_NONE);
-            }
-        };
-
-        // Is this mob "visible" to the player?
-        if (isVisibleStatus && isInHeightRange && isInRange)
-        {
-            tryAddToSpawnList();
-
             // TODO: Can/should this aggro routine be moved out of here and into the entity's first tick/spawn?
-            tapMobAggro(PChar, PCurrentMob);
-        }
-        else
-        {
-            tryRemoveFromSpawnList();
-        }
-    }
+            tapMobAggro(PChar, static_cast<CMobEntity*>(entity));
+        });
 }
 
 void CZoneEntities::SpawnPETs(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    // TODO: Rather than iterating every entity in the zone, we should be doing
-    //     : spatial partitioning to only check entities within a certain range of the player.
-    //     : This would change this loop to look like:
-    //     : Compare previous and current spatial partitioning results to determine which entities to add/remove from the spawn list.
-    for (const auto& [_, PCurrentEntity] : m_petList)
-    {
-        auto& spawnList = PChar->SpawnPETList;
-
-        const auto id              = PCurrentEntity->id;
-        const auto itr             = spawnList.find(id);
-        const auto isInSpawnList   = itr != spawnList.end();
-        const auto isInHeightRange = isWithinVerticalDistance(PChar, PCurrentEntity);
-        const auto isInRange       = isWithinDistance(PChar->loc.p, PCurrentEntity->loc.p, ENTITY_RENDER_DISTANCE);
-        const auto isVisibleStatus = PCurrentEntity->status == STATUS_TYPE::NORMAL || PCurrentEntity->status == STATUS_TYPE::UPDATE;
-
-        const auto tryAddToSpawnList = [&]()
+    syncSpawnListWithGrid(
+        PChar,
+        PChar->SpawnPETList,
+        TYPE_PET,
+        UPDATE_ALL_MOB,
+        /*Fn: visible*/ [&](CBaseEntity* entity)
         {
-            if (!isInSpawnList)
-            {
-                spawnList.emplace(id, PCurrentEntity);
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
-            }
-        };
-
-        const auto tryRemoveFromSpawnList = [&]()
-        {
-            if (isInSpawnList)
-            {
-                spawnList.erase(itr);
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_DESPAWN, UPDATE_NONE);
-            }
-        };
-
-        if (isVisibleStatus && isInHeightRange && isInRange)
-        {
-            tryAddToSpawnList();
-        }
-        else
-        {
-            tryRemoveFromSpawnList();
-        }
-    }
+            return (entity->status == STATUS_TYPE::NORMAL || entity->status == STATUS_TYPE::UPDATE) &&
+                   isWithinVerticalDistance(PChar, entity) &&
+                   isWithinDistance(PChar->loc.p, entity->loc.p, ENTITY_RENDER_DISTANCE);
+        });
 }
 
 void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
@@ -890,103 +947,48 @@ void CZoneEntities::SpawnNPCs(CCharEntity* PChar)
         return;
     }
 
-    // TODO: Rather than iterating every entity in the zone, we should be doing
-    //     : spatial partitioning to only check entities within a certain range of the player.
-    //     : This would change this loop to look like:
-    //     : Compare previous and current spatial partitioning results to determine which entities to add/remove from the spawn list.
-    const auto syncSpawn = [&](const EntityList_t& list, auto&& shouldBeSpawned)
-    {
-        auto& spawnList = PChar->SpawnNPCList;
-        for (const auto& [_, PEntity] : list)
+    // NPCs and transports are both objtype TYPE_NPC and share SpawnNPCList. One combined predicate
+    // covers their differing rules: a transport (ship model) spawns by proximity unless it's
+    // alwaysRelevant (those are driven by SpawnTransport/TransportTimer, not this proximity sync);
+    // a regular NPC spawns when in range OR alwaysRelevant. The alwaysRelevant NPCs - which a 3x3
+    // range query can't reach - are passed in via alwaysRelevantNpcs_ (collected each rebuild).
+    syncSpawnListWithGrid(
+        PChar,
+        PChar->SpawnNPCList,
+        TYPE_NPC,
+        UPDATE_ALL_MOB,
+        /*Fn: visible*/ [&](CBaseEntity* PEntity)
         {
-            const auto itr        = spawnList.find(PEntity->id);
-            const auto inSpawnSet = itr != spawnList.end();
-            const auto want       = shouldBeSpawned(PEntity);
-
-            if (want && !inSpawnSet)
+            if (PEntity->look.size == MODEL_SHIP)
             {
-                spawnList.emplace(PEntity->id, PEntity);
-                PChar->updateEntityPacket(PEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
+                return !static_cast<CNpcEntity*>(PEntity)->alwaysRelevant() &&
+                       isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
             }
-            else if (!want && inSpawnSet)
-            {
-                spawnList.erase(itr);
-                PChar->updateEntityPacket(PEntity, ENTITY_DESPAWN, UPDATE_NONE);
-            }
-        }
-    };
 
-    syncSpawn(
-        m_npcList,
-        [&](CBaseEntity* PEntity)
-        {
-            const auto inRange       = isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
-            const auto visibleStatus = PEntity->status == STATUS_TYPE::NORMAL || PEntity->status == STATUS_TYPE::UPDATE;
-            const auto alwaysRel     = PEntity->objtype == TYPE_NPC && static_cast<CNpcEntity*>(PEntity)->alwaysRelevant();
+            const bool visibleStatus = PEntity->status == STATUS_TYPE::NORMAL || PEntity->status == STATUS_TYPE::UPDATE;
+            const bool inRange       = isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
+            const bool alwaysRel     = static_cast<CNpcEntity*>(PEntity)->alwaysRelevant();
             return visibleStatus && (inRange || alwaysRel);
-        });
-
-    // Registered transports are broadcast at zone-in by SpawnTransport and driven by TransportTimer; everything else
-    // in m_TransportList is a static SubKind=4 prop that gets proximity-spawned regardless of status.
-    syncSpawn(
-        m_TransportList,
-        [&](CBaseEntity* PEntity)
-        {
-            if (static_cast<CNpcEntity*>(PEntity)->alwaysRelevant())
-            {
-                return false;
-            }
-
-            return isWithinDistance(PChar->loc.p, PEntity->loc.p, ENTITY_RENDER_DISTANCE);
-        });
+        },
+        /*Fn: onAdd (empty)*/ {},
+        &alwaysRelevantNpcs_);
 }
 
 void CZoneEntities::SpawnTRUSTs(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    // TODO: Rather than iterating every entity in the zone, we should be doing
-    //     : spatial partitioning to only check entities within a certain range of the player.
-    //     : This would change this loop to look like:
-    //     : Compare previous and current spatial partitioning results to determine which entities to add/remove from the spawn list.
-    for (const auto& [_, PCurrentEntity] : m_trustList)
-    {
-        auto& spawnList = PChar->SpawnTRUSTList;
-
-        const auto id              = PCurrentEntity->id;
-        const auto itr             = spawnList.find(id);
-        const auto isInSpawnList   = itr != spawnList.end();
-        const auto isInHeightRange = isWithinVerticalDistance(PChar, PCurrentEntity);
-        const auto isInRange       = isWithinDistance(PChar->loc.p, PCurrentEntity->loc.p, ENTITY_RENDER_DISTANCE);
-        const auto isVisibleStatus = PCurrentEntity->status == STATUS_TYPE::NORMAL || PCurrentEntity->status == STATUS_TYPE::UPDATE;
-
-        const auto tryAddToSpawnList = [&]()
+    syncSpawnListWithGrid(
+        PChar,
+        PChar->SpawnTRUSTList,
+        TYPE_TRUST,
+        UPDATE_ALL_MOB,
+        /*Fn: visible*/ [&](CBaseEntity* entity)
         {
-            if (!isInSpawnList)
-            {
-                spawnList.emplace(id, PCurrentEntity);
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_SPAWN, UPDATE_ALL_MOB);
-            }
-        };
-
-        const auto tryRemoveFromSpawnList = [&]()
-        {
-            if (isInSpawnList)
-            {
-                spawnList.erase(itr);
-                PChar->updateEntityPacket(PCurrentEntity, ENTITY_DESPAWN, UPDATE_NONE);
-            }
-        };
-
-        if (isVisibleStatus && isInHeightRange && isInRange)
-        {
-            tryAddToSpawnList();
-        }
-        else
-        {
-            tryRemoveFromSpawnList();
-        }
-    }
+            return (entity->status == STATUS_TYPE::NORMAL || entity->status == STATUS_TYPE::UPDATE) &&
+                   isWithinVerticalDistance(PChar, entity) &&
+                   isWithinDistance(PChar->loc.p, entity->loc.p, ENTITY_RENDER_DISTANCE);
+        });
 }
 
 float getSignificanceScore(CCharEntity* originChar, CCharEntity* targetChar)
@@ -1095,19 +1097,19 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
     // Find candidates to spawn
     MinHeap<CharScorePair> candidateCharacters;
 
-    FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PCurrentChar, m_charList)
+    const auto considerCandidate = [&](CCharEntity* PCurrentChar)
     {
         if (PCurrentChar != nullptr && PChar != PCurrentChar && PChar->SpawnPCList.find(PCurrentChar->id) == PChar->SpawnPCList.end())
         {
             if (PCurrentChar->m_isGMHidden || PChar->m_moghouseID != PCurrentChar->m_moghouseID)
             {
-                continue;
+                return;
             }
 
             float charDistance = distance(PChar->loc.p, PCurrentChar->loc.p);
             if (charDistance > CHARACTER_SYNC_DISTANCE || !isWithinVerticalDistance(PChar, PCurrentChar))
             {
-                continue;
+                return;
             }
 
             float significanceScore = getSignificanceScore(PChar, PCurrentChar);
@@ -1129,7 +1131,19 @@ void CZoneEntities::SpawnPCs(CCharEntity* PChar)
                 }
             }
         }
-    }
+    };
+
+    // Only score players in the 3x3 cell block instead of every player in the zone.
+    spatialGrid_.forEachInRange(
+        PChar->loc.p,
+        CHARACTER_SYNC_DISTANCE,
+        [&](CBaseEntity* entity)
+        {
+            if (entity->objtype == TYPE_PC)
+            {
+                considerCandidate(static_cast<CCharEntity*>(entity));
+            }
+        });
 
     // Check if any of the candidates can/should be spawned
     if (!candidateCharacters.empty())
@@ -1404,6 +1418,31 @@ void CZoneEntities::UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, 
         {
             return;
         }
+    }
+
+    // Grid-accelerated recipient selection for the common ENTITY_UPDATE case: instead of scanning
+    // every player in the zone (O(P) per broadcast -> O(P^2)/tick), query the spatial hash for the
+    // players near the entity.
+    if (type == ENTITY_UPDATE && !alwaysInclude && spatialGrid_.size() > 0)
+    {
+        spatialGrid_.forEachInRange(
+            PEntity->loc.p,
+            ENTITY_RENDER_DISTANCE,
+            [&](CBaseEntity* candidate)
+            {
+                if (candidate->objtype != TYPE_PC || candidate == PEntity)
+                {
+                    return;
+                }
+
+                auto* PCurrentChar = static_cast<CCharEntity*>(candidate);
+                if (charutils::hasEntitySpawned(PCurrentChar, PEntity))
+                {
+                    PCurrentChar->updateEntityPacket(PEntity, type, updatemask);
+                }
+            });
+
+        return;
     }
 
     FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PCurrentChar, m_charList)
@@ -1686,8 +1725,7 @@ auto CZoneEntities::mobAggroCheck(CMobEntity* PMob, timer::time_point tick) -> T
 
     ShowTraceFmt("CZoneEntities::ZoneServer: Mob Aggro: {} ({})", PMob->getName(), PMob->id);
 
-    // TODO: We desperately need spatial hashing or something to reduce this cost
-    FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PCurrentMob, m_mobList)
+    const auto checkCandidate = [&](CMobEntity* PCurrentMob)
     {
         const auto isInHeightRange = isWithinVerticalDistance(PMob, PCurrentMob);
         const auto isInRange       = isWithinDistance(PMob->loc.p, PCurrentMob->loc.p, ENTITY_RENDER_DISTANCE);
@@ -1700,7 +1738,19 @@ auto CZoneEntities::mobAggroCheck(CMobEntity* PMob, timer::time_point tick) -> T
                 PCurrentMob->PAI->Engage(PMob->targid);
             }
         }
-    }
+    };
+
+    // Only visit mobs in the 3x3 cell block around PMob, instead of every mob in the zone.
+    spatialGrid_.forEachInRange(
+        PMob->loc.p,
+        ENTITY_RENDER_DISTANCE,
+        [&](CBaseEntity* entity)
+        {
+            if (entity->objtype == TYPE_MOB)
+            {
+                checkCandidate(static_cast<CMobEntity*>(entity));
+            }
+        });
 
     co_return;
 }
@@ -1850,6 +1900,8 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
 
     luautils::OnZoneTick(this->m_zone);
 
+    rebuildSpatialGrid();
+
     // Snapshot each list, then tick inline.
     tickEntityScratch_.clear();
     FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PMob, m_mobList)
@@ -1942,6 +1994,7 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
     {
         if (auto itr = m_mobList.find(PMob->targid); itr != m_mobList.end())
         {
+            onEntityDespawned(itr->second);
             m_mobList.erase(itr);
             m_dynamicTargIdsToDelete.emplace_back(PMob->targid, timer::now());
             destroy(PMob);
@@ -1952,6 +2005,7 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
     {
         if (auto itr = m_npcList.find(PNpc->targid); itr != m_npcList.end())
         {
+            onEntityDespawned(itr->second);
             m_npcList.erase(itr);
             m_dynamicTargIdsToDelete.emplace_back(PNpc->targid, timer::now());
             destroy(PNpc);
@@ -1962,6 +2016,7 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
     {
         if (auto itr = m_petList.find(PPet->targid); itr != m_petList.end())
         {
+            onEntityDespawned(itr->second);
             m_petList.erase(itr);
             m_dynamicTargIdsToDelete.emplace_back(PPet->targid, timer::now());
             destroy(PPet);
@@ -1972,6 +2027,7 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
     {
         if (auto itr = m_trustList.find(PTrust->targid); itr != m_trustList.end())
         {
+            onEntityDespawned(itr->second);
             m_trustList.erase(itr);
             m_dynamicTargIdsToDelete.emplace_back(PTrust->targid, timer::now());
             destroy(PTrust);

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -111,6 +111,9 @@ private:
     auto trustTick(CTrustEntity* PTrust, timer::time_point tick) -> Task<void>;
     auto charTick(CCharEntity* PChar, timer::time_point tick) -> Task<void>;
 
+    // aggro check when a mob becomes visible
+    void tapMobAggro(CCharEntity* PChar, CMobEntity* PCurrentMob);
+
     Scheduler& scheduler_;
     MapConfig  config_;
 

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -33,8 +33,15 @@
 #include "entities/trust_entity.h"
 #include "enums/music_slot.h"
 
+#include "spatial_grid.h"
+
+#include <functional>
 #include <set>
 #include <vector>
+
+// Per-entity callbacks used by the spawn-sync helpers.
+using EntityFn       = std::function<bool(CBaseEntity*)>; // visibility predicate
+using EntityCallback = std::function<void(CBaseEntity*)>; // action run on a newly-spawned entity
 
 class CZoneEntities
 {
@@ -44,6 +51,9 @@ public:
 
     void HealAllMobs();
     void TryAddToNearbySpawnLists(CBaseEntity* PEntity);
+
+    void onEntityMoved(CBaseEntity* PEntity);
+    void onEntityDespawned(CBaseEntity* PEntity);
 
     CCharEntity* GetCharByName(const std::string& name); // finds the player if exists in zone
     CCharEntity* GetCharByID(uint32 id);
@@ -114,6 +124,16 @@ private:
     // aggro check when a mob becomes visible
     void tapMobAggro(CCharEntity* PChar, CMobEntity* PCurrentMob);
 
+    // clear and re-file every entity into the grid
+    void rebuildSpatialGrid();
+
+    // Sync one of a player's spawn lists against the proximity grid: drop now-invisible entries, then
+    // add in-range visible ones from a 3x3 cell query. `visible` carries the precise status/vertical/
+    // distance checks; `onAdd` runs per newly-added entity (mob aggro). `alwaysInclude` is an optional
+    // set of entities that must be considered regardless of range (NPCs flagged alwaysRelevant, which
+    // a range query can't find) - each is run through `visible` like any other candidate.
+    void syncSpawnListWithGrid(CCharEntity* PChar, SpawnIDList_t& spawnList, uint8 objtype, uint8 spawnFlag, const EntityFn& visible, const EntityCallback& onAdd = {}, const std::vector<CBaseEntity*>* alwaysInclude = nullptr);
+
     Scheduler& scheduler_;
     MapConfig  config_;
 
@@ -127,6 +147,10 @@ private:
     EntityList_t m_npcList;
     EntityList_t m_TransportList;
     EntityList_t m_charList;
+
+    SpatialGrid               spatialGrid_;        // proximity grid; rebuilt every tick (always on)
+    std::vector<uint32>       idsToRemoveScratch_; // reused scratch for grid spawn-list removals
+    std::vector<CBaseEntity*> alwaysRelevantNpcs_; // NPCs flagged alwaysRelevant; collected each rebuild, spawned regardless of range
 
     std::vector<CBaseEntity*> tickEntityScratch_; // reusable snapshot of an entity list for a per-entity tick phase
 

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -125,6 +125,8 @@ private:
     EntityList_t m_TransportList;
     EntityList_t m_charList;
 
+    std::vector<CBaseEntity*> tickEntityScratch_; // reusable snapshot of an entity list for a per-entity tick phase
+
     uint16           m_nextDynamicTargID; // The next dynamic targ ID to chosen -- SE rotates them forwards and skips entries that already exist.
     std::set<uint16> m_charTargIds;       // sorted set of targids for characters
     std::set<uint16> m_dynamicTargIds;    // sorted set of targids for dynamic entities


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I had some parts of this in my pathing PR, some lurking around in other un-published branches, etc.

This is probably best reviewed commit-by-commit, if you're interested.

For the lower-level changes like blowfish and "zlib", I had AI whip up exhaustive test benches to make sure they were bit-accurate, while still providing performance boosts.

I had some very horrible scripts to launch xi_map_tracy, xi_test_tracy, attach tracy-capture, do their things, extract to CSV, and feed into AI for scaling and comparisons. None of those were worth keeping, but they helped my workflow immensely.

**For the FlatHashMap:**
- It's faster and better on all fronts, but insertion/deletion invalidates all cached iterators into the container. Luckily for us, I refactored and removed any of those patterns YEARS ago, because that on-the-fly iterator tracking is scary.

**For the SpatialGrid: My test cases were combinations of:**
- Single player / Party of 6 / Alliance of 18 / 10x Alliances of 18
- Clumbed together in a zone / spread out evenly in a zone / clumped by group, but otherwise spread in a zone / spread across multiple zones
- Various A/B tests of each feature, sometimes in isolation, sometimes built on top of eachother

**Scheduler::TaskGroup:**
- Unfortunately for me, the overhead of setting up these parallel-ish groups and their associated gating was adding overhead that we never gained a benefit from. This added up to 4ms per tick, for zones with 700+ entities - substantial over time.

**A bunch of scratch buffer/packet reuse**
- We don't need to be allocating new stuff all the time.

A lot of my numbers are polluted by the overhead of my test benches, noise on my machine, etc. So I've asked Claude to gather everything up and be conservative about the reports:
<img width="352" height="238" alt="image" src="https://github.com/user-attachments/assets/128fd701-191c-444a-826e-8df826e424a4" />

<img width="675" height="400" alt="image" src="https://github.com/user-attachments/assets/a287f829-5393-445b-aff6-d083304dc311" />

What this means in real terms is probably a +10% improvement to the speed of our ticks at a base level, and a +50% improvement to tick performance in mob/player-heavy scenarios.

**The BIG DAWG for performance is still `mobTick(): "AI", pathing, LOS, etc.`**

EDIT: Updated numbers from the last 2 weeks of performance work (this PR included):
<img width="676" height="394" alt="image" src="https://github.com/user-attachments/assets/d618df7e-d47d-4ba3-b76f-f240aad044d9" />

