### PR TITLE
[lua, sql, cpp] Beastmaster Sic bugfix; Sic Era Module

### DIFF
--- a/modules/era/lua/globals/job_utils/beastmaster.lua
+++ b/modules/era/lua/globals/job_utils/beastmaster.lua
@@ -4,59 +4,98 @@
 require('modules/module_utils')
 -----------------------------------
 local moduleName = 'era_job_utils_beastmaster'
-
--- If Abyssea or later is enabled, no changes.
-if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
-end
-
 local m = Module:new(moduleName)
 
--- Reward: Override pet food healing values to pre-Abyssea values
--- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/08/2010)
-xi.job_utils.beastmaster.petFoodData =
-{
-    [xi.item.PET_FOOD_ALPHA_BISCUIT]   = { minHealing =  25, regen =  1, mndMult = 2, mndThreshold = 10 },
-    [xi.item.PET_FOOD_BETA_BISCUIT]    = { minHealing =  50, regen =  3, mndMult = 1, mndThreshold = 33 },
-    [xi.item.PET_FOOD_GAMMA_BISCUIT]   = { minHealing = 100, regen =  5, mndMult = 1, mndThreshold = 35 },
-    [xi.item.PET_FOOD_DELTA_BISCUIT]   = { minHealing = 150, regen =  8, mndMult = 2, mndThreshold = 40 },
-    [xi.item.PET_FOOD_EPSILON_BISCUIT] = { minHealing = 300, regen = 11, mndMult = 2, mndThreshold = 45 },
-    [xi.item.PET_FOOD_ZETA_BISCUIT]    = { minHealing = 350, regen = 14, mndMult = 3, mndThreshold = 45 },
-}
+if not xi.module.isContentEnabled('ABYSSEA') then
+    -- Reward: Override pet food healing values to pre-Abyssea values
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(09/08/2010)
+    xi.job_utils.beastmaster.petFoodData =
+    {
+        [xi.item.PET_FOOD_ALPHA_BISCUIT]   = { minHealing =  25, regen =  1, mndMult = 2, mndThreshold = 10 },
+        [xi.item.PET_FOOD_BETA_BISCUIT]    = { minHealing =  50, regen =  3, mndMult = 1, mndThreshold = 33 },
+        [xi.item.PET_FOOD_GAMMA_BISCUIT]   = { minHealing = 100, regen =  5, mndMult = 1, mndThreshold = 35 },
+        [xi.item.PET_FOOD_DELTA_BISCUIT]   = { minHealing = 150, regen =  8, mndMult = 2, mndThreshold = 40 },
+        [xi.item.PET_FOOD_EPSILON_BISCUIT] = { minHealing = 300, regen = 11, mndMult = 2, mndThreshold = 45 },
+        [xi.item.PET_FOOD_ZETA_BISCUIT]    = { minHealing = 350, regen = 14, mndMult = 3, mndThreshold = 45 },
+    }
 
--- Feral Howl: Apply merit recast reduction, remove extra accuracy from merits
-m:addOverride('xi.job_utils.beastmaster.useFeralHowl', function(player, target, ability, action)
-    local recastReduction = player:getMerit(xi.merit.FERAL_HOWL) - 150
-    action:setRecast(action:getRecast() - recastReduction)
+    -- Feral Howl: Apply merit recast reduction, remove extra accuracy from merits
+    m:addOverride('xi.job_utils.beastmaster.useFeralHowl', function(player, target, ability, action)
+        local recastReduction = player:getMerit(xi.merit.FERAL_HOWL) - 150
+        action:setRecast(action:getRecast() - recastReduction)
 
-    if
-        not xi.data.statusEffect.isTargetImmune(target, xi.effect.TERROR, xi.element.DARK) and
-        not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.TERROR) and
-        not xi.data.statusEffect.isEffectNullified(target, xi.effect.TERROR, 0)
-    then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.B_MINUS, xi.element.DARK, xi.mod.CHR, xi.effect.TERROR)
+        if
+            not xi.data.statusEffect.isTargetImmune(target, xi.effect.TERROR, xi.element.DARK) and
+            not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.TERROR) and
+            not xi.data.statusEffect.isEffectNullified(target, xi.effect.TERROR, 0)
+        then
+            local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.B_MINUS, xi.element.DARK, xi.mod.CHR, xi.effect.TERROR)
 
