### PR TITLE
Implement retail-style duplicate login handling

### DIFF
--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -260,31 +260,15 @@ void auth_session::read_func()
                                  "WHERE a.charid IN (SELECT charid FROM chars WHERE accid = ?)",
                                  accountID);
             }
-            // TODO: Lock out same account logging in multiple times. Can check data/view session existence on same IP/account?
-            // Not a real problem because the account is locked out when a character is logged in.
-
-            /*
-            const auto rset = db::preparedStmt("SELECT charid "
-                    "FROM accounts_sessions "
-                    "WHERE accid = ? LIMIT 1", accountID);
-            if (rset && rset->rowsCount() != 0 && rset->next())
+            // Retail behavior: if this account already has an active session, kick the old
+            // session and allow the new login to proceed. The map server's stale-session
+            // cleanup will handle disconnecting the old client.
+            const auto sessionCheck = db::preparedStmt("SELECT charid FROM accounts_sessions WHERE accid = ? LIMIT 1", accountID);
+            if (sessionCheck && sessionCheck->rowsCount() != 0)
             {
-                // TODO: kick player out of map server if already logged in
-                // uint32 charid = rset->get<uint32>("charid");
-
-                // This error message doesn't work when sent this way. Unknown how to transmit "1039" error message to a client already logged in.
-                // session_t& authenticatedSession = get_authenticated_session(socket_, session.sentAccountID);
-                // if (auto data = authenticatedSession.buffer_.data()session)
-                // {
-                //  generateErrorMessage(data->buffer_.data(), 139);
-                //  data->do_write(0x24);
-                //  return;
-                //}
-                ref<uint8>(buffer_.data(), 0) = LOGIN_ERROR_ALREADY_LOGGED_IN;
-                do_write(1);
-                return;
+                ShowInfoFmt("login_parse: account {} logging in from {}, clearing existing session", accountID, ipAddress);
+                db::preparedStmt("DELETE FROM accounts_sessions WHERE accid = ?", accountID);
             }
-            */
 
             // Success
             unsigned char hash[16];

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -51,6 +51,7 @@
 
 #include "utils/charutils.h"
 #include "utils/jailutils.h"
+#include "utils/petutils.h"
 #include "utils/serverutils.h"
 #include "utils/zoneutils.h"
 
@@ -153,52 +154,34 @@ void IPCClient::handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLog
 
     if (auto session = networking_.sessions().getSessionByAccountId(message.accountId))
     {
-        // Extreme overkill but...
-        // Scramble key so server rejects input
-        for (uint32_t& i : session->blowfish.key)
+        if (session->PChar)
         {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
+            ShowInfoFmt("handleMessage_AccountLogin: evicting session for account {} (duplicate login)", message.accountId);
 
-        for (uint32_t& i : session->prev_blowfish.key)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint32_t& i : session->blowfish.P)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint32_t& i : session->prev_blowfish.P)
-        {
-            i = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
-        }
-
-        for (uint8_t& i : session->blowfish.hash)
-        {
-            // uniform_int_distribution doesnt like uint8_t, so do some workaround
-            i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-        }
-
-        for (uint8_t& i : session->prev_blowfish.hash)
-        {
-            // uniform_int_distribution doesnt like uint8_t, so do some workaround
-            i = static_cast<uint8_t>(xirand::GetRandomNumber<uint16_t>(std::numeric_limits<uint16_t>::max()) % 255);
-        }
-
-        for (int i = 0; i < 4; i++)
-        {
-            for (uint32_t& x : session->blowfish.S[i])
+            // If the character is in combat, snapshot the mobs' hate before
+            // evicting so it can be restored when they next zone in. This stops a
+            // second session being used to instantly shed enmity, while leaving
+            // the normal logout-to-shed behaviour untouched.
+            if (session->PChar->hasEnmityEXPENSIVE())
             {
-                x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                charutils::captureDuplicateLoginEnmity(session->PChar.get());
             }
 
-            for (uint32_t& x : session->prev_blowfish.S[i])
+            session->PChar->StatusEffectContainer->SaveStatusEffects(true);
+            charutils::SaveCharPosition(session->PChar.get());
+
+            if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
             {
-                x = xirand::GetRandomNumber<uint32_t>(std::numeric_limits<uint32_t>::max());
+                petutils::DespawnPet(session->PChar.get());
             }
+
+            session->PChar->status = STATUS_TYPE::SHUTDOWN;
+            charutils::removeCharFromZone(session->PChar.get());
+            session->shuttingDown = 0; // Prevent destroySession from deleting the new accounts_sessions row
+            session->PChar.reset();
         }
