### PR TITLE
[lua] Remove Expeditionary Force KI on Nation Swap

### DIFF
--- a/scripts/globals/expeditionary_force.lua
+++ b/scripts/globals/expeditionary_force.lua
@@ -1,0 +1,55 @@
+-----------------------------------
+-- Expeditionary Force
+-----------------------------------
+xi = xi or {}
+xi.expeditionaryForce = xi.expeditionaryForce or {}
+
+-----------------------------------
+-- Tables
+-----------------------------------
+
+local regionKITable =
+{
+    [xi.region.ARAGONEU]         = xi.ki.ARAGONEU_EF_INSIGNIA,
+    [xi.region.DERFLAND]         = xi.ki.DERFLAND_EF_INSIGNIA,
+    [xi.region.ELSHIMO_LOWLANDS] = xi.ki.ELSHIMO_LOWLANDS_EF_INSIGNIA,
+    [xi.region.ELSHIMO_UPLANDS]  = xi.ki.ELSHIMO_UPLANDS_EF_INSIGNIA,
+    [xi.region.FAUREGANDI]       = xi.ki.FAUREGANDI_EF_INSIGNIA,
+    [xi.region.KOLSHUSHU]        = xi.ki.KOLSHUSHU_EF_INSIGNIA,
+    [xi.region.KUZOTZ]           = xi.ki.KUZOTZ_EF_INSIGNIA,
+    [xi.region.LITELOR]          = xi.ki.LITELOR_EF_INSIGNIA,
+    [xi.region.NORVALLEN]        = xi.ki.NORVALLEN_EF_INSIGNIA,
+    [xi.region.QUFIMISLAND]      = xi.ki.QUFIM_EF_INSIGNIA,
+    [xi.region.VALDEAUNIA]       = xi.ki.VALDEAUNIA_EF_INSIGNIA,
+    [xi.region.VOLLBOW]          = xi.ki.VOLLBOW_EF_INSIGNIA,
+    [xi.region.ZULKHEIM]         = xi.ki.ZULKHEIM_EF_INSIGNIA,
+}
+
+-----------------------------------
+-- Local functions
+-----------------------------------
+
+-----------------------------------
+-- Public functions
+-----------------------------------
+
+-- Dispose of every Expeditionary Force insignia the player is holding.
+-- Called on a nation change, since insignias are tied to the player's old allegiance.
+xi.expeditionaryForce.disposeInsigniaNationSwap = function(player)
+    -- Remove all insignias
+    local removed = false
+    for _, ki in pairs(regionKITable) do
+        if player:hasKeyItem(ki) then
+            player:delKeyItem(ki)
+            removed = true
+        end
+    end
+
+    -- If any insignia is removed, send message and reset character variables
+    if removed then
+        player:messageSpecial(zones[player:getZoneID()].text.INVALID_ENSIGNIAS)
+        player:setCharVar('[ExpForce]Participation', 0)
+        player:setCharVar('[ExpForce]NextConquestTally', 0)
+        player:setCharVar('[ExpForce]AwardCP', 0)
+    end
+end

--- a/scripts/zones/Heavens_Tower/IDs.lua
+++ b/scripts/zones/Heavens_Tower/IDs.lua
@@ -24,6 +24,7 @@ zones[xi.zone.HEAVENS_TOWER] =
         CALL_MULTIPLE_ALTER_EGO       = 7199, -- You are now able to call multiple alter egos.
         YOU_ACCEPT_THE_MISSION        = 7336, -- You have accepted the mission.
         FISHING_MESSAGE_OFFSET        = 7389, -- You can't fish here.
+        INVALID_ENSIGNIAS             = 7621, -- Your invalid ensignias have been disposed of.
         CELEBRATORY_GOODS             = 9123, -- An assortment of celebratory goods is available for purchase.
         OBTAINED_NUM_KEYITEMS         = 9201, -- Obtained key item: <number> <keyitem>!
         NOT_ACQUAINTED                = 9203, -- I'm sorry, but I don't believe we're acquainted. Please leave me be.

