### PR TITLE
Updating tutorial quest due to updates in retail tutorial

### DIFF
--- a/scripts/globals/teleports/survival_guide.lua
+++ b/scripts/globals/teleports/survival_guide.lua
@@ -72,6 +72,13 @@ xi.survivalGuide.onTrigger = function(player)
                 param = bit.bor(param, 0x2000)
             end
 
+            -- Hide the free tutorial teleport option unless the tutorial objective is active.
+            -- Bit 0x4000 suppresses the option; it is absent only when TutorialProgress is 11 or 12.
+            local tutorialStage = player:getCharVar('TutorialProgress')
+            if tutorialStage ~= 13 then
+                param = bit.bor(param, 0x4000)
+            end
+
             local g1, g2, g3, g4 = unpack(player:getTeleportTable(xi.teleport.type.SURVIVAL))
 
             -- param 1 = Does nothing.
@@ -157,12 +164,18 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option, npc)
                 local teleportCostGil  = 1000
                 local teleportCostTabs = 50
                 local canTeleport      = false
+				local tutorialStage    = player:getCharVar('TutorialProgress')
 
                 -- When all mog tablets are found, survival guides are free.
                 local allMogTabletsFound = false -- TODO: Implement mog tablets and fetch if they are all found here.
                 if allMogTabletsFound then
                     teleportCostGil  = 0
                     teleportCostTabs = 0
+				
+				-- Free teleport during tutorial survival guide objective.
+				elseif tutorialStage == 13 then
+					teleportCostGil  = 0
+					teleportCostTabs = 0
 
                 -- If the player has the "Rhapsody in White" KI, the cost is 10% of original gil or 20% of original tabs.
                 elseif player:hasKeyItem(xi.ki.RHAPSODY_IN_WHITE) then
@@ -186,6 +199,9 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option, npc)
 
                 if canTeleport then
                     player:setPos(guide.posX, guide.posY, guide.posZ, guide.posRot, guide.zoneId)
+					if tutorialStage == 13 then
+						player:setCharVar('TutorialProgress', 14)	-- Prevents infinite free teleports by not finishing tutorial.
+					end
                 end
             end
         end

--- a/scripts/globals/teleports/survival_guide.lua
+++ b/scripts/globals/teleports/survival_guide.lua
@@ -164,18 +164,18 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option, npc)
                 local teleportCostGil  = 1000
                 local teleportCostTabs = 50
                 local canTeleport      = false
-				local tutorialStage    = player:getCharVar('TutorialProgress')
+			    local tutorialStage    = player:getCharVar('TutorialProgress')
 
                 -- When all mog tablets are found, survival guides are free.
                 local allMogTabletsFound = false -- TODO: Implement mog tablets and fetch if they are all found here.
                 if allMogTabletsFound then
                     teleportCostGil  = 0
                     teleportCostTabs = 0
-				
-				-- Free teleport during tutorial survival guide objective.
-				elseif tutorialStage == 13 then
-					teleportCostGil  = 0
-					teleportCostTabs = 0
+
+                -- Free teleport during tutorial survival guide objective.
+                elseif tutorialStage == 13 then
+                    teleportCostGil  = 0
+                    teleportCostTabs = 0
 
                 -- If the player has the "Rhapsody in White" KI, the cost is 10% of original gil or 20% of original tabs.
                 elseif player:hasKeyItem(xi.ki.RHAPSODY_IN_WHITE) then
@@ -199,9 +199,9 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option, npc)
 
                 if canTeleport then
                     player:setPos(guide.posX, guide.posY, guide.posZ, guide.posRot, guide.zoneId)
-					if tutorialStage == 13 then
-						player:setCharVar('TutorialProgress', 14)	-- Prevents infinite free teleports by not finishing tutorial.
-					end
+                    if tutorialStage == 13 then
+                        player:setCharVar('TutorialProgress', 14)    -- Prevents infinite free teleports by not finishing tutorial.
+                    end
                 end
             end
         end

--- a/scripts/quests/tutorial.lua
+++ b/scripts/quests/tutorial.lua
@@ -7,23 +7,23 @@ xi.tutorial = xi.tutorial or {}
 xi.tutorial.onTrigger = function(player, npc, npc_event_offset, nation_offset)
     local stage = player:getCharVar('TutorialProgress')
     if stage == 1 then
-        player:startEvent(npc_event_offset + 22)				-- Tutorial NPC introduces themselves.
+        player:startEvent(npc_event_offset + 22)                -- Tutorial NPC introduces themselves.
     else
         local mLevel = player:getMainLvl()
         local sLevel = player:getSubLvl()
         if stage == 2 then
-            player:startEvent(npc_event_offset)					-- Tutorial NPC instructs you to get Signet.
+            player:startEvent(npc_event_offset)                 -- Tutorial NPC instructs you to get Signet.
         elseif stage == 3 then
             if not player:hasStatusEffect(xi.effect.SIGNET) then
-                player:startEvent(npc_event_offset + 1)			-- You talked to them without Signet.
+                player:startEvent(npc_event_offset + 1)         -- You talked to them without Signet.
             else
-                player:startEvent(npc_event_offset + 2)			-- Tutorial NPC asks you to eat.
+                player:startEvent(npc_event_offset + 2)         -- Tutorial NPC asks you to eat.
             end
         elseif stage == 4 then
             if not player:hasStatusEffect(xi.effect.FOOD) then
-                player:startEvent(npc_event_offset + 3)			-- You talked to them without eating.
+                player:startEvent(npc_event_offset + 3)         -- You talked to them without eating.
             else
