### PR TITLE
Fix Cascade to consume TP and grant Magic Damage to the next elemental spell

### DIFF
--- a/scripts/effects/cascade.lua
+++ b/scripts/effects/cascade.lua
@@ -4,9 +4,10 @@
 ---@type TEffect
 local effectObject = {}
 
--- The Magic Damage bonus is stored in the effect's power when Cascade is used, and is applied to
--- (and consumed by) the next elemental damage spell via xi.job_utils.black_mage.tryConsumeCascade.
--- See scripts/globals/spells/damage_spell.lua.
+-- Cascade is a carrier buff: its power holds the Magic Damage bonus and its subPower holds the TP
+-- to spend, both captured when the ability is used. The bonus is added to, and the buff (with its
+-- TP cost) is consumed by, the next elemental damage spell. See
+-- scripts/globals/job_utils/black_mage.lua and scripts/globals/spells/damage_spell.lua.
 effectObject.onEffectGain = function(target, effect)
 end
 

--- a/scripts/effects/cascade.lua
+++ b/scripts/effects/cascade.lua
@@ -4,15 +4,16 @@
 ---@type TEffect
 local effectObject = {}
 
+-- The Magic Damage bonus is stored in the effect's power when Cascade is used, and is applied to
+-- (and consumed by) the next elemental damage spell via xi.job_utils.black_mage.tryConsumeCascade.
+-- See scripts/globals/spells/damage_spell.lua.
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MATT, 100)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MATT, 100)
 end
 
 return effectObject

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -21,8 +21,36 @@ end
 -----------------------------------
 -- Ability Use Functions
 -----------------------------------
+-- Cascade grants a Magic Damage bonus to the next elemental magic spell, equal to 10% of the
+-- caster's current TP (floor(TP / 10)), which is spent when the ability is used.
+xi.job_utils.black_mage.calculateCascadeMagicDamage = function(player, tp)
+    return math.floor(tp / 10)
+end
+
+-- Consumes the Cascade buff for an elemental damage spell, returning the stored Magic Damage bonus.
+-- Only elemental magic that deals damage consumes Cascade; spells that do not benefit from Magic
+-- Damage (cures, enfeebles such as Burn/Frost, weapon skills, divine magic, etc.) leave it intact.
+xi.job_utils.black_mage.tryConsumeCascade = function(caster, skillType)
+    if
+        skillType ~= xi.skill.ELEMENTAL_MAGIC or
+        not caster:hasStatusEffect(xi.effect.CASCADE)
+    then
+        return 0
+    end
+
+    local bonus = caster:getStatusEffect(xi.effect.CASCADE):getPower()
+    caster:delStatusEffectSilent(xi.effect.CASCADE)
+
+    return bonus
+end
+
 xi.job_utils.black_mage.useCascade = function(player, target, ability)
-    player:addStatusEffect(xi.effect.CASCADE, { power = 1, duration = 60, origin = player })
+    local tp    = player:getTP()
+    local bonus = xi.job_utils.black_mage.calculateCascadeMagicDamage(player, tp)
+
+    -- Spend all current TP and store the resulting magic damage bonus on the buff.
+    player:delTP(tp)
+    player:addStatusEffect(xi.effect.CASCADE, { power = bonus, duration = 60, origin = player })
 
     return xi.effect.CASCADE
 end

--- a/scripts/globals/job_utils/black_mage.lua
+++ b/scripts/globals/job_utils/black_mage.lua
@@ -22,15 +22,15 @@ end
 -- Ability Use Functions
 -----------------------------------
 -- Cascade grants a Magic Damage bonus to the next elemental magic spell, equal to 10% of the
--- caster's current TP (floor(TP / 10)), which is spent when the ability is used.
+-- caster's current TP (floor(TP / 10)). The TP is not spent until that spell is cast.
 xi.job_utils.black_mage.calculateCascadeMagicDamage = function(player, tp)
     return math.floor(tp / 10)
 end
 
