### PR TITLE
Tests: Add Aggro-LOS test and Aggro-tap test

### DIFF
--- a/scripts/tests/systems/aggro_los.lua
+++ b/scripts/tests/systems/aggro_los.lua
@@ -1,0 +1,71 @@
+-----------------------------------
+-- Sight aggro respects line of sight (no aggro around a corner)
+--
+-- A Groundskeeper sits in a slightly-raised alcove in RuAun Gardens. A player
+-- standing in front of the alcove is in plain view and should be aggroed; a
+-- player who steps around the corner is hidden by the wall and should not be,
+-- even though the elevation and distance are nearly identical.
+--
+-- NOTE: We currently have a bug where these Groundskeepers do not have sight detection
+--     : set, so, we're forcing it on for this test.
+-----------------------------------
+
+describe('Sight aggro line of sight', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.RUAUN_GARDENS })
+    end)
+
+    -- The alcove Groundskeeper, picked out of RuAun's ~100 Groundskeepers by its
+    -- position rather than a brittle hardcoded entity id.
+    local function alcoveGroundskeeper()
+        local ax = 20.239
+        local ay = -41.729
+        local az = -340.048
+
+        local best     = nil
+        local bestDist = nil
+
+        for _, e in ipairs(player:getZone():queryEntitiesByName('Groundskeeper')) do
+            local dx   = e:getXPos() - ax
+            local dy   = e:getYPos() - ay
+            local dz   = e:getZPos() - az
+            local dist = dx * dx + dy * dy + dz * dz
+            if not bestDist or dist < bestDist then
+                best     = e
+                bestDist = dist
+            end
+        end
+
+        return best
+    end
+
+    it('aggros in front of the alcove but not around the corner', function()
+        local mob = alcoveGroundskeeper()
+
+        -- TODO: We shouldn't have to set these manually, they should be the default behaviours
+        --     : of this particular Groundskeeper
+        mob:setAggressive(true)
+        mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
+        mob:setMobMod(xi.mobMod.DETECTION, xi.detects.SIGHT)
+        mob:setMobMod(xi.mobMod.SIGHT_RANGE, 20)
+
+        -- Roam past the post-spawn neutral window so the mob can aggro at all.
+        for _ = 1, 10 do
+            xi.test.world:skipTime(5)
+            xi.test.world:tickEntity(mob)
+        end
+
+        -- Around the corner: within range and facing, but the wall blocks sight.
+        mob:lookAt(12.5537, -40.241, -347.141)
+        player.actions:move(12.5537, -40.241, -347.141, 30)
+        assert(not mob:isEngaged(), 'mob should not aggro a player hidden around the corner')
+
+        -- In front of the alcove: clear line of sight -> aggro.
+        mob:lookAt(11.1005, -40.241, -340.042)
+        player.actions:move(11.1005, -40.241, -340.042, 26)
+        assert(mob:isEngaged(), 'mob should aggro a player in plain view in front of the alcove')
+    end)
+end)

--- a/scripts/tests/systems/aggro_los.lua
+++ b/scripts/tests/systems/aggro_los.lua
@@ -44,6 +44,7 @@ describe('Sight aggro line of sight', function()
 
     it('aggros in front of the alcove but not around the corner', function()
         local mob = alcoveGroundskeeper()
+        assert(mob, 'alcove Groundskeeper not found')
 
         -- TODO: We shouldn't have to set these manually, they should be the default behaviours
         --     : of this particular Groundskeeper

--- a/scripts/tests/systems/aggro_retap.lua
+++ b/scripts/tests/systems/aggro_retap.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+-- Aggro is re-evaluated as the player moves (spawn-list onUpdate)
+-----------------------------------
+
+describe('Aggro re-tap on movement', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.IFRITS_CAULDRON })
+    end)
+
+    it('aggros a player who approaches a mob already in view', function()
+        local mob = player.entities:get('Volcanic_Bomb')
+        mob:respawn()
+
+        -- Aggro by sight (the "eyeline" case), at any level, within 20 yalms.
+        mob:setAggressive(true)
+        mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
+        mob:setMobMod(xi.mobMod.DETECTION, xi.detects.SIGHT)
+        mob:setMobMod(xi.mobMod.SIGHT_RANGE, 20)
+
+        -- Roam past the post-spawn neutral window so the mob can aggro at all.
+        for _ = 1, 10 do
+            xi.test.world:skipTime(5)
+            xi.test.world:tickEntity(mob)
+        end
+
+        local mx = mob:getXPos()
+        local my = mob:getYPos()
+        local mz = mob:getZPos()
+
+        -- Face the mob down the +x approach lane, so the player is inside its
+        -- sight line at both the far and near positions.
+        mob:lookAt(mx + 100.0, my, mz)
+
+        -- Step 1: enter render range, so the mob is shown to the client and added
+        -- to the spawn list, but stay outside its 20-yalm sight range. It is now
+        -- "in view" yet must not have aggroed.
+        player.actions:move(mx + 30.0, my, mz)
+        assert(not mob:isEngaged(), 'mob should not aggro from outside its sight range')
+
+        -- Step 2: approach into sight range with clear line of sight. The mob is
+        -- already in the spawn list, so aggro is only re-evaluated here via the
+        -- onUpdate re-tap.
+        player.actions:move(mx + 3.0, my, mz)
+        assert(mob:isEngaged(), 'mob should aggro a player who approaches into its eyeline')
+    end)
+end)

--- a/src/map/ximesh/ximesh.cpp
+++ b/src/map/ximesh/ximesh.cpp
@@ -26,6 +26,7 @@
 #include <common/utils.h>
 
 #include <array>
+#include <cmath>
 #include <fstream>
 #include <span>
 #include <unordered_map>
@@ -724,11 +725,17 @@ auto XiMesh::rayIntersect(const Vector3& start, const Vector3& end, const Ignore
         nextZ = std::numeric_limits<float>::infinity();
     }
 
-    const auto rayLength       = std::sqrt(dx * dx + dz * dz);
-    float      currentDistance = 0.0f;
+    float       currentDistance = 0.0f;
+    const int32 maxSteps        = static_cast<int32>(header_.gridWidth) + static_cast<int32>(header_.gridHeight) + 2;
+    int32       steps           = 0;
 
-    while ((col != endCol || row != endRow) && currentDistance < rayLength)
+    while ((col != endCol || row != endRow) && currentDistance < 1.0f)
     {
+        if (++steps > maxSteps)
+        {
+            break;
+        }
+
         // Move to whichever grid line is closer.
         if (nextX < nextZ)
         {
@@ -755,7 +762,7 @@ auto XiMesh::rayIntersect(const Vector3& start, const Vector3& end, const Ignore
             col2 = std::min<int32>(header_.gridWidth - 1, col + cellSearchDiff);
         }
 
-        if (currentDistance <= rayLength)
+        if (currentDistance <= 1.0f)
         {
             for (int32 r = row1; r <= row2; ++r)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Follow-up to https://github.com/LandSandBoat/server/pull/10426

Captures the aggro-on-update logic that was just fixed, and also adds a general (and popular) test for aggroing around corners.

Though, the test also encodes "these groundskeepers should aggro, and others shouldn't". We need new mob pools for the ones that aggro, in addition to the ones we have right now that don't.

Also adds a safety check into rayIntersect:
```
Without this, if garbage or "outside mesh" coords are passed in, we'll get a 2^40+ number to try and raycast again, making us essentially spin forever. This bounds that scenario so we come out at worst in under a second. No ideal, but better than death
```