-                player:startEvent(npc_event_offset + 4)			-- Tutorial NPC asks you to learn a weaponskill.
+                player:startEvent(npc_event_offset + 4)         -- Tutorial NPC asks you to learn a weaponskill.
             end
         elseif stage == 5 then
             local isSkilled = false
@@ -35,67 +35,66 @@ xi.tutorial.onTrigger = function(player, npc, npc_event_offset, nation_offset)
             end
 
             if not isSkilled then
-                player:startEvent(npc_event_offset + 5)			-- You talked without having any weaponskills.
+                player:startEvent(npc_event_offset + 5)         -- You talked without having any weaponskills.
             else
-                player:startEvent(npc_event_offset + 6)			-- Tutorial NPC asks you to activate Records of Eminence.
+                player:startEvent(npc_event_offset + 6)         -- Tutorial NPC asks you to activate Records of Eminence.
             end
         elseif stage == 6 then
             if not player:hasKeyItem(xi.ki.MEMORANDOLL) then
-                player:startEvent(npc_event_offset + 7)			-- You didn't get your memorandoll.
+                player:startEvent(npc_event_offset + 7)         -- You didn't get your memorandoll.
             else
-                player:startEvent(npc_event_offset + 8)			-- Tutorial NPC asks you to poke an auction house counter.
+                player:startEvent(npc_event_offset + 8)         -- Tutorial NPC asks you to poke an auction house counter.
             end
         elseif stage == 7 then
-            player:startEvent(npc_event_offset + 9)				-- You haven't yet found an auction house.
+            player:startEvent(npc_event_offset + 9)             -- You haven't yet found an auction house.
         elseif stage == 8 then
-            player:startEvent(npc_event_offset + 10)			-- Tutorial NPC asks you to reach level 5.
+            player:startEvent(npc_event_offset + 10)            -- Tutorial NPC asks you to reach level 5.
         elseif stage == 9 then
             if mLevel < 5 then
-                player:startEvent(npc_event_offset + 11)		-- Your main job is below level 5.
+                player:startEvent(npc_event_offset + 11)        -- Your main job is below level 5.
             else
-                player:startEvent(npc_event_offset + 12)		-- Tutorial NPC asks you to get a trust permit.
+                player:startEvent(npc_event_offset + 12)        -- Tutorial NPC asks you to get a trust permit.
             end
-        elseif stage == 10 then									-- Logic to determine if you have a trust permit from the same nation as the Tutorial NPC.
-			local nationKiParam = 0
+        elseif stage == 10 then                                 -- Logic to determine if you have a trust permit from the same nation as the Tutorial NPC.
+            local nationKiParam = 0
             if player:getZoneID() == xi.zone.BASTOK_MARKETS then
                 nationKiParam = 2
             elseif player:getZoneID() == xi.zone.SOUTHERN_SAN_DORIA then
                 nationKiParam = 4
             end
-			
             if not player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT + nationKiParam) then
-                player:startEvent(npc_event_offset + 13)		-- You don't have a trust permit from the nation of this NPC yet.
+                player:startEvent(npc_event_offset + 13)        -- You don't have a trust permit from the nation of this NPC yet.
             else
-                player:startEvent(npc_event_offset + 14)		-- Tutorial NPC asks you to learn how to teleport.
+                player:startEvent(npc_event_offset + 14)        -- Tutorial NPC asks you to learn how to teleport.
             end
-		-- Captures indicate nation offset begins being sent with events here.
-		-- This does make a difference in dialogue when discussing Konschtat Highlands, La Theine Plateau, Tahrongi Canyon, Selbina, and Mhaura.
-		-- Unclear if it makes a difference in dialogue for other events, included here to be certain retail behavior is followed.
+        -- Captures indicate nation offset begins being sent with events here.
+        -- This does make a difference in dialogue when discussing Konschtat Highlands, La Theine Plateau, Tahrongi Canyon, Selbina, and Mhaura.
+        -- Unclear if it makes a difference in dialogue for other events, included here to be certain retail behavior is followed.
         elseif
-			stage == 11 or
-			stage == 12
-		then
-            player:startEvent(npc_event_offset + 15, nation_offset)		-- You haven't touched the survival guides in the correct order yet.
+            stage == 11 or
+            stage == 12
+        then
+            player:startEvent(npc_event_offset + 15, nation_offset)     -- You haven't touched the survival guides in the correct order yet.
         elseif
-			stage == 13 or
-			stage == 14
-		then
-            player:startEvent(npc_event_offset + 16, nation_offset)		-- Tutorial NPC asks you to reach level 18.
+            stage == 13 or
+            stage == 14
+        then
+            player:startEvent(npc_event_offset + 16, nation_offset)     -- Tutorial NPC asks you to reach level 18.
         elseif stage == 15 then
             if mLevel < 18 then
-                player:startEvent(npc_event_offset + 17)				-- Your main job is not yet level 18.
-				-- Capture shows no offset sent here.
+                player:startEvent(npc_event_offset + 17)                -- Your main job is not yet level 18.
+                -- Capture shows no offset sent here.
             else
-               player:startEvent(npc_event_offset + 18, nation_offset)	-- Tutorial NPC asks you to unlock your support job.
+                player:startEvent(npc_event_offset + 18, nation_offset) -- Tutorial NPC asks you to unlock your support job.
             end
         elseif stage == 16 then
             if sLevel < 1 then
-                player:startEvent(npc_event_offset + 19, nation_offset)	-- You haven't set a subjob yet.
+                player:startEvent(npc_event_offset + 19, nation_offset) -- You haven't set a subjob yet.
             else
