### PR TITLE
[core] [C++] [lua] Restore optional targeting to TryCastSpell() / Cleanup Avatar.lua

### DIFF
--- a/scripts/globals/pets/avatar.lua
+++ b/scripts/globals/pets/avatar.lua
@@ -1,30 +1,167 @@
 -----------------------------------
 -- PET: Avatar
+-- TODO: More accurate Light Spirit logic. (Curaga Chance? Seems random.)
+-- TODO: Accurate HP/MP/Stat scaling for Spirits.
+-- TODO: There are some claims that position/facing of the Light Spirit can influence its behavior. Find out if it's real?
 -----------------------------------
 require('scripts/globals/summon')
+require('scripts/utils/utils')
 -----------------------------------
 
 xi = xi or {}
 xi.pets = xi.pets or {}
 xi.pets.avatar = xi.pets.avatar or {}
 
--- will determine, in seconds, the spirit's casting cooldown
--- Called every tick for player to adjust magic casting delay in real-time
-local function setMagicCastCooldown(pet)
-    local castingCooldown = 45
-    local master = pet:getMaster()
+xi.pets.avatar.lightSpiritSpells =
+{
+    buffs =
+    {
+        { spell = xi.magic.spell.PROTECT_V,   effect = xi.effect.PROTECT, tier = 5, level = 76 },
+        { spell = xi.magic.spell.PROTECT_IV,  effect = xi.effect.PROTECT, tier = 4, level = 68 },
+        { spell = xi.magic.spell.PROTECT_III, effect = xi.effect.PROTECT, tier = 3, level = 47 },
+        { spell = xi.magic.spell.PROTECT_II,  effect = xi.effect.PROTECT, tier = 2, level = 27 },
+        { spell = xi.magic.spell.PROTECT,     effect = xi.effect.PROTECT, tier = 1, level =  7 },
+        { spell = xi.magic.spell.SHELL_V,     effect = xi.effect.SHELL,   tier = 5, level = 76 },
+        { spell = xi.magic.spell.SHELL_IV,    effect = xi.effect.SHELL,   tier = 4, level = 68 },
+        { spell = xi.magic.spell.SHELL_III,   effect = xi.effect.SHELL,   tier = 3, level = 57 },
+        { spell = xi.magic.spell.SHELL_II,    effect = xi.effect.SHELL,   tier = 2, level = 37 },
+        { spell = xi.magic.spell.SHELL,       effect = xi.effect.SHELL,   tier = 1, level = 10 },
+        { spell = xi.magic.spell.HASTE,       effect = xi.effect.HASTE,             level = 48 },
+        { spell = xi.magic.spell.REGEN,       effect = xi.effect.REGEN,             level = 21 },
+    },
 
-    -- we already know master is a PC, this is just in case the pet gets disjointed somehow
+    cures =
+    {
+        { spell = xi.magic.spell.CURE_VI,                                           level = 80 },
+        { spell = xi.magic.spell.CURE_V,                                            level = 61 },
+        { spell = xi.magic.spell.CURE_IV,                                           level = 41 },
+        { spell = xi.magic.spell.CURE_III,                                          level = 21 },
+        { spell = xi.magic.spell.CURE_II,                                           level = 11 },
+        { spell = xi.magic.spell.CURE,                                              level =  1 },
+    },
+
+    curagas =
+    {
+        { spell = xi.magic.spell.CURAGA_V,                                          level = 91 },
+        { spell = xi.magic.spell.CURAGA_IV,                                         level = 71 },
+        { spell = xi.magic.spell.CURAGA_III,                                        level = 51 },
+        { spell = xi.magic.spell.CURAGA_II,                                         level = 31 },
+        { spell = xi.magic.spell.CURAGA,                                            level = 16 },
+    },
+}
+
+local function tryCureSpell(pet)
+    local master = pet:getMaster()
     if not master then
         return
     end
 
-    castingCooldown = castingCooldown - math.floor(xi.summon.getSummoningSkillOverCap(pet) / 3)
+    local cureTarget               = nil
+    local lowestHitPointPercentage = 100
 
-    if master:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
-        castingCooldown = castingCooldown - 5
+    for _, member in pairs(master:getAlliance()) do
+        if
+            member and
+            member:isAlive() and
+            pet:checkDistance(member) < 20
+        then
+            local memberHitPointPercentage = member:getHPP()
+
+            if
+                memberHitPointPercentage <= 75 and
+                memberHitPointPercentage < lowestHitPointPercentage
+            then
+                lowestHitPointPercentage = memberHitPointPercentage
+                cureTarget = member
+            end
+        end
     end
 
