### PR TITLE
[Fix] Trusts not getting interrupted

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1903,10 +1903,14 @@ auto CalculateTPFromDamageTaken(CBattleEntity* PAttacker, CBattleEntity* PDefend
 
 bool TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpell* PSpell)
 {
-    // Exceptions.
-    if (PDefender->objtype == TYPE_TRUST ||                                              // Caster is a trust.
-        PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Manafont) || // Caster has Manafont.
-        (SKILLTYPE)PSpell->getSkillType() == SKILL_SINGING)                              // Spell is a song.
+    // Early return: Spell can't be interrupted.
+    if ((SKILLTYPE)PSpell->getSkillType() == SKILL_SINGING)
+    {
+        return false;
+    }
+
+    // Early return: Manafont prevents interruptions.
+    if (PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Manafont))
     {
         return false;
     }
@@ -1962,24 +1966,27 @@ bool TryInterruptSpell(CBattleEntity* PAttacker, CBattleEntity* PDefender, CSpel
     // SIRDRatio:   No limits. Can be negative. A negative value will guarantee NOT being interrupted.
     float finalRatio = levelRatio * skillRatio * SIRDRatio; // TL;DR Higher = Worse = More chances to get interrupted.
 
-    // You get interrupted. Handle aquaveil.
-    if (chance < finalRatio)
+    // Early return: You don't get interrupted.
+    if (chance >= finalRatio)
     {
-        if (PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Aquaveil))
-        {
-            auto aquaCount = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Aquaveil)->GetPower();
-            if (aquaCount - 1 == 0) // removes the status, but still prevents the interrupt
-            {
-                PDefender->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Aquaveil);
-            }
-            else
-            {
-                PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Aquaveil)->SetPower(aquaCount - 1);
-            }
-            return false;
-        }
+        return false;
+    }
 
+    // Early return: You can't prevent interruption via Aquaveil effect.
+    if (!PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Aquaveil))
+    {
         return true;
+    }
+
+    // Handle aquaveil.
+    auto aquaCount = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Aquaveil)->GetPower();
+    if (aquaCount - 1 == 0) // removes the status, but still prevents the interrupt
+    {
+        PDefender->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Aquaveil);
+    }
+    else
+    {
+        PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Aquaveil)->SetPower(aquaCount - 1);
     }
 
     return false;


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As @sruon pointed out in PR #10204 trusts can get interrupted.

<img width="256" height="390" alt="imagen" src="https://github.com/user-attachments/assets/79a3fbf5-fc7c-43fa-af49-802b8b94c986" />

Also does a little cleanup. No actual changes to calculations.

## Steps to test these changes
Have Trusts in the party. Have them be interrupted sometimes?
