### PR TITLE
[Proposal] [Combat] Convert skillchain damage calculations to lua

### DIFF
--- a/scripts/data/element_tables.lua
+++ b/scripts/data/element_tables.lua
@@ -40,6 +40,21 @@ xi.data.element.dataTable =
     [xi.element.DARK   ] = { xi.element.LIGHT,   xi.day.DARKSDAY,     xi.weather.GLOOM,      xi.weather.DARKNESS,      xi.mod.DARK_SDT,    xi.mod.DARK_RES_RANK,    xi.mod.DARK_NULL,  xi.mod.DARK_ABSORB,  xi.mod.DARK_MAB,    xi.mod.DARK_MACC,    xi.mod.DARK_MEVA,    xi.mod.DARK_FTP_BONUS,    xi.mod.DARK_STAFF_BONUS,    xi.mod.FORCE_DARK_DWBONUS,      0,                     0,                                0                                 },
 }
 
+-- Table with skillchain elemental properties, keyed by element: Row -> Element; Column -> Skillchain ID
+xi.data.element.skillchainElementTable =
+{
+--                           1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16
+--                           T  C  L  S  R  D  I  I  G  D  F  F  L  D  L  D
+    [xi.element.FIRE   ] = { 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0 },
+    [xi.element.ICE    ] = { 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1 },
+    [xi.element.WIND   ] = { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0 },
+    [xi.element.EARTH  ] = { 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1 },
+    [xi.element.THUNDER] = { 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0 },
+    [xi.element.WATER  ] = { 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1 },
+    [xi.element.LIGHT  ] = { 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0 },
+    [xi.element.DARK   ] = { 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1 },
+}
+
 -- Get element to which the element being checked is weak against.
 xi.data.element.getElementWeakness = function(element)
     -- Validate fed value.

--- a/scripts/globals/combat/damage_multipliers.lua
+++ b/scripts/globals/combat/damage_multipliers.lua
@@ -14,10 +14,10 @@ xi.combat.damage.physicalElementSDT = function(target, physicalElement)
 
     local physicalElementSDTModifier =
     {
-        [xi.damageType.PIERCING] = xi.mod.PIERCE_SDT,
-        [xi.damageType.SLASHING] = xi.mod.SLASH_SDT,
-        [xi.damageType.BLUNT   ] = xi.mod.IMPACT_SDT,
-        [xi.damageType.HAND_TO_HAND     ] = xi.mod.HTH_SDT,
+        [xi.damageType.PIERCING    ] = xi.mod.PIERCE_SDT,
+        [xi.damageType.SLASHING    ] = xi.mod.SLASH_SDT,
+        [xi.damageType.BLUNT       ] = xi.mod.IMPACT_SDT,
+        [xi.damageType.HAND_TO_HAND] = xi.mod.HTH_SDT,
     }
 
     local sdt = 1 + target:getMod(physicalElementSDTModifier[physicalElement]) / 10000

