### PR TITLE
[C++] Prevent mobs with path flag patrol from buffing.

### DIFF
--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -1132,7 +1132,13 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
         end
     end
 
-    -- Handle mob initial spell casts (blaze spikes, protect, etc)
+    -- TODO: Test on retail to find out...
+    -- Do mobs buff inside of BCNMs with long cutscenes?
+    -- Do mobs buff when not engaged?
+    -- With a second player that has completed the mission as a "helper" to go inside skiping the
+    -- CS and watch if the mobs actually dont start casting until the initiator is out of the CS
+
+    --[[
     if player:getID() == initiatorId then
         local mobs = battlefield:getMobs(true, true)
         for _, mob in pairs(mobs) do
@@ -1149,6 +1155,7 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
             end
         end
     end
+    --]]
 
     local ID = zones[self.zoneId]
     player:messageSpecial(ID.text.ENTERING_THE_BATTLEFIELD_FOR, 0, self.index)

--- a/scripts/tests/systems/patrolling_mobs.lua
+++ b/scripts/tests/systems/patrolling_mobs.lua
@@ -1,0 +1,22 @@
+describe('Patrolling mobs', function()
+    it('does not cast buffs while patrolling', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.CASTLE_OZTROJA })
+        local mob    = player.entities:moveTo('Yagudo_Conductor')
+
+        mob:respawn()
+        mob:clearPath()
+        mob:delStatusEffect(xi.effect.MINNE)
+        mob:setSpellList(1) -- Knights Minne
+
+        local mobPosition = mob:getPos()
+        mob:pathThrough(
+        {
+            { x = mobPosition.x + 1, y = mobPosition.y, z = mobPosition.z },
+            { x = mobPosition.x,     y = mobPosition.y, z = mobPosition.z },
+        }, xi.path.flag.PATROL)
+
+        xi.test.world:skipTime(60)
+
+        assert(not mob:hasStatusEffect(xi.effect.MINNE), 'patrolling mob has not gained Minne')
+    end)
+end)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -79,7 +79,7 @@ auto CMobController::Tick(const timer::time_point tick) -> Task<void>
         }
         else if (!PMob->isDead())
         {
-            if (PMob->SpellContainer->HasSpells() && DoBuffTick())
+            if (PMob->SpellContainer->HasSpells() && !PMob->PAI->PathFind->IsPatrolling() && DoBuffTick())
             {
                 co_return;
             }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Prevents mobs with path flag patrol from casting, ensuring that they always keep formation.
* Adds a test to ensure this does not regress in the future.
* Removes a block of code in battlefield.lua that was forcibly making mobs cast spells upon entering the battlefield. (It is no longer needed, as mobs now buff inside battlefields normally)

## Steps to test these changes

Enter content with patrolling casters (in my case old limbus or dynamis, i'm honestly not sure where patrolling mobs live elsewhere) see patrolling mobs no longer cast.
