### PR TITLE
[lua] Additional Maat damage adjustments

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/Maat_smn.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Maat_smn.lua
@@ -39,7 +39,6 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)

--- a/scripts/zones/Balgas_Dais/mobs/Maat_whm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Maat_whm.lua
@@ -31,7 +31,6 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 6)
 
     -- Reset mob.

--- a/scripts/zones/Chamber_of_Oracles/mobs/Maat_nin.lua
+++ b/scripts/zones/Chamber_of_Oracles/mobs/Maat_nin.lua
@@ -36,7 +36,7 @@ entity.onMobInitialize = function(mob)
         end
 
         if damage >= 400 then
-            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 end

--- a/scripts/zones/Horlais_Peak/mobs/Maat_war.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Maat_war.lua
@@ -20,7 +20,7 @@ entity.onMobInitialize = function(mob)
         end
 
         if damage >= 584 then
-            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 end

--- a/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
+++ b/scripts/zones/Jade_Sepulcher/mobs/Raubahn.lua
@@ -26,7 +26,7 @@ entity.onMobInitialize = function(mob)
     mob:addListener('TAKE_DAMAGE', 'RAUBAHN_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
         if damage >= 400 then -- This might also increase Raubahn's accuracy.
             mob:messageText(mob, ID.text.RAUBAHN_GREATER_POWER)
-            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 end
@@ -35,7 +35,6 @@ entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setMod(xi.mod.DMGMAGIC, -1250) -- Observed at 99 and the skillchain damage in under level 71 vods
     mob:setMod(xi.mod.UFASTCAST, 70)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setMobMod(xi.mobMod.ROAM_COOL, 8)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 18)
 

--- a/scripts/zones/QuBia_Arena/mobs/Maat_brd.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maat_brd.lua
@@ -27,7 +27,6 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
     mob:setMod(xi.mod.SILENCE_RES_RANK, 4)
     mob:setMod(xi.mod.LIGHT_SLEEP_RES_RANK, 10)
 

--- a/scripts/zones/QuBia_Arena/mobs/Maat_drk.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Maat_drk.lua
@@ -22,7 +22,7 @@ entity.onMobInitialize = function(mob)
         end
 
         if damage >= 594 then
-            mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+            mobArg:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
         end
     end)
 end

--- a/scripts/zones/Talacca_Cove/mobs/Qultada.lua
+++ b/scripts/zones/Talacca_Cove/mobs/Qultada.lua
@@ -30,7 +30,6 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
-    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 125)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Maats damage to bring in more in line with reality for a level 70 doing the fight.

Maat's variable damage based on your level and damage dealt makes it difficult to hone down his base values depending on the testing available to the capper.

Fortunately extra testers have helped point out some of the more extreme values that I originally added and I was able to compare that against publicly posted vods against my own for more accurate values.

## Steps to test these changes

Fight Maat.  It should seem about right depending on the fight.