--- a/scripts/globals/combat/skillchain.lua
+++ b/scripts/globals/combat/skillchain.lua
@@ -1,0 +1,139 @@
+-----------------------------------
+-- Global file for skillchain calculations.
+-----------------------------------
+xi = xi or {}
+xi.combat = xi.combat or {}
+xi.combat.skillchain = xi.combat.skillchain or {}
+-----------------------------------
+
+local resistanceRankMultiplier =
+{
+    [-3] = 1.50,
+    [-2] = 1.30,
+    [-1] = 1.15,
+    [ 0] = 1.00,
+    [ 1] = 0.85,
+    [ 2] = 0.70,
+    [ 3] = 0.60,
+    [ 4] = 0.50,
+    [ 5] = 0.40,
+    [ 6] = 0.30,
+    [ 7] = 0.25,
+    [ 8] = 0.20,
+    [ 9] = 0.15,
+    [10] = 0.10,
+    [11] = 0.05,
+}
+
+local chainMultipliers =
+{
+    [1] = { 0.50, 0.60, 0.70, 0.80, 0.90, 1.00 }, -- Level 1
+    [2] = { 0.60, 0.75, 1.00, 1.25, 1.50, 1.75 }, -- Level 2
+    [3] = { 1.00, 1.50, 1.75, 2.00, 2.25, 2.50 }, -- Level 3
+    [4] = { 1.50, 1.80, 2.10, 2.40, 2.70, 3.00 }, -- Level 4 "Radiance/Umbra"
+}
+
+local function getSkillchainElementToUse(target, skillchainType)
+    -- Build skillchain available elements table.
+    local elementTable = {}
+    for i = xi.element.FIRE, xi.element.DARK do
+        if xi.data.element.skillchainElementTable[i][skillchainType + 1] > 0 then
+            table.insert(elementTable, #elementTable + 1, i)
+        end
+    end
+
+    -- Early return: Single elemental SC. No need to continue.
+    if #elementTable == 1 then
+        return elementTable[1]
+    end
+
+    -- Get lowest resistance rank value.
+    local lowestResRank = 11
+    local lowestElement = xi.element.NONE
+
+    for j = #elementTable, 1, -1 do
+        local resRankValue = target:getMod(xi.data.element.getElementalResistanceRankModifier(elementTable[j]))
+        if resRankValue <= lowestResRank then
+            lowestResRank = resRankValue
+            lowestElement = elementTable[j]
+        end
+    end
+
+    return lowestElement
+end
+
+-- Handles skillchain magic damage multipliers, called from C++ (battleutils::TakeSkillchainDamage)
+xi.combat.skillchain.calculateSkillchainDamage = function(actor, target, baseDamage)
+    local skillchainEffect = target:getStatusEffect(xi.effect.SKILLCHAIN)
+    if not skillchainEffect then
+        return 0
+    end
+
+    local skillchainType = skillchainEffect:getPower()
+    if skillchainType == 0 then
+        return 0
+    end
+
+    local skillchainLevel = skillchainEffect:getTier()
+    if skillchainLevel < 1 or skillchainLevel > 4 then
+        return 0
+    end
+
+    local skillchainCount = skillchainEffect:getSubPower()
+    if skillchainCount < 1 or skillchainCount > 6 then
+        return 0
+    end
+
+    local skillchainElement = getSkillchainElementToUse(target, skillchainType)
+    if xi.spells.damage.calculateNullification(target, skillchainElement, true, false) == 0 then
+        return 0
+    end
+
+    -- Calculate base damage and multipliers.
+    local finalDamage          = math.abs(baseDamage) -- Damage from skillchain, no matter if absorbed or not.
+    local levelMultiplier      = chainMultipliers[skillchainLevel][skillchainCount - 1] -- We substract 1 because the minimal ammount of WSs needed for a SC is 2.
+    local bonusMultiplier      = 1 + actor:getMod(xi.mod.SKILLCHAINBONUS) / 100
+    local damageMultiplier     = 1 + actor:getMod(xi.mod.SKILLCHAINDMG) / 10000
+    local dayWeatherMultiplier = xi.spells.damage.calculateDayAndWeather(actor, skillchainElement, false)
+    local staffMultiplier      = xi.spells.damage.calculateElementalStaffBonus(actor, skillchainElement)
+    local affinityMultiplier   = xi.spells.damage.calculateElementalAffinityBonus(actor, skillchainElement)
+    local resRankMultiplier    = resistanceRankMultiplier[target:getMod(xi.data.element.getElementalResistanceRankModifier(skillchainElement))]
+    local magicTakenMultiplier = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
+
+    -- Unconfirmed order.
+    local inninMultiplier      = 1 + actor:getMerit(xi.merit.INNIN_EFFECT) / 100
+    local sengikoriMultiplier  = 1 + target:getMod(xi.mod.SENGIKORI_SC_DMG_DEBUFF) / 100
+    local absorptionMultiplier = xi.spells.damage.calculateAbsorption(target, skillchainElement, true)
+
+    -- Apply multipliers in order and floor after each step.
+    finalDamage = math.floor(finalDamage * levelMultiplier)
+    finalDamage = math.floor(finalDamage * bonusMultiplier) + actor:getMod(xi.mod.MAGIC_DAMAGE)
+    finalDamage = math.floor(finalDamage * damageMultiplier)
+    finalDamage = math.floor(finalDamage * dayWeatherMultiplier)
+    finalDamage = math.floor(finalDamage * staffMultiplier)
+    finalDamage = math.floor(finalDamage * affinityMultiplier)
+    finalDamage = math.floor(finalDamage * resRankMultiplier)
+    finalDamage = math.floor(finalDamage * magicTakenMultiplier)
+    finalDamage = math.floor(finalDamage * inninMultiplier)
+    finalDamage = math.floor(finalDamage * sengikoriMultiplier)
+    finalDamage = math.floor(finalDamage * absorptionMultiplier)
+
+    -- Handle (reset) Sengikori.
+    target:setMod(xi.mod.SENGIKORI_SC_DMG_DEBUFF, 0)
+
+    -- Handle other damage alterations.
+    if finalDamage > 0 then
+        finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
+        finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
+        finalDamage = utils.clamp(utils.handleStoneskin(target, finalDamage), 0, 99999)
+        finalDamage = target:checkDamageCap(finalDamage)
+
+        target:takeDamage(finalDamage, actor, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL + skillchainElement)
+
+    -- Handle absorbption.
+    else
+        target:addHP(-finalDamage)
+    end
+
+    return finalDamage
+end

--- a/scripts/globals/magicburst.lua
+++ b/scripts/globals/magicburst.lua
@@ -1,22 +1,6 @@
 xi = xi or {}
 xi.magicburst = xi.magicburst or {}
 
-local matches =
-{
--- [element Id] = { resonance Id }
---    1  2  3  4  5  6  7  8  9  10 11 12 13 14 15 16 17
---    N  T  C  L  S  R  D  I  I  G  D  F  F  L  D  L  D
-    [xi.element.NONE   ] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
-    [xi.element.FIRE   ] = { 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0 },
-    [xi.element.ICE    ] = { 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 1 },
-    [xi.element.WIND   ] = { 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0 },
-    [xi.element.EARTH  ] = { 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1 },
-    [xi.element.THUNDER] = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0 },
-    [xi.element.WATER  ] = { 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1 },
-    [xi.element.LIGHT  ] = { 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 1, 0 },
-    [xi.element.DARK   ] = { 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1 },
-}
-
 ---@param target CBaseEntity
 ---@param actionElement number
 ---@return number, number
