### PR TITLE
xirand: Make usage deterministic on all platforms

### DIFF
--- a/scripts/tests/framework/packets.lua
+++ b/scripts/tests/framework/packets.lua
@@ -31,7 +31,7 @@ describe('Packets', function()
         local playerName = player:getName()
         local param0Offset = 0x0D + 8 + #playerName + 9
 
-        xi.test.world:setSeed(557)
+        xi.test.world:setSeed(1710)
         player.packets:send(0x0A2, p, ffi.sizeof(p))
 
         local incomingPackets = player.packets:getIncoming()

--- a/scripts/tests/framework/prng.lua
+++ b/scripts/tests/framework/prng.lua
@@ -1,6 +1,6 @@
 describe('PRNG', function()
     it('can be forced to a specific seed', function()
-        local expected = { 134, 137, 452, 22, 351, 912, 471, 75, 570, 636 }
+        local expected = { 141, 597, 964, 998, 667, 697, 572, 741, 488, 371 }
         local actual   = {}
 
         xi.test.world:setSeed(1)
@@ -15,7 +15,7 @@ describe('PRNG', function()
     end)
 
     it('test seed does not leak', function()
-        local expected = { 134, 137, 452, 22, 351, 912, 471, 75, 570, 636 }
+        local expected = { 141, 597, 964, 998, 667, 697, 572, 741, 488, 371 }
         local actual   = {}
 
         for _ = 1, 10 do

--- a/src/common/rng/detail/bounded_int.h
+++ b/src/common/rng/detail/bounded_int.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstdint>
 #include <random>
 
@@ -44,7 +45,8 @@ namespace xirand::detail
 /// @param count Number of distinct outcomes; result is in [0, count). Must be >= 1.
 /// @return A value in [0, count).
 /// @note Covers counts up to 2^32 (any range used in this codebase). Larger
-///       ranges would require a 64-bit variant.
+///       ranges would silently truncate to [0, 2^32) and would require a 64-bit
+///       variant; the debug assert below fails loudly if one is ever requested.
 template <std::uniform_random_bit_generator G>
 [[nodiscard]] constexpr auto bounded32(G& g, uint64_t count) -> uint32_t;
 
@@ -53,9 +55,13 @@ template <std::uniform_random_bit_generator G>
 template <std::uniform_random_bit_generator G>
 [[nodiscard]] constexpr auto xirand::detail::bounded32(G& g, uint64_t count) -> uint32_t
 {
+    // This helper consumes one 32-bit word per draw; a narrower engine can't feed it.
+    static_assert(sizeof(typename G::result_type) >= sizeof(uint32_t), "bounded32 requires a >= 32-bit engine");
+
+    assert(count <= (uint64_t{ 1 } << 32)); // larger ranges truncate; a 64-bit variant would be needed
     if (count >= (uint64_t{ 1 } << 32))
     {
-        return static_cast<uint32_t>(g()); // full 32-bit span
+        return static_cast<uint32_t>(g()); // exactly 2^32 -> full 32-bit span
     }
 
     const uint32_t range = static_cast<uint32_t>(count);

--- a/src/common/rng/detail/bounded_int.h
+++ b/src/common/rng/detail/bounded_int.h
@@ -1,0 +1,77 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+
+namespace xirand::detail
+{
+
+// Lemire's unbiased bounded-integer method. Deterministic and identical on
+// every platform, unlike std::uniform_int_distribution whose bit-consumption
+// algorithm is implementation-defined (libc++, libstdc++, and MSVC STL each
+// map the same engine bits to different integers).
+//
+// ATTR: Daniel Lemire, "Fast Random Integer Generation in an Interval"
+//       Paper:     https://arxiv.org/abs/1805.10941
+//       Blog:      https://lemire.me/blog/2016/06/30/fast-random-shuffling/
+//       Reference: https://github.com/lemire/fastrange
+//       The same widening-multiply-with-rejection method is used by Rust's
+//       `rand` crate (UniformInt::sample_single):
+//       https://github.com/rust-random/rand/blob/master/src/distr/uniform_int.rs
+//
+/// @param g     A 32-bit uniform random bit generator (e.g. Squirrel5).
+/// @param count Number of distinct outcomes; result is in [0, count). Must be >= 1.
+/// @return A value in [0, count).
+/// @note Covers counts up to 2^32 (any range used in this codebase). Larger
+///       ranges would require a 64-bit variant.
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto bounded32(G& g, uint64_t count) -> uint32_t;
+
+} // namespace xirand::detail
+
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto xirand::detail::bounded32(G& g, uint64_t count) -> uint32_t
+{
+    if (count >= (uint64_t{ 1 } << 32))
+    {
+        return static_cast<uint32_t>(g()); // full 32-bit span
+    }
+
+    const uint32_t range = static_cast<uint32_t>(count);
+
+    uint32_t x   = static_cast<uint32_t>(g());
+    uint64_t m   = static_cast<uint64_t>(x) * range;
+    uint32_t low = static_cast<uint32_t>(m);
+    if (low < range)
+    {
+        const uint32_t threshold = (0u - range) % range; // 2^32 % range
+        while (low < threshold)
+        {
+            x   = static_cast<uint32_t>(g());
+            m   = static_cast<uint64_t>(x) * range;
+            low = static_cast<uint32_t>(m);
+        }
+    }
+    return static_cast<uint32_t>(m >> 32);
+}

--- a/src/common/rng/detail/canonical_float.h
+++ b/src/common/rng/detail/canonical_float.h
@@ -1,0 +1,55 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <random>
+
+namespace xirand::detail
+{
+
+// Portable canonical value in [0, 1), built from a fixed 53 engine bits / 2^53.
+// Replaces std::uniform_real_distribution / std::generate_canonical, both of
+// which are implementation-defined and diverge across standard libraries.
+//
+// ATTR: The (a >> 5) * 2^26 + (b >> 6), all over 2^53 construction is the
+//       genrand_res53() routine from Matsumoto & Nishimura's Mersenne Twister
+//       reference implementation, and is the same formula NumPy uses for
+//       random_double().
+//       MT reference: http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/MT2002/CODES/mt19937ar.c
+//       NumPy:        https://github.com/numpy/numpy/blob/main/numpy/random/src/distributions/random_mtrand.c
+//
+/// @param g A 32-bit uniform random bit generator (e.g. Squirrel5).
+/// @return A double in [0, 1).
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto canonical53(G& g) -> double;
+
+} // namespace xirand::detail
+
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto xirand::detail::canonical53(G& g) -> double
+{
+    const uint64_t hi = static_cast<uint32_t>(g()) >> 5; // top 27 bits
+    const uint64_t lo = static_cast<uint32_t>(g()) >> 6; // top 26 bits
+    // (hi * 2^26 + lo) / 2^53  ->  [0, 1)
+    return (static_cast<double>(hi) * 67108864.0 + static_cast<double>(lo)) * (1.0 / 9007199254740992.0);
+}

--- a/src/common/rng/detail/canonical_float.h
+++ b/src/common/rng/detail/canonical_float.h
@@ -48,6 +48,9 @@ template <std::uniform_random_bit_generator G>
 template <std::uniform_random_bit_generator G>
 [[nodiscard]] constexpr auto xirand::detail::canonical53(G& g) -> double
 {
+    // This helper consumes one 32-bit word per draw; a narrower engine can't feed it.
+    static_assert(sizeof(typename G::result_type) >= sizeof(uint32_t), "canonical53 requires a >= 32-bit engine");
+
     const uint64_t hi = static_cast<uint32_t>(g()) >> 5; // top 27 bits
     const uint64_t lo = static_cast<uint32_t>(g()) >> 6; // top 26 bits
     // (hi * 2^26 + lo) / 2^53  ->  [0, 1)

--- a/src/common/rng/detail/shuffle.h
+++ b/src/common/rng/detail/shuffle.h
@@ -1,0 +1,62 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/rng/detail/bounded_int.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+#include <random>
+
+namespace xirand::detail
+{
+
+// Portable in-place shuffle. Replaces std::shuffle, whose index generation is
+// unspecified by the standard: each implementation drives it with an internal
+// uniform_int_distribution-equivalent and so produces a different permutation
+// from identical engine bits. Building the swap indices from detail::bounded32
+// makes the result deterministic and identical on every platform.
+//
+// ATTR: Fisher-Yates shuffle (Durstenfeld's in-place variant).
+//       https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+//
+/// @param first First iterator of the range to shuffle.
+/// @param last  One-past-the-end iterator of the range to shuffle.
+/// @param g     A 32-bit uniform random bit generator (e.g. Squirrel5).
+template <std::uniform_random_bit_generator G, std::random_access_iterator It>
+constexpr auto shuffle(It first, It last, G& g) -> void;
+
+} // namespace xirand::detail
+
+template <std::uniform_random_bit_generator G, std::random_access_iterator It>
+constexpr auto xirand::detail::shuffle(It first, It last, G& g) -> void
+{
+    using diff_t = std::iter_difference_t<It>;
+
+    // Walk from the back, swapping element i with a uniformly chosen j in [0, i].
+    for (diff_t i = (last - first) - 1; i > 0; --i)
+    {
+        const diff_t j = static_cast<diff_t>(bounded32(g, static_cast<uint64_t>(i) + 1));
+        std::iter_swap(first + i, first + j);
+    }
+}

--- a/src/common/rng/detail/weighted_index.h
+++ b/src/common/rng/detail/weighted_index.h
@@ -1,0 +1,85 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/rng/detail/canonical_float.h>
+
+#include <cstddef>
+#include <random>
+#include <span>
+
+namespace xirand::detail
+{
+
+// Portable weighted index selection. Replaces std::discrete_distribution, whose
+// construction and sampling are implementation-defined and diverge across
+// standard libraries. Picks index i with probability weights[i] / sum(weights),
+// matching std::discrete_distribution's semantics (zero-weight entries are never
+// selected; negative weights are undefined, as in the standard).
+//
+// ATTR: Inverse transform sampling over the cumulative distribution, a.k.a.
+//       roulette-wheel / fitness-proportionate selection.
+//       https://en.wikipedia.org/wiki/Inverse_transform_sampling
+//       https://en.wikipedia.org/wiki/Fitness_proportionate_selection
+//
+/// @param g       A 32-bit uniform random bit generator (e.g. Squirrel5).
+/// @param weights Span of non-negative weights.
+/// @return Index in [0, weights.size()); 0 if empty or total weight is zero.
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto weightedIndex(G& g, std::span<const double> weights) -> size_t;
+
+} // namespace xirand::detail
+
+template <std::uniform_random_bit_generator G>
+[[nodiscard]] constexpr auto xirand::detail::weightedIndex(G& g, std::span<const double> weights) -> size_t
+{
+    if (weights.empty())
+    {
+        return 0;
+    }
+
+    double total = 0.0;
+    for (const double w : weights)
+    {
+        total += w;
+    }
+
+    if (total <= 0.0)
+    {
+        return 0;
+    }
+
+    // Draw a point in [0, total) and walk the cumulative weights.
+    const double target     = canonical53(g) * total;
+    double       cumulative = 0.0;
+    for (size_t i = 0; i < weights.size(); ++i)
+    {
+        cumulative += weights[i];
+        if (target < cumulative)
+        {
+            return i;
+        }
+    }
+
+    // Only reachable via floating-point rounding at the very top of the range.
+    return weights.size() - 1;
+}

--- a/src/common/rng/detail/weighted_index.h
+++ b/src/common/rng/detail/weighted_index.h
@@ -80,6 +80,8 @@ template <std::uniform_random_bit_generator G>
         }
     }
 
-    // Only reachable via floating-point rounding at the very top of the range.
+    // Defensive fallback. Effectively unreachable: `cumulative` sums the weights in
+    // the same order as `total`, so after the final element cumulative == total exactly,
+    // and target = canonical53() * total < total, so the loop always returns first.
     return weights.size() - 1;
 }

--- a/src/common/rng/null.h
+++ b/src/common/rng/null.h
@@ -23,34 +23,43 @@
 
 #include <cstdint>
 #include <limits>
-#include <random>
 
 class NullRandomEngine
 {
 public:
     using result_type = uint64_t;
 
-    static constexpr result_type min()
-    {
-        return 0;
-    }
+    static constexpr auto min() -> result_type;
+    static constexpr auto max() -> result_type;
 
-    static constexpr result_type max()
-    {
-        return std::numeric_limits<result_type>::max();
-    }
+    constexpr auto operator()() -> result_type;
 
-    result_type operator()()
-    {
-        return (min() + max()) / 2;
-    }
-
-    void seed(result_type)
-    {
-    }
+    constexpr auto seed(result_type) -> void;
 
     template <class Sseq>
-    void seed(Sseq&)
-    {
-    }
+    constexpr auto seed(Sseq&) -> void;
 };
+
+constexpr auto NullRandomEngine::min() -> result_type
+{
+    return 0;
+}
+
+constexpr auto NullRandomEngine::max() -> result_type
+{
+    return std::numeric_limits<result_type>::max();
+}
+
+constexpr auto NullRandomEngine::operator()() -> result_type
+{
+    return (min() + max()) / 2;
+}
+
+constexpr auto NullRandomEngine::seed(result_type) -> void
+{
+}
+
+template <class Sseq>
+constexpr auto NullRandomEngine::seed(Sseq&) -> void
+{
+}

--- a/src/common/rng/squirrel5.h
+++ b/src/common/rng/squirrel5.h
@@ -24,6 +24,10 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <type_traits>
+
+template <typename T>
+concept SeedSequence = !std::is_arithmetic_v<T>;
 
 // ATTR: Squirrel Eiserloh https://www.gdcvault.com/play/1024365/Math-for-Game-Programmers-Noise
 // Original Source: http://eiserloh.net/noise/SquirrelNoise5.hpp
@@ -32,65 +36,79 @@ class Squirrel5
 public:
     using result_type = uint32_t;
 
-    static constexpr result_type min()
-    {
-        return 0;
-    }
+    static constexpr auto min() -> result_type;
+    static constexpr auto max() -> result_type;
 
-    static constexpr result_type max()
-    {
-        return std::numeric_limits<result_type>::max();
-    }
+    constexpr Squirrel5(result_type seed_val = 0);
 
-    Squirrel5(result_type seed_val = 0)
-    : m_seed(seed_val)
-    {
-    }
+    constexpr auto seed(result_type seed_val) -> void;
 
-    void seed(result_type seed_val)
-    {
-        m_seed     = seed_val;
-        m_position = 0;
-    }
+    template <SeedSequence Sseq>
+    constexpr auto seed(Sseq& seq) -> void;
 
-    template <class Sseq>
-    void seed(Sseq& seq)
-    {
-        std::array<uint32_t, 1> buf;
-        seq.generate(buf.begin(), buf.end());
-        m_seed     = buf[0];
-        m_position = 0;
-    }
+    constexpr auto operator()() -> result_type;
 
-    result_type operator()()
-    {
-        return noise(m_position++, m_seed);
-    }
-
-    static uint32_t noise(int32_t position, uint32_t seed)
-    {
-        constexpr uint32_t SQ5_BIT_NOISE1 = 0xd2a80a3f; // 11010010101010000000101000111111
-        constexpr uint32_t SQ5_BIT_NOISE2 = 0xa884f197; // 10101000100001001111000110010111
-        constexpr uint32_t SQ5_BIT_NOISE3 = 0x6C736F4B; // 01101100011100110110111101001011
-        constexpr uint32_t SQ5_BIT_NOISE4 = 0xB79F3ABB; // 10110111100111110011101010111011
-        constexpr uint32_t SQ5_BIT_NOISE5 = 0x1b56c4f5; // 00011011010101101100010011110101
-
-        uint32_t mangled = static_cast<uint32_t>(position);
-        mangled *= SQ5_BIT_NOISE1;
-        mangled += seed;
-        mangled ^= (mangled >> 9);
-        mangled += SQ5_BIT_NOISE2;
-        mangled ^= (mangled >> 11);
-        mangled *= SQ5_BIT_NOISE3;
-        mangled ^= (mangled >> 13);
-        mangled += SQ5_BIT_NOISE4;
-        mangled ^= (mangled >> 15);
-        mangled *= SQ5_BIT_NOISE5;
-        mangled ^= (mangled >> 17);
-        return mangled;
-    }
+    static constexpr auto noise(int32_t position, uint32_t seed) -> uint32_t;
 
 private:
     uint32_t m_seed     = 0;
     uint32_t m_position = 0;
 };
+
+constexpr auto Squirrel5::min() -> result_type
+{
+    return 0;
+}
+
+constexpr auto Squirrel5::max() -> result_type
+{
+    return std::numeric_limits<result_type>::max();
+}
+
+constexpr Squirrel5::Squirrel5(result_type seed_val)
+: m_seed(seed_val)
+{
+}
+
+constexpr auto Squirrel5::seed(result_type seed_val) -> void
+{
+    m_seed     = seed_val;
+    m_position = 0;
+}
+
+template <SeedSequence Sseq>
+constexpr auto Squirrel5::seed(Sseq& seq) -> void
+{
+    std::array<uint32_t, 1> buf;
+    seq.generate(buf.begin(), buf.end());
+    m_seed     = buf[0];
+    m_position = 0;
+}
+
+constexpr auto Squirrel5::operator()() -> result_type
+{
+    return noise(m_position++, m_seed);
+}
+
+constexpr auto Squirrel5::noise(int32_t position, uint32_t seed) -> uint32_t
+{
+    constexpr uint32_t SQ5_BIT_NOISE1 = 0xD2A80A3F; // 11010010101010000000101000111111
+    constexpr uint32_t SQ5_BIT_NOISE2 = 0xA884F197; // 10101000100001001111000110010111
+    constexpr uint32_t SQ5_BIT_NOISE3 = 0x6C736F4B; // 01101100011100110110111101001011
+    constexpr uint32_t SQ5_BIT_NOISE4 = 0xB79F3ABB; // 10110111100111110011101010111011
+    constexpr uint32_t SQ5_BIT_NOISE5 = 0x1B56C4F5; // 00011011010101101100010011110101
+
+    uint32_t mangled = static_cast<uint32_t>(position);
+    mangled *= SQ5_BIT_NOISE1;
+    mangled += seed;
+    mangled ^= (mangled >> 9);
+    mangled += SQ5_BIT_NOISE2;
+    mangled ^= (mangled >> 11);
+    mangled *= SQ5_BIT_NOISE3;
+    mangled ^= (mangled >> 13);
+    mangled += SQ5_BIT_NOISE4;
+    mangled ^= (mangled >> 15);
+    mangled *= SQ5_BIT_NOISE5;
+    mangled ^= (mangled >> 17);
+    return mangled;
+}

--- a/src/common/xirand.h
+++ b/src/common/xirand.h
@@ -161,8 +161,11 @@ template <std::integral T>
         return min;
     }
 
-    using U              = std::make_unsigned_t<T>;
-    const uint64_t count = static_cast<uint64_t>(static_cast<U>(max) - static_cast<U>(min));
+    // Compute the outcome count in U's own modulus. The extra cast back to U matters
+    // for types narrower than int: `U(max) - U(min)` would otherwise promote to int and,
+    // for a negative min, widen to a bogus huge count. Keeping it in U wraps correctly.
+    using U       = std::make_unsigned_t<T>;
+    const U count = static_cast<U>(static_cast<U>(max) - static_cast<U>(min));
     return static_cast<T>(static_cast<U>(min) + detail::bounded32(rng(), count));
 }
 