-                player:startEvent(npc_event_offset + 20)				-- Tutorial NPC congratulates you for finishing all their tasks.
+                player:startEvent(npc_event_offset + 20)                -- Tutorial NPC congratulates you for finishing all their tasks.
             end
         elseif stage == 17 then
-            player:startEvent(npc_event_offset + 21)					-- Tutorial NPC post-tutorial dialogue.
+            player:startEvent(npc_event_offset + 21)                    -- Tutorial NPC post-tutorial dialogue.
         end
     end
 end

--- a/scripts/quests/tutorial.lua
+++ b/scripts/quests/tutorial.lua
@@ -6,25 +6,26 @@ xi.tutorial = xi.tutorial or {}
 
 xi.tutorial.onTrigger = function(player, npc, npc_event_offset, nation_offset)
     local stage = player:getCharVar('TutorialProgress')
-    if stage == 0 then
-        player:startEvent(npc_event_offset + 17)
+    if stage == 1 then
+        player:startEvent(npc_event_offset + 22)				-- Tutorial NPC introduces themselves.
     else
         local mLevel = player:getMainLvl()
-        if stage == 1 then
-            player:startEvent(npc_event_offset)
-        elseif stage == 2 then
-            if not player:hasStatusEffect(xi.effect.SIGNET) then
-                player:startEvent(npc_event_offset + 1)
-            else
-                player:startEvent(npc_event_offset + 2)
-            end
+        local sLevel = player:getSubLvl()
+        if stage == 2 then
+            player:startEvent(npc_event_offset)					-- Tutorial NPC instructs you to get Signet.
         elseif stage == 3 then
-            if not player:hasStatusEffect(xi.effect.FOOD) then
-                player:startEvent(npc_event_offset + 3)
+            if not player:hasStatusEffect(xi.effect.SIGNET) then
+                player:startEvent(npc_event_offset + 1)			-- You talked to them without Signet.
             else
-                player:startEvent(npc_event_offset + 4)
+                player:startEvent(npc_event_offset + 2)			-- Tutorial NPC asks you to eat.
             end
         elseif stage == 4 then
+            if not player:hasStatusEffect(xi.effect.FOOD) then
+                player:startEvent(npc_event_offset + 3)			-- You talked to them without eating.
+            else
+                player:startEvent(npc_event_offset + 4)			-- Tutorial NPC asks you to learn a weaponskill.
+            end
+        elseif stage == 5 then
             local isSkilled = false
             for i = xi.skill.HAND_TO_HAND, xi.skill.STAFF do
                 if player:getSkillLevel(i) >= 5 then
@@ -34,92 +35,138 @@ xi.tutorial.onTrigger = function(player, npc, npc_event_offset, nation_offset)
             end
 
             if not isSkilled then
-                player:startEvent(npc_event_offset + 5)
+                player:startEvent(npc_event_offset + 5)			-- You talked without having any weaponskills.
             else
-                player:startEvent(npc_event_offset + 6)
+                player:startEvent(npc_event_offset + 6)			-- Tutorial NPC asks you to activate Records of Eminence.
             end
-        elseif stage == 5 then
-            player:startEvent(npc_event_offset + 7)
         elseif stage == 6 then
-            player:startEvent(npc_event_offset + 8, 0, 0, 0, xi.ki.CONQUEST_PROMOTION_VOUCHER, 0, 0, 0)
+            if not player:hasKeyItem(xi.ki.MEMORANDOLL) then
+                player:startEvent(npc_event_offset + 7)			-- You didn't get your memorandoll.
+            else
+                player:startEvent(npc_event_offset + 8)			-- Tutorial NPC asks you to poke an auction house counter.
+            end
         elseif stage == 7 then
-            if mLevel < 4 then
-                player:startEvent(npc_event_offset + 9)
-            else
-                player:startEvent(npc_event_offset + 10, 0, 0, nation_offset, 0, 0, 0, 0, 0)
-            end
+            player:startEvent(npc_event_offset + 9)				-- You haven't yet found an auction house.
         elseif stage == 8 then
-            player:startEvent(npc_event_offset + 11, 0, 0, nation_offset, 0, 0, 0, 0, 0)
+            player:startEvent(npc_event_offset + 10)			-- Tutorial NPC asks you to reach level 5.
         elseif stage == 9 then
-            player:startEvent(npc_event_offset + 12, 800 * xi.settings.main.EXP_RATE, 0, nation_offset, 0, 0, 0, 0, 0)
-        elseif stage == 10 then
-            if mLevel < 10 then
-                player:startEvent(npc_event_offset + 13, 0, 0, nation_offset, 0, 0, 0, 0, 0)
+            if mLevel < 5 then
+                player:startEvent(npc_event_offset + 11)		-- Your main job is below level 5.
             else
-                player:startEvent(npc_event_offset + 14, 0, 1000 * xi.settings.main.GIL_RATE, nation_offset, 0, 0, 0, 0, 0)
+                player:startEvent(npc_event_offset + 12)		-- Tutorial NPC asks you to get a trust permit.
             end
