### PR TITLE
[C++] Add lua hooks to modify conquest influence

### DIFF
--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -42,6 +42,7 @@
 #include "alliance.h"
 #include "aman.h"
 #include "battlefield.h"
+#include "conquest_system.h"
 #include "daily_system.h"
 #include "enmity_container.h"
 #include "fishingcontest.h"
@@ -9810,6 +9811,32 @@ void CLuaBaseEntity::delCP(int32 cp)
 
     charutils::AddPoints(PChar, charutils::GetConquestPointsName(PChar).c_str(), -cp);
     PChar->pushPacket<GP_SERV_COMMAND_CONQUEST>(PChar);
+}
+
+/************************************************************************
+ *  Function: gainConquestInfluence()
+ *  Purpose : Adds conquest influence to the player's nation and current region
+ *  Example : player:gainConquestInfluence(50)
+ *  Notes   : Applies the player's Moghancement region bonus.
+ ************************************************************************/
+
+void CLuaBaseEntity::gainConquestInfluence(int32 points)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    if (points <= 0)
+    {
+        ShowWarning("gainConquestInfluence: non-positive amount (%d) ignored.", points);
+        return;
+    }
+
+    auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
+
+    conquest::GainInfluencePoints(PChar, static_cast<uint32>(points));
 }
 
 /************************************************************************
@@ -20479,6 +20506,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("getCP", CLuaBaseEntity::getCP);
     SOL_REGISTER("addCP", CLuaBaseEntity::addCP);
     SOL_REGISTER("delCP", CLuaBaseEntity::delCP);
+    SOL_REGISTER("gainConquestInfluence", CLuaBaseEntity::gainConquestInfluence);
 
     SOL_REGISTER("getSeals", CLuaBaseEntity::getSeals);
     SOL_REGISTER("addSeals", CLuaBaseEntity::addSeals);

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -492,6 +492,7 @@ public:
     int32 getCP(); // Conquest points, not to be confused with Capacity Points
     void  addCP(int32 cp);
     void  delCP(int32 cp);
+    void  gainConquestInfluence(int32 points);
 
     int32 getSeals(uint8 sealType);
     void  addSeals(int32 points, uint8 sealType);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

To implement Expeditionary Force, we need two hooks for conquest influence:
- Add influence when a player opens a chest (under certain conditions)
- Add influence when an NM is killed (Influence gain depends on the person who spawned the NM, not the killer)
Ways to do this without granting CP don't exist.

To be able to accomplish both of these, this PR exposes two conquest functions to lua.
- Exposes conquest::GainInfluencePoints through player:gainConquestInfluence to Base Entity so players can gain influence without gaining CP. This will be used for the chests.
- Exposes conquest::AddInfluencePoints through AddConquestInfluence(amount, nation, region) to award influence to a nation. It was named this way to mimic the format of GetConquestBalance which calls conquest::GetBalance. This will be used for when the NMs die.

## Steps to test these changes

Add 
```
AddConquestInfluence(points, nation, region)
player:gainConquestInfluence(points)
```
in lua and observe Conquest Influence Points increases.