### PR TITLE
[lua, sql][module] COR Era Adjustment Modules; COR and module bug fix

### DIFF
--- a/modules/abyssea/sql/job_adjustments.sql
+++ b/modules/abyssea/sql/job_adjustments.sql
@@ -138,6 +138,10 @@ UPDATE abilities SET recastTime = 900 WHERE name = 'killer_instinct';
 -- Killer Instinct merit: Revert value to 150 seconds per level
 UPDATE merits SET value = 150 WHERE name = 'killer_instinct';
 
+------------------------------------
+-- Bard
+------------------------------------
+
 -- Mazurka: Revert to town/field only
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/08/2010)
 SET @TYPE_CITY     = 1;
@@ -246,3 +250,27 @@ UPDATE abilities SET recastTime = 900 WHERE name = 'deep_breathing';
 
 -- Deep Breathing merit: Revert value to 150 seconds per level
 UPDATE merits SET value = 150 WHERE name = 'deep_breathing';
+
+-----------------------------------
+-- Corsair
+-----------------------------------
+
+-- Double-Up: Revert recast from 5 to 7 seconds
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/19/2011)
+UPDATE abilities SET recastTime = 7 WHERE name = 'double-up';
+
+-- Snake Eye: Revert recast from 5 to 15 minutes
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+UPDATE abilities SET recastTime = 900 WHERE name = 'snake_eye';
+
+-- Snake Eye merit: Revert value to 150 seconds per level
+UPDATE merits SET value = 150 WHERE name = 'snake_eye';
+
+-- Fold: Revert recast from 5 to 15 minutes
+UPDATE abilities SET recastTime = 900 WHERE name = 'fold';
+
+-- Fold merit: Revert value to 150 seconds per level
+UPDATE merits SET value = 150 WHERE name = 'fold';
+
+-- Quick Draw: Revert range from 22 to 15 yalms
+UPDATE abilities SET `range` = 15 WHERE name = 'quick_draw';