-        elseif stage == 11 then
-            if not player:hasKeyItem(xi.ki.HOLLA_GATE_CRYSTAL + nation_offset) then
-                player:startEvent(npc_event_offset + 15, xi.ki.HOLLA_GATE_CRYSTAL + nation_offset, 0, nation_offset, 0, 0, 0, 0, 0)
+        elseif stage == 10 then									-- Logic to determine if you have a trust permit from the same nation as the Tutorial NPC.
+			local nationKiParam = 0
+            if player:getZoneID() == xi.zone.BASTOK_MARKETS then
+                nationKiParam = 2
+            elseif player:getZoneID() == xi.zone.SOUTHERN_SAN_DORIA then
+                nationKiParam = 4
+            end
+			
+            if not player:hasKeyItem(xi.ki.WINDURST_TRUST_PERMIT + nationKiParam) then
+                player:startEvent(npc_event_offset + 13)		-- You don't have a trust permit from the nation of this NPC yet.
             else
-                player:startEvent(npc_event_offset + 16, xi.ki.HOLLA_GATE_CRYSTAL + nation_offset, 1000 * xi.settings.main.EXP_RATE, 1789, 3, 0, 0, 0, 0)
+                player:startEvent(npc_event_offset + 14)		-- Tutorial NPC asks you to learn how to teleport.
             end
+		-- Captures indicate nation offset begins being sent with events here.
+		-- This does make a difference in dialogue when discussing Konschtat Highlands, La Theine Plateau, Tahrongi Canyon, Selbina, and Mhaura.
+		-- Unclear if it makes a difference in dialogue for other events, included here to be certain retail behavior is followed.
+        elseif
+			stage == 11 or
+			stage == 12
+		then
+            player:startEvent(npc_event_offset + 15, nation_offset)		-- You haven't touched the survival guides in the correct order yet.
+        elseif
+			stage == 13 or
+			stage == 14
+		then
+            player:startEvent(npc_event_offset + 16, nation_offset)		-- Tutorial NPC asks you to reach level 18.
+        elseif stage == 15 then
+            if mLevel < 18 then
+                player:startEvent(npc_event_offset + 17)				-- Your main job is not yet level 18.
+				-- Capture shows no offset sent here.
+            else
+               player:startEvent(npc_event_offset + 18, nation_offset)	-- Tutorial NPC asks you to unlock your support job.
+            end
+        elseif stage == 16 then
+            if sLevel < 1 then
+                player:startEvent(npc_event_offset + 19, nation_offset)	-- You haven't set a subjob yet.
+            else
+                player:startEvent(npc_event_offset + 20)				-- Tutorial NPC congratulates you for finishing all their tasks.
+            end
+        elseif stage == 17 then
+            player:startEvent(npc_event_offset + 21)					-- Tutorial NPC post-tutorial dialogue.
         end
     end
 end
 
 xi.tutorial.onAuctionTrigger = function(player)
-    if player:getCharVar('TutorialProgress') == 5 then
-        player:setCharVar('TutorialProgress', 6)
+    if player:getCharVar('TutorialProgress') == 7 then
+        player:setCharVar('TutorialProgress', 8)
+    end
+end
+
+xi.tutorial.onGuideTriggerFirst = function(player)
+    if player:getCharVar('TutorialProgress') == 11 then
+        player:setCharVar('TutorialProgress', 12)
+    end
+end
+
+xi.tutorial.onGuideTriggerSecond = function(player)
+    if player:getCharVar('TutorialProgress') == 12 then
+        player:setCharVar('TutorialProgress', 13)
     end
 end
 
 xi.tutorial.onEventFinish = function(player, csid, option, npc_event_offset, nation_offset)
-    if csid == npc_event_offset then
+    if csid == (npc_event_offset + 22) then
         player:setCharVar('TutorialProgress', 2)
+    elseif csid == npc_event_offset then
+        player:setCharVar('TutorialProgress', 3)
     elseif csid == (npc_event_offset + 2) then
         if npcUtil.giveItem(player, { { xi.item.STRIP_OF_MEAT_JERKY, 6 } }) then
-            player:setCharVar('TutorialProgress', 3)
+            player:setCharVar('TutorialProgress', 4)
         end
     elseif csid == (npc_event_offset + 4) then
-        player:setCharVar('TutorialProgress', 4)
+        player:setCharVar('TutorialProgress', 5)
     elseif csid == (npc_event_offset + 6) then
+        npcUtil.giveCurrency(player, 'gil', 100 * xi.settings.main.GIL_RATE)
+        player:setCharVar('TutorialProgress', 6)
+    elseif csid == (npc_event_offset + 8) then
         if player:getZoneID() == xi.zone.WINDURST_WOODS then
-            if npcUtil.giveItem(player, { { xi.item.WATER_CRYSTAL, 1 }, { xi.item.BIRD_EGG, 1 }, { xi.item.POT_OF_HONEY, 1 } }) then
-                player:setCharVar('TutorialProgress', 5)
+            if npcUtil.giveItem(player, { { xi.item.BIRD_EGG, 1 }, { xi.item.POT_OF_HONEY, 1 }, { xi.item.WATER_CRYSTAL, 1 } }) then
+                player:setCharVar('TutorialProgress', 7)
             end
         elseif player:getZoneID() == xi.zone.BASTOK_MARKETS then
-            if npcUtil.giveItem(player, { { xi.item.FIRE_CRYSTAL, 1 }, { xi.item.LIZARD_TAIL, 1 }, { xi.item.POT_OF_HONEY, 1 } }) then
-                player:setCharVar('TutorialProgress', 5)
+            if npcUtil.giveItem(player, { { xi.item.LIZARD_TAIL, 1 }, { xi.item.POT_OF_HONEY, 1 }, { xi.item.FIRE_CRYSTAL, 1 } }) then
+                player:setCharVar('TutorialProgress', 7)
             end
         elseif player:getZoneID() == xi.zone.SOUTHERN_SAN_DORIA then
