### PR TITLE
[lua] Enable EF conversations with conquest guards

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -22,32 +22,208 @@ local conquestConstants =
 }
 
 -----------------------------------
--- (LOCAL) expeditionary forces
--- TODO: implement this menu
+-- (LOCAL) Signet
 -----------------------------------
---[[
-local exForceMenuData =
-{
-    0x20006, ZULK_EF, 103, 0x000040, 20, xi.ki.ZULKHEIM_EF_INSIGNIA,
-    0x20007, NORV_EF, 104, 0x000080, 25, xi.ki.NORVALLEN_EF_INSIGNIA,
-    0x20009, DERF_EF, 109, 0x000200, 25, xi.ki.DERFLAND_EF_INSIGNIA,
-    0x2000B, KOLS_EF, 118, 0x000800, 20, xi.ki.KOLSHUSHU_EF_INSIGNIA,
-    0x2000C, ARAG_EF, 119, 0x001000, 25, xi.ki.ARAGONEU_EF_INSIGNIA,
-    0x2000D, FAUR_EF, 111, 0x002000, 35, xi.ki.FAUREGANDI_EF_INSIGNIA,
-    0x2000E, VALD_EF, 112, 0x004000, 40, xi.ki.VALDEAUNIA_EF_INSIGNIA,
-    0x2000F, QUFI_EF, 126, 0x008000, 25, xi.ki.QUFIM_EF_INSIGNIA,
-    0x20010, LITE_EF, 121, 0x010000, 35, xi.ki.LITELOR_EF_INSIGNIA,
-    0x20011, KUZO_EF, 114, 0x020000, 40, xi.ki.KUZOTZ_EF_INSIGNIA,
-    0x20012, VOLL_EF, 113, 0x040000, 65, xi.ki.VOLLBOW_EF_INSIGNIA,
-    0x20013, ELLO_EF, 123, 0x080000, 35, xi.ki.ELSHIMO_LOWLANDS_EF_INSIGNIA,
-    0x20014, ELUP_EF, 124, 0x100000, 45, xi.ki.ELSHIMO_UPLANDS_EF_INSIGNIA
-}
-]]--
-local function getExForceAvailable(player, guardNation)
-    return 0
+
+-- Bestow the nation's Signet.
+local function bestowSignet(player, pNation, pRank, mOffset)
+    local duration = (pRank + GetNationRank(pNation) + 3) * 3600
+
+    player:delStatusEffectsByFlag(xi.effectFlag.INFLUENCE, true)
+    player:addStatusEffect(xi.effect.SIGNET, { duration = duration, origin = player })
+    player:messageSpecial(mOffset + 1) -- 'You've received your nation's Signet!'
+
+    if player:getEminenceProgress(3367) then
+        xi.roe.onRecordTrigger(player, 3367) -- Complete Weekly Signet, brb objective.  This might be able to move to a status effect trigger
+    end
 end
 