--- a/modules/era/lua/globals/job_utils/corsair.lua
+++ b/modules/era/lua/globals/job_utils/corsair.lua
@@ -1,0 +1,379 @@
+-----------------------------------
+-- Module: Corsair Job Adjustments
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_job_utils_corsair'
+local m = Module:new(moduleName)
+
+-----------------------------------
+-- Rhapsodies of Vana'diel Era
+-----------------------------------
+
+if not xi.module.isContentEnabled('ROV') then
+    -- Beast Roll: Remove pet ranged attack
+    -- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
+    m:addOverride('xi.effects.beast_roll.onEffectGain', function(target, effect)
+        target:addPetMod(xi.mod.ATTP, effect:getPower())
+    end)
+
+    m:addOverride('xi.effects.beast_roll.onEffectLose', function(target, effect)
+        target:delPetMod(xi.mod.ATTP, effect:getPower())
+        xi.job_utils.corsair.onRollEffectLose(target, effect)
+    end)
+end
+
+-----------------------------------
+-- Seekers of Adoulin Era
+-----------------------------------
+if not xi.module.isContentEnabled('SOA') then
+    -- Phantom Roll powers and bonus changed in the SoA era
+    -- Source: https://forum.square-enix.com/ffxi/threads/41814-May-15-2014-%28JST%29-Version-Update
+    local soaRollData =
+    {
+        [xi.jobAbility.NINJA_ROLL] =
+        {
+            powers = { 4, 6,  8, 25, 10, 12, 14, 2, 17, 20, 30, 8 },
+            bonus  = 10,
+        },
+
+        [xi.jobAbility.WIZARDS_ROLL] =
+        {
+            powers = { 2, 3,  4,  4, 10,  5,  6, 7,  1,  7, 12, 4 },
+            bonus  = 4,
+        },
+
+        [xi.jobAbility.DANCERS_ROLL] =
+        {
+            powers = { 3, 4, 11,  4,  5,  6,  1, 7,  8,  8, 14, 3 },
+            bonus  = 3,
+        },
+    }
+
+    do
+        local rollModData = xi.job_utils.corsair.rollData
+
+        for abilityId, data in pairs(soaRollData) do
+            local rollInfo  = rollModData[abilityId]
+            rollInfo.powers = data.powers
+            rollInfo.bonus  = data.bonus
+        end
+    end
+end
+
+-----------------------------------
+-- Abyssea Era
+-----------------------------------
+if not xi.module.isContentEnabled('ABYSSEA') then
+    -- Phantom Roll powers and bonuses differ before the Abyssea era.
+    -- Source: https://forum.square-enix.com/ffxi/threads/20744?p=278735#post278735
+    local abysseaRollData =
+    {
+        [xi.jobAbility.WARLOCKS_ROLL] =
+        {
+            powers = {  2,  3,  4, 10,  4,  5,  6,  1,  7,  7, 12,  4 },
+            bonus  = 4,
+        },
+
+        [xi.jobAbility.BEAST_ROLL] =
+        {
+            powers = {  5,  6,  7, 19,  8,  9, 12,  2, 13, 14, 23,  8 },
+            bonus  = 8,
+        },
+
+        [xi.jobAbility.CHORAL_ROLL] =
+        {
+            powers = {  4, 17,  5,  6,  7,  2,  8, 10, 11, 12, 21,  8 },
+            bonus  = 8,
+        },
+
+        [xi.jobAbility.DANCERS_ROLL] =
+        {
+            powers = {  3,  4, 11,  4,  5,  6,  1,  7,  8,  8, 14,  3 },
+            bonus  = 3,
+        },
+
+        [xi.jobAbility.HEALERS_ROLL] =
+        {
+            powers = {  2,  3, 10,  4,  4,  5,  1,  6,  7,  7, 12,  3 },
+            bonus  = 3,
+        },
+
+        [xi.jobAbility.GALLANTS_ROLL] =
+        {
+            powers = {  4,  5, 15,  6,  7,  8,  3,  9, 10, 12, 20, 10 },
+            bonus  = 10,
+        },
+
+        [xi.jobAbility.DRACHEN_ROLL] =
+        {
+            powers = {  4,  5, 18,  7,  9, 10,  2, 11, 13, 15, 22,  8 },
+            bonus  = 8,
+        },
+
+        [xi.jobAbility.PUPPET_ROLL] =
+        {
+            powers = { 10, 13, 15, 40, 18, 20, 25,  5, 28, 30, 50, 15 },
+            bonus  = 15,
+        },
+    }
+
+    do
+        local rollData = xi.job_utils.corsair.rollData
+
+        for abilityId, data in pairs(abysseaRollData) do
+            local rollInfo  = rollData[abilityId]
+            rollInfo.powers = data.powers
+            rollInfo.bonus  = data.bonus
+        end
+    end
+
+    -- Healer's Roll: Revert from Cure potency bonus to MP heal bonus
+    m:addOverride('xi.effects.healers_roll.onEffectGain', function(target, effect)
+        effect:addMod(xi.mod.MPHEAL, effect:getPower())
+    end)
+
+    -- Gallant's Roll: Revert to proportional damage reflection relative to damage taken.
+    m:addOverride('xi.effects.gallants_roll.onEffectGain', function(target, effect)
+        effect:addMod(xi.mod.SPIKES, xi.subEffect.BLAZE_SPIKES)
+        target:addListener('TAKE_DAMAGE', 'GALLANTS_ROLL_REFLECT', function(entity, amount, attacker, attackType, damageType)
+            if
+                amount > 0 and
+                attackType == xi.attackType.PHYSICAL
+            then
+                entity:setMod(xi.mod.SPIKES_DMG, math.floor(amount * effect:getPower() / 100))
+            end
+        end)
+    end)
+
+    m:addOverride('xi.effects.gallants_roll.onEffectLose', function(target, effect)
+        target:removeListener('GALLANTS_ROLL_REFLECT')
+        target:setMod(xi.mod.SPIKES_DMG, 0)
+        super(target, effect)
+    end)
+
+    -- Drachen Roll: Revert from Pet Accuracy bonus to Pet Magic Acc/Attack bonus
+    m:addOverride('xi.effects.drachen_roll.onEffectGain', function(target, effect)
+        target:addPetMod(xi.mod.MATT, effect:getPower())
+        target:addPetMod(xi.mod.MACC, effect:getPower())
+    end)
+
+    m:addOverride('xi.effects.drachen_roll.onEffectLose', function(target, effect)
+        target:delPetMod(xi.mod.MATT, effect:getPower())
+        target:delPetMod(xi.mod.MACC, effect:getPower())
+        xi.job_utils.corsair.onRollEffectLose(target, effect)
+    end)
+
+    -- Puppet Roll: Revert from Pet Magic Acc/Attack bonus to Pet Accuracy bonus
+    m:addOverride('xi.effects.puppet_roll.onEffectGain', function(target, effect)
+        target:addPetMod(xi.mod.ACC, effect:getPower())
+        target:addPetMod(xi.mod.RACC, effect:getPower())
+    end)
+
+    m:addOverride('xi.effects.puppet_roll.onEffectLose', function(target, effect)
+        target:delPetMod(xi.mod.ACC, effect:getPower())
+        target:delPetMod(xi.mod.RACC, effect:getPower())
+        xi.job_utils.corsair.onRollEffectLose(target, effect)
+    end)
+
+    -- Light Shot / Dark Shot: Revert Dia and Bio subpower baselines to pre-April-2019 values (5/10/15 instead of 10/15/20).
+    -- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
+    local diaBasePowerByTier = xi.job_utils.corsair.quickDrawEffectBoostTable[xi.jobAbility.LIGHT_SHOT][1].basePowerByTier
+    diaBasePowerByTier[1] = 5
+    diaBasePowerByTier[3] = 10
+    diaBasePowerByTier[5] = 15
+
+    local bioBasePowerByTier = xi.job_utils.corsair.quickDrawEffectBoostTable[xi.jobAbility.DARK_SHOT][1].basePowerByTier
+    bioBasePowerByTier[2] = 5
+    bioBasePowerByTier[4] = 10
+    bioBasePowerByTier[6] = 15
+
+    -- Phantom Roll XI bonus: Reverts various bonuses added to rolling and having an XI effect active
+    -- - Disable reduced recast while an XI is active.
+    -- - Disable bust effect prevention while an XI is active.
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+    m:addOverride('xi.job_utils.corsair.checkForElevenRoll', function(caster)
+        return false
+    end)
+
+    -- - Disable Phantom Roll recast reset when landing on XI via Double-Up.
+    m:addOverride('xi.job_utils.corsair.useDoubleUp', function(caster, target, ability, action)
+        if caster:getID() == target:getID() then -- the COR handles all the calculations
+            local duEffect = caster:getStatusEffect(xi.effect.DOUBLE_UP_CHANCE)
+            local prevRoll = caster:getStatusEffect(duEffect:getSubPower())
+            local roll     = prevRoll:getSubPower()
+            local job      = duEffect:getTier()
+
+            caster:setLocalVar('corsairActiveRoll', duEffect:getSourceTypeParam())
+
+            local snakeEye = caster:getStatusEffect(xi.effect.SNAKE_EYE)
+
+            if snakeEye then
+                if roll >= 5 and math.random(1, 100) < snakeEye:getPower() then
+                    roll = 11
+                else
+                    roll = roll + 1
+                end
+
+                caster:delStatusEffect(xi.effect.SNAKE_EYE)
+            else
+                roll = roll + math.random(1, 6)
+            end
+
+            if roll >= 12 then -- bust
+                roll = 12
+                caster:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
+            end
+
+            caster:setLocalVar('corsairRollTotal', roll)
+            action:info(caster:getID(), roll - prevRoll:getSubPower())
+            xi.job_utils.corsair.checkForJobBonus(caster, job)
+        end
+
+        local total       = caster:getLocalVar('corsairRollTotal')
+        local activeRoll  = caster:getLocalVar('corsairActiveRoll')
+        local prevAbility = GetAbility(activeRoll)
+
+        if prevAbility then -- Apply rolls to target(s), including the COR
+            action:actionID(prevAbility:getID())
+
+            total = xi.job_utils.corsair.applyRoll(caster, target, prevAbility, total, true, ability)
+
+            if total > 11 then
+                action:setAnimation(target:getID(), 98) -- 98 is bust anim for all rolls
+            else
+                action:setAnimation(target:getID(), prevAbility:getAnimation())
+            end
+
+            return total
+        end
+    end)
+
+    -- Snake Eye: Revert to cooldown reduction from merit points, remove bonus free XI effect.
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+    m:addOverride('xi.job_utils.corsair.useSnakeEye', function(player, action)
+        local recastReduction = (player:getMerit(xi.merit.SNAKE_EYE) / 10) * 60
+        action:setRecast(action:getRecast() - recastReduction)
+
+        player:addStatusEffect(xi.effect.SNAKE_EYE, { power = 0, duration = 60, origin = player })
+
+        return xi.effect.SNAKE_EYE
+    end)
+
+    -- Fold: Revert to cooldown reduction from merit points, remove bonus phantom roll reset.
+    m:addOverride('xi.job_utils.corsair.useFold', function(player, action)
+        local sourceId   = player:getID()
+        local newestBust = nil
+        local newestRoll = nil
+        local bustExpiry = 0
+        local rollExpiry = 0
+
+        for _, effect in pairs(player:getStatusEffects()) do
+            local effectType = effect:getEffectType()
+            local expiry     = effect:getStartTime() + effect:getDuration() / 1000
+
+            if
+                effectType == xi.effect.BUST and
+                (newestBust == nil or expiry > bustExpiry)
+            then
+                newestBust = effect
+                bustExpiry = expiry
+            elseif
+                effect:hasEffectFlag(xi.effectFlag.ROLL) and
+                effect:getSourceTypeParam() == sourceId and
+                (newestRoll == nil or expiry > rollExpiry)
+            then
+                newestRoll = effect
+                rollExpiry = expiry
+            end
+        end
+
+        local selected = newestBust or newestRoll
+
+        if selected ~= nil then
+            player:delStatusEffect(selected:getEffectType())
+            player:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
+
+            local recastReduction = (player:getMerit(xi.merit.FOLD) / 10) * 60
+            action:setRecast(action:getRecast() - recastReduction)
+        end
+    end)
+
+    -- Elemental Shot: Revert TP gain and Marksmanship skillup added to Quick Draw.
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/08/2010)
+    m:addOverride('xi.job_utils.corsair.useElementalShot', function(actor, target, ability, action)
+        local abilityId = ability:getID()
+
+        -- Fetch specific ability data.
+        local data = xi.job_utils.corsair.quickDrawDataTable[abilityId]
+        if not data then
+            return
+        end
+
+        -- Handle card consumption.
+        if not actor:delItem(data.cardAmmo, 1) then
+            actor:delItem(xi.item.TRUMP_CARD, 1)
+        end
+
+        -- Handle recast.
+        action:setRecast(math.max(0, action:getRecast() - actor:getMod(xi.mod.QUICK_DRAW_RECAST)))
+
+        -- Handle claim.
+        target:updateClaim(actor)
+
+        -- Calculate resist rate.
+        local bonusAcc = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC)
+        local resist   = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.MARKSMANSHIP, 0,  data.element, xi.mod.AGI, 0, bonusAcc)
+
+        -- Handle damage.
+        local damage = 0
+        if data.canDamage then
+            damage = xi.job_utils.corsair.handleQuickDrawDamage(actor, target, action, data.element, resist)
+        end
+
+        -- Handle effect boost.
+        xi.job_utils.corsair.handleQuickDrawEffectBoost(actor, target, abilityId, data.multiplier)
+
+        -- Handle effect application.
+        if data.applyEffectId > 0 then
+            if
+                xi.data.statusEffect.isTargetImmune(target, data.applyEffectId, data.element) or
+                xi.data.statusEffect.isTargetResistant(actor, target, data.applyEffectId) or
+                not xi.data.statusEffect.isResistRateSuccessfull(data.applyEffectId, resist, 0)
+            then
+                ability:setMsg(xi.msg.basic.JA_MISS_2)
+                return data.applyEffectId
+            end
+
+            -- Light shot.
+            if data.applyEffectId == xi.effect.SLEEP_I then
+                if target:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = math.floor(90 * resist), subPower = data.element, origin = actor }) then
+                    ability:setMsg(xi.msg.basic.JA_ENFEEB_IS)
+                else
+                    ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
+                end
+
+                return xi.effect.SLEEP_I
+
+            -- Dark shot.
+            else
+                ability:setMsg(xi.msg.basic.JA_REMOVE_EFFECT_2)
+
+                local dispelledEffect = target:dispelStatusEffect()
+                if dispelledEffect == xi.effect.NONE then
+                    ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
+                end
+
+                return dispelledEffect
+            end
+        end
+
+        return damage
+    end)
+end
+
+if #m.overrides > 0 then
+    return m
+end
+
+return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/ranger.lua
+++ b/modules/era/lua/globals/job_utils/ranger.lua
@@ -54,7 +54,7 @@ end
 
 -- Register SoA reverts only before SoA content is enabled.
 if not xi.module.isContentEnabled('SOA') then