-            if npcUtil.giveItem(player, { { xi.item.FIRE_CRYSTAL, 1 }, { xi.item.CHUNK_OF_ROCK_SALT, 1 }, { xi.item.SLICE_OF_HARE_MEAT, 1 } }) then
-                player:setCharVar('TutorialProgress', 5)
+            if npcUtil.giveItem(player, { { xi.item.CHUNK_OF_ROCK_SALT, 1 }, { xi.item.SLICE_OF_HARE_MEAT, 1 }, { xi.item.FIRE_CRYSTAL, 1 } }) then
+                player:setCharVar('TutorialProgress', 7)
             end
         end
-    elseif csid == (npc_event_offset + 8) then
-        npcUtil.giveKeyItem(player, xi.ki.CONQUEST_PROMOTION_VOUCHER)
-        player:setCharVar('TutorialProgress', 7)
     elseif csid == (npc_event_offset + 10) then
-        if npcUtil.giveItem(player, xi.item.RAISING_EARRING) then
-            player:setCharVar('TutorialProgress', 8)
-        end
-    elseif csid == (npc_event_offset + 12) then
-        player:addExp(800 * xi.settings.main.EXP_RATE)
-        player:setCharVar('TutorialProgress', 10)
-    elseif csid == (npc_event_offset + 14) then
-        npcUtil.giveCurrency(player, 'gil', 1000)
-        player:setCharVar('TutorialProgress', 11)
-    elseif csid == (npc_event_offset + 16) then
-        if npcUtil.giveItem(player, { { xi.item.FREE_CHOCOPASS, 3 } }) then
-            player:addExp(1000 * xi.settings.main.EXP_RATE)
-            player:setCharVar('TutorialProgress', 0)
-        end
-    end
-end
-
-xi.tutorial.onMobDeath = function(player)
-    if player and player:getCharVar('TutorialProgress') == 8 then
+        npcUtil.giveKeyItem(player, xi.ki.CONQUEST_PROMOTION_VOUCHER)
         player:setCharVar('TutorialProgress', 9)
+    elseif csid == (npc_event_offset + 12) then
+        if npcUtil.giveItem(player, xi.item.RAISING_EARRING) then
+            player:setCharVar('TutorialProgress', 10)
+        end
+    elseif csid == (npc_event_offset + 14) then
+        if npcUtil.giveItem(player, xi.item.WARP_RING) then
+            player:setCharVar('TutorialProgress', 11)
+        end
+    elseif csid == (npc_event_offset + 16) then
+        if npcUtil.giveItem(player, { { xi.item.SALTENA, 12 } }) then
+            player:setCharVar('TutorialProgress', 15)
+        end
+    elseif csid == (npc_event_offset + 18) then
+        npcUtil.giveItem(player, xi.item.COPPER_AMAN_VOUCHER)
+        player:setCharVar('TutorialProgress', 16)
+    elseif csid == (npc_event_offset + 20) then
+        if npcUtil.giveItem(player, { { xi.item.FREE_CHOCOPASS, 12 }, { xi.item.ECHAD_RING, 1 } }) then
+            player:setCharVar('TutorialProgress', 17)
+        end
     end
 end

--- a/scripts/zones/Bastok_Markets/npcs/Gulldago.lua
+++ b/scripts/zones/Bastok_Markets/npcs/Gulldago.lua
@@ -10,11 +10,11 @@ require('scripts/quests/tutorial')
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    xi.tutorial.onTrigger(player, npc, 518, 1)
+    xi.tutorial.onTrigger(player, npc, 697, 1)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    xi.tutorial.onEventFinish(player, csid, option, 518, 1)
+    xi.tutorial.onEventFinish(player, csid, option, 697, 1)
 end
 
 return entity

--- a/scripts/zones/Bastok_Mines/npcs/Auction_Counter.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Auction_Counter.lua
@@ -2,10 +2,13 @@
 -- Area: Bastok Mines
 --  NPC: Auction Counter
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
+	xi.tutorial.onAuctionTrigger(player)
     player:sendMenu(xi.menuType.AUCTION)
 end
 