+-----------------------------------
+-- (LOCAL) Expeditionary Forces
+-----------------------------------
+
+-- Keep in this order as it is necessary to mimic retail during the removal of the key items.
+local exForceMenuData =
+{
+    [xi.region.ZULKHEIM        ] = { option = 0x20006, zone = xi.zone.VALKURM_DUNES,          menuBit = 0x000040, lvl = 20, ki = xi.ki.ZULKHEIM_EF_INSIGNIA         },
+    [xi.region.NORVALLEN       ] = { option = 0x20007, zone = xi.zone.JUGNER_FOREST,          menuBit = 0x000080, lvl = 25, ki = xi.ki.NORVALLEN_EF_INSIGNIA        },
+    [xi.region.DERFLAND        ] = { option = 0x20009, zone = xi.zone.PASHHOW_MARSHLANDS,     menuBit = 0x000200, lvl = 25, ki = xi.ki.DERFLAND_EF_INSIGNIA         },
+    [xi.region.KOLSHUSHU       ] = { option = 0x2000B, zone = xi.zone.BUBURIMU_PENINSULA,     menuBit = 0x000800, lvl = 20, ki = xi.ki.KOLSHUSHU_EF_INSIGNIA        },
+    [xi.region.ARAGONEU        ] = { option = 0x2000C, zone = xi.zone.MERIPHATAUD_MOUNTAINS,  menuBit = 0x001000, lvl = 25, ki = xi.ki.ARAGONEU_EF_INSIGNIA         },
+    [xi.region.FAUREGANDI      ] = { option = 0x2000D, zone = xi.zone.BEAUCEDINE_GLACIER,     menuBit = 0x002000, lvl = 35, ki = xi.ki.FAUREGANDI_EF_INSIGNIA       },
+    [xi.region.VALDEAUNIA      ] = { option = 0x2000E, zone = xi.zone.XARCABARD,              menuBit = 0x004000, lvl = 40, ki = xi.ki.VALDEAUNIA_EF_INSIGNIA       },
+    [xi.region.QUFIMISLAND     ] = { option = 0x2000F, zone = xi.zone.QUFIM_ISLAND,           menuBit = 0x008000, lvl = 25, ki = xi.ki.QUFIM_EF_INSIGNIA            },
+    [xi.region.LITELOR         ] = { option = 0x20010, zone = xi.zone.THE_SANCTUARY_OF_ZITAH, menuBit = 0x010000, lvl = 35, ki = xi.ki.LITELOR_EF_INSIGNIA          },
+    [xi.region.KUZOTZ          ] = { option = 0x20011, zone = xi.zone.EASTERN_ALTEPA_DESERT,  menuBit = 0x020000, lvl = 40, ki = xi.ki.KUZOTZ_EF_INSIGNIA           },
+    [xi.region.VOLLBOW         ] = { option = 0x20012, zone = xi.zone.CAPE_TERIGGAN,          menuBit = 0x040000, lvl = 65, ki = xi.ki.VOLLBOW_EF_INSIGNIA          },
+    [xi.region.ELSHIMO_LOWLANDS] = { option = 0x20013, zone = xi.zone.YUHTUNGA_JUNGLE,        menuBit = 0x080000, lvl = 35, ki = xi.ki.ELSHIMO_LOWLANDS_EF_INSIGNIA },
+    [xi.region.ELSHIMO_UPLANDS ] = { option = 0x20014, zone = xi.zone.YHOATOR_JUNGLE,         menuBit = 0x100000, lvl = 45, ki = xi.ki.ELSHIMO_UPLANDS_EF_INSIGNIA  },
+}
+
+local exForceGateGlyphTable =
+{
+    -- [overseerNpcName] = glyphItemId
+    ['Crying_Wind_IM'  ] = xi.item.BASTOK_MINES_GLYPH,
+    ['Rabid_Wolf_IM'   ] = xi.item.BASTOK_MARKETS_GLYPH,
+    ['Flying_Axe_IM'   ] = xi.item.PORT_BASTOK_GLYPH,
+    ['Achantere_TK'    ] = xi.item.NORTH_SANDORIA_GLYPH,
+    ['Aravoge_TK'      ] = xi.item.WEST_SANDORIA_GLYPH,
+    ['Arpevion_TK'     ] = xi.item.EAST_SANDORIA_GLYPH,
+    ['Harara_WW'       ] = xi.item.WINDURST_WOODS_GLYPH,
+    ['Milma-Hapilma_WW'] = xi.item.PORT_WINDURST_GLYPH,
+    ['Puroiko-Maiko_WW'] = xi.item.WINDURST_WATERS_GLYPH,
+}
+
+local exForceCityGlyphTable =
+{
+    -- [nation] = that nation's three glyphs
+    [xi.nation.SANDORIA] = { xi.item.NORTH_SANDORIA_GLYPH, xi.item.WEST_SANDORIA_GLYPH,  xi.item.EAST_SANDORIA_GLYPH   },
+    [xi.nation.BASTOK  ] = { xi.item.BASTOK_MINES_GLYPH,   xi.item.BASTOK_MARKETS_GLYPH, xi.item.PORT_BASTOK_GLYPH     },
+    [xi.nation.WINDURST] = { xi.item.WINDURST_WOODS_GLYPH, xi.item.PORT_WINDURST_GLYPH,  xi.item.WINDURST_WATERS_GLYPH },
+}
+
+local exForceNumberRequiredTable =
+{
+    -- [Standing] = partySize
+    [0] = 4, -- No standing
+    [1] = 6,
+    [2] = 5,
+    [3] = 4,
+}
+
+-- CP awarded on collection, by count of participated regions the nation controls.
+-- When looking at the wiki, the data appears to follow a cubic. Extrapolating that would put 13 to be 27,175 CP. This seems unrealistic.
+-- Instead the data from https://ffxiclopedia.fandom.com/wiki/Talk:Expeditionary_Force is used as it is more conservative.
+local exForceCPRewardTable =
+{
+    -- [regionsControlled] = cp
+    [ 0] =    0,
+    [ 1] = 3000, -- Verified in capture
+    [ 2] = 4200, -- Verified in capture
+    [ 3] = 4680, -- +480 per region
+    [ 4] = 5160,
+    [ 5] = 5640,
+    [ 6] = 6120,
+    [ 7] = 6600,
+    [ 8] = 7080,
+    [ 9] = 7560,
+    [10] = 8040,
+    [11] = 8520,
+    [12] = 9000,
+    [13] = 9480,
+}
+
+-- Helper to parse region out of the exForceMenu data
+local function getExForceRegion(option)
+    for regionId, data in pairs(exForceMenuData) do
+        if data.option == option then
+            return regionId
+        end
+    end
+end
+
+-- Bitmask of every region this player can sign up for. 0 = the EF menu does not appear.
+local function getExForceAvailable(player, npc, guardNation)
+    -- Only one of the nine gate guards can trigger this
+    if
+        exForceGateGlyphTable[npc:getName()] == nil or
+        player:getNation() ~= guardNation
+    then
+        return 0
+    end
+
+    local mask = 0
+
+    -- Setup the bit mask for all the available regions
+    -- The bit masks are stored in the exForceMenuData.
+    for regionId, data in pairs(exForceMenuData) do
+        local owner = GetRegionOwner(regionId)
+
+        -- Region is available if:
+        --  The player's nation does not own the region.
+        --  The player's ally does not own the region.
+        --  The player has visited the region's outpost.
+        if
+            owner ~= guardNation and
+            not xi.conquest.areAllies(guardNation, owner) and
+            player:hasVisitedZone(data.zone)
+        then
+            mask = bit.bor(mask, data.menuBit)
+        end
+    end
+
+    return mask
+end
+
+-- This is to display the warp information after getting the badge, quitting EF, or giving the CP reward.
 local function getExForceReward(player, guardNation)
