### PR TITLE
[lua] Add a random normal number generator to utils

### DIFF
--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -283,6 +283,50 @@ function utils.clamp(input, minValue, maxValue)
     return input
 end
 
+-- Generates a number from a normal distribution. If lower and/or upper is defined, then the number is resampled
+-- up to 5 total times to follow the normal distribution.
+-- Note: When using limits, make sure most samples will fall in your bounds to limit redraws.
+-- Examples:
+-- utils.randomNormal(3.5, 1.5, 2, 7) : Mean of 3.5, standard deviation of 1.5, 2 lower limit, 7 upper limit.
+-- utils.randomNormal(3.5, 1.5) : Mean of 3.5, standard deviation of 1.5, no lower or upper limit.
+-- utils.randomNormal(3.5, 1.5, 0) : Mean of 3.5, standard deviation of 1.5, 0 lower limit, no upper limit.
+-- utils.randomNormal(3.5, 1.5, nil, 7) : Mean of 3.5, standard deviation of 1.5, no lower limit, 7 upper limit.
+---@nodiscard
+---@param mean number
+---@param stddev number
+---@param lower number? Optional lower bound; draws below it are rejected.
+---@param upper number? Optional upper bound; draws above it are rejected.
+---@return number
+function utils.randomNormal(mean, stddev, lower, upper)
+    local value = 0
+
+    -- Try up to 5 draws, rejecting any that land outside the optional bounds.
+    for _ = 1, 5 do
+        -- Box-Muller equation to create a normal distribution from two uniform distributions.
+        -- 1 - math.random() gives (0, 1], so math.log never sees 0.
+        local u1 = 1 - math.random()
+        local u2 = math.random()
+        value = mean + stddev * math.sqrt(-2 * math.log(u1)) * math.cos(2 * math.pi * u2)
+
+        local belowLower = lower and value < lower
+        local aboveUpper = upper and value > upper
+        if not belowLower and not aboveUpper then
+            return value
+        end
+    end
+
+    -- All 5 draws missed. Clamp.
+    if lower and value < lower then
+        return lower
+    end
+
+    if upper and value > upper then
+        return upper
+    end
+
+    return value
+end
+
 --  Returns a table containing all the elements in the specified range.
 --  Source: https://github.com/mebens/range
 ---@nodiscard


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There are no utilities to create a random normal number. It was noted for Expeditionary Force that the distance mobs spawn from the banner were randomly distributed with a lower and upper clamp and not a random uniform distance, so we need a method to make a random normal number.

The implementation is based on the Box-Muller transform. It generates a random normal number based on two uniform random numbers bounded by (0, 1). The current implementation isn't technically correct as math.random gives you [0, 1). However, with the 1 - math.random() guard for U1, this should be near identical. 
Box-Muller transform: https://en.wikipedia.org/wiki/Box%E2%80%93Muller_transform
To convert this to a random normal, you just do mean + standard deviation * Z0

The redraw is needed when clamping because if you don't redraw, what ends up happening is you get higher probabilities than desired at the lower and upper limits. Devs implementing this util should make sure it is a high percentage chance the number will fall within the clamps to minimize redraws (I added a comment note about this). Just in case a dev did not, I added a redraw maximum of 5 to guard from too many redraws.

## Steps to test these changes

In a lua file, call utils.randomNormal().