-    local scavengeData = require('modules/era/lua/globals/job_utils/scavenge_data')
+    local scavengeData = require('modules/era/lua/data/scavenge_data')
 
     -- Scavenge: Revert to pre-SoA zone-based item gathering and reduce duration with merits
     -- Source: https://ffxiclopedia.fandom.com/wiki/Scavenge/Items

--- a/modules/era/lua/zones/Al_Zahbi/npcs/Chayaya.lua
+++ b/modules/era/lua/zones/Al_Zahbi/npcs/Chayaya.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- Chayaya Shop Adjustments
+-- Removes OOE Corsair rolls added to shop inventory in the WotG era
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'chayaya_shop_adjust'
+
+if xi.module.isContentEnabled('WOTG') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.zones.Al_Zahbi.npcs.Chayaya.onTrigger', function(player, npc)
+    local stock =
+    {
+        { xi.item.DART,               10, },
+        { xi.item.HAWKEYE,            60, },
+        { xi.item.GRENADE,          1204, },
+        { xi.item.IRON_ARROW,          8, },
+        { xi.item.WARRIOR_DIE,     68000, },
+        { xi.item.MONK_DIE,        22400, },
+        { xi.item.WHITE_MAGE_DIE,   5000, },
+        { xi.item.BLACK_MAGE_DIE, 108000, },
+        { xi.item.RED_MAGE_DIE,    62000, },
+        { xi.item.THIEF_DIE,       50400, },
+        { xi.item.PALADIN_DIE,     90750, },
+        { xi.item.DARK_KNIGHT_DIE,  2205, },
+        { xi.item.BEASTMASTER_DIE, 26600, },
+        { xi.item.BARD_DIE,        12780, },
+        { xi.item.RANGER_DIE,       1300, },
+    }
+
+    player:showText(npc, zones[xi.zone.AL_ZAHBI].text.CHAYAYA_SHOP_DIALOG)
+    xi.shop.general(player, stock)
+end)
+
+return m