+    -- This is to catch instances where the player gets the badge and goes to a guard at another nation's embassy.
+    if player:getNation() ~= guardNation then
+        return 0
+    end
+
+    -- Only show menu if the player has the EF badge
+    local badge = player:getStatusEffect(xi.effect.EF_BADGE)
+    if badge == nil then
+        -- A paid reward is stashed and waiting
+        if player:getCharVar('[ExpForce]AwardCP') > 0 then
+            return 0x400
+        end
+
+        return 0
+    end
+
+    local region = exForceMenuData[badge:getPower()]
+    -- This is a guard. The starter regions exist in the client but were removed from Retail.
+    if region == nil then
+        return 0
+    end
+
+    -- regionRow 6-20 = eventOption (0x20006-0x20014) minus the 0x20000 base.
+    local regionRow = region.option - 0x20000
+    return 0x80000000 + bit.lshift(regionRow, 5)
+end
+
+-- Validate the sign-up party.
+-- Returns the overseer result code for the first failed check (1-4), or 0 if every check passes.
+local function exForceValidateSignup(player, guardNation, minLevel, numRequired)
+    -- Get all party members currently in zone for the check
+    local zoneId = player:getZoneID()
+    local inZone = {}
+    for _, member in pairs(player:getParty()) do
+        if member:getZoneID() == zoneId then
+            table.insert(inZone, member)
+        end
+    end
+
+    -- The checks are in this order and not grouped by party member to match the order of how retail checks
+
+    -- 1: not enough members present in the overseer's zone
+    if #inZone < numRequired then
+        return 1
+    end
+
+    -- 2: a party member is not a citizen of the overseer's nation
+    for _, member in ipairs(inZone) do
+        if member:getNation() ~= guardNation then
+            return 2
+        end
+    end
+
+    -- 3: a member is below the Conquest rank requirement
+    for _, member in ipairs(inZone) do
+        if member:getRank(guardNation) < 3 then
+            return 3
+        end
+    end
+
+    -- 4: a member is below the region's minimum level
+    for _, member in ipairs(inZone) do
+        if member:getMainLvl() < minLevel then
+            return 4
+        end
+    end
+
     return 0
 end
 
