### PR TITLE
Core: Refactor use of AI::StateStack

### DIFF
--- a/scripts/tests/systems/combat/interrupt.lua
+++ b/scripts/tests/systems/combat/interrupt.lua
@@ -1,0 +1,130 @@
+-- Coverage for prevent-action interrupts of a casting entity.
+--
+-- Original bug (UAF -> crash): a sleep landing while an entity resolved its own cast
+-- tore the running CMagicState out from under its own DoUpdate -> heap-use-after-free.
+--
+-- A MAGIC_USE listener fires only when a cast actually completes, so it's a reliable
+-- "did the spell go off?" signal.
+
+describe('Action interrupts', function()
+    -- CLuaBaseEntity::getCurrentAction() values
+    local actionMagicCasting = 30
+    local actionSleep        = 27 -- inactive due to a prevent-action effect
+
+    ---@type CClientEntityPair
+    local caster
+
+    ---@type CTestEntity
+    local target
+
+    before_each(function()
+        caster = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE, job = xi.job.BLM, level = 99 })
+        target = caster.entities:moveTo('Wild_Rabbit')
+        target:respawn() -- reset to full HP/alive; a prior test's cast may have killed it
+        local pos = caster:getPos()
+        target:setPos(pos.x, pos.y, pos.z)
+        caster:addSpell(xi.magic.spell.STONE)
+    end)
+
+    -- Advance enough for a cast to finish and the (completed or interrupted) magic state
+    -- to retire and the entity to settle into its next state.
+    local function settle()
+        for _ = 1, 5 do
+            xi.test.world:skipTime(3)
+        end
+    end
+
+    it('completes a cast normally when nothing prevents it', function()
+        caster:addStatusEffect(xi.effect.CHAINSPELL, { power = 0, duration = 60, origin = caster })
+
+        local completed = false
+        caster:addListener('MAGIC_USE', 'TEST_USE', function()
+            completed = true
+        end)
+
+        caster.actions:useSpell(target, xi.magic.spell.STONE)
+        settle()
+
+        caster:removeListener('TEST_USE')
+
+        assert(completed, 'cast should complete')
+        assert(caster:getCurrentAction() ~= actionSleep, 'caster should not be inactive')
+    end)
+
+    it('does not crash when slept during its own cast resolution; the cast still completes', function()
+        caster:addStatusEffect(xi.effect.CHAINSPELL, { power = 0, duration = 60, origin = caster })
+
+        local completed = false
+        caster:addListener('MAGIC_USE', 'TEST_USE', function()
+            completed = true
+        end)
+
+        target:addListener('MAGIC_TAKE', 'TEST_SLEEP', function(_, magicCaster)
+            magicCaster:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = 60, origin = magicCaster })
+        end)
+
+        caster.actions:useSpell(target, xi.magic.spell.STONE)
+        settle()
+
+        caster:removeListener('TEST_USE')
+        target:removeListener('TEST_SLEEP')
+
+        assert(completed, 'cast should complete (the sleep lands at the finish, after the check)')
+        assert(caster:hasStatusEffect(xi.effect.SLEEP_I), 'caster should be asleep')
+        assert(caster:getCurrentAction() == actionSleep, 'caster should be parked inactive afterward')
+    end)
+
+    it('does not cancel a cast mid-flight; it interrupts at the finish', function()
+        local completed = false
+        caster:addListener('MAGIC_USE', 'TEST_USE', function()
+            completed = true
+        end)
+
+        caster.actions:useSpell(target, xi.magic.spell.STONE)
+
+        -- Land the sleep while the (non-instant) cast is still in progress.
+        caster:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = 60, origin = caster })
+
+        -- One partial tick: the cast must still be running -- the sleep does not cancel it.
+        xi.test.world:tickEntity(caster)
+        assert(caster:getCurrentAction() == actionMagicCasting, 'sleep must not cancel a cast mid-flight')
+
+        -- Now let it reach its finish, where the prevent-action effect interrupts it.
+        settle()
+
+        caster:removeListener('TEST_USE')
+
+        assert(not completed, 'cast should be interrupted at its finish, not completed')
+        assert(caster:hasStatusEffect(xi.effect.SLEEP_I), 'caster should be asleep')
+        assert(caster:getCurrentAction() == actionSleep, 'caster should be parked inactive')
+    end)
+
+    it('does not interrupt a cast if the stun wears off before the finish', function()
+        local completed = false
+        caster:addListener('MAGIC_USE', 'TEST_USE', function()
+            completed = true
+        end)
+
+        caster.actions:useSpell(target, xi.magic.spell.STONE) -- ~2s cast (no Chainspell)
+
+        -- Stun mid-cast, short enough to wear off well before the cast would complete.
+        caster:addStatusEffect(xi.effect.STUN, { power = 1, duration = 1, origin = caster })
+
+        settle() -- the 1s stun wears off well before the cast's finish check
+
+        caster:removeListener('TEST_USE')
+
+        assert(completed, 'cast should complete -- the stun wore off before the finish')
+        assert(not caster:hasStatusEffect(xi.effect.STUN), 'stun should have worn off')
+    end)
+
+    it('parks a non-casting entity inactive when a prevent-action effect lands', function()
+        assert(caster:getCurrentAction() ~= actionSleep, 'precondition: caster is not already inactive')
+
+        caster:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = 60, origin = caster })
+        xi.test.world:tickEntity(caster)
+
+        assert(caster:hasStatusEffect(xi.effect.SLEEP_I), 'caster should be asleep')
+        assert(caster:getCurrentAction() == actionSleep, 'idle caster should be parked inactive by the poll')
+    end)
+end)