--- a/modules/era/lua/zones/Nashmau/npcs/Jajaroon.lua
+++ b/modules/era/lua/zones/Nashmau/npcs/Jajaroon.lua
@@ -1,0 +1,39 @@
+-----------------------------------
+-- Jajaroon Shop Adjustments
+-- Removes Trump Card Case added in Abyssea
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'jajaroon_shop_adjust'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.zones.Al_Zahbi.npcs.Chayaya.onTrigger', function(player, npc)
+    local stock =
+    {
+        { xi.item.FIRE_CARD,           48 },
+        { xi.item.ICE_CARD,            48 },
+        { xi.item.WIND_CARD,           48 },
+        { xi.item.EARTH_CARD,          48 },
+        { xi.item.THUNDER_CARD,        48 },
+        { xi.item.WATER_CARD,          48 },
+        { xi.item.LIGHT_CARD,          48 },
+        { xi.item.DARK_CARD,           48 },
+        { xi.item.SAMURAI_DIE,      35200 },
+        { xi.item.NINJA_DIE,          600 },
+        { xi.item.DRAGOON_DIE,       9216 },
+        { xi.item.SUMMONER_DIE,     40000 },
+        { xi.item.BLUE_MAGE_DIE,     3525 },
+        { xi.item.CORSAIR_DIE,        316 },
+        { xi.item.PUPPETMASTER_DIE, 82500 },
+    }
+
+    player:showText(npc, zones[xi.zone.NASHMAU].text.JAJAROON_SHOP_DIALOG)
+    xi.shop.general(player, stock)
+end)
+
+return m

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -10,7 +10,7 @@ xi.job_utils.corsair = xi.job_utils.corsair or {}
 -----------------------------------
 
 -- Table used for Corsair's Phantom Roll calculations
-local rollData =
+xi.job_utils.corsair.rollData =
 {
     [xi.jobAbility.CORSAIRS_ROLL] =
     {
@@ -355,7 +355,7 @@ local rollData =
     },
 }
 