@@ -105,7 +281,7 @@ local function setHomepointFee(player, guardNation)
         if rank <= 5 then
             fee = 100 * math.pow(2, rank - 1)
         else
-            fee = (800 * rank) - 2400
+            fee = 800 * rank - 2400
         end
     end
 
@@ -1183,18 +1359,53 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
         return
     end
 
+    -- EXPEDITIONARY FORCE: Collect expired insignia and give awards
+    -- Any of the 3 gate guards or the embassy guards for the player's nation.
+    if
+        pNation == guardNation and
+        guardType <= xi.conquest.guard.FOREIGN
+    then
+        local stamp = player:getCharVar('[ExpForce]NextConquestTally')
+        if stamp ~= 0 and stamp < NextConquestTally() then
+            -- Dispose of every expired insignia on the way in (paid and unpaid both do this).
+            local mOffset = zones[player:getZoneID()].text.CONQUEST
+            for _, data in pairs(exForceMenuData) do
+                if player:hasKeyItem(data.ki) then
+                    player:messageSpecial(mOffset + 121, data.ki)
+                    player:delKeyItem(data.ki)
+                end
+            end
+
+            -- Calculate the CP reward
+            local participation = player:getCharVar('[ExpForce]Participation')
+            local controlled    = 0
+            for regionId in pairs(exForceMenuData) do
+                if
+                    bit.band(participation, bit.lshift(1, regionId)) ~= 0 and
+                    GetRegionOwner(regionId) == player:getNation()
+                then
+                    controlled = controlled + 1
+                end
+            end
+
+            player:setCharVar('[ExpForce]AwardCP', exForceCPRewardTable[controlled])
+            player:setCharVar('[ExpForce]Participation', 0)
+            player:setCharVar('[ExpForce]NextConquestTally', 0)
+        end
+    end
+
     -- SUPPLY RUNS
     if
         pNation == guardNation and
         areSuppliesRotten(player, npc, guardType)
     then
-        -- do nothing else
+        return
     elseif
         pNation == guardNation and
         guardType >= xi.conquest.guard.OUTPOST and
         canDeliverSupplies(player, guardNation, guardEvent, guardRegion)
     then
-        -- do nothing else
+        return
 
     -- JEUNO OVERSEERS
     elseif guardType == xi.conquest.guard.CITY and guardNation == xi.nation.OTHER then
@@ -1208,7 +1419,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
     -- CITY AND FOREIGN OVERSEERS
     elseif guardType <= xi.conquest.guard.FOREIGN then
         local a1 = getArg1(player, guardNation, guardType)