--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -257,7 +257,7 @@ auto Application::isRunningInCI() const -> bool
     return args_->get<bool>("--ci");
 }
 
-void Application::run()
+auto Application::run() -> bool
 {
     ShowInfo("Creating engine");
     engine_ = createEngine();
@@ -292,8 +292,11 @@ void Application::run()
         catch (std::exception& e)
         {
             ShowErrorFmt("Fatal exception: {}", e.what());
+            return false;
         }
     }
+
+    return true;
 }
 
 auto Application::scheduler() -> Scheduler&

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -87,7 +87,7 @@ public:
     //
 
     // Is expected to block until requestExit() is called and/or isRunning() returns false
-    virtual void run();
+    virtual auto run() -> bool;
 
     void requestExit();
     auto closeRequested() const -> bool;

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -207,7 +207,7 @@ bool CAIContainer::Internal_Engage(uint16 targetid)
         {
             if (ForceChangeState<CAttackState>(entity, targetid))
             {
-                entity->OnEngage(*static_cast<CAttackState*>(m_stateStack.top().get()));
+                entity->OnEngage(*static_cast<CAttackState*>(GetCurrentState()));
 
                 // Resume being inactive if entity has a status effect preventing them from doing actions
                 if (entity->StatusEffectContainer->HasPreventActionEffect(true))
@@ -356,11 +356,31 @@ bool CAIContainer::Internal_UseItem(uint16 targetid, uint8 loc, uint8 slotid)
 
 CState* CAIContainer::GetCurrentState()
 {
-    if (!m_stateStack.empty())
+    return m_currentState.get();
+}
+
+void CAIContainer::enterState(std::unique_ptr<CState> next)
+{
+    // Suspend the state we're leaving beneath the new one, which becomes current.
+    if (m_currentState)
     {
-        return m_stateStack.top().get();
+        m_stateStack.push(std::move(m_currentState));
     }
-    return nullptr;
+    m_currentState = std::move(next);
+}
+
+void CAIContainer::resumeNextState()
+{
+    // The current state is finished; resume the one suspended beneath it, or go idle.
+    if (m_stateStack.empty())
+    {
+        m_currentState.reset();
+    }
+    else
+    {
+        m_currentState = std::move(m_stateStack.top());
+        m_stateStack.pop();
+    }
 }
 
 bool CAIContainer::CanChangeState()
@@ -395,6 +415,7 @@ void CAIContainer::Reset()
         Controller->Reset();
     }
 
+    m_currentState.reset();
     while (!m_stateStack.empty())
     {
         m_stateStack.pop();
@@ -433,34 +454,52 @@ auto CAIContainer::Tick(timer::time_point tick) -> Task<void>
         co_await Controller->Tick(tick);
     }
 
-    while (!m_stateStack.empty())
-    {
-        CState* top = m_stateStack.top().get();
+    //
+    // The current state is held in m_currentState (not on the stack) while it runs, so a
+    // re-entrant change can't free the object we're executing in. Entering a state only
+    // suspends the current one beneath it, never frees it.
+    //
 
-        if (top)
+    // The guard is a backstop against
+    // a state that completes and re-enters itself every iteration (the stack is capped at
+    // 10, so a healthy tick drains well within this bound).
+    int guard = 0;
+
+    while (m_currentState)
+    {
+        if (++guard > 32)
         {
-            // If DoUpdate returns true, the state has signaled it's done
-            // Clean it up.
-            // If the state stack is not empty, the next state will be polled.
-            if (top->DoUpdate(tick))
+            ShowWarning("AI state loop exceeded its iteration bound; breaking to avoid a hang.");
+            break;
+        }
+
+        CState* running = m_currentState.get();
+
+        if (running->DoUpdate(tick))
+        {
+            // A state can enter a successor during its own update (e.g. petskill
+            // re-engages), which becomes current. Only retire the state we actually ran.
+            if (running == m_currentState.get())
             {
-                // the state may change (and get cleaned up) during DoUpdate as a consequence of things it does
-                // Only clean up the state if the current state is still the same one we ran DoUpdate on
-                if (top == GetCurrentState())
-                {
-                    top->Cleanup(tick);
-                    m_stateStack.pop();
-                }
-            }
-            else // The state isn't done yet, preserve the state stack and bail out
-            {
-                break;
+                running->Cleanup(tick);
+                resumeNextState();
             }
         }
-        else // This should be dead code, but just in case...
+        else // Not finished: leave it current and stop.
         {
             break;
         }
+    }
+
+    // Magic and mobskill states decide their own interrupt at their finish (mid-action
+    // prevent-action effects don't cancel them on retail), so we never force them inactive
+    // from here. Once such a state ends, this poll parks the entity inactive.
+    if (auto* battle = dynamic_cast<CBattleEntity*>(PEntity);
+        battle && battle->isAlive() && !IsCurrentState<CInactiveState>() &&
+        !IsCurrentState<CMagicState>() && !IsCurrentState<CMobSkillState>() &&
+        battle->StatusEffectContainer->HasPreventActionEffect())
+    {
+        Inactive(0ms, false);
     }
 
     PEntity->PostTick();
@@ -470,24 +509,24 @@ auto CAIContainer::Tick(timer::time_point tick) -> Task<void>
 
 bool CAIContainer::IsStateStackEmpty()
 {
-    return m_stateStack.empty();
+    return !m_currentState;
 }
 
 void CAIContainer::ClearStateStack()
 {
-    while (!m_stateStack.empty())
+    while (m_currentState)
     {
-        m_stateStack.top()->Cleanup(timer::now());
-        m_stateStack.pop();
+        m_currentState->Cleanup(timer::now());
+        resumeNextState();
     }
 }
 
 void CAIContainer::InterruptStates()
 {
-    while (!m_stateStack.empty() && m_stateStack.top()->CanInterrupt())
+    while (m_currentState && m_currentState->CanInterrupt())
     {
-        m_stateStack.top()->Cleanup(timer::now());
-        m_stateStack.pop();
+        m_currentState->Cleanup(timer::now());
+        resumeNextState();
     }
 }
 
@@ -579,10 +618,10 @@ bool CAIContainer::Internal_Synth(SKILLTYPE synthSkill)
 
 void CAIContainer::CheckCompletedStates()
 {
-    while (!m_stateStack.empty() && m_stateStack.top()->IsCompleted())
+    while (m_currentState && m_currentState->IsCompleted())
     {
-        m_stateStack.top()->Cleanup(timer::now());
-        m_stateStack.pop();
+        m_currentState->Cleanup(timer::now());
+        resumeNextState();
     }
 }
 
@@ -593,4 +632,9 @@ bool CAIContainer::Accept_Raise()
         static_cast<CDeathState*>(PEntity->PAI->GetCurrentState())->acceptRaise();
     }
     return false;
+}
+
+size_t CAIContainer::stateCount() const
+{
+    return m_stateStack.size() + (m_currentState ? 1 : 0);
 }

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _AI_H
-#define _AI_H
+#pragma once
 
 #include <memory>
 #include <stack>
