### PR TITLE
[lua] Add isEngaged() to Dispel lua spell lists

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
@@ -74,7 +74,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [26] = { xi.magic.spell.CURE_IV,      mob,    true,  xi.action.type.HEALING_TARGET,       33,                  0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPEL, target, false, xi.action.type.NONE, nil, 100 })
     end
 

--- a/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Bladmall.lua
@@ -197,7 +197,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         table.insert(spellList, #spellList + 1, { xi.magic.spell.ERASE, mob, true, xi.action.type.NONE, nil, 100 })
     end
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPELGA, target, false, xi.action.type.NONE, nil, 100 })
     end
 

--- a/scripts/zones/QuBia_Arena/mobs/Maldaramet_B_DAurphe.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maldaramet_B_DAurphe.lua
@@ -37,7 +37,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [12] = { xi.magic.spell.BIND,         target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BIND,      0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPEL, target, false, xi.action.type.NONE, nil, 100 })
     end
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut.lua
@@ -152,7 +152,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [10] = { xi.magic.spell.PHALANX,   mob,    false, xi.action.type.ENHANCING_FORCE_SELF, xi.effect.PHALANX,   0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPELGA, target, false, xi.action.type.NONE, nil, 0, 100 })
     end
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Bahamut_bv2.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Bahamut_bv2.lua
@@ -220,7 +220,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [10] = { xi.magic.spell.PHALANX,   mob,    false, xi.action.type.ENHANCING_FORCE_SELF, xi.effect.PHALANX,   0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPELGA, target, false, xi.action.type.NONE, nil, 0, 100 })
     end
 

--- a/scripts/zones/Riverne-Site_B01/mobs/Vrtra_bv2.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Vrtra_bv2.lua
@@ -147,7 +147,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [3] = { xi.magic.spell.SLEEPGA_II, target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLEEP_I,   0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPELGA, target, false, xi.action.type.NONE, nil, 0, 100 })
     end
 

--- a/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
+++ b/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
@@ -71,7 +71,10 @@ entity.onMobSpellChoose = function(mob, target)
         [4] = { xi.magic.spell.GRAVIGA,   target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.WEIGHT,    0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPELGA, target, false, xi.action.type.NONE, nil, 100 })
     end
 

--- a/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Crew_rdm.lua
+++ b/scripts/zones/The_Ashu_Talif/mobs/Ashu_Talif_Crew_rdm.lua
@@ -81,7 +81,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [23] = { xi.magic.spell.SLOW,         target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.SLOW,      3, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPEL, target, false, xi.action.type.NONE, nil, 0, 100 })
     end
 

--- a/scripts/zones/Waughroon_Shrine/mobs/Maat_rdm.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Maat_rdm.lua
@@ -108,7 +108,10 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [25] = { xi.magic.spell.GRAVITY,     target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.WEIGHT,    0, 100 },
     }
 
-    if target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) then
+    if
+        target:hasStatusEffectByFlag(xi.effectFlag.DISPELABLE) and
+        mob:isEngaged()
+    then
         table.insert(spellList, #spellList + 1, { xi.magic.spell.DISPEL, target, false, xi.action.type.NONE, nil, 100 })
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This should never be able to be chosen outside of combat, so adds isEngaged() to them to guard it.

## Steps to test these changes

Run the Wyrmking Descends