-        local a2 = getExForceAvailable(player, guardNation)
+        local a2 = getExForceAvailable(player, npc, guardNation)
         local a3 = conquestRanking()
         local a4 = suppliesAvailableBitmask(player, guardNation)
         local a5 = player:getTeleport(guardNation)
@@ -1238,7 +1449,30 @@ xi.conquest.overseerOnEventUpdate = function(player, csid, option, guardNation)
 
     local stock = getStock(player, guardNation, option)
 
-    if stock ~= nil then
+    -- EXPEDITIONARY FORCE - Region select
+    if
+        option >= 131078 and
+        option <= 131092
+    then
+        local regionId       = getExForceRegion(option)
+        local numberRequired = exForceNumberRequiredTable[GetNationRank(guardNation)]
+        local minLevel       = exForceMenuData[regionId].lvl
+        local failCode       = exForceValidateSignup(player, guardNation, minLevel, numberRequired)
+
+        -- One or more party members are below the minimum required level
+        if failCode == 4 then
+            player:updateEvent(4, 0, 0, 0, 0, 0, minLevel)
+
+        -- All other fail codes
+        elseif failCode ~= 0 then
+            player:updateEvent(failCode)
+
+        -- Badge granted in overseerOnEventFinish
+        else
+            player:updateEvent(5)
+        end
+
+    elseif stock ~= nil then
         local pRank = GetNationRank(pNation)
         local u1    = 2 -- default: player is correct job and level to equip item
         local u2    = 0 -- default: player has enough CP for item
@@ -1287,33 +1521,35 @@ xi.conquest.overseerOnEventUpdate = function(player, csid, option, guardNation)
     end
 end
 
--- Additional checks to ensure that the player can actually purchase the item requested from the overseer.
--- Returns price of the item if valid, -1 if invalid.
-local function canPurchaseItem(player, stock, pRank, guardNation, mOffset, option)
-    -- Validate stock
-    if stock == nil then
-        return -1
+-- Handle item purchuase.
+local function handlePurchuase(player, option, pNation, pRank, guardNation, mOffset)
+    local stock = getStock(player, guardNation, option)
+    if not stock then
+        return
     end
 
-    -- validate localVar (cheat protection)
     local boughtItem = player:getLocalVar('boughtItemCP')
     player:setLocalVar('boughtItemCP', 0)
 
     if stock.item ~= boughtItem then
         player:messageSpecial(mOffset + 61, stock.item) -- 'Your rank is too low to purchase the <item>.'
-        return -1
+        return
     end
 
     -- validate rank
     if stock.rank and pRank < stock.rank then
         player:messageSpecial(mOffset + 61, stock.item) -- 'Your rank is too low to purchase the <item>.'
-        return -1
+        return
     end
 
-    -- validate price
+    local isEXPRing = option <= 32933 and option >= 32935
+    if isEXPRing and not canBuyExpRing(player, stock.item) then
+        return
+    end
+
     local price = stock.cp
     if
-        stock.rank ~= nil and
+        stock.rank and
         player:getNation() ~= guardNation and
         guardNation ~= xi.nation.OTHER
     then
@@ -1324,67 +1560,58 @@ local function canPurchaseItem(player, stock, pRank, guardNation, mOffset, optio
         end
     end
 
-    if player:getCP() < price then
-        if
-            option <= 32933 and
-            option >= 32935 and
-            not player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)
-        then
-            player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- 'You do not have enough conquest points to purchase the <item>.'
-            return -1
+    if player:getCP() >= price then
+        if npcUtil.giveItem(player, stock.item) then
+            player:delCP(price)
         end
+    elseif isEXPRing and player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER) then
+        if npcUtil.giveItem(player, stock.item) then
+            player:delKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)
+            player:setCharVar('CONQUEST_RING_RECHARGE', 1, NextConquestTally())
+        end
+    else
+        player:messageSpecial(mOffset + 62, 0, 0, stock.item) -- 'You do not have enough conquest points to purchase the <item>.'
+        return
     end
 