+
+        networking_.sessions().destroySession(session);
     }
 }
 
@@ -208,9 +191,46 @@ void IPCClient::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& mess
 
     auto session = networking_.sessions().getSessionByCharId(message.charId);
 
-    if (session) // Update in case of edge case
+    if (session)
     {
-        session->last_update = timer::now();
+        if (session->PChar)
+        {
+            // Active character in this session means a duplicate login —
+            // the old client is still in the world. Evict it (retail: new login wins).
+            ShowInfoFmt("handleMessage_CharZone: evicting active session for charid {} (duplicate login)", message.charId);
+
+            // Snapshot combat enmity (if any) so it can be restored when the
+            // character zones back in — a second session can't be used to shed hate.
+            if (session->PChar->hasEnmityEXPENSIVE())
+            {
+                charutils::captureDuplicateLoginEnmity(session->PChar.get());
+            }
+
+            session->PChar->StatusEffectContainer->SaveStatusEffects(true);
+            charutils::SaveCharPosition(session->PChar.get());
+
+            if (session->PChar->PPet != nullptr && session->PChar->PPet->objtype == TYPE_MOB)
+            {
+                petutils::DespawnPet(session->PChar.get());
+            }
+
+            session->PChar->status = STATUS_TYPE::SHUTDOWN;
+            charutils::removeCharFromZone(session->PChar.get());
+            // removeCharFromZone sets shuttingDown=1 for SHUTDOWN status, which
+            // would cause destroySession to DELETE the accounts_sessions row.
+            // That row now belongs to the new session, so prevent the deletion.
+            session->shuttingDown = 0;
+            session->PChar.reset();
+
+            networking_.sessions().destroySession(session);
+
+            networking_.sessions().createPendingSession(message.charId);
+        }
+        else
+        {
+            // PChar is null — normal zoning (session waiting for client reconnect)
+            session->last_update = timer::now();
+        }
     }
     else
     {

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -28,6 +28,9 @@
 
 #include <array>
 #include <chrono>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "lua/luautils.h"
 
@@ -62,6 +65,7 @@
 #include "ability.h"
 #include "alliance.h"
 #include "conquest_system.h"
+#include "enmity_container.h"
 #include "grades.h"
 #include "ipc_client.h"
 #include "item_container.h"
@@ -71,6 +75,7 @@
 #include "map_networking.h"
 #include "mob_modifier.h"
 #include "nominate_manager.h"
+#include "notoriety_container.h"
 #include "recast_container.h"
 #include "roe.h"
 #include "spell.h"
@@ -8136,6 +8141,137 @@ void removeCharFromZone(CCharEntity* PChar)
     charutils::SaveLastLogout(PChar);
 
     PChar->status = STATUS_TYPE::DISAPPEAR;
+}
+
+// --- Duplicate-login enmity persistence (anti-exploit) -----------------------
+//
+// When a second session takes over an account (retail "new login wins"), the
+// character currently in the world is evicted by the IPC handlers in
+// ipc_client.cpp. Without extra handling that eviction also drops the character
+// out of every mob's enmity list, so a player could open a second client
+// mid-fight to instantly shed all hate and escape death.
+//
+// To block that exploit while preserving the legitimate "sleep a mob then log
+// out to shed enmity" mechanic, we snapshot the mobs' hate (CE/VE) at eviction
+// time and re-apply it the next time the character zones in. A normal logout
+// never goes through the duplicate-login eviction path, so it still sheds
+// enmity exactly as on retail.
+// -----------------------------------------------------------------------------
+namespace
+{
+    struct CapturedEnmity_t
+    {
+        uint32 mobId;
+        int32  CE;
+        int32  VE;
+    };
+
+    struct CapturedEnmityRecord_t
+    {
+        timer::time_point             capturedAt;
+        std::vector<CapturedEnmity_t> entries;
+    };
+
+    // Keyed by charid. Holds enmity snapshots taken when a character is evicted
+    // by a duplicate (second session) login, to be restored on its next zone-in.
+    std::unordered_map<uint32, CapturedEnmityRecord_t> g_duplicateLoginEnmity;
+    std::mutex                                         g_duplicateLoginEnmityMutex;
+
+    // How long a captured snapshot stays valid. After this a relog is treated as
+    // a normal return (mobs would have reset/deaggroed on their own by then).
+    constexpr auto kDuplicateLoginEnmityTTL = std::chrono::seconds(180);
+} // namespace
+
+void captureDuplicateLoginEnmity(CCharEntity* PChar)
+{
+    if (PChar == nullptr || PChar->PNotorietyContainer == nullptr)
+    {
+        return;
+    }
+
+    std::vector<CapturedEnmity_t> entries;
+
+    // PNotorietyContainer is the list of mobs that currently hold enmity on PChar.
+    for (auto* PEntity : *PChar->PNotorietyContainer)
+    {
+        auto* PMob = dynamic_cast<CMobEntity*>(PEntity);
+        if (PMob == nullptr || PMob->PEnmityContainer == nullptr)
+        {
+            continue;
+        }
+
+        const int32 CE = PMob->PEnmityContainer->GetCE(PChar);
+        const int32 VE = PMob->PEnmityContainer->GetVE(PChar);
+
+        if (CE > 0 || VE > 0)
+        {
+            entries.push_back({ PMob->id, CE, VE });
+        }
+    }
+
+    if (entries.empty())
+    {
+        return;
+    }
+
+    const std::size_t count = entries.size();
+
+    {
+        std::lock_guard<std::mutex> lock(g_duplicateLoginEnmityMutex);
+        g_duplicateLoginEnmity[PChar->id] = { timer::now(), std::move(entries) };
+    }
+
+    ShowInfoFmt("captureDuplicateLoginEnmity: stored {} enmity entr(y/ies) for charid {}", count, PChar->id);
+}
+
+void restoreDuplicateLoginEnmity(CCharEntity* PChar)
+{
+    if (PChar == nullptr)
+    {
+        return;
+    }
+
+    CapturedEnmityRecord_t record;
+    {
+        std::lock_guard<std::mutex> lock(g_duplicateLoginEnmityMutex);
+        auto                        it = g_duplicateLoginEnmity.find(PChar->id);
+        if (it == g_duplicateLoginEnmity.end())
+        {
+            return;
+        }
+        record = std::move(it->second);
+        g_duplicateLoginEnmity.erase(it);
+    }
+
+    if (timer::now() > record.capturedAt + kDuplicateLoginEnmityTTL)
+    {
+        return;
+    }
+
+    uint32 restored = 0;
+    for (const auto& entry : record.entries)
+    {
+        auto* PMob = dynamic_cast<CMobEntity*>(zoneutils::GetEntity(entry.mobId, TYPE_MOB));
+        if (PMob == nullptr || PMob->PEnmityContainer == nullptr || PMob->isDead())
+        {
+            continue;
+        }
+
+        // Mob must still share the character's zone (it could have been killed and
+        // respawned elsewhere, or the character could have zoned out before relog).
+        if (PMob->getZone() != PChar->getZone())
+        {
+            continue;
+        }
+
+        PMob->PEnmityContainer->UpdateEnmity(PChar, entry.CE, entry.VE);
+        ++restored;
+    }
+
+    if (restored > 0)
+    {
+        ShowInfoFmt("restoreDuplicateLoginEnmity: re-applied enmity from {} mob(s) onto charid {}", restored, PChar->id);
+    }
 }
 
 void updateSession(MapSession* PSession, CCharEntity* PChar, CZone* currentZone)

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -306,6 +306,14 @@ void forceSynthCritFail(const std::string& sourceFunction, CCharEntity* PChar);
 
 void removeCharFromZone(CCharEntity* PChar);
 