+    if not cureTarget then
+        return
+    end
+
+    local petLevel   = pet:getMainLvl()
+    local spellGroup = xi.pets.avatar.lightSpiritSpells.cures
+
+    if
+        petLevel >= 16 and
+        -- TODO: Check this. Guessed.
+        math.random(1, 100) <= math.min(10 + xi.summon.getSummoningSkillOverCap(pet), 50)
+    then
+        spellGroup = xi.pets.avatar.lightSpiritSpells.curagas
+    end
+
+    for _, spellData in ipairs(spellGroup) do
+        if petLevel >= spellData.level then
+            return spellData.spell, cureTarget
+        end
+    end
+
+    return nil, nil
+end
+
+local function tryBuffSpell(pet)
+    local master = pet:getMaster()
+    if not master then
+        return
+    end
+
+    local petLevel     = pet:getMainLvl()
+    local partyMembers = utils.shuffle(master:getParty())
+
+    for _, spellData in ipairs(xi.pets.avatar.lightSpiritSpells.buffs) do
+        if petLevel >= spellData.level then
+            for _, member in ipairs(partyMembers) do
+                if
+                    member and
+                    member:isAlive() and
+                    pet:checkDistance(member) < 20
+                then
+                    local statusEffect = member:getStatusEffect(spellData.effect)
+                    local canApplyBuff = not statusEffect or spellData.tier and statusEffect:getTier() < spellData.tier
+
+                    if canApplyBuff then
+                        return spellData.spell, member
+                    end
+                end
+            end
+        end
+    end
+
+    return nil, nil
+end
+
+local function getMagicCastCooldown(pet)
+    -- 45 Seconds is the neutral spell cooldown if you are at your natural summoning skill cap.
+    local castingCooldown = 45
+
+    local master = pet:getMaster()
+
+    if not master then
+        return 0
+    end
+
+    -- You are penalized if your summoning skill is below your max skill for your level, increasing spell cooldown by 1 second for every 3 skill under, up to a maximum of 90s.
+    -- You are rewarded if your summoning skill is above your max skill for your level, reducing spell cooldown by 1 second for every 3 skill over, down to a minimum of 30s.
+    local summoningSkill  = master:getSkillLevel(xi.skill.SUMMONING_MAGIC)
+    local maxSkill        = master:getMaxSkillLevel(pet:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC)
+    local skillDifference = summoningSkill - maxSkill
+
+    if skillDifference >= 0 then
+        castingCooldown = castingCooldown - math.floor(skillDifference / 3)
+    else
+        castingCooldown = castingCooldown + math.floor(math.abs(skillDifference) / 3)
+    end
+
+    castingCooldown = math.min(math.max(castingCooldown, 30), 90)
+
+    -- Astral Flow sets the spell cooldown to 30 seconds, regardless of skill.
+    if master:hasStatusEffect(xi.effect.ASTRAL_FLOW) then
+        castingCooldown = 30
+    end
+
+    -- Weather & Spirit Cast Reductions
     castingCooldown = castingCooldown - master:getMod(xi.mod.SPIRIT_CAST_REDUCTION)
 
     local petElement = master:getPetElement()
@@ -54,31 +191,7 @@ local function setMagicCastCooldown(pet)
         castingCooldown = castingCooldown + 3
     end
 
-    -- "Buff mode" is enabled for first cast after spawn and after casting any enhancing magic
-    if pet:getLocalVar('AVATAR_BUFF_MODE_OFF') ~= 1 then
-        castingCooldown = math.floor(castingCooldown / 2)
-    end
-
-    -- cast delay is ~1s past the finish of last spell, so we add casting time (or time since spell interrupt) to the castingCooldown
-    -- this is done by simply tracking the elapsed time since action is no longer xi.action.category.MAGIC_CASTING
-    local lastCastTime = pet:getLocalVar('AVATAR_LAST_CASTINGTIME')
-    local lastCastTimeStamp = pet:getLocalVar('AVATAR_LAST_CAST_TIMESTAMP')
-    if
-        lastCastTimeStamp > 0 and
-        GetSystemTime() - lastCastTimeStamp > lastCastTime
-    then
-        lastCastTime = GetSystemTime() - lastCastTimeStamp
-    end
-
-    if
-        lastCastTime > 0 and
-        pet:getCurrentAction() ~= xi.action.category.MAGIC_CASTING
-    then
-        pet:setLocalVar('AVATAR_LAST_CAST_TIMESTAMP', 0)
-        pet:setLocalVar('AVATAR_LAST_CASTINGTIME', lastCastTime)
-    end
-
-    pet:setMobMod(xi.mobMod.MAGIC_COOL, lastCastTime + math.max(castingCooldown, 0))
+    return math.max(castingCooldown, 1)
 end
 
 -- Sets the SMN pet's base damage.