-    return price
+    if stock.rank then
+        player:setTitle(titlesGranted[pNation][stock.rank])
+    end
 end
 
 xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, guardType, guardRegion)
     local pNation  = player:getNation()
     local pRank    = player:getRank(pNation)
-    local sRegion  = player:getCharVar('supplyQuest_region')
-    local sOutpost = outposts[sRegion]
     local mOffset  = zones[player:getZoneID()].text.CONQUEST
 
     if xi.garrison.onEventFinish(player, csid, option, guardNation, guardType, guardRegion) then
         return
     end
 
-    -- SIGNET
+    -- Signet -> Grant.
     if option == 1 then
-        local duration = (pRank + GetNationRank(pNation) + 3) * 3600
-        player:delStatusEffectsByFlag(xi.effectFlag.INFLUENCE, true)
-        player:addStatusEffect(xi.effect.SIGNET, { duration = duration, origin = player })
-        player:messageSpecial(mOffset + 1) -- 'You've received your nation's Signet!'
+        bestowSignet(player, pNation, pRank, mOffset)
 
-        if player:getEminenceProgress(3367) then
-            xi.roe.onRecordTrigger(player, 3367) -- Complete Weekly Signet, brb objective.  This might be able to move to a status effect trigger
+    -- Supply Run -> Finish.
+    elseif option == 2 then
+        if guardNation ~= pNation then
+            return
         end
 
-    -- BEGIN SUPPLY RUN
-    elseif
-        option >= 65541 and
-        option <= 65565 and
-        guardType <= xi.conquest.guard.FOREIGN
-    then
-        local region  = option - 65541
-        local outpost = outposts[region]
-
-        if outpost ~= nil then
-            npcUtil.giveKeyItem(player, outpost.ki)
-            player:setCharVar('supplyQuest_started', VanadielUniqueDay())
-            player:setCharVar('supplyQuest_region', region)
-            player:setCharVar('supplyQuest_fresh', NextConquestTally())
+        if guardType < xi.conquest.guard.OUTPOST then
+            return
         end
 
-    -- FINISH SUPPLY RUN
-    elseif
-        option == 2 and
-        guardType >= xi.conquest.guard.OUTPOST and
-        sRegion == guardRegion and
-        sOutpost ~= nil and
-        player:hasKeyItem(sOutpost.ki) and
-        guardNation == pNation
-    then
+        local sRegion  = player:getCharVar('supplyQuest_region')
+        if sRegion ~= guardRegion then
+            return
+        end
+
+        local sOutpost = outposts[sRegion]
+        if not player:hasKeyItem(sOutpost.ki) then
+            return
+        end
+
         player:delKeyItem(sOutpost.ki)
         player:addCP(sOutpost.cp)
         player:messageSpecial(mOffset) -- 'You've earned conquest points!'
@@ -1396,7 +1623,7 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
             player:addTeleport(guardNation, sRegion + 5)
         end
 
-    -- SET HOMEPOINT
+    -- Homepoint -> Set.
     elseif option == 4 then
         if player:delGil(setHomepointFee(player, guardNation)) then
             player:setHomePoint()
@@ -1405,41 +1632,83 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
             player:messageSpecial(mOffset + 95) -- 'You do not have enough gil to set your home point here.'
         end
 
