### PR TITLE
[lua] Audit Aqueducts locked doors

### DIFF
--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir8.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir8.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Area: Phomiuna_Aqueducts
---  NPC: _ir7 (Iron Gate)
--- !pos -70.8 -1.5 60 27
+--  NPC: _ir8 (Iron Gate)
+-- !pos 20 -1.5 50 0
 -----------------------------------
 local ID = zones[xi.zone.PHOMIUNA_AQUEDUCTS]
 -----------------------------------
@@ -9,10 +9,7 @@ local ID = zones[xi.zone.PHOMIUNA_AQUEDUCTS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if
-        player:getXPos() > -70.8 and
-        npc:getAnimation() == xi.animation.CLOSE_DOOR
-    then
+    if player:getZPos() > 50 and npc:getAnimation() == xi.animation.CLOSE_DOOR then
         if npcUtil.tradeHasExactly(trade, xi.item.BRONZE_KEY) then
             player:confirmTrade()
             player:messageSpecial(ID.text.ITEM_BREAKS, xi.item.BRONZE_KEY)
@@ -36,7 +33,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getXPos() <= -70.8 then
+    if player:getZPos() <= 50 then
         npc:openDoor(15)
     elseif npc:getAnimation() == xi.animation.CLOSE_DOOR then
         local noValidationFlag = 0x8000

--- a/scripts/zones/Phomiuna_Aqueducts/npcs/_ir9.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/npcs/_ir9.lua
@@ -9,30 +9,40 @@ local ID = zones[xi.zone.PHOMIUNA_AQUEDUCTS]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    -- TODO: There may be a message displayed onTrade if the door is open.
-    if player:getXPos() >= -70 and npc:getAnimation() == 9 then
+    if player:getXPos() < 70 and npc:getAnimation() == xi.animation.CLOSE_DOOR then
         if npcUtil.tradeHasExactly(trade, xi.item.BRONZE_KEY) then
             player:confirmTrade()
             player:messageSpecial(ID.text.ITEM_BREAKS, xi.item.BRONZE_KEY)
             npc:openDoor(15)
-        elseif
-            player:getMainJob() == xi.job.THF and
-            (npcUtil.tradeHasExactly(trade, xi.item.SKELETON_KEY) or
-            npcUtil.tradeHasExactly(trade, xi.item.SET_OF_THIEFS_TOOLS) or
-            npcUtil.tradeHasExactly(trade, xi.item.LIVING_KEY))
-        then
-            -- TODO: Needs verification for messages displayed, and if picking is 100% successful.
-            player:confirmTrade()
-            npc:openDoor(15)
+        elseif player:getMainJob() == xi.job.THF then
+            local itemId = npcUtil.tradeHasExactly(trade, xi.item.SKELETON_KEY) and xi.item.SKELETON_KEY or 0
+
+            itemId = npcUtil.tradeHasExactly(trade, xi.item.SET_OF_THIEFS_TOOLS) and xi.item.SET_OF_THIEFS_TOOLS or itemId
+            itemId = npcUtil.tradeHasExactly(trade, xi.item.LIVING_KEY) and xi.item.LIVING_KEY or itemId
+
+            if itemId ~= 0 then
+                local noValidationFlag = 0x8000
+
+                player:showText(npc, bit.bor(ID.text.ITEM_BREAKS + 2, noValidationFlag), itemId, 0, 0, 0, false, false)
+                player:confirmTrade()
+
+                npc:openDoor(15)
+            end
         end
     end
 end
 
 entity.onTrigger = function(player, npc)
-    if player:getXPos() <= -71 then
+    if player:getXPos() >= 70 then
         npc:openDoor(15)
-    elseif npc:getAnimation() == 9 then
-        player:messageSpecial(ID.text.DOOR_LOCKED, xi.item.BRONZE_KEY)
+    elseif npc:getAnimation() == xi.animation.CLOSE_DOOR then
+        local noValidationFlag = 0x8000
+
+        if player:getMainJob() == xi.job.THF then
+            player:showText(npc, bit.bor(ID.text.DOOR_LOCKED + 1, noValidationFlag), xi.item.BRONZE_KEY, xi.item.SET_OF_THIEFS_TOOLS, 0, 0, false, false)
+        else
+            player:showText(npc, bit.bor(ID.text.DOOR_LOCKED, noValidationFlag), xi.item.BRONZE_KEY, 0, 0, 0, false, false)
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #10332

tl;dr: the doors were missing some messaging, one door that had a one way lock was just not implemented, and one door had a bad pos check.

## Steps to test these changes

Open the three doors from one side only without a key. The side where the doors need to be pulled in rather than pushed out is where it is locked.
Click the door on non-THF main job and get "bronze key" message
Click the door on THF main job and get "bronze key or thieves tool" message
Unlock with bronze key and it it says it breaks
Unlock with one of the three key types and see the message indicates you used that tool.
