### PR TITLE
[core] New Alter ego upgrade categories, minor CHAT_NAME names update

### DIFF
--- a/src/map/enums/alter_ego_points.h
+++ b/src/map/enums/alter_ego_points.h
@@ -24,13 +24,15 @@
 // Alter Ego upgrade categories
 enum class AlterEgoCategory : uint8_t
 {
-    HP  = 8,
-    MP  = 9,
-    STR = 10,
-    DEX = 11,
-    VIT = 12,
-    AGI = 13,
-    INT = 14,
-    MND = 15,
-    CHR = 16,
+    HP           = 8,
+    MP           = 9,
+    STR          = 10,
+    DEX          = 11,
+    VIT          = 12,
+    AGI          = 13,
+    INT          = 14,
+    MND          = 15,
+    CHR          = 16,
+    CombatSkills = 17,
+    MagicSkills  = 18,
 };

--- a/src/map/packets/c2s/0x0b6_chat_name.cpp
+++ b/src/map/packets/c2s/0x0b6_chat_name.cpp
@@ -57,8 +57,8 @@ const auto auditTell = [](Scheduler& scheduler, CCharEntity* PChar, const std::s
 auto GP_CLI_COMMAND_CHAT_NAME::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
     return PacketValidator(PChar)
-        .mustEqual(this->unknown00, 3, "unknown00 not 3")
-        .mustEqual(this->unknown01, 0, "unknown01 not 0");
+        .mustEqual(this->unknown04, 3, "unknown04 not 3")
+        .mustEqual(this->unknown05, 0, "unknown05 not 0");
 }
 
 void GP_CLI_COMMAND_CHAT_NAME::process(MapSession* PSession, CCharEntity* PChar) const

--- a/src/map/packets/c2s/0x0b6_chat_name.h
+++ b/src/map/packets/c2s/0x0b6_chat_name.h
@@ -26,8 +26,8 @@
 // https://github.com/atom0s/XiPackets/tree/main/world/client/0x00B6
 // This packet is sent by the client when sending tells to another player.
 GP_CLI_PACKET_VLA(GP_CLI_COMMAND_CHAT_NAME, Mes,
-                  uint8_t unknown00;
-                  uint8_t unknown01;
-                  uint8_t sName[15];
-                  uint8_t Mes[128]; // Variable length
+                  uint8_t unknown04; // PS2: Dammy
+                  uint8_t unknown05; // PS2: (New; did not exist.)
+                  uint8_t sName[15]; // PS2: sName
+                  uint8_t Mes[128];  // PS2: Mes (Variable length)
 );


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Adds the 2 new Alter Ego upgrade categories
- Updates CHAT_NAME fields to mirror updated XiPackets doc

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Does nothing.
<!-- Clear and detailed steps to test your changes here -->