--- a/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
@@ -56,6 +56,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setNation(newNation)
         player:setGil(player:getGil() - cost)
         player:setRankPoints(0)
+
+        -- Remove Expeditionary Force insignias
+        xi.expeditionaryForce.disposeInsigniaNationSwap(player)
     end
 end
 

--- a/scripts/zones/Metalworks/IDs.lua
+++ b/scripts/zones/Metalworks/IDs.lua
@@ -44,6 +44,7 @@ zones[xi.zone.METALWORKS] =
         CONQUEST                      = 8232,  -- You've earned conquest points!
         GLAROCIQUET_DIALOG            = 8234,  -- I am <name>, a Temple Knight. I am one of the guards charged with overseeing San d'Oria's conquest campaign.
         LEXUN_MARIXUN_DIALOG          = 8236,  -- I am <name>, a War Warlock. I am one of the guards charged with overseeing Windurst's conquest campaign.
+        INVALID_ENSIGNIAS             = 8354,  -- Your invalid ensignias have been disposed of.
         EXTENDED_MISSION_OFFSET       = 8622,  -- Go to Ore Street and talk to Medicine Eagle. He says he was there when the commotion started.
         STEEL_CYCLONE_LEARNED         = 9040,  -- You have learned the weapon skill Steel Cyclone!
         DETONATOR_LEARNED             = 9065,  -- You have learned the weapon skill Detonator!

--- a/scripts/zones/Metalworks/npcs/Mythily.lua
+++ b/scripts/zones/Metalworks/npcs/Mythily.lua
@@ -56,6 +56,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setNation(newNation)
         player:setGil(player:getGil() - cost)
         player:setRankPoints(0)
+
+        -- Remove Expeditionary Force insignias
+        xi.expeditionaryForce.disposeInsigniaNationSwap(player)
     end
 end
 

--- a/scripts/zones/Northern_San_dOria/IDs.lua
+++ b/scripts/zones/Northern_San_dOria/IDs.lua
@@ -104,6 +104,7 @@ zones[xi.zone.NORTHERN_SAN_DORIA] =
         EUGBALLION_OPEN_DIALOG        = 11680, -- Have a look at these goods imported direct from Qufim Island!
         CHAUPIRE_SHOP_DIALOG          = 11681, -- San d'Orian woodcraft is the finest in the land!
         CONQUEST                      = 11747, -- You've earned conquest points!
+        INVALID_ENSIGNIAS             = 11869, -- Your invalid ensignias have been disposed of.
         FFR_BONCORT                   = 12094, -- Hmm... With magic, I could get hold of materials a mite easier. I'll have to check this mart out.
         FFR_CAPIRIA                   = 12095, -- A flyer? For me? Some reading material would be a welcome change of pace, indeed!
         FFR_VILLION                   = 12096, -- Opening a shop of magic, without consulting me first? I must pay this Regine a visit!

--- a/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
@@ -56,6 +56,9 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setNation(newNation)
         player:setGil(player:getGil() - cost)
         player:setRankPoints(0)
+
+        -- Remove Expeditionary Force insignias
+        xi.expeditionaryForce.disposeInsigniaNationSwap(player)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Expeditionary Force insignias are supposed to be removed when you swap nations. This PR
- Creates initial expeditionary_force.lua file
- Adds Invalid Ensignias string ID for the three zones where nation swaps can occur.
- Adds a hook into expeditionary_force to remove insignias and send message if one was removed.

I did a hook into the expeditionary_force.lua file so I didn't reproduce the KI list and function for all 3 NPCs.

Video showing the nation swap: https://youtu.be/Lcw7DhtaExY?t=614

Fun fact, they misspelled Insignias as Ensignias in the zone strings.

## Steps to test these changes

!addkeyitem QUFIM_EF_INSIGNIA (or any of the EF insignias)
Swap nations