--- a/scripts/zones/Bastok_Mines/npcs/Survival_Guide.lua
+++ b/scripts/zones/Bastok_Mines/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: Bastok Mines
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerFirst(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/Konschtat_Highlands/mobs/Amber_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Amber_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Amber Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Amethyst_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Amethyst_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Amethyst Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Bendigeit_Vran.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Bendigeit Vran
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -32,10 +30,6 @@ entity.onAdditionalEffect = function(mob, target, damage)
     }
 
     return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Forger.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Forger.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Forger
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -13,10 +11,6 @@ end
 
 entity.onMobMobskillChoose = function(mob, target, skillId)
     return xi.mobSkill.BERSERK_BOMB
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Ghillie_Dhu.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Ghillie_Dhu.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Ghillie Dhu
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -50,7 +48,6 @@ entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 204)
     -- I think he still counts for the FoV page? Most NM's do not though.
     xi.regime.checkRegime(player, mob, 81, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Goblin_Ambusher.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Goblin_Ambusher.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Goblin Ambusher
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 84, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Goblin_Butcher.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Goblin_Butcher.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Goblin Butcher
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 84, 3, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Goblin_Tinkerer.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Goblin_Tinkerer.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Goblin Tinkerer
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 84, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Greater_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Greater_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Greater Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Haty.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Haty
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -16,10 +14,6 @@ entity.onMobRoam = function(mob)
     then
         DespawnMob(mob:getID())
     end
-end
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Highlander_Lizard.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Highlander_Lizard.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Highlander Lizard
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -33,7 +31,6 @@ entity.onMobDeath = function(mob, player, optParams)
     -- I think he still counts the FoV pages? Most NM's do not though.
     xi.regime.checkRegime(player, mob, 20, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 82, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Huge_Wasp.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Huge_Wasp.lua
@@ -2,15 +2,12 @@
 -- Area: Konschtat Highlands
 --  Mob: Huge Wasp
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 81, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 82, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Mad_Sheep.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Mad_Sheep.lua
@@ -4,14 +4,9 @@
 -- Note: Place holder Stray Mary
 -----------------------------------
 local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
-end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.STRAY_MARY[1], 5, 300) -- 5 minute minimum

--- a/scripts/zones/Konschtat_Highlands/mobs/Mist_Lizard.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Mist_Lizard.lua
@@ -2,15 +2,12 @@
 -- Area: Konschtat Highlands
 --  Mob: Mist Lizard
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 20, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 82, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Onyx_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Onyx_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Onyx Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Rampaging_Ram.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Rampaging_Ram.lua
@@ -4,7 +4,6 @@
 -- Note: PH for Steelfleece, spawned by Tremor Ram
 -----------------------------------
 local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -23,7 +22,6 @@ entity.spawnPoints =
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 205)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Konschtat_Highlands/mobs/Rock_Eater.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Rock_Eater.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Rock Eater
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 20, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Steelfleece_Baldarich.lua
@@ -8,7 +8,6 @@ mixins =
     require('scripts/mixins/job_special'),
     require('scripts/mixins/draw_in'),
 }
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -44,7 +43,6 @@ end
 entity.onMobDeath = function(mob, player, optParams)
     if player then
         player:addTitle(xi.title.THE_HORNSPLITTER)
-        xi.tutorial.onMobDeath(player)
     end
 end
 

--- a/scripts/zones/Konschtat_Highlands/mobs/Stray_Mary.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Stray_Mary.lua
@@ -2,8 +2,6 @@
 -- Area: Konschtat Highlands
 --   NM: Stray Mary
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
 -----------------------------------
 ---@type TMobEntity
@@ -24,7 +22,6 @@ entity.onMobDeath = function(mob, player, optParams)
     if player then
         player:addTitle(xi.title.MARYS_GUIDE)
         xi.hunts.checkHunt(mob, player, 203)
-        xi.tutorial.onMobDeath(player)
         xi.magian.onMobDeath(mob, player, optParams, set{ 710 })
     end
 end

--- a/scripts/zones/Konschtat_Highlands/mobs/Strolling_Sapling.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Strolling_Sapling.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Strolling Sapling
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 81, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Tremor_Ram.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Tremor_Ram.lua
@@ -4,14 +4,9 @@
 -- Note: PH for Rampaging Ram
 -----------------------------------
 local ID = zones[xi.zone.KONSCHTAT_HIGHLANDS]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
-end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.RAMPAGING_RAM, 10, 1200) -- 20 min

--- a/scripts/zones/Konschtat_Highlands/mobs/Veteran_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Veteran_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Veteran Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Konschtat_Highlands/mobs/Young_Quadav.lua
+++ b/scripts/zones/Konschtat_Highlands/mobs/Young_Quadav.lua
@@ -2,14 +2,11 @@
 -- Area: Konschtat Highlands
 --  Mob: Young Quadav
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 83, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Acro_Bat.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Acro_Bat.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Acro Bat
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 71, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Akbaba.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Akbaba.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Akbaba
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 69, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Battering_Ram.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Battering_Ram.lua
@@ -4,14 +4,8 @@
 -----------------------------------
 local ID = zones[xi.zone.LA_THEINE_PLATEAU]
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobDeath = function(mob, player, optParams)
-    xi.tutorial.onMobDeath(player)
-end
 
 entity.onMobDespawn = function(mob)
     xi.mob.phOnDespawn(mob, ID.mob.LUMBERING_LAMBERT, 10, 1200) -- 20 minutes

--- a/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Bloodtear_Baldurf.lua
@@ -7,7 +7,6 @@ mixins =
     require('scripts/mixins/job_special'),
     require('scripts/mixins/draw_in'),
 }
-require('scripts/quests/tutorial')
 -----------------------------------
 local ID = zones[xi.zone.LA_THEINE_PLATEAU]
 -----------------------------------
@@ -58,7 +57,6 @@ end
 entity.onMobDeath = function(mob, player, optParams)
     if player then
         player:addTitle(xi.title.THE_HORNSPLITTER)
-        xi.tutorial.onMobDeath(player)
     end
 end
 

--- a/scripts/zones/La_Theine_Plateau/mobs/Coral_Crab.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Coral_Crab.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Coral Crab
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 70, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Gale_Bats.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Gale_Bats.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Gale Bats
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 71, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Grass_Funguar.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Grass_Funguar.lua
@@ -2,15 +2,12 @@
 -- Area: La Theine Plateau
 --  Mob: Grass Funguar
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 6, 1, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 71, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Huge_Wasp.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Huge_Wasp.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Huge Wasp
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 5, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Lumbering_Lambert.lua
@@ -2,8 +2,6 @@
 -- Area: La Theine Plateau
 --  Mob: Lumbering Lambert
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 local ID = zones[xi.zone.LA_THEINE_PLATEAU]
 -----------------------------------
 ---@type TMobEntity
@@ -35,7 +33,6 @@ entity.spawnPoints =
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 156)
-    xi.tutorial.onMobDeath(player)
     xi.magian.onMobDeath(mob, player, optParams, set{ 579 })
 end
 

