### PR TITLE
[core] Remove pending deleted pets from players spawnlists

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1819,6 +1819,14 @@ auto CZoneEntities::petTick(CPetEntity* PPet, timer::time_point tick) -> Task<vo
             PCurrentMob->PEnmityContainer->Clear(PPet->id);
         }
 
+        FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PChar, m_charList)
+        {
+            if (PChar->SpawnPETList.find(PPet->id) != PChar->SpawnPETList.end())
+            {
+                PChar->SpawnPETList.erase(PPet->id);
+            }
+        }
+
         m_petsToDelete.emplace_back(PPet);
         co_return;
     }
@@ -1862,7 +1870,7 @@ auto CZoneEntities::trustTick(CTrustEntity* PTrust, timer::time_point tick) -> T
 
         FOR_EACH_PAIR_CAST_SECOND(CCharEntity*, PChar, m_charList)
         {
-            if (distance(PChar->loc.p, PTrust->loc.p) < ENTITY_RENDER_DISTANCE)
+            if (PChar->SpawnTRUSTList.find(PTrust->id) != PChar->SpawnTRUSTList.end())
             {
                 PChar->SpawnTRUSTList.erase(PTrust->id);
             }


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1) Remove pending deleted pets from players spawnlists
2) trusts had only a distance check, but the trust may (or may not) be in the players spawnlists anyway so we check for presence in the list instead

## Steps to test these changes

Spawn pets/trusts and despawn them. Breakpoint to see they're actually getting removed