### PR TITLE
[lua] [sql] Self-Destruct and Hypothermal Combustion adjustments

### DIFF
--- a/scripts/actions/mobskills/hypothermal_combustion.lua
+++ b/scripts/actions/mobskills/hypothermal_combustion.lua
@@ -18,12 +18,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = skill:getMobHP() / 3
-    params.fTP            = { 1, 1, 1 }
-    params.element        = xi.element.ICE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.ICE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.0, 1.0, 1.0 }
+    params.element            = xi.element.ICE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.ICE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/hypothermal_combustion_tzar.lua
+++ b/scripts/actions/mobskills/hypothermal_combustion_tzar.lua
@@ -15,12 +15,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = skill:getMobHP() / 3
-    params.fTP            = { 1.0, 1.0, 1.0 }
-    params.element        = xi.element.ICE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.ICE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.0, 1.0, 1.0 }
+    params.element            = xi.element.ICE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.ICE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_bomb.lua
+++ b/scripts/actions/mobskills/self-destruct_bomb.lua
@@ -14,12 +14,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     -- Self Destruct does use the player's HP to determine the max damage it can do.  This means a player at 100% hp has a 25% chance to die if full damage is taken, given the bomb has enough HP.
-    params.baseDamage     = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
-    params.fTP            = { 1.00, 1.00, 1.00 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.00, 1.00, 1.00 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_bomb_321.lua
+++ b/scripts/actions/mobskills/self-destruct_bomb_321.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = 9999 + mob:getHP()
-    params.fTP            = { 2.5, 2.5, 2.5 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.WIPE_SHADOWS
+    params.baseDamage         = 9999 + mob:getHP()
+    params.fTP                = { 2.5, 2.5, 2.5 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.WIPE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_bomb_big.lua
+++ b/scripts/actions/mobskills/self-destruct_bomb_big.lua
@@ -22,12 +22,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
-    params.fTP            = { 1.00, 1.00, 1.00 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.00, 1.00, 1.00 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_cluster_1_death.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_1_death.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
-    params.fTP            = { 1.00, 1.00, 1.00 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.00, 1.00, 1.00 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_cluster_2.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_2.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = skill:getMobHP()
-    params.fTP            = { 0.40, 0.40, 0.40 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = skill:getMobHP()
+    params.fTP                = { 0.50, 0.50, 0.50 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     if mob:getPool() == xi.mobPool.RAZON then
         params.baseDamage = mob:getMaxHP()

--- a/scripts/actions/mobskills/self-destruct_cluster_2_death.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_2_death.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
-    params.fTP            = { 1.00, 1.00, 1.00 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.00, 1.00, 1.00 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_cluster_3.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_3.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = skill:getMobHP()
-    params.fTP            = { 0.40, 0.40, 0.40 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = skill:getMobHP()
+    params.fTP                = { 0.33, 0.33, 0.33 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     if mob:getPool() == xi.mobPool.RAZON then
         params.baseDamage = mob:getMaxHP()

--- a/scripts/actions/mobskills/self-destruct_cluster_3_death.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_3_death.lua
@@ -14,12 +14,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
-    params.fTP            = { 1.00, 1.00, 1.00 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = math.min(target:getMaxHP() * math.random(0.7, 1.1), mob:getHP())
+    params.fTP                = { 1.00, 1.00, 1.00 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/self-destruct_cluster_razon.lua
+++ b/scripts/actions/mobskills/self-destruct_cluster_razon.lua
@@ -15,12 +15,13 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = skill:getMobHP()
-    params.fTP            = { 2.0, 2.0, 2.0 }
-    params.element        = xi.element.FIRE
-    params.attackType     = xi.attackType.BREATH
-    params.damageType     = xi.damageType.FIRE
-    params.shadowBehavior = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
+    params.baseDamage         = skill:getMobHP()
+    params.fTP                = { 2.0, 2.0, 2.0 }
+    params.element            = xi.element.FIRE
+    params.attackType         = xi.attackType.BREATH
+    params.damageType         = xi.damageType.FIRE
+    params.skipMagicBonusDiff = true
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
 
     local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
 

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -557,7 +557,7 @@ INSERT INTO `mob_skills` VALUES (525,269,'battery_charge',0,0.0,7.0,2000,1500,1,
 INSERT INTO `mob_skills` VALUES (526,875,'berserk',0,0.0,7.0,2000,1000,1,0,0,0,0,0,0); -- Snoll Berserk
 INSERT INTO `mob_skills` VALUES (527,876,'freeze_rush',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (528,877,'cold_wave',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (529,878,'hypothermal_combustion',1,0.0,10.0,2000,3600,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (529,878,'hypothermal_combustion',1,0.0,10.0,2000,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (530,900,'memento_mori',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (531,901,'silence_seal',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (532,902,'envoutement',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
@@ -600,10 +600,10 @@ INSERT INTO `mob_skills` VALUES (568,867,'formation_attack',0,0.0,7.0,2000,1500,
 INSERT INTO `mob_skills` VALUES (569,868,'refueling',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (570,869,'circle_of_flames',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (571,870,'self-destruct_cluster_3',1,0.0,10.0,2000,3000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (572,871,'self-destruct_cluster_3_death',1,0.0,10.0,2000,5000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (572,871,'self-destruct_cluster_3_death',1,0.0,10.0,2000,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (573,872,'self-destruct_cluster_2',1,0.0,10.0,2000,3000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (574,873,'self-destruct_cluster_2_death',1,0.0,10.0,2000,5000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (575,874,'self-destruct_cluster_1_death',1,0.0,10.0,2000,5000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (574,873,'self-destruct_cluster_2_death',1,0.0,10.0,2000,4000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (575,874,'self-destruct_cluster_1_death',1,0.0,10.0,2000,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (576,910,'back_heel',0,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
 INSERT INTO `mob_skills` VALUES (577,911,'jettatura',4,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (578,912,'nihility_song',1,0.0,12.5,2000,1500,4,0,0,0,0,0,0);
@@ -1672,7 +1672,7 @@ INSERT INTO `mob_skills` VALUES (1636,1132,'trebuchet',1,0.0,7.0,2000,1500,4,0,0
 -- INSERT INTO `mob_skills` VALUES (1641,23,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1642,1386,'whirl_of_rage',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1643,1387,'smite_of_rage',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1644,878,'hypothermal_combustion',1,0.0,20.0,2000,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1644,878,'hypothermal_combustion',1,0.0,20.0,2000,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1645,876,'freeze_rush',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1646,877,'cold_wave',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1647,1598,'berserk',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This adjusts Self-Destruct and Hypothermal Combustion to ignore MDB as Tanaka intended.  

It also adjusts Hypothermal Combustion to be the same as Self-Destruct.  
<img width="226" height="272" alt="image" src="https://github.com/user-attachments/assets/e78365b4-443c-4736-bf1c-92313842f8d1" />
<img width="711" height="204" alt="image" src="https://github.com/user-attachments/assets/c2660d50-8eae-4948-a511-04a47df34fb2" />
Because as it turns out, its literally the same thing but ice.

It can be seen in Siknoz's caps that Snoll Tzar Self-Destruct follows the same damage parameters.
https://youtu.be/VRDnzJZZv88?t=2144

This also adjusts the cluster self destructs of 1 clusters with 3 up and 2 up to be 50% and 33% of the mobs current hp respectively.

<img width="661" height="428" alt="image" src="https://github.com/user-attachments/assets/f49d1e69-124c-481c-bc2d-121a6b834969" />

<img width="638" height="524" alt="image" src="https://github.com/user-attachments/assets/0d0f5781-bbc7-4d32-8334-70274bd000e3" />


I tested this one multiple times.  The 2nd cluster explosion is stronger, and most assuredly is 50% of the mob's current HP.


Also, adjusts ready times:

[18:12:34][AView] Self-Destruct [MonSkill (F)]
Actor: 16896140 (Nitro Cluster), ID: 574, Animation: 873, Message: 185, Ready Time: 4170ms, Range: 5.22, Spread: 8.46

[14:26:22][AView] Self-Destruct [MonSkill (F)]
Actor: 16896141 (Nitro Cluster), ID: 572, Animation: 871, Message: 185, Ready Time: 4171ms, Range: 9.21, Spread: 7.30

[15:48:17][AView] Self-Destruct [MonSkill (F)]
Actor: 16896140 (Nitro Cluster), ID: 575, Animation: 874, Message: 185, Ready Time: 4187ms, Range: 4.41, Spread: 6.04

[17:29:49][AView] Hypothermal Combustion [MonSkill (F)]
Actor: 16797928 (Agloolik), ID: 529, Animation: 878, Message: 185, Ready Time: 4070ms, Range: 7.82, Spread: 8.42

Who knows if Snoll Tzar is the same, its currently set to 5000.

## Steps to test these changes

Get blown up.