--- a/scripts/zones/La_Theine_Plateau/mobs/Mad_Sheep.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Mad_Sheep.lua
@@ -2,15 +2,12 @@
 -- Area: La Theine Plateau
 --  Mob: Mad Sheep
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 69, 1, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 70, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Nihniknoovi.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Nihniknoovi.lua
@@ -2,8 +2,6 @@
 -- Area: La Theine Plateau
 --  Mob: Nihniknoovi
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -13,7 +11,6 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 153)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Plague_Bats.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Plague_Bats.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Plague Bats
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 71, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Poison_Bat.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Poison_Bat.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Poison Bat
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 71, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Poison_Funguar.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Poison_Funguar.lua
@@ -3,14 +3,12 @@
 --  Mob: Poison Funguar
 -----------------------------------
 local ID = zones[xi.zone.LA_THEINE_PLATEAU]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 71, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/La_Theine_Plateau/mobs/Strolling_Sapling.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Strolling_Sapling.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Strolling Sapling
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 5, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Thickshell.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Thickshell.lua
@@ -2,14 +2,11 @@
 -- Area: La Theine Plateau
 --  Mob: Thickshell
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 70, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/La_Theine_Plateau/mobs/Tumbling_Truffle.lua
+++ b/scripts/zones/La_Theine_Plateau/mobs/Tumbling_Truffle.lua
@@ -2,8 +2,6 @@
 -- Area: La Theine Plateau
 --  Mob: Tumbling Truffle
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 local ID = zones[xi.zone.LA_THEINE_PLATEAU]
 -----------------------------------
 ---@type TMobEntity