@@ -63,7 +62,10 @@ public:
     bool Inactive(timer::duration _duration, bool canChangeState);
     bool Untargetable(timer::duration _duration, bool canChangeState); // Used to make owner entity untargetable & inactionable in TargetFind for _duration
 
-    /* Internal Controller functions */
+    //
+    // Internal Controller functions
+    //
+
     bool Internal_Engage(uint16 targetid);
     bool Internal_Cast(uint16 targetid, SpellID spellid);
     bool Internal_ChangeTarget(uint16 targetid);
@@ -85,28 +87,20 @@ public:
     bool    IsStateStackEmpty();
     void    ClearStateStack();
     void    InterruptStates();
+
     // Pop the top state if it's the expected state
     template <typename State>
-    bool PopState()
-    {
-        if (IsCurrentState<State>())
-        {
-            m_stateStack.pop();
-            return true;
-        }
+    bool PopState();
 
-        return false;
-    }
-    /* Or have each state return a static number/string that Lua can use as well, in case this is not sufficient */
+    // Or have each state return a static number/string that Lua can use as well, in case this is not sufficient
     template <typename State, typename = std::enable_if_t<std::is_base_of<CState, State>::value>>
-    bool IsCurrentState()
-    {
-        return dynamic_cast<State*>(GetCurrentState());
-    }
+    bool IsCurrentState();
+
     bool IsSpawned();
     bool IsRoaming();
     bool IsEngaged();
     bool IsUntargetable();