@@ -43,7 +27,7 @@ xi.magicburst.formMagicBurst = function(target, actionElement)
         return 0, 0
     end
 
-    local isMatch = matches[actionElement][resonance:getPower() + 1] > 0 and true or false
+    local isMatch = xi.data.element.skillchainElementTable[actionElement][resonance:getPower()] > 0 and true or false
     if not isMatch then
         return 0, 0
     end
@@ -53,5 +37,9 @@ end
 
 -- Returns a boolean if the element matches the skillchain property given
 xi.magicburst.doesElementMatchWeaponskill = function(actionElement, SCProp)
-    return matches[actionElement][SCProp + 1] > 0 and true or false
+    if SCProp == 0 then
+        return false
+    end
+
+    return xi.data.element.skillchainElementTable[actionElement][SCProp] > 0 and true or false
 end

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3460,170 +3460,6 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
     return ActionProcSkillChain::None;
 }
 
-// This whole thing need re-evaluated
-// TODO: move skillchains to lua
-// This is horrible...
-int16 GetSkillchainMinimumResistance(SKILLCHAIN_ELEMENT element, CBattleEntity* PDefender, ELEMENT& appliedEle)
-{
-    static const Mod resistances[][4] = {
-        { Mod::NONE, Mod::NONE, Mod::NONE, Mod::NONE },        // SC_NONE
-        { Mod::LIGHT_SDT, Mod::NONE, Mod::NONE, Mod::NONE },   // SC_TRANSFIXION
-        { Mod::DARK_SDT, Mod::NONE, Mod::NONE, Mod::NONE },    // SC_COMPRESSION
-        { Mod::FIRE_SDT, Mod::NONE, Mod::NONE, Mod::NONE },    // SC_LIQUEFACTION
-        { Mod::EARTH_SDT, Mod::NONE, Mod::NONE, Mod::NONE },   // SC_SCISSION
-        { Mod::WATER_SDT, Mod::NONE, Mod::NONE, Mod::NONE },   // SC_REVERBERATION
-        { Mod::WIND_SDT, Mod::NONE, Mod::NONE, Mod::NONE },    // SC_DETONATION
-        { Mod::ICE_SDT, Mod::NONE, Mod::NONE, Mod::NONE },     // SC_INDURATION
-        { Mod::THUNDER_SDT, Mod::NONE, Mod::NONE, Mod::NONE }, // SC_IMPACTION
-
-        { Mod::EARTH_SDT, Mod::DARK_SDT, Mod::NONE, Mod::NONE },   // SC_GRAVITATION
-        { Mod::ICE_SDT, Mod::WATER_SDT, Mod::NONE, Mod::NONE },    // SC_DISTORTION
-        { Mod::FIRE_SDT, Mod::LIGHT_SDT, Mod::NONE, Mod::NONE },   // SC_FUSION
-        { Mod::WIND_SDT, Mod::THUNDER_SDT, Mod::NONE, Mod::NONE }, // SC_FRAGMENTATION
-
-        { Mod::FIRE_SDT, Mod::WIND_SDT, Mod::THUNDER_SDT, Mod::LIGHT_SDT }, // SC_LIGHT
-        { Mod::ICE_SDT, Mod::EARTH_SDT, Mod::WATER_SDT, Mod::DARK_SDT },    // SC_DARKNESS
-        { Mod::FIRE_SDT, Mod::WIND_SDT, Mod::THUNDER_SDT, Mod::LIGHT_SDT }, // SC_LIGHT
-        { Mod::ICE_SDT, Mod::EARTH_SDT, Mod::WATER_SDT, Mod::DARK_SDT },    // SC_DARKNESS_II
-    };
-
-    auto resRankToAbsorbMod = [](const Mod resistanceRank) -> Mod
-    {
-        switch (resistanceRank)
-        {
-            case Mod::FIRE_RES_RANK:
-                return Mod::FIRE_ABSORB;
-            case Mod::ICE_RES_RANK:
-                return Mod::ICE_ABSORB;
-            case Mod::WIND_RES_RANK:
-                return Mod::WIND_ABSORB;
-            case Mod::EARTH_RES_RANK:
-                return Mod::EARTH_ABSORB;
-            case Mod::THUNDER_RES_RANK:
-                return Mod::LTNG_ABSORB;
-            case Mod::WATER_RES_RANK:
-                return Mod::WATER_ABSORB;
-            case Mod::LIGHT_RES_RANK:
-                return Mod::LIGHT_ABSORB;
-            case Mod::DARK_RES_RANK:
-                return Mod::DARK_ABSORB;
-            default:
-                return Mod::NONE;
-        }
-    };
-
-    auto getAbsorbElementOrDefault = [&](const Mod resRanks[4], const Mod fallback) -> Mod
-    {
-        for (int i = 0; i < 4; ++i)
-        {
-            if (resRanks[i] == Mod::NONE)
-            {
-                continue;
-            }
-
-            if (PDefender->getMod(resRankToAbsorbMod(resRanks[i])) > 0)
-            {
-                return resRanks[i];
-            }
-        }
-        return fallback;
-    };
-
-    Mod defMod = Mod::NONE;
-
-    switch (element)
-    {
-        // Level 1 skill chains
-        case SC_LIQUEFACTION:
-        case SC_IMPACTION:
-        case SC_DETONATION:
-        case SC_SCISSION:
-        case SC_REVERBERATION:
-        case SC_INDURATION:
-        case SC_COMPRESSION:
-        case SC_TRANSFIXION:
-            defMod = resistances[element][0];
-            break;
-
-            // Level 2 skill chains
-        case SC_FUSION:
-        case SC_FRAGMENTATION:
-        case SC_GRAVITATION:
-        case SC_DISTORTION:
-            if (PDefender->getMod(resistances[element][0]) < PDefender->getMod(resistances[element][1]))
-            {
-                defMod = resistances[element][0];
-            }
-            else
-            {
-                defMod = resistances[element][1];
-            }
-            break;
-
-            // Level 3 & 4 skill chains
-        case SC_LIGHT:
-        case SC_LIGHT_II:
-        case SC_DARKNESS:
-        case SC_DARKNESS_II:
-            if (PDefender->getMod(resistances[element][0]) < PDefender->getMod(resistances[element][1]))
-            {
-                defMod = resistances[element][0];
-            }
-            else
-            {
-                defMod = resistances[element][1];
-            }
-            if (PDefender->getMod(resistances[element][2]) < PDefender->getMod(defMod))
-            {
-                defMod = resistances[element][2];
-            }
-            if (PDefender->getMod(resistances[element][3]) < PDefender->getMod(defMod))
-            {
-                defMod = resistances[element][3];
-            }
-            break;
-
-        default:
-            ShowWarning("Invalid Skillchain Type received (%d).", element);
-            return 0;
-            break;
-    }
-
-    defMod = getAbsorbElementOrDefault(resistances[element], defMod);
-
-    switch (defMod)
-    {
-        case Mod::FIRE_RES_RANK:
-            appliedEle = ELEMENT_FIRE;
-            break;
-        case Mod::ICE_RES_RANK:
-            appliedEle = ELEMENT_ICE;
-            break;
-        case Mod::WIND_RES_RANK:
-            appliedEle = ELEMENT_WIND;
-            break;
-        case Mod::EARTH_RES_RANK:
-            appliedEle = ELEMENT_EARTH;
-            break;
-        case Mod::THUNDER_RES_RANK:
-            appliedEle = ELEMENT_THUNDER;
-            break;
-        case Mod::WATER_RES_RANK:
-            appliedEle = ELEMENT_WATER;
-            break;
-        case Mod::LIGHT_RES_RANK:
-            appliedEle = ELEMENT_LIGHT;
-            break;
-        case Mod::DARK_RES_RANK:
-            appliedEle = ELEMENT_DARK;
-            break;
-        default:
-            break;
-    }
-
-    return PDefender->getMod(defMod);
-}
-
 std::vector<ELEMENT> GetSkillchainMagicElement(SKILLCHAIN_ELEMENT skillchain)
 {
     static const std::unordered_map<SKILLCHAIN_ELEMENT, std::vector<ELEMENT>> resonanceToElement = {
@@ -3675,70 +3511,8 @@ auto TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, in
         return 0;
     }
 
-    CStatusEffect* PEffect = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Skillchain, 0);
-
-    if (PEffect == nullptr)
-    {
-        ShowWarning("battleutils::TakeSkillchainDamage() - PEffect was null.");
-        return 0;
-    }
-
-    // Determine the skill chain level and elemental resistance.
-    SKILLCHAIN_ELEMENT skillchain = (SKILLCHAIN_ELEMENT)PEffect->GetPower();
-    uint16             chainLevel = PEffect->GetTier();
-    uint16             chainCount = PEffect->GetSubPower();
-    ELEMENT            appliedEle = ELEMENT_NONE;
-    int16              resistance = GetSkillchainMinimumResistance(skillchain, PDefender, appliedEle);
-
-    if (chainLevel <= 0 || chainLevel > 4 || chainCount <= 0 || chainCount > 5)
-    {
-        ShowWarning("chainLevel (%d) or chainCount (%d) exceeds bounds.", chainLevel, chainCount);
-        return 0;
-    }
-
-    // Skill chain damage = (Closing Damage)
-    //                      × (Skill chain Level/Number from Table)
-    //                      × (1 + Skill chain Bonus ÷ 100)
-    //                      × (1 + Skill chain Damage + %/100)
-    //            TODO:     × (1 + Day/Weather bonuses)
-    //            TODO:     × (1 + Staff Affinity)
-
-    const auto closingDamage      = static_cast<float>(abs(lastSkillDamage));
-    const auto skillchainLevel    = g_SkillChainDamageModifiers[chainLevel][chainCount] / 1000.0f;
-    const auto skillchainBonus    = (100.0f + PAttacker->getMod(Mod::SKILLCHAINBONUS)) / 100.0f;
-    const auto skillchainDmgBonus = (10000.0f + PAttacker->getMod(Mod::SKILLCHAINDMG)) / 10000.0f;
-    const auto dayWeatherBonus    = 1.0f; // TODO: Implement day/weather bonuses
-    const auto staffAffinity      = 1.0f; // TODO: Implement staff affinity
-
-    int32 damage = std::floor(closingDamage * skillchainLevel * skillchainBonus * skillchainDmgBonus * dayWeatherBonus * staffAffinity);
-
-    auto* PChar = dynamic_cast<CCharEntity*>(PAttacker);
-    if (PChar && PChar->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Innin) && behind(PChar->loc.p, PDefender->loc.p, 64))
-    {
-        damage = std::floor(static_cast<float>(damage) * (1.0f + PChar->PMeritPoints->GetMeritValue(MERIT_INNIN_EFFECT, PChar) / 100.0f));
-    }
-
-    if (PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) > 0)
-    {
-        damage = std::floor(static_cast<float>(damage) * (1.0f + PDefender->getMod(Mod::SENGIKORI_SC_DMG_DEBUFF) / 100.0f));
-        PDefender->setModifier(Mod::SENGIKORI_SC_DMG_DEBUFF, 0); // Consume the effect
-    }
-
-    float damageReductionMult = (10000.0f + static_cast<float>(resistance)) / 10000.0f;
-
-    damage = std::floor(static_cast<float>(damage) * damageReductionMult);
-    damage = MagicDmgTaken(PDefender, damage, appliedEle);
-    if (damage > 0)
-    {
-        damage = std::max(damage - PDefender->getMod(Mod::PHALANX), 0);
-        damage = HandleOneForAll(PDefender, damage);
-        damage = HandleStoneskin(PDefender, damage);
-        HandleAfflatusMiseryDamage(PDefender, damage);
-    }
-    damage = std::clamp(damage, -99999, 99999);
-
-    uint16 elementOffset = static_cast<uint16>(xi::DamageType::Elemental) + static_cast<uint16>(appliedEle);
-    PDefender->takeDamage(damage, PAttacker, ATTACK_TYPE::SPECIAL, appliedEle == ELEMENT_NONE ? xi::DamageType::None : static_cast<xi::DamageType>(elementOffset), true);
+    // Call out to lua for all damage functions. Also processes actual damage application.
+    int32 damage = luautils::callGlobal<int32>("xi.combat.skillchain.calculateSkillchainDamage", PAttacker, PDefender, lastSkillDamage);
 
     battleutils::ClaimMob(PDefender, PAttacker);
     PDefender->updatemask |= UPDATE_STATUS;
@@ -3754,14 +3528,15 @@ auto TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, in
                 PDefender->animation = ANIMATION_NONE;
                 PDefender->updatemask |= UPDATE_HP;
             }
+            break;
         }
-        break;
 
         case TYPE_MOB:
         {
             static_cast<CMobEntity*>(PDefender)->PEnmityContainer->UpdateEnmityFromDamage(taChar ? taChar : PAttacker, std::abs(damage)); // assume negative damage (healing) deals the same enmity as dealing damage
+            break;
         }
-        break;
+
         default:
         {
             break;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Converts the damage calculations and damage handling for skillchains to lua.
- Adds and/or reorders a few missing multiplier steps.
- Globalize Skillchain elemental properties, since magic bursts also used them.
- Fixes elemental choosing for skillchains. We were defaulting to the last element in the element priority order. First matching element (for the lowest resistance rank) should be the default.

## Steps to test these changes
Skillchain.