@@ -26,7 +24,6 @@ entity.spawnPoints =
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 154)
     xi.regime.checkRegime(player, mob, 71, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
     xi.magian.onMobDeath(mob, player, optParams, set{ 68 })
 end
 

--- a/scripts/zones/North_Gustaberg/npcs/Survival_Guide.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: North Gustaberg
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerSecond(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Survival_Guide.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: Northern San d'Oria
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerFirst(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/Port_San_dOria/npcs/Auction_Counter.lua
+++ b/scripts/zones/Port_San_dOria/npcs/Auction_Counter.lua
@@ -2,10 +2,13 @@
 -- Area: Port San d'Oria
 --  NPC: Auction Counter
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
+    xi.tutorial.onAuctionTrigger(player)
     player:sendMenu(xi.menuType.AUCTION)
 end
 

--- a/scripts/zones/Port_Windurst/npcs/Survival_Guide.lua
+++ b/scripts/zones/Port_Windurst/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: Port Windurst
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerFirst(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/Southern_San_dOria/npcs/Alaune.lua
+++ b/scripts/zones/Southern_San_dOria/npcs/Alaune.lua
@@ -10,11 +10,11 @@ require('scripts/quests/tutorial')
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    xi.tutorial.onTrigger(player, npc, 916, 0)
+    xi.tutorial.onTrigger(player, npc, 3640, 0)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    xi.tutorial.onEventFinish(player, csid, option, 916, 0)
+    xi.tutorial.onEventFinish(player, csid, option, 3640, 0)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Akbaba.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Akbaba.lua
@@ -2,14 +2,11 @@
 -- Area: Tahrongi Canyon
 --  Mob: Akbaba
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 31, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Crawler.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Crawler.lua
@@ -4,14 +4,12 @@
 -- Note: PH for Herbage Hunter
 -----------------------------------
 local ID = zones[xi.zone.TAHRONGI_CANYON]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 96, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Rarab.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Canyon_Rarab.lua
@@ -2,14 +2,11 @@
 -- Area: Tahrongi Canyon
 --  Mob: Canyon Rarab
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 94, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Habrok.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Habrok.lua
@@ -2,8 +2,6 @@
 -- Area: Tahrongi Canyon
 --  Mob: Habrok
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -23,7 +21,6 @@ end
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.hunts.checkHunt(mob, player, 258)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Tahrongi_Canyon/mobs/Killer_Bee.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Killer_Bee.lua
@@ -2,15 +2,12 @@
 -- Area: Tahrongi Canyon
 --  Mob: Killer Bee
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 30, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 95, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Pygmaioi.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Pygmaioi.lua
@@ -2,15 +2,12 @@
 -- Area: Tahrongi Canyon
 --  Mob: Pygmaioi
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 94, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 95, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Strolling_Sapling.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Strolling_Sapling.lua
@@ -2,14 +2,11 @@
 -- Area: Tahrongi Canyon
 --  Mob: Strolling Sapling
 -----------------------------------
-require('scripts/quests/tutorial')
------------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 30, 1, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 return entity

--- a/scripts/zones/Tahrongi_Canyon/mobs/Wild_Dhalmel.lua
+++ b/scripts/zones/Tahrongi_Canyon/mobs/Wild_Dhalmel.lua
@@ -4,14 +4,12 @@
 -- Note: PH for Serpopard Ishtar
 -----------------------------------
 local ID = zones[xi.zone.TAHRONGI_CANYON]
-require('scripts/quests/tutorial')
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 96, 2, xi.regime.type.FIELDS)
-    xi.tutorial.onMobDeath(player)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/West_Ronfaure/npcs/Survival_Guide.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: West Ronfaure
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerSecond(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/West_Sarutabaruta/npcs/Survival_Guide.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Survival_Guide.lua
@@ -2,10 +2,13 @@
 -- Area: West Sarutabaruta
 --  NPC: Survival Guide
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, targetNpc)
+    xi.tutorial.onGuideTriggerSecond(player)
     xi.survivalGuide.onTrigger(player)
 end
 

--- a/scripts/zones/Windurst_Walls/npcs/Auction_Counter.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Auction_Counter.lua
@@ -2,10 +2,13 @@
 -- Area: Windurst Walls
 --  NPC: Auction Counter
 -----------------------------------
+require('scripts/quests/tutorial')
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
+    xi.tutorial.onAuctionTrigger(player)
     player:sendMenu(xi.menuType.AUCTION)
 end
 

--- a/scripts/zones/Windurst_Woods/npcs/Selele.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Selele.lua
@@ -10,11 +10,11 @@ require('scripts/quests/tutorial')
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    xi.tutorial.onTrigger(player, npc, 813, 2)
+    xi.tutorial.onTrigger(player, npc, 988, 2)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)
-    xi.tutorial.onEventFinish(player, csid, option, 813, 2)
+    xi.tutorial.onEventFinish(player, csid, option, 988, 2)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

An update to the retail tutorial broke the tutorial implementation on LSB.
Capture shows that NPC offsets have changed; additionally, quest objectives have changed and quest rewards have changed.

Updated npc_event_offset on all three tutorial NPCs (697 for Gulldago, 3640 for Alaune, 988 for Selele).
Removed lines "require('scripts/quests/tutorial')" and "xi.tutorial.onMobDeath(player)" from all mobs in Konschtat Highlands, La Theine Plateau, and Tahrongi Canyon.
(In the few cases it left an empty entity.onMobDeath function, the entire function was deleted.)
Added logic to Auction Counters in Bastok Mines, Port San d'Oria, and Windurst Walls to advance tutorial.
Added functions to Survival Guides in Bastok Mines, North Gustaberg, Northern San d'Oria, Port Windurst, West Ronfaure, and West Sarutabaruta to advance tutorial and enforce activating them in the correct order.
Fixed survival guides so that they hide the 'free teleport for the objective' option at all times except during the correct tutorial stage.
Added a small piece of quest stage logic to the Survival Guide teleport to prevent an exploit allowing infinite free teleports by simply never completing the tutorial.
Rewrote tutorial.lua to implement the correct checks, events, and rewards for the new tutorial quest.
Tested retail tutorial with several characters. Additionally, here is a wiki link describing the updated tutorial steps and rewards: https://www.bg-wiki.com/ffxi/Category:Tutorial_NPC

## Steps to test these changes

Validation Against Retail:
Learned weaponskill for the appropriate step. Defeated enemy without using weaponskill. Returned to town. Objective fulfilled, confirming retail doesn't check if you've used the skill, just learned it.
Checked that auction counters in Port San'doria advance the tutorial. Presume behavior is the same in other nations (Bastok Mines, Windurst Walls). Unclear why Auction House check logic was not implemented in those zones to begin with.
Talked to Tutorial NPC after obtaining *color* card KI to ensure that was insufficient to advance tutorial.
Talked to Tutorial NPC after obtaining trust spell but before completing trust quest to confirm Trust Permit KI explicitly was what was being checked for.
Activated Bastok Mines Survival Guide before starting tutorial. After getting the objective, went directly to North Gustaberg Survival Guide, used it to teleport back to Bastok Mines, used Warp Ring to return to Gulldago. Objective not considered fulfilled.
Confirms that Nation survival guide must be activated *after* starting the tutorial objective.
Received warp objective, walked directly to West Ronfaure Survival Guide. Walked back to tutorial npc. Confirmed objective not considered fulfilled. Then activated North Sandoria Survival Guide - both guides have now been activated, but out of order. Confirmed objective not fulfilled. Went back to West Ronfaure Survival Guide. Activated it and walked back to tutorial NPC. Objective completed.
Confirms that retail behavior is simply checking if you have activated both guides in order after receiving the objective. Teleporting from the survival guide and using the Warp Ring are not actually checked.
Began the tutorial in Bastok, traveled to Windurst and continued the tutorial - tutorial NPC behaved as if she had been helping me all along. Traveled to San d'Oria and further continued tutorial.
Confirms that in retail, tutorial progress is global instead of tied to a particular nation.
The update to the retail tutorial allowed old characters to redo the tutorial. Went through the tutorial with a max level character; confirmed retail has no checks to see if you already have the rewards, and simply balks at proceeding if you already have a Raising Earring, Warp Ring, or Echad Ring, telling you to sort your inventory.
All other steps consist of doing a single task; validation came by talking to the tutorial npc without performing the task, then talking after performing the task.

Local Testing:
Created fresh characters in all three nations. Began tutorial with each. At each stage of the tutorial, I spoke to the tutorial NPC first without fulfilling the objective to verify correct dialogue and that the tutorial did not advance, then fulfilled the objective and advanced the tutorial.
Checked inventory and key items to verify the receipt of correct rewards at each stage.
Attempted to complete warp stage of the tutorial by activating survival guides out of order - verified that activation order is enforced. Repeated visits to survival guides to verify that "One-time free teleport for the objective" option only appears during the appropriate tutorial step, and is only usable once. Verified that free teleport is, in fact, free.

99.9% confident quest behavior is identical to retail. Makes very simple assumptions about internal consistency - all that remains untested is the several dozen tiny permutations of otherwise tested scenarios. (Would it have made a difference if instead of nation hopping Bastok -> Windurst -> San 'doria, I went Bastok -> San d'Oria -> Windurst? What if I did it at a different stage of the tutorial?)