--- a/src/common/xirand.h
+++ b/src/common/xirand.h
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <concepts>
+#include <cstdint>
 #include <initializer_list>
 #include <iterator>
 #include <map>
@@ -34,11 +35,16 @@
 #include <type_traits>
 #include <vector>
 
+#include <common/rng/detail/bounded_int.h>
+#include <common/rng/detail/canonical_float.h>
+#include <common/rng/detail/shuffle.h>
+#include <common/rng/detail/weighted_index.h>
+
 //
 // @brief Random Engine Selection
 //
 // Define one of the following macros to select a specific RNG engine.
-// If none are defined, XIRAND_MT64 (std::mt19937_64) is used by default.
+// If none are defined, Squirrel5 is used by default.
 //
 // - XIRAND_PCG64
 // - XIRAND_PCG32
@@ -57,13 +63,14 @@ using SelectedRandomEngine = pcg32;
 #elif defined(XIRAND_MT32)
 using SelectedRandomEngine = std::mt19937;
 #elif defined(XIRAND_SQUIRREL5)
-#include "rng/squirrel5.h"
+#include <common/rng/squirrel5.h>
 using SelectedRandomEngine = Squirrel5;
 #elif defined(XIRAND_NULL)
-#include "rng/null.h"
+#include <common/rng/null.h>
 using SelectedRandomEngine = NullRandomEngine;
