### PR TITLE
[core, sql] Tweak Traverser Stone default column value, add tests

### DIFF
--- a/scripts/tests/systems/abyssea/traverser_stones.lua
+++ b/scripts/tests/systems/abyssea/traverser_stones.lua
@@ -1,0 +1,54 @@
+describe('Traverser Stones', function()
+    ---@type CClientEntityPair
+    local player
+
+    local function advanceUntilStonesIncrease(from)
+        for _ = 1, 64 do
+            if player:getAvailableTraverserStones() > from then
+                return
+            end
+
+            xi.test.world:skipToNextVanaDay()
+        end
+
+        error('Traverser Stones did not accrue in time')
+    end
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE })
+    end)
+
+    it('does not accrue before the epoch is set', function()
+        assert(player:getTraverserEpoch() == 0)
+        assert(player:getAvailableTraverserStones() == 0)
+    end)
+
+    it('persists the epoch when set', function()
+        player:setTraverserEpoch()
+
+        assert(player:getTraverserEpoch() > 0)
+    end)
+
+    it('accrues one stone per interval', function()
+        player:setTraverserEpoch()
+
+        local baseline = player:getAvailableTraverserStones()
+        advanceUntilStonesIncrease(baseline)
+        assert(player:getAvailableTraverserStones() == baseline + 1)
+
+        advanceUntilStonesIncrease(baseline + 1)
+        assert(player:getAvailableTraverserStones() == baseline + 2)
+    end)
+
+    it('subtracts claimed stones from available', function()
+        player:setTraverserEpoch()
+
+        local baseline = player:getAvailableTraverserStones()
+        advanceUntilStonesIncrease(baseline)
+
+        local available = player:getAvailableTraverserStones()
+        player:addClaimedTraverserStones(available)
+        assert(player:getClaimedTraverserStones() == available)
+        assert(player:getAvailableTraverserStones() == 0)
+    end)
+end)

--- a/sql/char_unlocks.sql
+++ b/sql/char_unlocks.sql
@@ -13,7 +13,7 @@ CREATE TABLE `char_unlocks` (
   `campaign_windy` int(10) unsigned NOT NULL DEFAULT 0,
   `homepoints` blob DEFAULT NULL,
   `survivals` blob DEFAULT NULL,
-  `traverser_start` TIMESTAMP DEFAULT 0,
+  `traverser_start` TIMESTAMP NULL DEFAULT NULL,
   `traverser_claimed` int(10) unsigned NOT NULL DEFAULT 0,
   `abyssea_conflux` blob DEFAULT NULL,
   `waypoints` blob DEFAULT NULL,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7689,7 +7689,7 @@ earth_time::time_point getTraverserEpoch(CCharEntity* PChar)
     const auto rset = db::preparedStmt("SELECT UNIX_TIMESTAMP(traverser_start) AS start FROM char_unlocks WHERE charid = ? LIMIT 1", PChar->id);
     FOR_DB_SINGLE_RESULT(rset)
     {
-        return earth_time::time_point(std::chrono::seconds(rset->get<uint32>("start")));
+        return earth_time::time_point(std::chrono::seconds(rset->getOrDefault<uint32>("start", 0)));
     }
 
     return earth_time::time_point(std::chrono::seconds(0));
@@ -7740,7 +7740,7 @@ uint32 getAvailableTraverserStones(CCharEntity* PChar)
     const auto rset = db::preparedStmt("SELECT UNIX_TIMESTAMP(traverser_start) AS start, traverser_claimed FROM char_unlocks WHERE charid = ? LIMIT 1", PChar->id);
     FOR_DB_SINGLE_RESULT(rset)
     {
-        traverserEpoch   = earth_time::time_point(std::chrono::seconds(rset->get<uint32>("start")));
+        traverserEpoch   = earth_time::time_point(std::chrono::seconds(rset->getOrDefault<uint32>("start", 0)));
         traverserClaimed = rset->get<uint32>("traverser_claimed");
     }
 

--- a/tools/migrations/055_traverser_start_nullable.py
+++ b/tools/migrations/055_traverser_start_nullable.py
@@ -1,0 +1,30 @@
+import mariadb
+
+
+def migration_name():
+    return "Make traverser_start nullable"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    cur.execute("DESCRIBE char_unlocks traverser_start;")
+    return cur.fetchone()[2] == "NO"  # This returns the content of the Null column
+
+
+def migrate(cur, db):
+    try:
+        cur.execute("""
+                    ALTER TABLE char_unlocks
+                        MODIFY traverser_start TIMESTAMP NULL DEFAULT NULL;
+                    """)
+        cur.execute("""
+                    UPDATE char_unlocks
+                    SET traverser_start = NULL
+                    WHERE traverser_start = '0000-00-00 00:00:00';
+                    """)
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes #9893 
Replaces #10195 

Forces default to NULL, along with an explicit migration. 
Adds relevant tests.

## Steps to test these changes
- 1. New char with NULL column
- 2. player:setTraverserEpoch()
- 3. Verify SQL now has a timestamp
- 4. Manipulate timestamp to be backdated
- 5. Verify you get right amount of stones on re-zoning