+
     // whether AI is currently able to change state from external means
     bool CanChangeState();
     bool CanFollowPath();
@@ -135,62 +129,111 @@ public:
 protected:
     // input controller
     std::unique_ptr<CController> Controller;
+
     // current synchronized server time (before AI loop execution)
     timer::time_point m_Tick;
     timer::time_point m_PrevTick;
+
     // entity who holds this AI
     CBaseEntity* PEntity;
 
     void CheckCompletedStates();
-    template <typename T, typename... Args>
-    bool ChangeState(Args&&... args)
-    {
-        if (m_stateStack.size() > 10)
-        {
-            ShowWarning("State Stack size exceeds maximum.");
-            return false;
-        }
 
-        if (CanChangeState())
-        {
-            try
-            {
-                CheckCompletedStates();
-                m_stateStack.emplace(std::make_unique<T>(std::forward<Args>(args)...));
-                return true;
-            }
-            catch (CStateInitException& e)
-            {
-                PEntity->HandleErrorMessage(e.packet);
-            }
-        }
+    template <typename T, typename... Args>
+    bool ChangeState(Args&&... args);
+
+    template <typename T, typename... Args>
+    bool ForceChangeState(Args&&... args);
+
+private:
+    // Suspend the current state (if any) beneath `next`, then make `next` current.
+    void enterState(std::unique_ptr<CState> next);
+
+    // Finish with the current state and resume the one suspended beneath it (or go idle).
+    void resumeNextState();
+
+    size_t stateCount() const;
+
+    // The state the entity is currently in (null == idle). It lives here rather than on
+    // the stack so it can never be freed from underneath its own DoUpdate; m_stateStack
+    // holds the states suspended beneath it.
+    std::unique_ptr<CState>             m_currentState;
+    std::stack<std::unique_ptr<CState>> m_stateStack;
+
+    CAIActionQueue ActionQueue;
+};
+
+//
+// Template impls
+//
+
+template <typename State>
+bool CAIContainer::PopState()
+{
+    if (IsCurrentState<State>())
+    {
+        resumeNextState();
+        return true;
+    }
+
+    return false;
+}
+
+template <typename State, typename>
+bool CAIContainer::IsCurrentState()
+{
+    return dynamic_cast<State*>(GetCurrentState());
+}
+
+template <typename T, typename... Args>
+bool CAIContainer::ChangeState(Args&&... args)
+{
+    if (stateCount() > 10)
+    {
+        ShowWarning("State Stack size exceeds maximum.");
         return false;
     }
-    template <typename T, typename... Args>
-    bool ForceChangeState(Args&&... args)
-    {
-        if (m_stateStack.size() > 10)
-        {
-            ShowWarning("State Stack size exceeds maximum.");
-            return false;
-        }
 
+    if (CanChangeState())
+    {
         try
         {
             CheckCompletedStates();
-            m_stateStack.emplace(std::make_unique<T>(std::forward<Args>(args)...));
+
+            // Construct first: if it throws, the current state is left untouched.
+            enterState(std::make_unique<T>(std::forward<Args>(args)...));
             return true;
         }
         catch (CStateInitException& e)
         {
             PEntity->HandleErrorMessage(e.packet);
         }
+    }
+
+    return false;
+}
+
+template <typename T, typename... Args>
+bool CAIContainer::ForceChangeState(Args&&... args)
+{
+    if (stateCount() > 10)
+    {
+        ShowWarning("State Stack size exceeds maximum.");
         return false;
     }
 
-private:
-    std::stack<std::unique_ptr<CState>> m_stateStack;
-    CAIActionQueue                      ActionQueue;
-};
+    try
+    {
+        CheckCompletedStates();
 
-#endif
+        // Construct first: if it throws, the current state is left untouched.
+        enterState(std::make_unique<T>(std::forward<Args>(args)...));
+        return true;
+    }
+    catch (CStateInitException& e)
+    {
+        PEntity->HandleErrorMessage(e.packet);
+    }
+
+    return false;
+}

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -121,10 +121,11 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     // if spell:setFlag(xi.magic.spellFlag.NO_START_MSG) is called, don't give spell start packet
     if (GetSpell()->getFlag() & SPELLFLAG_NO_START_MSG)
     {
-        action.ForEachResult([&](action_result_t& result)
-                             {
-                                 result.messageID = MsgBasic::None;
-                             });
+        action.ForEachResult(
+            [&](action_result_t& result)
+            {
+                result.messageID = MsgBasic::None;
+            });
     }
 
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
@@ -252,6 +253,16 @@ bool CMagicState::Update(timer::time_point tick)
             return false;
         }
 
