### PR TITLE
[C++] [lua] Disable SQL Fallback for valid lua spell overrides

### DIFF
--- a/scripts/globals/combat/entity_behavior.lua
+++ b/scripts/globals/combat/entity_behavior.lua
@@ -306,9 +306,9 @@ xi.combat.behavior.chooseAction = function(actor, mainTarget, optionalTargets, a
         }
     end
 
-    -- Something went wrong.
+    -- Something went wrong or nothing to cast right now.
     if #actionList == 0 then
-        return nil, nil
+        return 0, nil
     end
 
     -- Calculate total weight of the new list.

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3365,13 +3365,16 @@ std::tuple<Maybe<SpellID>, Maybe<CBattleEntity*>> OnMobSpellChoose(CBattleEntity
         }
     }
 
-    uint32 newSpellId = result.get_type(0) == sol::type::number ? result.get<int32>(0) : 0;
-
     std::tuple<Maybe<SpellID>, Maybe<CBattleEntity*>> retVal = {};
 
-    if (newSpellId > 0)
+    if (result.get_type(0) == sol::type::number)
     {
-        std::get<0>(retVal) = static_cast<SpellID>(newSpellId);
+        const auto newSpellId = result.get<int32>(0);
+
+        if (newSpellId >= 0)
+        {
+            std::get<0>(retVal) = static_cast<SpellID>(newSpellId);
+        }
     }
 
     if (newTarget)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mobs using spell lists in lua would sometimes run out of things to cast (either from being on cooldown or having all buffs active) - when this happened the helper would return nil which would force a sql fallback/lookup for a valid spell. 

This PR changes the lua binding to be valid as long as a number is received back, allowing for 0 to be returned. 

This basically means that...
nil = something went wrong with the lua override, use sql
0 = override worked, but nothing to cast right now
greater than 0 = valid spell returned 

## Steps to test these changes

Enter Royale Ramble, see mobs buff normally and follow lua spell list.