-#else
-using SelectedRandomEngine = std::mt19937_64;
+#else // Default
+#include <common/rng/squirrel5.h>
+using SelectedRandomEngine = Squirrel5;
 #endif
 
 static_assert(std::uniform_random_bit_generator<SelectedRandomEngine>, "SelectedRandomEngine must satisfy the UniformRandomBitGenerator concept");
@@ -88,9 +95,11 @@ void seed();
 /// @param min Minimum value (inclusive).
 /// @param max Maximum value (exclusive).
 /// @return Random value in [min, max).
-/// @note max is subtracted by one as per an inconsistency in the standard, see
-///       https://bugs.llvm.org/show_bug.cgi?id=18767#c1
-///       This change results in both real and integer templates having the same min/max range.
+/// @note Both the integer and real overloads are half-open [min, max) by construction
+///       (detail::bounded32 / detail::canonical53), so they share the same min/max range.
+///       This no longer relies on std::uniform_int_distribution's closed-interval
+///       convention (linked issue, the source of the old workaround:
+///       https://bugs.llvm.org/show_bug.cgi?id=18767#c1).
 template <std::integral T>
 [[nodiscard]] inline auto GetRandomNumber(T min, T max) -> T;
 
@@ -132,6 +141,12 @@ template <std::ranges::random_access_range R>
 template <typename Container>
 [[nodiscard]] inline auto GetWeightedElement(const Container& table) -> typename Container::key_type;
 