@@ -104,57 +217,41 @@ xi.pets.avatar.onMobSpawn = function(pet)
     -- Set up avatar's base damage.
     xi.pets.avatar.calculateAvatarWeaponDamage(pet)
 
-    -- Spawn mods and listeners for Light Spirit functionality.
-    if pet:getPetID() == xi.petId.LIGHT_SPIRIT then
-        -- Stop pet from immediately casting a spell on spawn and respecting the cooldowns by exiting early if MAGIC_COOL is 1
-        pet:setMobMod(xi.mobMod.MAGIC_COOL, 1)
-        pet:setMod(xi.mod.MPP, 500)
+    local petType       = pet:getPetID()
+
+    -- Only Spirits cast Magic.
+    if
+        petType >= xi.petId.FIRE_SPIRIT and
+        petType <= xi.petId.DARK_SPIRIT
+    then
+        local spellCooldown = getMagicCastCooldown(pet)
+        -- Freshly summoned spirits may not cast until their spell cooldown is up.
+        pet:setMobMod(xi.mobMod.MAGIC_DELAY, 0)
+        pet:setMagicCastingEnabled(false)
+
+        pet:timer(spellCooldown * 1000, function(petArg)
+            petArg:setMagicCastingEnabled(true)
+        end)
+
+        -- TODO: Get accurate HP/MP values for spirits. This is wrong, but without it Elementals would have extremely low MP amounts.
+        pet:setMod(xi.mod.MPP, 300)
         pet:updateHealth()
         pet:setMP(pet:getMaxMP())
 
-        -- Add listener to player to fine-tune spirit pact cast delays in realtime
-        master:addListener('TICK', 'SMN_SPIRIT_CAST_DELAY', function(masterArg)
-            local petArg = masterArg:getPet()
-
-            if petArg and petArg:getMobMod(xi.mobMod.MAGIC_COOL) > 1 then
-                setMagicCastCooldown(petArg)
-            end
-        end)
-
-        master:addListener('ABILITY_USE', 'SMN_SPIRIT_CAST_DELAY' .. 'ABILITY', function(masterArg, target, skill, action)
-            local petArg  = masterArg:getPet()
-            if not petArg then
-                return
-            end
-
-            local skillId = skill:getID()
-            if
-                skillId == xi.jobAbility.ASSAULT or
-                skillId == xi.jobAbility.RETREAT
-            then
-                -- Reset cast cooldown via same method as fresh spawn
-                petArg:setMobMod(xi.mobMod.MAGIC_COOL, 1)
-                petArg:setLocalVar('AVATAR_BUFF_MODE_OFF', 1)
-            end
-        end)
+        pet:setMobMod(xi.mobMod.MAGIC_COOL, spellCooldown)
     end
 end
 
-xi.pets.avatar.onMobDeath = function(pet)
-    local master = pet:getMaster()
+-- Assault from Idle will trigger onMobEngage.
+xi.pets.avatar.onMobEngage = function(pet)
+    if pet:getPetID() == xi.petId.LIGHT_SPIRIT then
+        local spellCooldown = getMagicCastCooldown(pet)
 
-    if master and master:getObjType() == xi.objType.PC then
-        master:removeListener('SMN_SPIRIT_CAST_DELAY')
-        master:removeListener('SMN_SPIRIT_CAST_DELAY' .. 'ABILITY')
+        pet:setMobMod(xi.mobMod.MAGIC_COOL, spellCooldown)
     end
 end
 
--- Is this unused? wtf is this for?
 xi.pets.avatar.onMobSpellChoose = function(pet)
-    -- Note that:
-    -- returning -1 (or a spell the spirit cannot cast) in this function forces TryCastSpell to exit without choosing/casting a spell, but
-    -- will still set the m_LastMagicTime to ensure next call of this function is after the cast delay
-    -- Also, if we return nothing (or zero) TryCastSpell will default to normal mob casting behavior (nukes from spell list, etc)
     local master = pet:getMaster()
     if
         not master or