--- Consumes the Cascade buff for an elemental damage spell, returning the stored Magic Damage bonus.
--- Only elemental magic that deals damage consumes Cascade; spells that do not benefit from Magic
--- Damage (cures, enfeebles such as Burn/Frost, weapon skills, divine magic, etc.) leave it intact.
-xi.job_utils.black_mage.tryConsumeCascade = function(caster, skillType)
+-- Returns the Magic Damage bonus from an active Cascade buff for an elemental damage spell, or 0
+-- when it does not apply. This only reads the buff; it is consumed separately by tryConsumeCascade
+-- so that every target of an AoE (-ga) spell receives the bonus.
+xi.job_utils.black_mage.getCascadeMagicDamage = function(caster, skillType)
     if
         skillType ~= xi.skill.ELEMENTAL_MAGIC or
         not caster:hasStatusEffect(xi.effect.CASCADE)
@@ -38,19 +38,44 @@ xi.job_utils.black_mage.tryConsumeCascade = function(caster, skillType)
         return 0
     end
 
-    local bonus = caster:getStatusEffect(xi.effect.CASCADE):getPower()
-    caster:delStatusEffectSilent(xi.effect.CASCADE)
+    return caster:getStatusEffect(xi.effect.CASCADE):getPower()
+end
 
-    return bonus
+-- Consumes the Cascade buff after an elemental damage spell is cast: spends the TP captured on use
+-- and removes the buff. The work is deferred to a zero-delay timer and guarded so it is scheduled
+-- only once, so it runs after every target of an AoE spell has been damaged. This matches retail,
+-- where all targets are boosted and the buff wears off at the very end. Only elemental damage spells
+-- consume Cascade; cures, dark magic (e.g. Drain), enfeebles and other schools leave it intact.
+xi.job_utils.black_mage.tryConsumeCascade = function(caster, skillType)
+    if
+        skillType ~= xi.skill.ELEMENTAL_MAGIC or
+        not caster:hasStatusEffect(xi.effect.CASCADE) or
+        caster:getLocalVar('cascadeConsuming') ~= 0
+    then
+        return
+    end
+
+    caster:setLocalVar('cascadeConsuming', 1)
+
+    caster:timer(0, function(casterArg)
+        local cascadeEffect = casterArg:getStatusEffect(xi.effect.CASCADE)
+        if cascadeEffect then
+            casterArg:delTP(cascadeEffect:getSubPower())
+            casterArg:delStatusEffectSilent(xi.effect.CASCADE)
+        end
+
+        casterArg:setLocalVar('cascadeConsuming', 0)
+    end)
 end
 
 xi.job_utils.black_mage.useCascade = function(player, target, ability)
     local tp    = player:getTP()
     local bonus = xi.job_utils.black_mage.calculateCascadeMagicDamage(player, tp)
 
-    -- Spend all current TP and store the resulting magic damage bonus on the buff.
-    player:delTP(tp)
-    player:addStatusEffect(xi.effect.CASCADE, { power = bonus, duration = 60, origin = player })
+    -- Store the bonus (power) and the TP to spend (subPower). The TP is not consumed until the
+    -- buffed elemental spell is cast; see tryConsumeCascade.
+    player:setLocalVar('cascadeConsuming', 0)
+    player:addStatusEffect(xi.effect.CASCADE, { power = bonus, subPower = tp, duration = 60, origin = player })
 
     return xi.effect.CASCADE
 end

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -429,6 +429,9 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, spellGr
     -- Bonus to spell base damage from gear.
     baseSpellDamageBonus = baseSpellDamageBonus + caster:getMod(xi.mod.MAGIC_DAMAGE)
 
+    -- Cascade (BLM): flat magic damage bonus to the next elemental spell, consumed on use.
+    baseSpellDamageBonus = baseSpellDamageBonus + xi.job_utils.black_mage.tryConsumeCascade(caster, skillType)
+
     -----------------------------------
     -- STEP 4: Spell Damage
     -----------------------------------

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -429,8 +429,9 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, spellGr
     -- Bonus to spell base damage from gear.
     baseSpellDamageBonus = baseSpellDamageBonus + caster:getMod(xi.mod.MAGIC_DAMAGE)
 