+/// @brief Shuffles a random_access_range in place using the thread-local engine.
+/// @tparam R Random access range type.
+/// @param range The container or range to shuffle.
+template <std::ranges::random_access_range R>
+inline auto ShuffleInPlace(R&& range) -> void;
+
 } // namespace xirand
 
 //
@@ -146,8 +161,9 @@ template <std::integral T>
         return min;
     }
 
-    std::uniform_int_distribution<T> dist(min, max - 1);
-    return dist(rng());
+    using U              = std::make_unsigned_t<T>;
+    const uint64_t count = static_cast<uint64_t>(static_cast<U>(max) - static_cast<U>(min));
+    return static_cast<T>(static_cast<U>(min) + detail::bounded32(rng(), count));
 }
 
 template <std::floating_point T>
@@ -158,8 +174,8 @@ template <std::floating_point T>
         return min;
     }
 
-    std::uniform_real_distribution<T> dist(min, max);
-    return dist(rng());
+    const double unit = detail::canonical53(rng());
+    return static_cast<T>(static_cast<double>(min) + unit * (static_cast<double>(max) - static_cast<double>(min)));
 }
 
 template <typename T>
@@ -189,13 +205,7 @@ template <std::ranges::random_access_range R>
 
 [[nodiscard]] inline auto xirand::GetWeightedIndex(std::span<const double> weights) -> size_t
 {
-    if (weights.empty())
-    {
-        return 0;
-    }
-
-    std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
-    return dist(rng());
+    return detail::weightedIndex(rng(), weights);
 }
 
 [[nodiscard]] inline auto xirand::GetWeightedIndex(std::initializer_list<double> weights) -> size_t
