### PR TITLE
Core: Slightly cleaner exit for xi_map

### DIFF
--- a/src/map/main.cpp
+++ b/src/map/main.cpp
@@ -19,13 +19,27 @@
 ===========================================================================
 */
 
-#include "map_application.h"
+#include <map/map_application.h>
+
+#include <common/lua.h>
+
+#include <cstdlib>
+#include <memory>
 
 int main(int argc, char** argv)
 {
-    const auto mapApp = std::make_unique<MapApplication>(argc, argv);
+    auto mapApp = std::make_unique<MapApplication>(argc, argv);
 
-    mapApp->run();
+    const auto success = mapApp->run();
 
-    return 0;
+    const auto exitCode = success ? EXIT_SUCCESS : EXIT_FAILURE;
+
+    // Explicitly destroy MapApplication before the lua state get cleaned up
+    mapApp.reset();
+
+    // TODO: This should be in ~Application but it needs more testing for xi_map
+    // TODO: This wouldn't be needed if lua wasn't global
+    lua_cleanup();
+
+    return exitCode;
 }

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -19,9 +19,10 @@
 ===========================================================================
 */
 
-#include "common/lua.h"
-#include "common/tracy.h"
-#include "test_application.h"
+#include <test/test_application.h>
+
+#include <common/lua.h>
+#include <common/tracy.h>
 
 #include <cstdlib>
 #include <iostream>
@@ -35,7 +36,7 @@ int main(int argc, char** argv)
 
     const auto success = testApp->run();
 
-    const int exitCode = success ? EXIT_SUCCESS : EXIT_FAILURE;
+    const auto exitCode = success ? EXIT_SUCCESS : EXIT_FAILURE;
 
     // Explicitly destroy TestApplication before the lua state get cleaned up
     testApp.reset();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

ASAN reported some leaks on exit, not a huge deal, but we may as well fix them as we did it for xi_test