### PR TITLE
XiMesh: Speed up raycast with broad-phase culling

### DIFF
--- a/src/map/ximesh/ximesh.cpp
+++ b/src/map/ximesh/ximesh.cpp
@@ -19,7 +19,7 @@
 ===========================================================================
 */
 
-#include "ximesh.h"
+#include <map/ximesh/ximesh.h>
 
 #include <common/logging.h>
 #include <common/tracy.h>
@@ -36,6 +36,39 @@
 namespace
 {
 
+//
+// File-format layout
+//
+
+constexpr uint32 kBytesPerVertex   = 3 * sizeof(float);                                                    // x, y, z per vertex
+constexpr uint32 kBytesPerTriangle = 3 * sizeof(uint16);                                                   // 3 indices per triangle
+constexpr size_t kTransformBytes   = sizeof(MeshPlacement::rotation) + sizeof(MeshPlacement::translation); // 3x3 rotation + vec3 translation
+
+//
+// Grid
+//
+
+constexpr float  kCellSize         = 4.0f; // world units per grid cell
+constexpr uint32 kCullMinTriangles = 1;    // AABB broad-phase threshold
+
+//
+// zlib decompression
+//
+
+constexpr size_t kZlibChunkSize       = 32 * 1024;        // inflate buffer (32 KB)
+constexpr size_t kMaxDecompressedSize = 64 * 1024 * 1024; // hard cap (64 MB)
+
+//
+// Ray-cast tolerances
+//
+
+constexpr float kRayTriEpsilon   = 0.0000001f; // Moller-Trumbore parallel/degenerate cull
+constexpr float kParallelEpsilon = 1e-6f;      // ray has ~no horizontal component (grid DDA)
+constexpr float kZeroDirEpsilon  = 1e-8f;      // direction component ~0 (reciprocal clamp)
+constexpr float kLargeReciprocal = 1e30f;      // finite stand-in for 1/0 (large, but won't overflow when scaled)
+constexpr float kFloorEpsilon    = 0.01f;      // floor-height tolerance in query()
+constexpr float kAabbPad         = 0.1f;       // block-AABB padding for the broad-phase cull (yalms)
+
 template <typename T>
 auto readAt(const std::span<const uint8> buf, const uint32 offset) -> T
 {
@@ -49,15 +82,8 @@ auto readAt(const std::span<const uint8> buf, const uint32 offset) -> T
     return val;
 }
 
-constexpr uint32 BYTES_PER_VERTEX   = 3 * sizeof(float);  // x, y, z
-constexpr uint32 BYTES_PER_TRIANGLE = 3 * sizeof(uint16); // 3 indices
-constexpr float  CELL_SIZE          = 4.0f;               // world units per grid cell
-
 auto zlibDecompress(const std::vector<uint8>& rawData) -> std::vector<uint8>
 {
-    constexpr size_t CHUNK_SIZE            = 32 * 1024;        // 32 KB
-    constexpr size_t MAX_DECOMPRESSED_SIZE = 64 * 1024 * 1024; // 64 MB
-
     z_stream stream{};
     if (inflateInit(&stream) != Z_OK)
     {
@@ -69,7 +95,7 @@ auto zlibDecompress(const std::vector<uint8>& rawData) -> std::vector<uint8>
 
     std::vector<uint8> result;
     result.reserve(rawData.size() * 4);
-    std::array<uint8, CHUNK_SIZE> chunk{};
+    std::array<uint8, kZlibChunkSize> chunk{};
 
     int rc = Z_OK;
     while (rc != Z_STREAM_END)
@@ -87,7 +113,7 @@ auto zlibDecompress(const std::vector<uint8>& rawData) -> std::vector<uint8>
         const size_t bytesWritten = chunk.size() - stream.avail_out;
         result.insert(result.end(), chunk.data(), chunk.data() + bytesWritten);
 
-        if (result.size() > MAX_DECOMPRESSED_SIZE)
+        if (result.size() > kMaxDecompressedSize)
         {
             inflateEnd(&stream);
             return {};
@@ -132,17 +158,51 @@ auto vertexAt(const MeshBlock& block, const uint16 vertexIdx) -> Vector3
     return Vector3{ v[0], v[1], v[2] };
 }
 
-// Möller–Trumbore ray/triangle intersection.
-auto rayIntersectTriangle(const Vector3& v1, const Vector3& v2, const Vector3& v3, const Vector3& rayOrigin, const Vector3& rayVector) -> std::optional<Vector3>
+// Broad-phase slab test: does the object-space ray SEGMENT (origin o, direction reciprocal invD,
+// parameter t in [0, 1]) overlap the AABB [bmin, bmax]? `invD` is the componentwise reciprocal of the
+// segment vector, with near-zero axes clamped to a large finite value (avoids inf*0 = NaN). Used to
+// skip a whole block's triangles when the ray misses its bounds; never culls a real hit, since the
+// AABB encloses every triangle in the block.
+auto segmentHitsAABB(const Vector3& o, const Vector3& invD, const Vector3& bmin, const Vector3& bmax) -> bool
 {
-    constexpr float EPSILON = 0.0000001f;
+    const float tx1  = (bmin.x - o.x) * invD.x;
+    const float tx2  = (bmax.x - o.x) * invD.x;
+    float       tmin = std::min(tx1, tx2);
+    float       tmax = std::max(tx1, tx2);
 
+    const float ty1 = (bmin.y - o.y) * invD.y;
+    const float ty2 = (bmax.y - o.y) * invD.y;
+    tmin            = std::max(tmin, std::min(ty1, ty2));
+    tmax            = std::min(tmax, std::max(ty1, ty2));
+
+    const float tz1 = (bmin.z - o.z) * invD.z;
+    const float tz2 = (bmax.z - o.z) * invD.z;
+    tmin            = std::max(tmin, std::min(tz1, tz2));
+    tmax            = std::min(tmax, std::max(tz1, tz2));
+
+    return tmax >= std::max(tmin, 0.0f) && tmin <= 1.0f;
+}
+
+// Componentwise reciprocal of a segment vector for segmentHitsAABB; near-zero axes are clamped to a
+// large finite magnitude so the slab test stays NaN-free for axis-aligned rays.
+auto reciprocalDir(const Vector3& d) -> Vector3
+{
+    return Vector3{
+        std::abs(d.x) > kZeroDirEpsilon ? 1.0f / d.x : kLargeReciprocal,
+        std::abs(d.y) > kZeroDirEpsilon ? 1.0f / d.y : kLargeReciprocal,
+        std::abs(d.z) > kZeroDirEpsilon ? 1.0f / d.z : kLargeReciprocal,
+    };
+}
+
+// Moller-Trumbore ray/triangle intersection.
+auto rayIntersectTriangle(const Vector3& v1, const Vector3& v2, const Vector3& v3, const Vector3& rayOrigin, const Vector3& rayVector) -> Maybe<Vector3>
+{
     const auto edge1 = v2 - v1;
     const auto edge2 = v3 - v1;
     const auto h     = rayVector.crossProduct(edge2);
     const auto a     = edge1.dotProduct(h);
 
-    if (a > -EPSILON && a < EPSILON)
+    if (a > -kRayTriEpsilon && a < kRayTriEpsilon)
     {
         return std::nullopt;
     }
@@ -166,7 +226,7 @@ auto rayIntersectTriangle(const Vector3& v1, const Vector3& v2, const Vector3& v
 
     const auto t = f * edge2.dotProduct(q);
 
-    if (t > EPSILON && t <= 1.0f)
+    if (t > kRayTriEpsilon && t <= 1.0f)
     {
         return Vector3(rayOrigin + rayVector * t);
     }
@@ -265,8 +325,8 @@ auto XiMesh::load(const std::string& filename) -> bool
         const auto barrierFlag   = readAt<uint16>(buf, fileOffset + 4);
         block.hasBarriers        = barrierFlag > 0;
 
-        const uint32 vertexBytes = vertexCount * BYTES_PER_VERTEX;
-        const uint32 indexBytes  = triangleCount * BYTES_PER_TRIANGLE;
+        const uint32 vertexBytes = vertexCount * kBytesPerVertex;
+        const uint32 indexBytes  = triangleCount * kBytesPerTriangle;
         const uint32 metaBytes   = triangleCount; // 1 byte per triangle
 
         const uint32 vertexOffset = fileOffset + 8;
@@ -283,6 +343,28 @@ auto XiMesh::load(const std::string& filename) -> bool
 
         block.vertices.resize(vertexCount * 3);
         std::memcpy(block.vertices.data(), buf.data() + vertexOffset, vertexBytes);
+
+        // Local-space AABB for the ray broad-phase cull in rayIntersectCell.
+        if (vertexCount > 0)
+        {
+            Vector3 mn{ block.vertices[0], block.vertices[1], block.vertices[2] };
+            Vector3 mx = mn;
+            for (uint16 vi = 1; vi < vertexCount; ++vi)
+            {
+                const float* v = &block.vertices[vi * 3];
+                mn.x           = std::min(mn.x, v[0]);
+                mn.y           = std::min(mn.y, v[1]);
+                mn.z           = std::min(mn.z, v[2]);
+                mx.x           = std::max(mx.x, v[0]);
+                mx.y           = std::max(mx.y, v[1]);
+                mx.z           = std::max(mx.z, v[2]);
+            }
+
+            // Pad the bounds so the slab broad-phase never rejects a hit lying exactly on a face due to
+            // float rounding (a corner-grazing ray).
+            block.aabbMin = Vector3{ mn.x - kAabbPad, mn.y - kAabbPad, mn.z - kAabbPad };
+            block.aabbMax = Vector3{ mx.x + kAabbPad, mx.y + kAabbPad, mx.z + kAabbPad };
+        }
 
         block.indices.resize(triangleCount * 3);
         std::memcpy(block.indices.data(), buf.data() + indexOffset, indexBytes);
@@ -308,14 +390,13 @@ auto XiMesh::load(const std::string& filename) -> bool
             .roofed = flags.roofed != 0,
         };
 
-        constexpr size_t TRANSFORM_BYTES = sizeof(placement.rotation) + sizeof(placement.translation);
-        if (fileOffset + 4 + TRANSFORM_BYTES > buf.size())
+        if (fileOffset + 4 + kTransformBytes > buf.size())
         {
             ShowErrorFmt("XiMesh: Placement OOB at offset 0x{:X} (bufSize={})", fileOffset, buf.size());
             return std::nullopt;
         }
 
-        std::memcpy(placement.rotation.data(), buf.data() + fileOffset + 4, TRANSFORM_BYTES);
+        std::memcpy(placement.rotation.data(), buf.data() + fileOffset + 4, kTransformBytes);
 
         placements_.emplace_back(placement);
         return it->second;
@@ -409,8 +490,8 @@ auto XiMesh::load(const std::string& filename) -> bool
 auto XiMesh::worldToCell(const float x, const float z) const -> std::pair<int, int>
 {
     return {
-        static_cast<int>(std::floor(x / CELL_SIZE)) + header_.gridWidth / 2,
-        static_cast<int>(std::floor(z / CELL_SIZE)) + header_.gridHeight / 2,
+        static_cast<int>(std::floor(x / kCellSize)) + header_.gridWidth / 2,
+        static_cast<int>(std::floor(z / kCellSize)) + header_.gridHeight / 2,
     };
 }
 
@@ -438,13 +519,12 @@ auto XiMesh::query(const float x, const float y, const float z) const -> std::op
         std::optional<CellHit> best;
         for (uint16 ref = 0; ref < cell.count; ++ref)
         {
-            constexpr float EPSILON              = 0.01f;
             const auto& [blockIdx, placementIdx] = entries_[cell.offset + ref];
             const auto& block                    = blocks_[blockIdx];
             const auto& place                    = placements_[placementIdx];
 
             // Skip placements entirely above query point
-            if (place.yMax < y - EPSILON)
+            if (place.yMax < y - kFloorEpsilon)
             {
                 continue;
             }
@@ -466,7 +546,7 @@ auto XiMesh::query(const float x, const float y, const float z) const -> std::op
                 }
 
                 // Pick the closest triangle above the query point (Y is negative-up).
-                if (triY >= y - EPSILON && (!best || triY < best->y))
+                if (triY >= y - kFloorEpsilon && (!best || triY < best->y))
                 {
                     const auto& meta = block.metas[triIdx];
                     best             = CellHit{
@@ -601,27 +681,27 @@ auto XiMesh::rayIntersect(const Vector3& start, const Vector3& end, const Ignore
     const auto dx = end.x - start.x;
     const auto dz = end.z - start.z;
 
-    if (std::abs(dx) < 1e-6f && std::abs(dz) < 1e-6f)
+    if (std::abs(dx) < kParallelEpsilon && std::abs(dz) < kParallelEpsilon)
     {
         return false;
     }
 
     const auto stepCol = dx > 0 ? 1 : -1;
     const auto stepRow = dz > 0 ? 1 : -1;
-    const auto deltaX  = std::abs(dx) < 1e-6f ? std::numeric_limits<float>::infinity() : std::abs(CELL_SIZE / dx);
-    const auto deltaZ  = std::abs(dz) < 1e-6f ? std::numeric_limits<float>::infinity() : std::abs(CELL_SIZE / dz);
+    const auto deltaX  = std::abs(dx) < kParallelEpsilon ? std::numeric_limits<float>::infinity() : std::abs(kCellSize / dx);
+    const auto deltaZ  = std::abs(dz) < kParallelEpsilon ? std::numeric_limits<float>::infinity() : std::abs(kCellSize / dz);
 
     float nextX{};
     float nextZ{};
 
     if (dx > 0)
     {
-        const auto rightEdge = (col + 1) * CELL_SIZE - header_.gridWidth * (CELL_SIZE / 2.0f);
+        const auto rightEdge = (col + 1) * kCellSize - header_.gridWidth * (kCellSize / 2.0f);
         nextX                = (rightEdge - start.x) / dx;
     }
     else if (dx < 0)
     {
-        const auto leftEdge = col * CELL_SIZE - header_.gridWidth * (CELL_SIZE / 2.0f);
+        const auto leftEdge = col * kCellSize - header_.gridWidth * (kCellSize / 2.0f);
         nextX               = (leftEdge - start.x) / dx;
     }
     else
@@ -631,12 +711,12 @@ auto XiMesh::rayIntersect(const Vector3& start, const Vector3& end, const Ignore
 
     if (dz > 0)
     {
-        const auto bottomEdge = (row + 1) * CELL_SIZE - header_.gridHeight * (CELL_SIZE / 2.0f);
+        const auto bottomEdge = (row + 1) * kCellSize - header_.gridHeight * (kCellSize / 2.0f);
         nextZ                 = (bottomEdge - start.z) / dz;
     }
     else if (dz < 0)
     {
-        const auto topEdge = row * CELL_SIZE - header_.gridHeight * (CELL_SIZE / 2.0f);
+        const auto topEdge = row * kCellSize - header_.gridHeight * (kCellSize / 2.0f);
         nextZ              = (topEdge - start.z) / dz;
     }
     else
@@ -750,6 +830,7 @@ auto XiMesh::rayIntersectCell(const Vector3& start, const Vector3& end, const YR
     uint16  lastPlacementIdx = UINT16_MAX;
     Vector3 oStart{};
     Vector3 oDiff{};
+    Vector3 oInvDiff{};
     uint32  v1Off = 0;
     uint32  v3Off = 2;
 
@@ -780,12 +861,22 @@ auto XiMesh::rayIntersectCell(const Vector3& start, const Vector3& end, const YR
                 el[0][1] * worldDiff.x + el[1][1] * worldDiff.y + el[2][1] * worldDiff.z,
                 el[0][2] * worldDiff.x + el[1][2] * worldDiff.y + el[2][2] * worldDiff.z,
             };
+            oInvDiff        = reciprocalDir(oDiff);
             const auto flip = placementFlips_[placementIdx];
             v1Off           = flip ? 2u : 0u;
             v3Off           = flip ? 0u : 2u;
         }
 
         const auto triCount = block.metas.size();
+
+        // Broad-phase: skip the whole block when the object-space ray segment misses its bounds.
+        // Only worth the slab test for blocks with several triangles (cheap vs the narrow-phase, but
+        // not free for a 1-2 triangle block that the ray passes through anyway).
+        if (triCount > kCullMinTriangles && !segmentHitsAABB(oStart, oInvDiff, block.aabbMin, block.aabbMax))
+        {
+            continue;
+        }
+
         for (size_t triIdx = 0; triIdx < triCount; ++triIdx)
         {
             const auto base = triIdx * 3;
@@ -827,6 +918,7 @@ auto XiMesh::rayIntersectCellHitInfo(const Vector3& start, const Vector3& end, c
     uint16  lastPlacementIdx = UINT16_MAX;
     Vector3 oStart{};
     Vector3 oDiff{};
+    Vector3 oInvDiff{};
     uint32  v1Off = 0;
     uint32  v3Off = 2;
 
@@ -857,12 +949,22 @@ auto XiMesh::rayIntersectCellHitInfo(const Vector3& start, const Vector3& end, c
                 el[0][1] * worldDiff.x + el[1][1] * worldDiff.y + el[2][1] * worldDiff.z,
                 el[0][2] * worldDiff.x + el[1][2] * worldDiff.y + el[2][2] * worldDiff.z,
             };
+            oInvDiff        = reciprocalDir(oDiff);
             const auto flip = placementFlips_[placementIdx];
             v1Off           = flip ? 2u : 0u;
             v3Off           = flip ? 0u : 2u;
         }
 
         const auto triCount = block.metas.size();
+
+        // Broad-phase: skip the whole block when the object-space ray segment misses its bounds.
+        // Only worth the slab test for blocks with several triangles (cheap vs the narrow-phase, but
+        // not free for a 1-2 triangle block that the ray passes through anyway).
+        if (triCount > kCullMinTriangles && !segmentHitsAABB(oStart, oInvDiff, block.aabbMin, block.aabbMax))
+        {
+            continue;
+        }
+
         for (size_t triIdx = 0; triIdx < triCount; ++triIdx)
         {
             const auto base = triIdx * 3;

--- a/src/map/ximesh/ximesh_structs.h
+++ b/src/map/ximesh/ximesh_structs.h
@@ -107,6 +107,8 @@ struct MeshBlock
     std::vector<uint16>       indices;       // 3 per triangle
     std::vector<TriangleMeta> metas;         // 1 per triangle
     bool                      hasBarriers{}; // true if any triangle in this block is a barrier
+    Vector3                   aabbMin{};     // local-space bounds, for ray broad-phase culling
+    Vector3                   aabbMax{};     // local-space bounds, for ray broad-phase culling
 };
 
 struct MeshPlacement


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Speedups run from **x2.99 to x3.44** through my testing across multiple zones.

- Halvung behaviour remains the same
- General testing around corners in Dyna Bastok remains the same