### PR TITLE
[test] Remove changing wall groundskeeper aggro from aggro test

### DIFF
--- a/scripts/tests/systems/aggro_los.lua
+++ b/scripts/tests/systems/aggro_los.lua
@@ -46,13 +46,6 @@ describe('Sight aggro line of sight', function()
         local mob = alcoveGroundskeeper()
         assert(mob, 'alcove Groundskeeper not found')
 
-        -- TODO: We shouldn't have to set these manually, they should be the default behaviours
-        --     : of this particular Groundskeeper
-        mob:setAggressive(true)
-        mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
-        mob:setMobMod(xi.mobMod.DETECTION, xi.detects.SIGHT)
-        mob:setMobMod(xi.mobMod.SIGHT_RANGE, 20)
-
         -- Roam past the post-spawn neutral window so the mob can aggro at all.
         for _ = 1, 10 do
             xi.test.world:skipTime(5)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We don't need to tweak the aggro of wall groundskeepers anymore, so this test should run without forcing that.

## Steps to test these changes

CI passes