+    -- Expeditionary Force -> Teleport. Order is: Signet, Remove badge, Obtain KI, obtain Glyph.
+    elseif option == 5 then
+        local badge    = player:getStatusEffect(xi.effect.EF_BADGE)
+        local regionId = badge:getPower()
+        local overseer = player:getEventTarget()
+
+        -- Only stamp when starting a fresh batch in case of a tally that lands mid-menu.
+        if player:getCharVar('[ExpForce]NextConquestTally') == 0 then
+            -- Needed to know when the key item expires. Okay to overwrite as cleanup occurs when initiating conversation.
+            player:setCharVar('[ExpForce]NextConquestTally', NextConquestTally())
+        end
+
+        bestowSignet(player, pNation, pRank, mOffset)
+
+        -- Replace badge with key item
+        player:delStatusEffect(xi.effect.EF_BADGE)
+        npcUtil.giveKeyItem(player, exForceMenuData[regionId].ki)
+
+        -- If you have a glyph from the city, you cannot get a second one.
+        local cityGlyphs = exForceCityGlyphTable[pNation]
+        if
+            not player:hasItem(cityGlyphs[1]) and
+            not player:hasItem(cityGlyphs[2]) and
+            not player:hasItem(cityGlyphs[3])
+        then
+            npcUtil.giveItem(player, exForceGateGlyphTable[overseer:getName()])
+        end
+
+        -- Outpost warp player
+        player:addStatusEffect(xi.effect.TELEPORT, {
+            power    = xi.teleport.id.OUTPOST,
+            duration = 1,
+            origin   = player,
+            icon     = 0,
+            subPower = regionId,
+        })
+
+    -- Expeditionary Force -> Grant CP.
+    elseif option == 7 then
+        local cp = player:getCharVar('[ExpForce]AwardCP')
+        player:addCP(cp)
+        player:messageSpecial(mOffset + 124, 0, cp) -- "You received x conquest points!"
+        player:messageSpecial(mOffset + 122)        -- "Your invalid insignias have been disposed of.""
+        player:setCharVar('[ExpForce]AwardCP', 0)
+
+    -- Expeditionary Force -> Quit.
+    elseif option == 8 then
+        player:delStatusEffect(xi.effect.EF_BADGE)
+
     -- PURCHASE CP ITEM
     elseif option >= 32768 and option <= 32944 then
-        local stock = getStock(player, guardNation, option)
-        local price = canPurchaseItem(player, stock, pRank, guardNation, mOffset, option) -- Validation included.
+        handlePurchuase(player, option, pNation, pRank, guardNation, mOffset)
 
-        if price < 0 then
-            return
+    -- Supply Run -> Begin.
+    elseif
+        option >= 65541 and
+        option <= 65565 and
+        guardType <= xi.conquest.guard.FOREIGN
+    then
+        local region  = option - 65541
+        local outpost = outposts[region]
+
+        if outpost then
+            npcUtil.giveKeyItem(player, outpost.ki)
+            player:setCharVar('supplyQuest_started', VanadielUniqueDay())
+            player:setCharVar('supplyQuest_region', region)
+            player:setCharVar('supplyQuest_fresh', NextConquestTally())
         end
 
-        -- validate exp rings
-        if
-            option >= 32933 and
-            option <= 32935 and
-            not canBuyExpRing(player, stock.item)
-        then
-            return
-        end
-
-        -- make sale
-        if npcUtil.giveItem(player, stock.item) then
-            if option >= 32933 and option <= 32935 then
-                player:setCharVar('CONQUEST_RING_RECHARGE', 1, NextConquestTally())
-
-                if player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER) then
-                    player:delKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER)
-
-                    return
-                end
-            end
-
-            player:delCP(price)
-            if stock.rank ~= nil then
-                player:setTitle(titlesGranted[pNation][stock.rank])
-            end
-        end
+    -- Expeditionary Force -> Region Selected.
+    elseif
+        option >= 131078 and
+        option <= 131092
+    then
+        local regionId = getExForceRegion(option)
+        player:delStatusEffect(xi.effect.EF_BADGE) -- We can get here if we already have the badge. No need for check as delStatusEffect covers it.
+        player:addStatusEffect(xi.effect.EF_BADGE, { power = regionId, origin = player, flag = xi.effectFlag.ON_ZONE })
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This implements the Expeditionary Force text with the conquest guards.  This is one of the larger files for EF. I could not find an easy way to break this down into smaller chunks. Please let me know if you need me to change it.