@@ -163,332 +260,51 @@ xi.pets.avatar.onMobSpellChoose = function(pet)
         return
     end
 
-    -- meta checks for fresh pet, etc
-    pet:setLocalVar('AVATAR_LAST_CASTINGTIME', 0)
-    pet:setLocalVar('AVATAR_LAST_CAST_TIMESTAMP', GetSystemTime())
-
-    -- early exit from casting a spell to prevent immediately casting a spell after being summoned
-    if pet:getMobMod(xi.mobMod.MAGIC_COOL) == 1 then
-        setMagicCastCooldown(pet)
-
-        return xi.magic.spell.INDI_REGEN
+    -- No override for spirits that are not Light Spirit.
+    if pet:getPetID() ~= xi.petId.LIGHT_SPIRIT then
+        return nil, nil
     end
 
-    -- ensures magic casting delay is no longer halved
-    pet:setLocalVar('AVATAR_BUFF_MODE_OFF', 1)
+    local spellCooldown = getMagicCastCooldown(pet)
 
-    -- Core functionality to decide which spell to use
-    local spellID, spellTarget = xi.pets.avatar.getSpiritSpell(pet)
-
-    -- Final items to cast the spell and ensure cast delay is proper
-    local spell = GetSpell(spellID)
-    if spell then
-        if spell:getSkillType() == xi.skill.ENHANCING_MAGIC then
-            -- half casting delay
-            pet:setLocalVar('AVATAR_BUFF_MODE_OFF', 0)
-        end
-
-        pet:castSpell(spellID, spellTarget or pet)
-        setMagicCastCooldown(pet)
-
-        return xi.magic.spell.INDI_REGEN
+    -- Update spell cooldown.
+    if pet:isEngaged() then
+        pet:setMobMod(xi.mobMod.MAGIC_COOL, spellCooldown)
+    else
+        pet:setMobMod(xi.mobMod.MAGIC_COOL, math.max(math.floor(spellCooldown / 2), 1))
     end
 
-    return 0
-end
+    -- Check for wounded allies first.
+    local spellToCast, spellTarget = tryCureSpell(pet)
 
----@param pet CBaseEntity
----@return integer, CBaseEntity?
-xi.pets.avatar.getSpiritSpell = function(pet)
-    local spellID = 0
-    local spellTarget = nil
-    local petID = pet:getPetID()
-    -- add more logic as needed with its own function
-    if petID == xi.petId.LIGHT_SPIRIT then
-        -- TODO: Align spirit and light spirit functions for return consistency and consolidate.
-        spellID, spellTarget = xi.pets.avatar.getLightSpiritSpell(pet)
-    end
-
-    return spellID, spellTarget
-end
-
-xi.pets.avatar.lightSpiritBuffs =
-{
-    [xi.effect.PROTECT] =
-    {
-        {
-            spell = xi.magic.spell.PROTECT_V,
-            power = 220,
-            level = 76,
-        },
-        {
-            spell = xi.magic.spell.PROTECT_IV,
-            power = 140,
-            level = 68,
-        },
-        {
-            spell = xi.magic.spell.PROTECT_III,
-            power = 90,
-            level = 47,
-        },
-        {
-            spell = xi.magic.spell.PROTECT_II,
-            power = 50,
-            level = 27,
-        },
-        {
-            spell = xi.magic.spell.PROTECT,
-            power = 20,
-            level = 7,
-        },
-    },
-    [xi.effect.SHELL] =
-    {
-        {
-            spell = xi.magic.spell.SHELL_V,
-            power = 2930,
-            level = 76,
-        },
-        {
-            spell = xi.magic.spell.SHELL_IV,
-            power = 2617,
-            level = 68,
-        },
-        {
-            spell = xi.magic.spell.SHELL_III,
-            power = 2188,
-            level = 57,
-        },
-        {
-            spell = xi.magic.spell.SHELL_II,
-            power = 1641,
-            level = 37,
-        },
-        {
-            spell = xi.magic.spell.SHELL,
-            power = 1055,
-            level = 10,
-        },
-    },
-    [xi.effect.REGEN] =
-    {
-        {
-            spell = xi.magic.spell.REGEN,
-            power = 0, -- Light spirit does not overwrite
-            level = 21,
-        },
-    },
-    [xi.effect.HASTE] =
-    {
-        {
-            spell = xi.magic.spell.HASTE,
-            power = 0, -- Light spirit does not overwrite
-            level = 48,
-        },
-    },
-}
-
-xi.pets.avatar.lightSpiritCures =
-{
-    [xi.magic.spellFamily.CURE] =
-    {
-        {
-            spell = xi.magic.spell.CURE_VI,
-            level = 80,
-        },
-        {
-            spell = xi.magic.spell.CURE_V,
-            level = 61,
-        },
-        {
-            spell = xi.magic.spell.CURE_IV,
-            level = 41,
-        },
-        {
-            spell = xi.magic.spell.CURE_III,
-            level = 21,
-        },
-        {
-            spell = xi.magic.spell.CURE_II,
-            level = 11,
-        },
-        {
-            spell = xi.magic.spell.CURE,
-            level = 1,
-        },
-    },
-    [xi.magic.spellFamily.CURAGA] =
-    {
-        {
-            spell = xi.magic.spell.CURAGA_V,
-            level = 91,
-        },
-        {
-            spell = xi.magic.spell.CURAGA_IV,
-            level = 71,
-        },
-        {
-            spell = xi.magic.spell.CURAGA_III,
-            level = 51,
-        },
-        {
-            spell = xi.magic.spell.CURAGA_II,
-            level = 31,
-        },
-        {
-            spell = xi.magic.spell.CURAGA,
-            level = 16,
-        },
-    },
-}
-
-xi.pets.avatar.getLightSpiritBuffs = function(pet)
-    -- returns a table of the highest-tier buffs available to this light spirit pet
-    local petLvl = pet:getMainLvl()
-    local buffs = {}
-    for effect, buffData in pairs(xi.pets.avatar.lightSpiritBuffs) do
-        -- loop over every spell for this effect and exit on the first that the pet can cast
-        for _, spellData in ipairs(buffData) do
-            if petLvl >= spellData.level then
-                table.insert(buffs, {
-                    effect = effect,
-                    spell = spellData.spell,
-                    power = spellData.power
-                })
-                break
-            end
-        end
-    end
-
-    return buffs
-end
-
-xi.pets.avatar.getLightSpiritCure = function(pet)
-    -- curaga can be used on anyone in the alliance and isn't determined by how many need a heal (assumed to be based on skill over cap)
-    local petLvl = pet:getMainLvl()
-    local spellFamily = xi.magic.spellFamily.CURE
     if