+// Duplicate-login (second session) anti-exploit: capture the mobs' hate on a
+// character right before it is evicted by a duplicate login, then restore that
+// hate when the character next zones in. This stops players using a second
+// session to instantly shed enmity, while leaving the normal logout-to-shed
+// behaviour (e.g. sleep a mob then log out) completely unaffected.
+void captureDuplicateLoginEnmity(CCharEntity* PChar);
+void restoreDuplicateLoginEnmity(CCharEntity* PChar);
+
 void updateSession(MapSession* PSession, CCharEntity* PChar, CZone* currentZone);
 void loadDeathTimestamp(CCharEntity* PChar);
 void loadZoningFlag(CCharEntity* PChar);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -25,6 +25,7 @@
 #include "aman.h"
 #include "battlefield.h"
 #include "campaign_system.h"
+#include "charutils.h"
 #include "common/logging.h"
 #include "conquest_system.h"
 #include "entities/mob_entity.h"
@@ -1396,6 +1397,11 @@ void AfterZoneIn(CBaseEntity* PEntity)
 
     PChar->aman().onZoneIn();
     luautils::AfterZoneIn(PChar);
+
+    // Re-apply any enmity that was captured when this character was evicted by a
+    // duplicate (second session) login, so a second session can't be used to
+    // shed hate. No-op for normal logins.
+    charutils::restoreDuplicateLoginEnmity(PChar);
 }
 
 auto IsAlwaysOutOfNationControl(const REGION_TYPE region) -> bool