-        if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.TERROR, resistanceRate, 0) then
-            target:addStatusEffect(xi.effect.TERROR, { power = 1, duration = 10 * resistanceRate, origin = player })
+            if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.TERROR, resistanceRate, 0) then
+                target:addStatusEffect(xi.effect.TERROR, { power = 1, duration = 10 * resistanceRate, origin = player })
+            end
         end
-    end
 
-    return xi.effect.TERROR
-end)
+        return xi.effect.TERROR
+    end)
 
--- Killer Insinct: Apply merit recast reduction, remove extra duration from merits
-m:addOverride('xi.job_utils.beastmaster.useKillerInstinct', function(player, target, ability, action)
-    local recastReduction = player:getMerit(xi.merit.KILLER_INSTINCT) - 150
-    action:setRecast(action:getRecast() - recastReduction)
+    -- Killer Insinct: Apply merit recast reduction, remove extra duration from merits
+    m:addOverride('xi.job_utils.beastmaster.useKillerInstinct', function(player, target, ability, action)
+        local recastReduction = player:getMerit(xi.merit.KILLER_INSTINCT) - 150
+        action:setRecast(action:getRecast() - recastReduction)
 
-    -- Notes: Pet ecosystem is assigned to the subPower, then mapped to the correct killer mod in the effect script.
-    local pet          = player:getPet()
-    local petEcosystem = pet:getEcosystem()
-    local power        = 10
+        -- Notes: Pet ecosystem is assigned to the subPower, then mapped to the correct killer mod in the effect script.
+        local pet          = player:getPet()
+        local petEcosystem = pet:getEcosystem()
+        local power        = 10
 
-    target:addStatusEffect(xi.effect.KILLER_INSTINCT, { power = power, duration = 60, origin = player, subPower = petEcosystem })
+        target:addStatusEffect(xi.effect.KILLER_INSTINCT, { power = power, duration = 60, origin = player, subPower = petEcosystem })
 
-    return xi.effect.KILLER_INSTINCT
-end)
+        return xi.effect.KILLER_INSTINCT
+    end)
+end
 
-return m
+if not xi.module.isContentEnabled('WOTG') then
+    -- Jug pet skill lists mapped to mob species for utilization in Sic.
+    -- Baseline skill lists in mob_skill_list.sql for jugs map to pet_skill.sql for use in "Ready"
+    -- This breaks when reverting to Sic, causing jug pets to use the wrong skills
+    local jugSkillLists =
+    {
+        [xi.mobSpecies.RABBIT]       = 206,
+        [xi.mobSpecies.SHEEP]        = 226,
+        [xi.mobSpecies.CRAB]         = 372,
+        [xi.mobSpecies.MANDRAGORA]   = 903,
+        [xi.mobSpecies.TIGER]        = 242,
+        [xi.mobSpecies.FLYTRAP]      = 114,
+        [xi.mobSpecies.HILL_LIZARD]  = 174,
+        [xi.mobSpecies.FLY]          = 113,
+        [xi.mobSpecies.EFT]          =  98,
+        [xi.mobSpecies.FUNGUAR]      = 116,
+        [xi.mobSpecies.BEETLE]       =  49,
+        [xi.mobSpecies.ANTLION]      =  26,
+        [xi.mobSpecies.DIREMITE]     =  81,
+        [xi.mobSpecies.SABOTENDER]   = 939,
+    }
+
+    -- Jug Pets: Applies a skill list on spawn of pet to properly utilize Sic.
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(11/09/2009)
+    m:addOverride('xi.job_utils.beastmaster.useCallBeast', function(player, target, ability, action)
+        super(player, target, ability, action)
+
+        local pet = player:getPet()
+        if pet then
+            local listId = jugSkillLists[pet:getSpecies()]
+            if listId then
+                pet:setMobMod(xi.mobMod.SKILL_LIST, listId)
+            end
+        end
+    end)
+end
+
+-- Return a real module only when a content gate registered overrides.
+-- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
+if #m.overrides > 0 then
+    return m
+end
+
+return { name = moduleName }