-        petLvl >= 16 and
-        math.random(100) <= 2 * xi.summon.getSummoningSkillOverCap(pet)
+        spellToCast and
+        spellToCast > 0
     then
-        spellFamily = xi.magic.spellFamily.CURAGA
+        return spellToCast, spellTarget
     end
 
-    for _, spellData in ipairs(xi.pets.avatar.lightSpiritCures[spellFamily]) do
-        if petLvl >= spellData.level then
-            return spellData.spell
+    -- If no wounded allies, and not engaged, cast a buff.
+    if not pet:isEngaged() then
+        spellToCast, spellTarget = tryBuffSpell(pet)
+
+        if
+            spellToCast and
+            spellToCast > 0
+        then
+            return spellToCast, spellTarget
         end
     end
 
-    return 0
+    -- If no wounded allies, and engaged, cast an offensive spell.
+    return nil, nil
 end
 
-xi.pets.avatar.getLightSpiritSpell = function(pet)
-    -- returns the spirit's preferred target based on positioning
-    local master = pet:getMaster()
-    if not master then
-        return 0, nil
-    end
+-- Retreat from Engaged will trigger onMobDisengage.
+xi.pets.avatar.onMobDisengage = function(pet)
+    if pet:getPetID() == xi.petId.LIGHT_SPIRIT then
+        local spellCooldown = getMagicCastCooldown(pet)
 