### PR DESCRIPTION
**_I affirm:_**
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have tested my code since the last commit in the PR.
- [x] I have _**rebased**_ this PR on the latest `base` branch.

## What does this pull request do?

Implements retail-style duplicate login handling: when an account logs in while it already has an active session, the new login wins and the old client is booted.

### 1. `auth_session.cpp` — open the gate
On login, if the account already has an `accounts_sessions` row, clear it so the new login isn't rejected by the `CHARACTER_ALREADY_LOGGED_IN` check at character select (`data_session.cpp`). This replaces the old commented-out TODO block that tried to *reject* duplicate logins (not retail).

### 2. `ipc_client.cpp` — actually boot the old client, immediately
The `AccountLogin` IPC (sent a few lines before the DB clear) is the real eviction mechanism — xi_map does **not** monitor the session table (my original step #5 was wrong about that). In stock, that IPC only **scrambles the old session's blowfish keys** so the client goes link-dead, then waits for `cleanupSessions()` to time it out (~`MAX_TIME_LASTUPDATE`).

This PR changes `handleMessage_AccountLogin` (and the `CharZone` safety net) to **evict the old character immediately and deterministically**: save status effects + position, despawn pet, `removeCharFromZone`, `destroySession` — and reset `shuttingDown` so it does not delete the *new* session's `accounts_sessions` row. This removes the link-dead window and the reliance on the timeout, so the old client can't keep occupying the world alongside the new one (addresses the double-login concern).

### 3. `charutils.cpp/.h` + `zoneutils.cpp` — enmity persistence (anti-exploit)
Evicting the character pulls it out of every mob's enmity list. On its own, that means a player could open a **second client mid-fight to instantly shed all hate and escape death**. To block that while keeping the legitimate "sleep a mob, then log out to shed enmity" mechanic, we snapshot the mobs' hate (CE/VE) at eviction and re-apply it on the character's next zone-in (`AfterZoneIn`, 180s TTL). A normal logout never goes through the eviction path, so it sheds enmity exactly as on retail.

This third part is logically separable — happy to split it into its own PR if you'd prefer to keep this one focused on the core login change.

## Steps to test
1. Build the stack (xi_connect, xi_world, xi_map).
2. Log in with a test account and enter the world (creates the `accounts_sessions` row).
3. Log in again with the same account from a second client.
   - **Expected:** the second login succeeds and the first character is evicted from the world immediately (not after a timeout); the first client is disconnected.
4. Anti-exploit: aggro a mob on client 1, then log in on client 2 → relog the character.
   - **Expected:** the mob re-aggros on zone-in (enmity restored). Log shows `restoreDuplicateLoginEnmity: re-applied enmity from N mob(s)`.
5. Legit logout: with a single client, sleep/aggro a mob then `/logout` and relog.
   - **Expected:** the mob does **not** re-aggro (enmity shed as normal — no capture happened).