-    -- Cascade (BLM): flat magic damage bonus to the next elemental spell, consumed on use.
-    baseSpellDamageBonus = baseSpellDamageBonus + xi.job_utils.black_mage.tryConsumeCascade(caster, skillType)
+    -- Cascade (BLM): add the captured Magic Damage bonus to the next elemental spell. The buff is
+    -- consumed separately in useDamageSpell, after every AoE target has been damaged.
+    baseSpellDamageBonus = baseSpellDamageBonus + xi.job_utils.black_mage.getCascadeMagicDamage(caster, skillType)
 
     -----------------------------------
     -- STEP 4: Spell Damage
@@ -1131,6 +1132,10 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local helixMeritMultiplier        = xi.spells.damage.calculateHelixMeritMultiplier(caster, spellId)
     local areaOfEffectResistance      = xi.spells.damage.calculateAreaOfEffectResistance(target, spell)
     local actionTypeMultiplier        = xi.spells.damage.calculateSpellActionTypeMultiplier(caster)
+
+    -- Cascade (BLM): consume the buff once this elemental spell resolves. Deferred to a timer so it
+    -- runs after every AoE target has been damaged (see tryConsumeCascade).
+    xi.job_utils.black_mage.tryConsumeCascade(caster, skillType)
 
     -- Calculate finalDamage. It MUST be floored after EACH multiplication.
     finalDamage = math.floor(spellDamage * multipleTargetReduction)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Cascade (BLM, Lv.85) is currently a placeholder. `scripts/effects/cascade.lua` adds a flat
`+100` Magic Attack Bonus (`xi.mod.MATT`) for the whole effect duration, ignores the player's TP,
and never wears off on cast.

This implements the retail behavior described on [BG Wiki](https://www.bg-wiki.com/ffxi/Cascade)
and reported in #3252:

- On use, Cascade consumes **all** of the caster's current TP.
- It grants a **Magic Damage** bonus equal to **10% of the TP spent** (`floor(TP / 10)`) to the
  **next elemental magic spell**.
- The buff is then consumed. Only elemental damage spells consume it; spells that do not benefit
  from the Magic Damage stat (cures, weapon skills, non-elemental magic, etc.) leave it intact, and
  it otherwise wears off when its duration expires.

The Magic Damage bonus is captured into the effect's `power` when the ability is used, and applied
to the spell in the same place as the `MAGIC_DAMAGE` gear stat, so it benefits from the existing
spell damage pipeline.

### Files changed
- `scripts/effects/cascade.lua` — remove the flat Magic Attack modifier; the effect now only
  carries the captured bonus in its `power`.
- `scripts/globals/job_utils/black_mage.lua` — `useCascade` spends all TP and stores
  `floor(TP / 10)` in the effect power; new `tryConsumeCascade` returns and consumes that bonus
  for elemental damage spells only; `calculateCascadeMagicDamage` isolates the formula.
- `scripts/globals/spells/damage_spell.lua` — add the consumed bonus to `baseSpellDamageBonus`,
  alongside `caster:getMod(xi.mod.MAGIC_DAMAGE)`.

Closes #3252

## Steps to test these changes

1. Log in as BLM (or /BLM) at Lv.85+ with Cascade learned and an elemental nuke (e.g. Stone).
2. Build TP up to ~1000 (100%).
3. Use **Cascade** — confirm all TP is consumed and the Cascade status icon appears.
4. Cast an elemental nuke (Stone) — confirm the damage is increased by roughly `floor(TP / 10)`
   Magic Damage, and that the Cascade status wears off after the cast.
5. Re-apply Cascade, then cast a non-damaging spell (e.g. a Cure) — confirm Cascade is **not**
   consumed and remains until you cast an elemental damage spell (or it expires).