@@ -229,6 +239,11 @@ template <typename Container>
         weights.push_back(static_cast<double>(weight));
     }
 
-    std::discrete_distribution<size_t> dist(weights.begin(), weights.end());
-    return elements[dist(rng())];
+    return elements[detail::weightedIndex(rng(), std::span<const double>(weights))];
+}
+
+template <std::ranges::random_access_range R>
+inline auto xirand::ShuffleInPlace(R&& range) -> void
+{
+    detail::shuffle(std::ranges::begin(range), std::ranges::end(range), rng());
 }

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -426,7 +426,7 @@ auto CMobController::MobSkill(int listId) -> bool
         return false;
     }
 
-    std::shuffle(skillList.begin(), skillList.end(), xirand::rng());
+    xirand::ShuffleInPlace(skillList);
     CBattleEntity* PActionTarget{ nullptr };
 
     uint16 chosenSkillId = 0;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5134,7 +5134,7 @@ bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
         if (activeCooldownList.size() > 1)
         {
             // Shuffle active cooldowns and take first (loaded deck)
-            std::shuffle(std::begin(activeCooldownList), std::end(activeCooldownList), xirand::rng());
+            xirand::ShuffleInPlace(activeCooldownList);
             loadedDeckChance = 100;
         }
 
@@ -5166,7 +5166,7 @@ bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
         if (resetCandidateList.size() > 1)
         {
             // Shuffle if more than 1 ability
-            std::shuffle(std::begin(resetCandidateList), std::end(resetCandidateList), xirand::rng());
+            xirand::ShuffleInPlace(resetCandidateList);
         }
 
         // Reset first ability (shuffled or only)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     ${REPORTERS_SOURCES}
     enums/test_status.h
     enums/tick_type.h