This PR allows you to get your EF Badge, get your EF KI, and grants rewards for EF participation.

### Flow of the Guard Interactions
**Collecting reward works for your 3 gate guards plus your embassy guard (no others)**
- Check always happens when initiating the conversation with the guard (Matches retail with the loss of key item message)
- If you have a CP reward, it then we go to OnEventFinish and grant the CP and exit the event.

**Initiating EF only works for your 3 gate guards**

Get Badge: Select to Join EF -> Checks which EFs are Available -> You Select Region -> Ensures you are allowed to sign up -> Grants EF Badge for that region

Have Badge: Change EF - This will give you a badge for the new region.

Have Badge: Cancel EF - This will remove the badge.

Have Badge: Teleport to Region -> Signet/Remove Badge/Give Glyph/Give KI

### CP Reward Justification
You get CP for each region you participated in and your nation owns in the next tally. We were able to test for 0, 1, and 2 for CP reward. The rest of the data is from elsewhere.

When looking at the wiki, the data appears to follow a cubic. Extrapolating that would put the reward fo 13 to be 27,175 CP. This seems unrealistic.

Instead the data from https://ffxiclopedia.fandom.com/wiki/Talk:Expeditionary_Force is used as it is more conservative. The person who posted information about this also had several messages where they corrected the Wiki and I verified they were right.

### Captures
Cannot turn in expired KI to Outpost Guard: https://youtu.be/wr8rDesUaNY
Cannot turn in expired KI to Jeuno Guard or Zone Guard, but turned it into embassy guard: https://www.youtube.com/watch?v=vaVH00FWHWY
Turning in key items with 2 regions owned: https://youtu.be/Lcw7DhtaExY and https://drive.google.com/file/d/1A6-QsEDFtK9Wzifk_juDU4_M55AXlU_V/view?usp=drive_link
Going through the signup tests: https://www.youtube.com/watch?v=l9DzBCHJxr8 and https://drive.google.com/file/d/1szyT6BYfNTdI4UBYFExiy_pFMZMwrCIh/view?usp=sharing
Not caring that party members are not in zone: https://www.youtube.com/watch?v=UliVwqkLRNM and https://drive.google.com/file/d/103ekoyfjW3A7I_GWk39vivPU0LP6XSDF/view?usp=sharing

I can't find the PoV video for when you have the badge and want to change EF and when you have the badge and cancel EF. However, the logic can be inferred from the events available.

## Steps to test these changes

Three characters required. Change the exForceNumberRequiredTable temporarily to 2 for all values on the right.

Run on two characters:
!changejob MNK 40
!setplayernation CharA 1
!setrank CharA 3

You can verify the badge with !geteffects CharA
Party CharA + CharB, both in the same zone, both citizens, both rank 3+, both level 20+, both have visited Buburimu. Talk to guard, pick Kolshushu, verify badge. 
Talk to guard, change E.F. registration, verify badge.
Talk to guard, quit E.F., verify lack of badge.
Talk to guard, pick Kolshushu, get badge. Talk to guard, teleport to region, verify badge is gone, KI is obtained, and you are in new zone with glyph. Do !checkvar CharA [ExpForce]NextConquestTally 

Also check the failures.
CharA + CharB both in same zone: 
- One not citizen
- One not rank 3
- One not level 20+
- One not visited Buburimu
- Make sure regions you own are absent from the options

Check that it only cares if a character in the zone. Add CharC to the party but in a different zone. See that CharC is never checked.


To check getting reward, one one character do:
!addkeyitem KOLSHUSHU_EF_INSIGNIA
!setplayervar CharA [ExpForce]NextConquestTally 1
!setplayervar CharA [ExpForce]Participation 64
Then talk to one of the guards

