### PR TITLE
[core] [lua] Add some zoning guardrails & remove unused/broken function, fix dropped 0x00As

### DIFF
--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -814,10 +814,6 @@ end
 function CBaseEntity:forceRezone()
 end
 
----@return nil
-function CBaseEntity:forceLogout()
-end
-
 ---@nodiscard
 ---@return table
 function CBaseEntity:getPos()

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -153,6 +153,8 @@ void IPCClient::handleMessage_AccountLogin(const IPP& ipp, const ipc::AccountLog
 
     if (auto session = networking_.sessions().getSessionByAccountId(message.accountId))
     {
+        session->forceLinkDead = true; // Don't accept any more updates for last packet received time
+
         // Extreme overkill but...
         // Scramble key so server rejects input
         for (uint32_t& i : session->blowfish.key)
@@ -210,7 +212,7 @@ void IPCClient::handleMessage_CharZone(const IPP& ipp, const ipc::CharZone& mess
 
     if (session) // Update in case of edge case
     {
-        session->last_update = timer::now();
+        session->tapLastUpdate();
     }
     else
     {

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -3343,14 +3343,6 @@ void CLuaBaseEntity::forceRezone()
     }
 }
 
-void CLuaBaseEntity::forceLogout()
-{
-    if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
-    {
-        charutils::ForceLogout(PChar);
-    }
-}
-
 /************************************************************************
  *  Function: getPos()
  *  Purpose : Returns a table of signed coordinates (x,y,z,rot)
@@ -21010,7 +21002,6 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("sendEntityUpdateToPlayer", CLuaBaseEntity::sendEntityUpdateToPlayer);
     SOL_REGISTER("sendEmptyEntityUpdateToPlayer", CLuaBaseEntity::sendEmptyEntityUpdateToPlayer);
     SOL_REGISTER("forceRezone", CLuaBaseEntity::forceRezone);
-    SOL_REGISTER("forceLogout", CLuaBaseEntity::forceLogout);
 
     // Abyssea
     SOL_REGISTER("getAvailableTraverserStones", CLuaBaseEntity::getAvailableTraverserStones);

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -217,7 +217,6 @@ public:
     void sendEmptyEntityUpdateToPlayer(CLuaBaseEntity* entityToUpdate);
 
     void forceRezone();
-    void forceLogout();
 
     auto  getPos() -> sol::table;
     void  showPosition();

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -357,6 +357,13 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
             }
         }
 
+        // This is when a real decrypt of the current key hits.
+        // We gate this variable to allow no longer allow incoming 0x00As to be handled
+        if (decryptCount == 0)
+        {
+            PSession->hasDecryptedPacket = true;
+        }
+
         // reading data size
         uint32 PacketDataSize = ref<uint32>(buff, *buffsize - sizeof(int32) - 16);
 

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -403,7 +403,7 @@ int32 MapNetworking::parse(uint8* buff, size_t* buffsize, MapSession* PSession)
     {
         // Update the time we last got a char sync packet
         // The client can spam some other packets when trying to zone, preventing timely session deletions
-        PSession->last_update = timer::now();
+        PSession->tapLastUpdate();
     }
 
     for (uint8* SmallPD_ptr = PacketData_Begin; SmallPD_ptr + (ref<uint8>(SmallPD_ptr, 1) & 0xFE) * 2 <= PacketData_End && (ref<uint8>(SmallPD_ptr, 1) & 0xFE);
@@ -538,8 +538,19 @@ int32 MapNetworking::send_parse(uint8* buff, size_t* buffsize, MapSession* PSess
 
                     incrementKeyAfterEncrypt = true;
 
-                    // Set client port to zero, indicating the client tried to zone out and no longer has a port until the next 0x00A
-                    db::preparedStmt("UPDATE accounts_sessions SET client_port = 0, last_zoneout_time = NOW() WHERE charid = ?", PSession->charID);
+                    if (PSession->zone_type != GP_GAME_LOGOUT_STATE::LOGOUT)
+                    {
+                        auto ip   = PSession->zone_ipp.getIP();
+                        auto port = PSession->zone_ipp.getPort();
+
+                        // Set client port to zero, indicating the client tried to zone out and no longer has a port until the next 0x00A
+                        db::preparedStmt("UPDATE accounts_sessions SET server_addr = ?, server_port = ?, client_port = 0, last_zoneout_time = NOW() WHERE charid = ?", ip, port, PSession->charID);
+                    }
+                    else
+                    {
+                        // This probably isn't necessary - the session should be deleted shortly.
+                        db::preparedStmt("UPDATE accounts_sessions SET client_port = 0, last_zoneout_time = NOW() WHERE charid = ?", PSession->charID);
+                    }
                 }
 
                 std::memcpy(buff + *buffsize, *PSmallPacket, PSmallPacket->getSize());

--- a/src/map/map_session.cpp
+++ b/src/map/map_session.cpp
@@ -25,7 +25,8 @@
 
 void MapSession::incrementBlowfish()
 {
-    prev_blowfish = blowfish;
+    hasDecryptedPacket = false;
+    prev_blowfish      = blowfish;
 
     blowfish.key[4] += 2;
 

--- a/src/map/map_session.cpp
+++ b/src/map/map_session.cpp
@@ -51,3 +51,11 @@ auto MapSession::toString() -> std::string
 {
     return fmt::format("MapSession: client_ipp: {}", client_ipp.toString());
 }
+
+void MapSession::tapLastUpdate()
+{
+    if (!forceLinkDead)
+    {
+        last_update = earth_time::now();
+    }
+}

--- a/src/map/map_session.h
+++ b/src/map/map_session.h
@@ -46,13 +46,14 @@ struct MapSession
     uint16                       server_packet_id   = 0;  // id of the last packet sent by the server
     NetworkBuffer                server_packet_data = {}; // data of the packet, which was previously sent to the client
     size_t                       server_packet_size = 0;  // the size of the packet that was previously sent to the client
-    timer::time_point            last_update        = {}; // time of last packet recv
+    earth_time::time_point       last_update        = {}; // time of last packet recv
     blowfish_t                   blowfish           = {}; // unique decypher keys, these are the currently expected keys
     std::unique_ptr<CCharEntity> PChar;                   // game char
-    uint8                        shuttingDown = 0;        // prevents double session closing
-    uint32                       charID       = 0;
-    uint32                       accountID    = 0;
-
+    uint8                        shuttingDown  = 0;       // prevents double session closing
+    uint32                       charID        = 0;
+    uint32                       accountID     = 0;
+    uint32                       next_zone_id  = 0;
+    bool                         forceLinkDead = false;
     // Store old blowfish data, when a player recieves 0x00B their key should increment
     // If it doesn't, and we can still successfully decrypt here, that means we need to resend 0x00B.
     blowfish_t prev_blowfish = {};
@@ -63,6 +64,7 @@ struct MapSession
 
     void incrementBlowfish();
     void initBlowfish();
+    void tapLastUpdate();
 
     auto toString() -> std::string;
 };

--- a/src/map/map_session.h
+++ b/src/map/map_session.h
@@ -49,11 +49,13 @@ struct MapSession
     earth_time::time_point       last_update        = {}; // time of last packet recv
     blowfish_t                   blowfish           = {}; // unique decypher keys, these are the currently expected keys
     std::unique_ptr<CCharEntity> PChar;                   // game char
-    uint8                        shuttingDown  = 0;       // prevents double session closing
-    uint32                       charID        = 0;
-    uint32                       accountID     = 0;
-    uint32                       next_zone_id  = 0;
-    bool                         forceLinkDead = false;
+    uint8                        shuttingDown       = 0;  // prevents double session closing
+    uint32                       charID             = 0;
+    uint32                       accountID          = 0;
+    uint32                       next_zone_id       = 0;
+    bool                         forceLinkDead      = false; // Don't allow last_update tap if forced to die
+    bool                         hasDecryptedPacket = false; // used to check if the client still needs an 0x00A
+
     // Store old blowfish data, when a player recieves 0x00B their key should increment
     // If it doesn't, and we can still successfully decrypt here, that means we need to resend 0x00B.
     blowfish_t prev_blowfish = {};

--- a/src/map/map_session_container.cpp
+++ b/src/map/map_session_container.cpp
@@ -61,9 +61,9 @@ auto MapSessionContainer::createSession(IPP ipp) -> MapSession*
 
     auto map_session_data = std::make_unique<MapSession>();
 
-    map_session_data->scheduler   = &scheduler_;
-    map_session_data->last_update = timer::now();
-    map_session_data->client_ipp  = ipp;
+    map_session_data->scheduler  = &scheduler_;
+    map_session_data->client_ipp = ipp;
+    map_session_data->tapLastUpdate();
 
     sessions_[ipp] = std::move(map_session_data);
 
@@ -85,9 +85,9 @@ auto MapSessionContainer::createPendingSession(uint32 charId) -> MapSession*
 
     auto map_session_data = std::make_unique<MapSession>();
 
-    map_session_data->scheduler   = &scheduler_;
-    map_session_data->last_update = timer::now(); // This may need adjustment if sessions feel like they take too long to free
-    map_session_data->charID      = charId;
+    map_session_data->scheduler = &scheduler_;
+    map_session_data->charID    = charId;
+    map_session_data->tapLastUpdate();
 
     pending_sessions_[charId] = std::move(map_session_data);
 
@@ -209,7 +209,7 @@ void MapSessionContainer::cleanupSessions(IPP mapIPP)
         auto& map_session_data = it->second;
 
         auto* PChar = map_session_data->PChar.get();
-        auto  now   = timer::now();
+        auto  now   = earth_time::now();
 
         if (now > map_session_data->last_update + 5s)
         {
@@ -313,7 +313,7 @@ void MapSessionContainer::cleanupSessions(IPP mapIPP)
         {
             auto& map_session_data = pair.second;
 
-            auto now = timer::now();
+            auto now = earth_time::now();
 
             if (now > map_session_data->last_update + std::chrono::seconds(timeoutSetting))
             {

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -38,7 +38,7 @@ auto GP_CLI_COMMAND_LOGIN::validate(MapSession* PSession, const CCharEntity* PCh
 {
     return PacketValidator(PChar)
         .mustEqual(PChar->id, this->UniqueNo, "Player ID mismatch")
-        .mustNotEqual(PSession->blowfish.status == BLOWFISH_ACCEPTED && PChar->status == STATUS_TYPE::NORMAL, true, "Player already logged in.");
+        .mustNotEqual(PSession->blowfish.status == BLOWFISH_ACCEPTED && PChar->status == STATUS_TYPE::NORMAL && PSession->hasDecryptedPacket, true, "Player already logged in.");
 }
 
 void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) const

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7327,15 +7327,6 @@ auto SendToZone(CCharEntity* PChar, uint16 zoneId) -> bool
         return false;
     }
 
-    auto ip   = ipp.getIP();
-    auto port = ipp.getPort();
-    db::preparedStmt("UPDATE accounts_sessions "
-                     "SET server_addr = ?, server_port = ? "
-                     "WHERE charid = ?",
-                     ip,
-                     port,
-                     PChar->id);
-
     db::preparedStmt("UPDATE chars "
                      "SET pos_zone = ?, pos_prevzone = ?, pos_rot = ?,"
                      "pos_x = ?, pos_y = ?, pos_z = ?,"

--- a/src/test/lua/lua_client_entity_pair.cpp
+++ b/src/test/lua/lua_client_entity_pair.cpp
@@ -76,7 +76,7 @@ void CLuaClientEntityPair::tick()
 {
     TracyZoneScoped;
 
-    testChar_->session()->last_update = timer::now();
+    testChar_->session()->tapLastUpdate();
     packets().parseIncoming();
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

forceLogout() just causes crashes and its intent is not obviously functionally different than leaveGame(), and in addition it is unused so it's being removed.

Add some guard rails to zoning logic to only allow updates of the last packet time if we're not force DCing the session.
Issue a different DB update when logging out/shutting down after 0x00B is sent to the client.

Fixed an edge case where dropped 0x00As would not resend

## Steps to test these changes

Zone, d/c, etc. see nothing unusual.
