### PR TITLE
[yaml] Update names of some statuses that share the same script

### DIFF
--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -26,6 +26,7 @@ status_effects:
 
   sleep_i:
     id: 2
+    name: sleep
     flags:
       - damage
       - death
@@ -109,6 +110,7 @@ status_effects:
 
   curse_i:
     id: 9
+    name: curse
     flags:
       - death
       - waltzable
@@ -170,6 +172,7 @@ status_effects:
 
   charm_i:
     id: 14
+    name: charm
     flags:
       - death
       - no_cancel
@@ -199,7 +202,7 @@ status_effects:
 
   charm_ii:
     id: 17
-    name: charm_i
+    name: charm
     flags:
       - death
       - no_cancel
@@ -220,7 +223,7 @@ status_effects:
 
   sleep_ii:
     id: 19
-    name: sleep_i
+    name: sleep
     flags:
       - damage
       - death
@@ -234,7 +237,7 @@ status_effects:
   # Zombie
   curse_ii:
     id: 20
-    name: curse_i
+    name: curse
     flags:
       - death
       - no_rest
@@ -1669,7 +1672,7 @@ status_effects:
 
   encumbrance_ii:
     id: 177
-    name: encumbrance_i
+    name: encumbrance
     flags:
       - on_zone
       - no_cancel
@@ -2394,6 +2397,7 @@ status_effects:
 
   encumbrance_i:
     id: 259
+    name: encumbrance
     flags:
       - no_cancel
       - hide_timer
@@ -4635,7 +4639,7 @@ status_effects:
 
   embolden:
     id: 534
-    name: emboldened
+    name: embolden
     flags:
       - death
       - on_zone
@@ -5221,7 +5225,7 @@ status_effects:
 
   magic_evasion_boost:
     id: 611
-    name: magic_evasion_boost_ii
+    name: magic_evasion_boost
     flags:
       - death
 
@@ -5249,6 +5253,7 @@ status_effects:
 
   boost_ii:
     id: 615
+    name: boost
     flags:
       - attack
       - empathy


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Some statuses were looking for their unique name as a script e.g. charm_i was looking for charm_i.lua but it was supposed to look up charm.lua

## Steps to test these changes

`!exec target:useMobAbility(xi.mobSkill.CHARM, player)` on a mob
Get charmed, then get uncharmed when it wears off