### PR TITLE
[Magic] Implement Cascade JA and effect properly

### DIFF
--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -2184,6 +2184,7 @@ status_effects:
     id: 229
     flags:
       - death
+      - magic_end
       - on_zone
       - on_jobchange
 

--- a/scripts/effects/cascade.lua
+++ b/scripts/effects/cascade.lua
@@ -5,14 +5,12 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.MATT, 100)
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.MATT, 100)
 end
 
 return effectObject

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -404,7 +404,6 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, spellGr
         -- BLM Job Point: With Manawell mDMG +1
         if caster:hasStatusEffect(xi.effect.MANAWELL) then
             baseSpellDamageBonus = baseSpellDamageBonus + caster:getJobPointLevel(xi.jp.MANAWELL_EFFECT)
-            caster:delStatusEffectSilent(xi.effect.MANAWELL)
         end
 
         -- BLM Job Point: Magic Damage Bonus
@@ -428,6 +427,14 @@ xi.spells.damage.calculateBaseDamage = function(caster, target, spellId, spellGr
 
     -- Bonus to spell base damage from gear.
     baseSpellDamageBonus = baseSpellDamageBonus + caster:getMod(xi.mod.MAGIC_DAMAGE)
+
+    -- Bonus to spell base damage from Cascade effect.
+    if
+        skillType == xi.skill.ELEMENTAL_MAGIC and
+        caster:hasStatusEffect(xi.effect.CASCADE)
+    then
+        baseSpellDamageBonus = baseSpellDamageBonus + math.floor(caster:getTP() / 10)
+    end
 
     -----------------------------------
     -- STEP 4: Spell Damage

--- a/sql/abilities.sql
+++ b/sql/abilities.sql
@@ -269,7 +269,7 @@ INSERT INTO `abilities` VALUES (250,'avatars_favor',15,55,1,300,176,100,0,94,200
 INSERT INTO `abilities` VALUES (251,'ready',9,25,1,0,102,0,0,83,2000,0,6,4,0,0,0,0,902,64,'WOTG');
 INSERT INTO `abilities` VALUES (252,'restraint',1,77,1,600,9,100,0,220,2000,0,6,0,0,0,1,300,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (253,'perfect_counter',2,79,1,60,22,100,0,221,2000,0,6,0,0,0,1,80,0,0,'ABYSSEA');
-INSERT INTO `abilities` VALUES (254,'mana_wall',4,76,1,600,39,0,0,222,2000,0,6,0,0,0,1,0,0,0,'ABYSSEA');
+INSERT INTO `abilities` VALUES (254,'mana_wall',4,76,1,600,39,100,0,222,2000,0,6,0,0,0,1,0,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (255,'divine_emblem',7,78,1,180,80,100,0,222,2000,0,6,0,0,0,1,3600,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (256,'nether_void',8,78,1,300,91,100,0,224,2000,0,6,0,0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (257,'double_shot',11,79,1,180,126,0,0,225,2000,0,6,0,0,0,1,80,0,0,'ABYSSEA');
@@ -287,7 +287,7 @@ INSERT INTO `abilities` VALUES (269,'impetus',2,88,1,300,31,100,0,240,2000,0,6,0
 INSERT INTO `abilities` VALUES (270,'divine_caress',3,83,1,60,32,100,0,254,2000,0,6,0,0,0,0,0,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (271,'sacrosanctity',3,95,1,600,33,100,0,268,2000,0,6,0,1,14,0,0,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (272,'enmity_douse',4,87,4,600,34,100,0,257,2000,0,6,10,0,0,1,0,0,0,'ABYSSEA'); -- check animation
-INSERT INTO `abilities` VALUES (273,'manawell',4,95,3,600,35,100,0,252,2000,0,6,20,0,0,1,80,0,0,'ABYSSEA');
+INSERT INTO `abilities` VALUES (273,'manawell',4,95,3,600,35,319,0,252,2000,0,6,20,0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (274,'saboteur',5,83,1,300,36,0,0,258,2000,0,6,0,0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (275,'spontaneity',5,95,3,600,37,0,0,259,2000,0,6,20,0,0,1,80,0,0,'ABYSSEA');
 INSERT INTO `abilities` VALUES (276,'conspirator',6,87,1,300,40,0,0,237,2000,0,6,0,1,14,1,80,0,4,'ABYSSEA');
@@ -331,7 +331,7 @@ INSERT INTO `abilities` VALUES (322,'maintenance',18,30,1,90,214,0,0,83,2000,0,6
 INSERT INTO `abilities` VALUES (323,'brazen_rush',1,96,1,3600,254,100,0,271,2000,0,6,0,0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (324,'inner_strength',2,96,1,3600,254,100,0,272,2000,0,6,0,0,0,0,0,0,0,'SOA'); -- check animation
 INSERT INTO `abilities` VALUES (325,'asylum',3,96,4,3600,254,100,0,273,2000,0,6,0,1,14,0,0,0,0,'SOA');
-INSERT INTO `abilities` VALUES (326,'subtle_sorcery',4,96,1,3600,254,0,0,274,2000,0,6,0,0,0,0,0,0,0,'SOA'); -- check animation
+INSERT INTO `abilities` VALUES (326,'subtle_sorcery',4,96,1,3600,254,100,0,274,2000,0,6,0,0,0,0,0,0,0,'SOA');
 INSERT INTO `abilities` VALUES (327,'stymie',5,96,1,3600,254,100,0,275,2000,0,6,0,0,0,1,80,0,0,'SOA');
 INSERT INTO `abilities` VALUES (328,'larceny',6,96,4,3600,254,453,0,181,2000,0,3,3,0,0,0,0,0,0,'SOA');
 INSERT INTO `abilities` VALUES (329,'intervene',7,96,4,3600,254,110,0,120,2000,0,3,3,0,0,0,340,0,0,'SOA');
@@ -393,7 +393,7 @@ INSERT INTO `abilities` VALUES (384,'contradance',19,50,1,300,229,0,0,81,2000,0,
 INSERT INTO `abilities` VALUES (385,'apogee',15,70,1,180,108,100,0,94,2000,0,6,0,0,0,1,80,0,0,'SOA');
 INSERT INTO `abilities` VALUES (386,'entrust',21,75,1,600,93,100,0,332,2000,0,6,0,0,0,1,300,0,0,'SOA');
 INSERT INTO `abilities` VALUES (387,'bestial_loyalty',9,23,1,1200,94,100,0,83,2000,0,6,0,0,0,1,0,900,0,'SOA');
-INSERT INTO `abilities` VALUES (388,'cascade',4,85,1,60,12,100,0,333,2000,0,6,0,0,0,0,0,0,0,'ROV'); -- check animation
+INSERT INTO `abilities` VALUES (388,'cascade',4,85,1,60,12,100,0,336,2000,0,6,0,0,0,0,0,0,0,'ROV');
 INSERT INTO `abilities` VALUES (389,'consume_mana',8,55,1,60,95,0,0,337,2000,0,6,0,0,0,1,1300,0,0,'ROV');
 INSERT INTO `abilities` VALUES (390,'naturalists_roll',17,67,1,60,193,420,0,328,2000,0,6,0,1,8,1,80,0,8,'ROV'); -- No Enhancing Magic Duration MOD, Empty PH effect exists
 INSERT INTO `abilities` VALUES (391,'runeists_roll',17,70,1,60,193,420,0,329,2000,0,6,0,1,8,1,80,0,8,'ROV');

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -2690,6 +2690,13 @@ void CBattleEntity::OnCastFinished(CMagicState& state, action_t& action)
 
     StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::MagicEnd);
 
+    // Remove Cascade effect and consume TP.
+    if (PSpell->getSkillType() == SKILL_ELEMENTAL_MAGIC && StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Cascade))
+    {
+        StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Cascade);
+        this->health.tp = 0;
+    }
+
     PRecastContainer->Add(RECAST_MAGIC, static_cast<Recast>(PSpell->getID()), action.recast);
 }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Fixes Cascade JA effect incorrectly giving MAB instead to a TP-based bonus to elemental spells base damage.
- Additionally, fixes an effect-flag of manawell.
- Also reviews and corrects a few JAs message ids and animations

Closes #3252
Closes #10445

## Steps to test these changes
Cast elemental magic with varying amounts of TP and the cascade effect.