--- a/modules/wotg/sql/job_adjustments.sql
+++ b/modules/wotg/sql/job_adjustments.sql
@@ -23,6 +23,22 @@ UPDATE `abilities` SET `recastTime` = 180 WHERE `name` = 'reward';
 -- Reward merit: Revert value to 6 seconds per level
 UPDATE `merits` SET `value` = 6 WHERE `name` = 'reward';
 
+-- Sic: Allow use with jug pets in addition to charmed mobs
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(11/09/2009)
+UPDATE `abilities` SET `addType` = 192 WHERE `name` = 'sic';
+
+-- Mob Skill List Adjustments to allow Jug Pets to utilize proper skill lists before Ready exists
+-- Add Wild Oats and Leaf Dagger to Nonno skill list for Mandragora jug pets
+-- Needed due to mandragora jug pets should not have access to photosyntesis
+INSERT INTO `mob_skill_lists` VALUES ('Nonno',903,302);
+INSERT INTO `mob_skill_lists` VALUES ('Nonno',903,305);
+
+-- Rework Emperador De Altepa skill list for Amigo Sabotender jug pet
+-- Needed due to sabotender jug pets should not have access to photosyntesis
+DELETE FROM `mob_skill_lists` WHERE `skill_list_name` = 'Emperador_de_Altepa';
+INSERT INTO `mob_skill_lists` VALUES ('Emperador_de_Altepa',939,321);
+INSERT INTO `mob_skill_lists` VALUES ('Emperador_de_Altepa',939,322);
+
 -- Heel: Revert recast from 5 seconds to 10 seconds
 -- Source: http://www.playonline.com/pcd/update/ff11us/20071120wwnX41/detail.html
 UPDATE `abilities` SET `recastTime` = 10 WHERE `name` = 'heel';

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -356,12 +356,13 @@ xi.job_utils.beastmaster.checkSic = function(player, target, ability)
 
     if pet == nil then
         return xi.msg.basic.REQUIRES_A_PET, 0
-    elseif pet:getHP() == 0 then
+    elseif
+        pet:getHP() == 0 or
+        not pet:hasTPMoves()
+    then
         return xi.msg.basic.UNABLE_TO_USE_JA, 0
     elseif pet:getTarget() == nil then
         return xi.msg.basic.PET_CANNOT_DO_ACTION, 0
-    elseif not pet:hasTPMoves() then
-        return xi.msg.basic.UNABLE_TO_USE_JA, 0
     end
 
     return 0, 0

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -19058,18 +19058,19 @@ bool CLuaBaseEntity::hasTPMoves()
         return false;
     }
 
-    uint16 speciesID = 0;
-
-    if (m_PBaseEntity->objtype & TYPE_PET)
+    auto* PMob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    if (!PMob)
     {
-        speciesID = static_cast<CPetEntity*>(m_PBaseEntity)->m_Species;
+        return false;
     }
-    else if (m_PBaseEntity->objtype & TYPE_MOB)
-    {
-        speciesID = static_cast<CMobEntity*>(m_PBaseEntity)->m_Species;
-    }
-    const std::vector<uint16>& MobSkills = battleutils::GetMobSkillList(speciesID);
 
+    uint16 skillListID = static_cast<uint16>(PMob->getMobMod(MOBMOD_SKILL_LIST));
+    if (skillListID == 0)
+    {
+        skillListID = PMob->m_MobSkillList;
+    }
+
+    const std::vector<uint16>& MobSkills = battleutils::GetMobSkillList(skillListID);
     return !MobSkills.empty();
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Sic was utilizing a check hasTpMoves that was mapping a pet's mob family directly to see if they have a matching skill list. Not every pet species ID directly matches a skill list ID of the same, which was causing some charmed pets from failing to use Sic. This updates that binding to directly check if the pet has a skill list or not.
- Updates era modules to return the usage of Sic to jug pets. Required mapping a table of skill lists for in era jug pets since their existing skill lists map to pet_skill.sql used through Ready.

## Steps to test these changes

- Charm an open world mob, see that you can properly trigger Sic on the mob
- Load modules, summon a jug pet. Give the pet TP and use Sic. See that it uses the proper skill list for its family.