+    tests/rng_spread_tests.cpp
     in_memory_sink.h
     mock_manager.cpp
     mock_manager.h

--- a/src/test/tests/rng_spread_tests.cpp
+++ b/src/test/tests/rng_spread_tests.cpp
@@ -1,0 +1,130 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+//
+// Compile-time uniformity tests for the RNG. Everything here is
+// consteval, so seeding, drawing, and histogramming happen entirely during
+// compilation: the static_asserts below fail the build if the spread is skewed.
+// This translation unit emits no runtime code; it is linked into xi_test purely
+// so the compiler evaluates the checks.
+//
+
+#include <common/rng/detail/bounded_int.h>
+#include <common/rng/detail/canonical_float.h>
+#include <common/rng/squirrel5.h>
+
+#include <array>
+#include <cstdint>
+
+namespace xirand::test
+{
+
+// Largest absolute deviation of any bucket from the ideal uniform count.
+template <std::size_t Buckets>
+[[nodiscard]] consteval auto worstDeviation(const std::array<std::uint32_t, Buckets>& histogram, std::uint32_t ideal) -> std::uint32_t
+{
+    std::uint32_t worst = 0;
+    for (const std::uint32_t count : histogram)
+    {
+        const std::uint32_t deviation = count > ideal ? count - ideal : ideal - count;
+        worst                         = deviation > worst ? deviation : worst;
+    }
+
+    return worst;
+}
+
+// Integer path: seeds a fresh engine, draws Samples values in [0, Buckets) via
+// bounded32, and returns the worst bucket deviation. Small relative to
+// Samples/Buckets == even spread.
+template <std::uint32_t Buckets, std::uint32_t Samples, typename Engine = Squirrel5>
+[[nodiscard]] consteval auto maxBucketDeviation(std::uint32_t seed) -> std::uint32_t
+{
+    static_assert(Buckets > 0, "need at least one bucket");
+    static_assert(Samples >= Buckets, "need at least one expected sample per bucket");
+
+    std::array<std::uint32_t, Buckets> histogram{};
+
+    Engine g(seed);
+    for (std::uint32_t i = 0; i < Samples; ++i)
+    {
+        ++histogram[detail::bounded32(g, Buckets)];
+    }
+
+    return worstDeviation(histogram, Samples / Buckets);
+}
+
+// Float path: same idea, but draws canonical53 (a double in [0, 1)) and buckets by
+// unit * Buckets. Exercises canonical53 rather than bounded32.
+template <std::uint32_t Buckets, std::uint32_t Samples, typename Engine = Squirrel5>
+[[nodiscard]] consteval auto maxCanonicalBucketDeviation(std::uint32_t seed) -> std::uint32_t
+{
+    static_assert(Buckets > 0, "need at least one bucket");
+    static_assert(Samples >= Buckets, "need at least one expected sample per bucket");
+
+    std::array<std::uint32_t, Buckets> histogram{};
+
+    Engine g(seed);
+    for (std::uint32_t i = 0; i < Samples; ++i)
+    {
+        const double unit = detail::canonical53(g); // [0, 1)
+        ++histogram[static_cast<std::uint32_t>(unit * Buckets)];
+    }
+
+    return worstDeviation(histogram, Samples / Buckets);
+}
+
+// True when every bucket lands within tolerancePermille (parts per thousand) of the
+// ideal uniform count for the given seed.
+template <std::uint32_t Buckets, std::uint32_t Samples, typename Engine = Squirrel5>
+[[nodiscard]] consteval auto spreadWithin(std::uint32_t seed, std::uint32_t tolerancePermille) -> bool
+{
+    const std::uint32_t ideal   = Samples / Buckets;
+    const std::uint32_t allowed = static_cast<std::uint32_t>((static_cast<std::uint64_t>(ideal) * tolerancePermille) / 1000u);
+
+    return maxBucketDeviation<Buckets, Samples, Engine>(seed) <= allowed;
+}
+
+template <std::uint32_t Buckets, std::uint32_t Samples, typename Engine = Squirrel5>
+[[nodiscard]] consteval auto canonicalSpreadWithin(std::uint32_t seed, std::uint32_t tolerancePermille) -> bool
+{
+    const std::uint32_t ideal   = Samples / Buckets;
+    const std::uint32_t allowed = static_cast<std::uint32_t>((static_cast<std::uint64_t>(ideal) * tolerancePermille) / 1000u);
+
+    return maxCanonicalBucketDeviation<Buckets, Samples, Engine>(seed) <= allowed;
+}
+
+//
+// Compile-time self-tests: the default engine must spread evenly for seed 0xDEADBEEF.
+// Over Samples draws into Buckets the per-bucket standard deviation is
+// ~sqrt(Samples * (1/Buckets) * (1 - 1/Buckets)); the tolerances below sit ~4.7 sigma
+// out, so a failure means a real distribution bug, not noise.
+//
+// Sample counts are chosen so each static_assert fits the stock constexpr-step budget
+// with margin (int ceiling ~29k, float ~19k); no CMake step-budget bump is required.
+//
+
+inline constexpr std::uint32_t kIntSamples   = 24000; // 10 buckets -> 1 sigma ~1.9%
+inline constexpr std::uint32_t kFloatSamples = 14000; // 10 buckets -> 1 sigma ~2.5%
+
+static_assert(spreadWithin<10, kIntSamples>(0xDEADBEEF, 90), "integer spread too skewed");           // within 9%
+static_assert(canonicalSpreadWithin<10, kFloatSamples>(0xDEADBEEF, 120), "float spread too skewed"); // within 12%
+
+} // namespace xirand::test


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Replace default engine with Squirrel5
- Replace distribution helpers with techniques taken from Rust, NumPy, etc.
- Fix long-standing workaround for open/closed intervals
- Updates test seeds and outputs to match
- Reformat

Just for fun, this also makes our xirand usage constexpr... if we ever wanted that?