-    local posTarget = nil
-    local posSpellID = 0
-    local buffTarget = nil
-    local buffSpellID = 0
-    local cureTarget = nil
-    local spellID = 0
-
-    if not pet:isEngaged() then
-        pet:lookAt(master:getPos())
-    else
-        -- don't do logic to buff anyone if pet is engaged. buffTarget will be reset below
-        buffTarget = master
-    end
-
-    local distance  = pet:checkDistance(master) -- starts as distance to master, updated to be distance to the posTarget
-    local hpp       = 100
-    local alliance  = master:getAlliance()
-    local party     = master:getParty()
-
-    for _, member in pairs(alliance) do
-        local tempHPP = member:getHPP()
-        if
-            pet:checkDistance(member) < 20 and
-            tempHPP < hpp
-        then
-            -- tiered chance of healing based on how low they are
-            -- flip a coin for every 25% hp the player has missing
-            for hpColor = 1, 3 do
-                if
-                    tempHPP < 25 * hpColor and
-                    math.random(1, 100) <= 50
-                then
-                    hpp = tempHPP
-                    cureTarget = member
-
-                    break
-                end
-            end
-        end
-    end
-
-    if cureTarget then
-        spellID = xi.pets.avatar.getLightSpiritCure(pet)
-
-        return spellID, cureTarget
-    else
-        local lightSpiritBuffs = xi.pets.avatar.getLightSpiritBuffs(pet)
-
-        for _, member in pairs(party) do
-            local tempDistance = pet:checkDistance(member)
-            if
-                not member:hasStatusEffect(xi.effect.INVISIBLE) and
-                (tempDistance <= distance or
-                not buffTarget)
-            then
-                -- Light Spirit will overwrite lower tiered Protect and Shell spells but will not overwrite Haste or Regen
-                local tempSpellID = 0
-
-                for _, spellData in ipairs(lightSpiritBuffs) do
-                    if
-                        not member:getStatusEffect(spellData.effect) or
-                        member:getStatusEffect(spellData.effect):getPower() < spellData.power
-                    then
-                        -- exit loop once a buff is found to be applied
-                        tempSpellID = spellData.spell
-
-                        break
-                    end
-                end
-
-                if tempSpellID > 0 and tempDistance < 20 then
-                    if
-                        tempDistance < distance and
-                        pet:isFacing(member)
-                    then
-                        posSpellID = tempSpellID
-                        distance = tempDistance
-                        posTarget = member
-                    elseif not buffTarget then
-                        buffSpellID = tempSpellID
-                        buffTarget = member
-                    end
-                end
-            end
-        end
-
-        -- only buff in combat if positioning is encouraging it
-        if pet:isEngaged() then
-            buffTarget = nil
-            buffSpellID = 0
-        end
-
-        if posTarget then
-            buffTarget = posTarget
-            spellID = posSpellID
-        else
-            spellID = buffSpellID
-        end
-
-        return spellID, buffTarget
+        pet:setMobMod(xi.mobMod.MAGIC_COOL, math.max(math.floor(spellCooldown / 2), 1))
     end
 end

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -628,8 +628,16 @@ auto CMobController::TryCastSpell() -> bool
         return false; // Target out of range.
     }
 
-    // Perform cast.
-    CastSpell(chosenSpellId.value());
+    // Perform cast. If there is a valid target override, cast at that target, otherwise cast normally.
+    // We need this because CastSpell has its own targetfind and PCastTarget is not used for it.
+    if (maybeTargetOverride.has_value() && PCastTarget)
+    {
+        Cast(PCastTarget->targid, chosenSpellId.value());
+    }
+    else
+    {
+        CastSpell(chosenSpellId.value());
+    }
     return true;
 }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Restores optional targeting from onMobSpellChoose() to be carried through into TryCastSpell(), a regression that happened during a cleanup a few months ago. 

* Now if the target override has value, casts the spell at that target, otherwise falls to castSpell(), which picks its own target. 

Cleans up Avatar.lua

* Spirit magic cooldown now effected negatively if summoning skill is under cap, up to a maximum of 90s.
* Spirit magic cooldown reduction from skill now capped at 30s.
* Astral Flow now sets the magic cooldown of spirits to 30s.
* Refactors Light Spirit code, behavior is the same as before minus some position / facing code I could not verify. 
* Spirits now incur their spell cooldown on summon and must wait before casting magic.
* Recast times now calculated after each spell instead of being evaluated with a listener every tick. 
* Recast times now calculated in onMobEngage / onMobDisengage (Assault / Retreat triggers these) instead of listeners.

## Captures / Sources
https://ffxiclopedia.fandom.com/wiki/Spirit_Guide_by_Spira#Project_Spirits:_Compilation_of_Elemental_Spirit_Info - Used for general information about Light Spirit and Spirits in general. Fact checked some of the magic cooldown stuff.
https://wiki.ffo.jp/html/2307.html - Used for some various info, like Astral Flow magic cooldown.
Maximum cast time capture log : 
[Klair.log](https://github.com/user-attachments/files/29520927/Klair.log)

Was 99 SMN w/2 Summoning Skill here (Observed 90s)

Minimum time of 30s verified by @WinterSolstice8 and @Tanyrus

## Steps to test these changes

Cast regular spirits, see them cast offensive spells when engaged. Try out light spirit, see it buff out of combat, and cast offensive magic in combat.