+        // Slept/stunned/petrified/etc. at the moment of completion: the cast is interrupted.
+        // A prevent-action effect that lands mid-cast does not cancel the cast on retail;
+        // the interrupt is decided here, at the finish, mirroring CMobSkillState.
+        if (m_PEntity->StatusEffectContainer->HasPreventActionEffect())
+        {
+            m_PEntity->OnCastInterrupted(*this, action, msg, false);
+            Complete();
+            return false;
+        }
+
         if (m_interrupted)
         {
             m_PEntity->OnCastInterrupted(*this, action, msg, false);
@@ -274,10 +285,11 @@ bool CMagicState::Update(timer::time_point tick)
         // Zero messageID so spells dont emit messages
         if (GetSpell()->getFlag() & SPELLFLAG_NO_FINISH_MSG)
         {
-            action.ForEachResult([&](action_result_t& result)
-                                 {
-                                     result.messageID = MsgBasic::None;
-                                 });
+            action.ForEachResult(
+                [&](action_result_t& result)
+                {
+                    result.messageID = MsgBasic::None;
+                });
         }
 
         m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -183,10 +183,11 @@ bool CMobSkillState::Update(timer::time_point tick)
         // Zero message ID
         if (m_PSkill->getFlag() & SKILLFLAG_NO_FINISH_MSG)
         {
-            action.ForEachResult([&](action_result_t& result)
-                                 {
-                                     result.messageID = MsgBasic::None;
-                                 });
+            action.ForEachResult(
+                [&](action_result_t& result)
+                {
+                    result.messageID = MsgBasic::None;
+                });
         }
 
         // Only send packet if action was populated (e.g. interrupts return early)

--- a/src/map/map_application.cpp
+++ b/src/map/map_application.cpp
@@ -107,7 +107,7 @@ void MapApplication::registerCommands(ConsoleService& console)
     console.registerCommand("backtrace", "Print backtrace", std::bind(&MapEngine::onBacktrace, mapEngine, std::placeholders::_1));
 }
 
-void MapApplication::run()
+auto MapApplication::run() -> bool
 {
     engine_ = createEngine();
     if (!engine_)
@@ -127,5 +127,8 @@ void MapApplication::run()
     catch (const std::exception& e)
     {
         ShowCriticalFmt("Fatal Exception: {}", e.what());
+        return false;
     }
+
+    return true;
 }

--- a/src/map/map_application.h
+++ b/src/map/map_application.h
@@ -46,7 +46,7 @@ public:
 
     auto createEngine() -> std::unique_ptr<Engine> override;
     void registerCommands(ConsoleService& console) override;
-    void run() override;
+    auto run() -> bool override;
 
 private:
     MapConfig engineConfig_{};

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -502,7 +502,7 @@ bool CStatusEffectContainer::AddStatusEffect(std::unique_ptr<CStatusEffect> PSta
 
         m_StatusEffectSet.insert(std::move(PStatusEffectPtr));
 
-        ApplyStateAlteringEffects(PStatusEffect);
+        HandleEffectGainSideEffects(PStatusEffect);
 
         luautils::OnEffectGain(m_POwner, PStatusEffect);
         m_POwner->PAI->EventHandler.triggerListener("EFFECT_GAIN", m_POwner, PStatusEffect);
@@ -773,8 +773,7 @@ void CStatusEffectContainer::KillAllStatusEffect()
     m_POwner->UpdateHealth();
 }
 