-local quickDrawDataTable =
+xi.job_utils.corsair.quickDrawDataTable =
 {
     [xi.jobAbility.FIRE_SHOT   ] = { cardAmmo = xi.item.FIRE_CARD,    element = xi.element.FIRE,    multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
     [xi.jobAbility.ICE_SHOT    ] = { cardAmmo = xi.item.ICE_CARD,     element = xi.element.ICE,     multiplier = 1.2, canDamage = true,  applyEffectId = 0                 },
@@ -367,7 +367,7 @@ local quickDrawDataTable =
     [xi.jobAbility.DARK_SHOT   ] = { cardAmmo = xi.item.DARK_CARD,    element = xi.element.DARK,    multiplier = 1.5, canDamage = false, applyEffectId = xi.effect.NONE    }, -- Dispel
 }
 
-local quickDrawEffectBoostTable =
+xi.job_utils.corsair.quickDrawEffectBoostTable =
 {
     [xi.jobAbility.FIRE_SHOT] =
     {
@@ -403,13 +403,13 @@ local quickDrawEffectBoostTable =
 
     [xi.jobAbility.LIGHT_SHOT] =
     {
-        { effectId = xi.effect.DIA, capByTier = { [1] = 10, [3] = 15, [5] = 20, [7] = 25, [9] = 30 } },
+        { effectId = xi.effect.DIA, basePowerByTier = { [1] = 10, [3] = 15, [5] = 20, [7] = 25, [9] = 30 } },
     },
 
     [xi.jobAbility.DARK_SHOT] =
     {
-        { effectId = xi.effect.BIO,       capByTier = { [2] = 10, [4] = 15, [6] = 20, [8] = 25, [10] = 30 } },
-        { effectId = xi.effect.BLINDNESS, capGlobal = 30                                                    },
+        { effectId = xi.effect.BIO,       basePowerByTier = { [2] = 10, [4] = 15, [6] = 20, [8] = 25, [10] = 30 } },
+        { effectId = xi.effect.BLINDNESS, capGlobal = 30                                                          },
     },
 }
 
@@ -424,26 +424,6 @@ local rollEnhanceMods =
 -----------------------------------
 -- Local helper functions
 -----------------------------------
-
--- Sets local var if party contains specified job
-local function checkForJobBonus(caster, job)
-    if job == xi.job.NONE then
-        caster:setLocalVar('corsairRollBonus', 0)
-        return
-    end
-
-    if caster:hasPartyJob(job) then
-        caster:setLocalVar('corsairRollBonus', 1)
-        return
-    end
-
-    if math.random(1, 100) <= caster:getMod(xi.mod.JOB_BONUS_CHANCE) then
-        caster:setLocalVar('corsairRollBonus', 1)
-        return
-    end
-
-    caster:setLocalVar('corsairRollBonus', 0)
-end
 
 local function corsairSetup(caster, ability, action, effect, job)
     local roll = math.random(1, 6)
@@ -479,12 +459,12 @@ local function corsairSetup(caster, ability, action, effect, job)
     -- In short, it seems the minimum recast time is 15 seconds.
     action:setRecast(utils.clamp(recastTime - recastReduction, 15, 300))
 
-    checkForJobBonus(caster, job)
+    xi.job_utils.corsair.checkForJobBonus(caster, job)
 end
 
 -- Handle application of roll or bust effects on party members
 local function applyCorsairEffect(caster, target, abilityId, power, subPower)
-    local rollInfo = rollData[abilityId]
+    local rollInfo = xi.job_utils.corsair.rollData[abilityId]
     if not rollInfo then
         return false
     end
@@ -597,10 +577,192 @@ local function applyCorsairEffect(caster, target, abilityId, power, subPower)
     return target:addStatusEffect(effectId, effectParams)
 end
 
+-----------------------------------
+-- Global helper functions
+-----------------------------------
+
+xi.job_utils.corsair.checkForElevenRoll = function(caster)
+    local effects = caster:getStatusEffects()
+
+    for _, effect in pairs(effects) do
+        if
+            effect:hasEffectFlag(xi.effectFlag.ROLL) and
+            effect:getSubPower() == 11
+        then
+            return true
+        end
+    end
+
+    return false
+end
+
+xi.job_utils.corsair.onRollEffectLose = function(player, effect)
+    -- Ignore effect loss if COR is doubling up
+    if player:getLocalVar('corsairApplyingRoll') == 1 then
+        return
+    end
+
+    if
+        player:hasStatusEffect(xi.effect.DOUBLE_UP_CHANCE) and
+        player:getLocalVar('corsairDuEffect') == effect:getEffectType()
+    then
+        player:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
+        player:setLocalVar('corsairDuEffect', 0)
+    end
+end
+
+xi.job_utils.corsair.handleQuickDrawDamage = function(player, target, action, element, resist)
+    -- Calculate Quick Draw damage - https://wiki.ffo.jp/html/3349.html TODO: QUICK_DRAW_TRIPLE_DAMAGE gear mod needs research
+    local damage                 = 2 * player:getRangedDmg() + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT) + player:getMod(xi.mod.QUICK_DRAW_DMG)
+    local deathPenaltyMultiplier = 1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100
+    local damageAdditiveBonus    = player:getMod(xi.mod.MAGIC_DAMAGE)
+    local elementalStaffBonus    = xi.spells.damage.calculateElementalStaffBonus(player, element)
+    local affinityMultiplier     = xi.spells.damage.calculateElementalAffinityBonus(player, element)
+    local dayWeatherMultiplier   = xi.spells.damage.calculateDayAndWeather(player, element, false)
+    local magicBonusDiff         = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element, 0)
+
+    -- Unconfirmed order.
+    local sdtMultiplier          = xi.combat.damage.magicalElementSDT(target, element)
+    local additionalResistTier   = xi.spells.damage.calculateAdditionalResistTier(player, target, element)
+    local elementalAbsorption    = xi.spells.damage.calculateAbsorption(target, element, false)
+    local elementalNullification = xi.spells.damage.calculateNullification(target, element, false, false)
+
+    -- Apply multipliers and bonuses.
+    damage = math.floor(damage * deathPenaltyMultiplier)
+    damage = math.floor(damage + damageAdditiveBonus)
+    damage = math.floor(damage * elementalStaffBonus)
+    damage = math.floor(damage * affinityMultiplier)
+    damage = math.floor(damage * dayWeatherMultiplier)
+    damage = math.floor(damage * magicBonusDiff)
+    damage = math.floor(damage * sdtMultiplier)
+    damage = math.floor(damage * resist)
+    damage = math.floor(damage * additionalResistTier)
+    damage = math.floor(damage * elementalAbsorption)
+    damage = math.floor(damage * elementalNullification)
+
+    -- TODO: Investigate. Whats actually needed from this?
+    damage = xi.ability.takeDamage(target, player, { targetTPMult = 0 }, true, damage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + element, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
+
+    return damage
+end
+
+xi.job_utils.corsair.handleQuickDrawEffectBoost = function(player, target, abilityId, multiplier)
+    local effectData = xi.job_utils.corsair.quickDrawEffectBoostTable[abilityId]
+    if not effectData then
+        return
+    end
+
+    -- Gather eligible effects that have not yet been boosted.
+    local effects = {}
+    for _, entryTable in ipairs(effectData) do
+        local effectChecked = target:getStatusEffect(entryTable.effectId)
+
+        if effectChecked then
+            local eligible = false
+
+            -- Check for Dia/Bio.
+            if entryTable.basePowerByTier then
+                local basePower = entryTable.basePowerByTier[effectChecked:getTier()]
+                eligible        = basePower and effectChecked:getSubPower() <= basePower
+
+            -- Check for all other eligible effects
+            else
+                eligible = effectChecked:getPower() < entryTable.capGlobal
+            end
+
+            if eligible then
+                table.insert(effects, { effect = effectChecked, entry = entryTable })
+            end
+        end
+    end
+
+    -- Early return: No effect can be boosted, either because it's capped or isn't present.
+    if #effects <= 0 then
+        return
+    end
+
+    -- Select effect entry from table and fetch it's content.
+    local selected = effects[math.random(1, #effects)]
+    local effect   = selected.effect
+    local entry    = selected.entry
+
+    -- Fetch effect data.
+    local effectId        = effect:getEffectType()
+    local effectPower     = effect:getPower()
+    local effectTick      = effect:getTick() / 1000
+    local effectDuration  = effect:getDuration() / 1000
+    local effectSubPower  = effect:getSubPower()
+    local effectSubType   = effect:getSubType()
+    local effectTier      = effect:getTier()
+    local effectStartTime = effect:getStartTime()
+    local effectOriginID  = effect:getOriginID()
+
+    -- Apply boost to Dia or Bio effects. They can only be boosted once. "Cannot be stacked."
+    if entry.basePowerByTier then
+        -- TODO: Determine power effect of Bio. Current retail bug with Dark Shot removes the DoT effect from Bio currently.
+        if effectId == xi.effect.DIA then
+            effectPower = effectPower + 1
+        end
+
+        effectSubPower = effectSubPower + math.floor(100 * 28 / 1024) -- TODO: Change ATTP, DEFP and similar mods from base 100 to base 10k
+
+    -- Apply boost to all other eligible effects.
+    else
+        if effectId >= xi.effect.BURN and effectId <= xi.effect.DROWN then
+            effectPower = math.min(effectPower + 2, entry.capGlobal)
+        else
+            effectPower = math.min(effectPower * multiplier, entry.capGlobal)
+        end
+    end
+
+    -- Remove the existing effect and reapply it with the new power/subPower values.
+    target:delStatusEffectSilent(effectId)
+
+    local params =
+    {
+        power    = effectPower,
+        tick     = effectTick,
+        duration = effectDuration,
+        subPower = effectSubPower,
+        subType  = effectSubType,
+        tier     = effectTier,
+        origin   = player,
+    }
+
+    target:addStatusEffect(effectId, params)
+
+    -- Update the start time and origin ID of the new effect to match the original effect.
+    local newEffect = target:getStatusEffect(effectId)
+    if newEffect then
+        newEffect:setStartTime(effectStartTime)
+        newEffect:setOriginID(effectOriginID)
+    end
+end
+
+-- Sets local var if party contains specified job
+xi.job_utils.corsair.checkForJobBonus = function(caster, job)
+    if job == xi.job.NONE then
+        caster:setLocalVar('corsairRollBonus', 0)
+        return
+    end
+
+    if caster:hasPartyJob(job) then
+        caster:setLocalVar('corsairRollBonus', 1)
+        return
+    end
+
+    if math.random(1, 100) <= caster:getMod(xi.mod.JOB_BONUS_CHANCE) then
+        caster:setLocalVar('corsairRollBonus', 1)
+        return
+    end
+
+    caster:setLocalVar('corsairRollBonus', 0)
+end
+
 -- in_ability == current_ability if not using doubleup. current_ability is used to set the message whether you're using a doubleup or not.
-local function applyRoll(caster, target, inAbility, total, isDoubleup, currentAbility)
+xi.job_utils.corsair.applyRoll = function(caster, target, inAbility, total, isDoubleup, currentAbility)
     local abilityId   = inAbility:getID()
-    local rollInfo    = rollData[abilityId]
+    local rollInfo    = xi.job_utils.corsair.rollData[abilityId]
     local effectpower = total >= 12 and rollInfo.bustPower or rollInfo.powers[total]    -- Get roll or bust power values
     local enhanceMod  = rollEnhanceMods[abilityId]                                      -- Check for roll enhancement gear mod specific to the rolled ability
     local doBonus     = enhanceMod and math.random(1, 100) <= caster:getMod(enhanceMod) -- Chance to enhance roll based on gear mod
@@ -662,169 +824,6 @@ local function applyRoll(caster, target, inAbility, total, isDoubleup, currentAb
     return total
 end
 
-local function handleQuickDrawDamage(player, target, action, element, resist)
-    -- Calculate Quick Draw damage - https://wiki.ffo.jp/html/3349.html TODO: QUICK_DRAW_TRIPLE_DAMAGE gear mod needs research
-    local damage                 = 2 * player:getRangedDmg() + 2 * player:getJobPointLevel(xi.jp.QUICK_DRAW_EFFECT) + player:getMod(xi.mod.QUICK_DRAW_DMG)
-    local deathPenaltyMultiplier = 1 + player:getMod(xi.mod.QUICK_DRAW_DMG_PERCENT) / 100
-    local damageAdditiveBonus    = player:getMod(xi.mod.MAGIC_DAMAGE)
-    local elementalStaffBonus    = xi.spells.damage.calculateElementalStaffBonus(player, element)
-    local affinityMultiplier     = xi.spells.damage.calculateElementalAffinityBonus(player, element)
-    local dayWeatherMultiplier   = xi.spells.damage.calculateDayAndWeather(player, element, false)
-    local magicBonusDiff         = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element, 0)
-
-    -- Unconfirmed order.
-    local sdtMultiplier          = xi.combat.damage.magicalElementSDT(target, element)
-    local additionalResistTier   = xi.spells.damage.calculateAdditionalResistTier(player, target, element)
-    local elementalAbsorption    = xi.spells.damage.calculateAbsorption(target, element, false)
-    local elementalNullification = xi.spells.damage.calculateNullification(target, element, false, false)
-
-    -- Apply multipliers and bonuses.
-    damage = math.floor(damage * deathPenaltyMultiplier)
-    damage = math.floor(damage + damageAdditiveBonus)
-    damage = math.floor(damage * elementalStaffBonus)
-    damage = math.floor(damage * affinityMultiplier)
-    damage = math.floor(damage * dayWeatherMultiplier)
-    damage = math.floor(damage * magicBonusDiff)
-    damage = math.floor(damage * sdtMultiplier)
-    damage = math.floor(damage * resist)
-    damage = math.floor(damage * additionalResistTier)
-    damage = math.floor(damage * elementalAbsorption)
-    damage = math.floor(damage * elementalNullification)
-
-    -- TODO: Investigate. Whats actually needed from this?
-    damage = xi.ability.takeDamage(target, player, { targetTPMult = 0 }, true, damage, xi.attackType.MAGICAL, xi.damageType.ELEMENTAL + element, xi.slot.RANGED, 1, 0, 0, 0, action, nil)
-
-    return damage
-end
-
-local function handleQuickDrawEffectBoost(player, target, abilityId, multiplier)
-    local effectData = quickDrawEffectBoostTable[abilityId]
-    if not effectData then
-        return
-    end
-
-    -- Gather eligible effects that are below the power cap.
-    local effects = {}
-    for _, entryTable in ipairs(effectData) do
-        local effectChecked = target:getStatusEffect(entryTable.effectId)
-
-        if effectChecked then
-            local eligible = false
-
-            -- Check for Dia/Bio.
-            if entryTable.capByTier then
-                local basePower = entryTable.capByTier[effectChecked:getTier()]
-                eligible        = basePower and basePower < effectChecked:getSubPower()
-
-            -- Check for all other eligible effects
-            else
-                eligible = effectChecked:getPower() < entryTable.capGlobal
-            end
-
-            if eligible then
-                table.insert(effects, { effect = effectChecked, entry = entryTable })
-            end
-        end
-    end
-
-    -- Early return: No effect can be boosted, either because it's capped or isn't present.
-    if #effects <= 0 then
-        return
-    end
-
-    -- Select effect entry from table and fetch it's content.
-    local selected = effects[math.random(1, #effects)]
-    local effect   = selected.effect
-    local entry    = selected.entry
-
-    -- Fetch effect data.
-    local effectId        = effect:getEffectType()
-    local effectPower     = effect:getPower()
-    local effectTick      = effect:getTick() / 1000
-    local effectDuration  = effect:getDuration() / 1000
-    local effectSubPower  = effect:getSubPower()
-    local effectSubType   = effect:getSubType()
-    local effectTier      = effect:getTier()
-    local effectStartTime = effect:getStartTime()
-    local effectOriginID  = effect:getOriginID()
-
-    -- Apply boost to Dia or Bio effects. They can only be boosted once. "Cannot be stacked."
-    if entry.capByTier then
-        -- TODO: Determine power effect of Bio. Current retail bug with Dark Shot removes the DoT effect from Bio currently.
-        if effectId == xi.effect.DIA then
-            effectPower = effectPower + 1
-        end
-
-        -- If subPower exceeds cap, clamp it.
-        effectSubPower = effectSubPower + math.floor(100 * 28 / 1024) -- TODO: Change ATTP, DEFP and similar mods from base 100 to base 10k
-
-    -- Apply boost to all other eligible effects.
-    else
-        if effectId >= xi.effect.BURN and effectId <= xi.effect.DROWN then
-            effectPower = math.min(effectPower + 2, entry.capGlobal)
-        else
-            effectPower = math.min(effectPower * multiplier, entry.capGlobal)
-        end
-    end
-
-    -- Remove the existing effect and reapply it with the new power/subPower values.
-    target:delStatusEffectSilent(effectId)
-
-    local params =
-    {
-        power    = effectPower,
-        tick     = effectTick,
-        duration = effectDuration,
-        subPower = effectSubPower,
-        subType  = effectSubType,
-        tier     = effectTier,
-        origin   = player,
-    }
-
-    target:addStatusEffect(effectId, params)
-
-    -- Update the start time and origin ID of the new effect to match the original effect.
-    local newEffect = target:getStatusEffect(effectId)
-    if newEffect then
-        newEffect:setStartTime(effectStartTime)
-        newEffect:setOriginID(effectOriginID)
-    end
-end
-
------------------------------------
--- Global helper functions
------------------------------------
-
-xi.job_utils.corsair.checkForElevenRoll = function(caster)
-    local effects = caster:getStatusEffects()
-
-    for _, effect in pairs(effects) do
-        if
-            effect:hasEffectFlag(xi.effectFlag.ROLL) and
-            effect:getSubPower() == 11
-        then
-            return true
-        end
-    end
-
-    return false
-end
-
-xi.job_utils.corsair.onRollEffectLose = function(player, effect)
-    -- Ignore effect loss if COR is doubling up
-    if player:getLocalVar('corsairApplyingRoll') == 1 then
-        return
-    end
-
-    if
-        player:hasStatusEffect(xi.effect.DOUBLE_UP_CHANCE) and
-        player:getLocalVar('corsairDuEffect') == effect:getEffectType()
-    then
-        player:delStatusEffectSilent(xi.effect.DOUBLE_UP_CHANCE)
-        player:setLocalVar('corsairDuEffect', 0)
-    end
-end
-
 -----------------------------------
 -- Ability Check functions
 -----------------------------------
@@ -834,7 +833,7 @@ end
 xi.job_utils.corsair.onRollAbilityCheck = function(player, target, ability)
     local abilityId = ability:getID()
     local numBusts  = player:numBustEffects()
-    local effectId  = rollData[abilityId].effect
+    local effectId  = xi.job_utils.corsair.rollData[abilityId].effect
     local maxRolls  = player:getMainJob() == xi.job.COR and 2 or 1
 
     if player:hasStatusEffect(effectId) then
@@ -876,7 +875,7 @@ xi.job_utils.corsair.checkFold = function(player)
 end
 
 xi.job_utils.corsair.checkQuickDraw = function(player, ability)
-    local data = quickDrawDataTable[ability:getID()]
+    local data = xi.job_utils.corsair.quickDrawDataTable[ability:getID()]
     if not data then
         return xi.msg.basic.CANNOT_PERFORM, 0
     end
@@ -921,7 +920,7 @@ end
 -- Called by Phantom Rolls' onUseAbility
 xi.job_utils.corsair.onRollUseAbility = function(caster, target, ability, action)
     local abilityId = ability:getID()
-    local rollInfo  = rollData[abilityId]
+    local rollInfo  = xi.job_utils.corsair.rollData[abilityId]
     local effectId  = rollInfo.effect
     local bonusJob  = rollInfo.bonusJob
 
@@ -929,7 +928,7 @@ xi.job_utils.corsair.onRollUseAbility = function(caster, target, ability, action
         corsairSetup(caster, ability, action, effectId, bonusJob)
     end
 
-    return applyRoll(caster, target, ability, caster:getLocalVar('corsairRollTotal'), false, ability)
+    return xi.job_utils.corsair.applyRoll(caster, target, ability, caster:getLocalVar('corsairRollTotal'), false, ability)
 end
 
 xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
@@ -966,7 +965,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
 
         caster:setLocalVar('corsairRollTotal', roll)
         action:info(caster:getID(), roll - prevRoll:getSubPower())
-        checkForJobBonus(caster, job)
+        xi.job_utils.corsair.checkForJobBonus(caster, job)
     end
 
     local total       = caster:getLocalVar('corsairRollTotal')
@@ -976,7 +975,7 @@ xi.job_utils.corsair.useDoubleUp = function(caster, target, ability, action)
     if prevAbility then -- Apply rolls to target(s), including the COR
         action:actionID(prevAbility:getID())
 
-        total = applyRoll(caster, target, prevAbility, total, true, ability)
+        total = xi.job_utils.corsair.applyRoll(caster, target, prevAbility, total, true, ability)
 
         if total > 11 then
             action:setAnimation(target:getID(), 98) -- 98 is bust anim for all rolls
@@ -992,7 +991,7 @@ xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
     local abilityId = ability:getID()
 
     -- Fetch specific ability data.
-    local data = quickDrawDataTable[abilityId]
+    local data = xi.job_utils.corsair.quickDrawDataTable[abilityId]
     if not data then
         return
     end
@@ -1015,7 +1014,7 @@ xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
     -- Handle damage.
     local damage = 0
     if data.canDamage then
-        damage = handleQuickDrawDamage(actor, target, action, data.element, resist)
+        damage = xi.job_utils.corsair.handleQuickDrawDamage(actor, target, action, data.element, resist)
     end
 
     if damage > 0 then
@@ -1024,7 +1023,7 @@ xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
     end
 
     -- Handle effect boost.
-    handleQuickDrawEffectBoost(actor, target, abilityId, data.multiplier)
+    xi.job_utils.corsair.handleQuickDrawEffectBoost(actor, target, abilityId, data.multiplier)
 
     -- Handle effect application.
     if data.applyEffectId > 0 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds new Corsair job util and sql modules to revert era behavior or remove items from NPC stocks.
- Bug fixes:
   - Light and Dark Shot were not boosting their respective subpowers, corrected the value check whether or not the subpower is eligible for boost
   - Ranger module was referencing the scavenge_data.lua at a path that doesn't exist, causing the module to error
- In order to module things in as minimal a way as I could think of, it required exposing a lot of the corsair functions. Open to alternative ideas if there's another approach.

## Steps to test these changes

- Load related module folders in init.txt
- Jump on COR and see that the abilities are adjusted as described in the comments found in the module