### PR TITLE
[lua] Set wall groundskeepers to aggro

### DIFF
--- a/scripts/enum/mob_pool.lua
+++ b/scripts/enum/mob_pool.lua
@@ -48,6 +48,7 @@ xi.mobPool =
     WREAKER                = 4382, -- Wreaker (CoP 1-3 Spire Battle)
     ZIZZY_ZILLAH           = 4509, -- Zizzy Zillah (Mamook NM)
     QNAERN_WHM             = 4651, -- Qn'Aern WHM benediction check
+    GROUNDSKEEPER_WALL     = 5128, -- Groundskeepers in wall that aggro
     AMNAF_PSYCHEFLAYER     = 5310, -- Reset enmity on sleepga
     SELHTEUS_DAWN          = 5417, -- Selhteus (CoP 8-4 Dawn)
     FAHRAFAHR_THE_BLOODIED = 6750, -- Reset Enmity on Drop Hammer

--- a/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Groundskeeper.lua
@@ -8,6 +8,14 @@ local ID = zones[xi.zone.RUAUN_GARDENS]
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    -- Force wall groundskeepers to aggro
+    -- We can't set this in the DB because they are still doll species but not "special" in any way other than this
+    if mob:getPool() == xi.mobPool.GROUNDSKEEPER_WALL then
+        mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.MAGIC, xi.detects.SIGHT))
+    end
+end
+
 entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 143, 2, xi.regime.type.FIELDS)
     xi.regime.checkRegime(player, mob, 144, 1, xi.regime.type.FIELDS)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Due to mob species system, we have to script the wall groundskeepers to aggro. They do already have pools for the walls and as far as I can tell they are correct already.

Closes #10432

## Steps to test these changes

Try to aggro wall groundskeepers, get aggroed.