-// Apply any state alterations for the effect if applicable.
-void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffect)
+void CStatusEffectContainer::HandleEffectGainSideEffects(CStatusEffect* StatusEffect)
 {
     TracyZoneScoped;
 
@@ -800,11 +799,6 @@ void CStatusEffectContainer::ApplyStateAlteringEffects(CStatusEffect* StatusEffe
             if (effect == xi::StatusEffect::SleepIi || effect == xi::StatusEffect::Lullaby)
             {
                 StatusEffect->SetIcon(static_cast<uint16>(xi::StatusEffect::SleepI));
-            }
-
-            if (!m_POwner->PAI->IsCurrentState<CInactiveState>() && !m_POwner->PAI->IsCurrentState<CMobSkillState>())
-            {
-                m_POwner->PAI->Inactive(0ms, false);
             }
         }
     }

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -70,7 +70,7 @@ public:
     void DelStatusEffectsByType(uint16 Type);
     auto DelStatusEffectByTier(xi::StatusEffect StatusID, uint16 power) -> bool;
     void KillAllStatusEffect();
-    void ApplyStateAlteringEffects(CStatusEffect* StatusEffect);
+    void HandleEffectGainSideEffects(CStatusEffect* StatusEffect);
 
     auto HasStatusEffect(xi::StatusEffect StatusID) -> bool;               // We check the presence of the effect
     auto HasStatusEffect(xi::StatusEffect StatusID, uint16 SubID) -> bool; // Check the presence of an effect with a unique Subid

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -23,6 +23,7 @@
 #include "common/tracy.h"
 #include "test_application.h"
 
+#include <cstdlib>
 #include <iostream>
 #include <memory>
 
@@ -32,7 +33,9 @@ int main(int argc, char** argv)
 
     auto testApp = std::make_unique<TestApplication>(argc, argv);
 
-    testApp->run();
+    const auto success = testApp->run();
+
+    const int exitCode = success ? EXIT_SUCCESS : EXIT_FAILURE;
 
     // Explicitly destroy TestApplication before the lua state get cleaned up
     testApp.reset();
@@ -48,5 +51,5 @@ int main(int argc, char** argv)
     std::cin.get();
 #endif
 
-    return 0;
+    return exitCode;
 }

--- a/src/test/test_application.cpp
+++ b/src/test/test_application.cpp
@@ -105,7 +105,7 @@ auto TestApplication::createEngine() -> std::unique_ptr<Engine>
     return nullptr;
 }
 
-void TestApplication::run()
+auto TestApplication::run() -> bool
 {
     TracyZoneScoped;
 
@@ -167,12 +167,9 @@ void TestApplication::run()
             // Print to stderr directly if needed
             captureLogger();
 
-            auto success = co_await static_cast<TestEngine*>(engine_.get())->executeTests();
-            if (!success)
-            {
-                std::exit(EXIT_FAILURE);
-            }
-
+            // Record the result and exit through the normal path so main() can run
+            // lua_cleanup() before the process tears down.
+            success_ = co_await static_cast<TestEngine*>(engine_.get())->executeTests();
             this->requestExit();
         });
 
@@ -183,8 +180,10 @@ void TestApplication::run()
     catch (const std::exception& e)
     {
         ShowCriticalFmt("Fatal Exception: {}", e.what());
-        std::exit(EXIT_FAILURE);
+        success_ = false;
     }
+
+    return success_;
 }
 
 // Replace all loggers sinks with the in-memory sink

--- a/src/test/test_application.h
+++ b/src/test/test_application.h
@@ -35,9 +35,11 @@ public:
     ~TestApplication() override;
 
     auto createEngine() -> std::unique_ptr<Engine> override;
-    void run() override;
+    auto run() -> bool override;
     void captureLogger() const;
 
 private:
     std::shared_ptr<InMemorySink> sink_;
+
+    bool success_{ false };
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes ASan complaints, which would lead to mysterious crashes.

Adds a little logical change which may or may not be correct - plz review.

- Removes direct use of the top of the state stack, in favour of a separate member where we keep the current state.
- Adds tests to reproduce previous ASan errors and a few other logical tests - now all passing
- General tidying