### PR TITLE
[C++] Fix Meikyo Shisui / Sekkanoki TP spent Interactions

### DIFF
--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -94,11 +94,15 @@ void CWeaponSkillState::SpendCost()
     auto tp = 0;
     if (m_PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::MeikyoShisui))
     {
-        tp = m_PEntity->addTP(-1000);
+        // Meikyo Shisui uses the entitys current TP value for the weaponskill. 3K -> 2K -> 1K. So we set TP the entities current amount.
+        tp = m_PEntity->health.tp;
+        m_PEntity->addTP(-1000);
     }
     else if (m_PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Sekkanoki))
     {
-        tp = m_PEntity->addTP(-1000);
+        // Sekkanoki counts as a 1000 TP weaponskill.
+        tp = 1000;
+        m_PEntity->addTP(-1000);
         m_PEntity->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Sekkanoki);
     }
     else


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an interaction with Meikyo Shisui where weaponskills should calculate their fTP based off the entities current TP even though they only cost 1000 TP. (For Example, the first weaponskill after using Meikyo Shisui is calculated as if you spent 3K, then 2K, then 1K etc.)

Retail Proof : https://www.youtube.com/watch?v=ZAWsFyMJe00

Also fixes Sekkanoki to only count as spending 1k.

<img width="636" height="395" alt="image" src="https://github.com/user-attachments/assets/16459451-fbc4-4943-bb1a-1369580ff314" />

## Steps to test these changes

Easiest way I found was to test Starlight as SAM/RDM. See 3K/2K/1K MP return after using Meikyo Shisui
See 1K MP return with 3000 TP with Sekkanoki

Thanks to @WinterSolstice8 for the help with this
