### PR TITLE
[core, test] Tweak Moghancement tiebreaking; gardening/moghancements tests

### DIFF
--- a/scripts/enum/gardening.lua
+++ b/scripts/enum/gardening.lua
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Gardening
+-----------------------------------
+xi = xi or {}
+xi.gardening = xi.gardening or {}
+
+---@enum xi.gardening.stage
+xi.gardening.stage =
+{
+    EMPTY                  = 0,
+    INITIAL                = 1,
+    FIRST_SPROUTS          = 2,
+    FIRST_SPROUTS_2        = 3,
+    FIRST_SPROUTS_CRYSTAL  = 4,
+    SECOND_SPROUTS         = 5,
+    SECOND_SPROUTS_2       = 6,
+    SECOND_SPROUTS_CRYSTAL = 7,
+    SECOND_SPROUTS_3       = 8,
+    THIRD_SPROUTS          = 9,
+    MATURE_PLANT           = 10,
+    WILTED                 = 11,
+}
+
+---@enum xi.gardening.plant
+xi.gardening.plant =
+{
+    NONE            = 0,
+    FRUIT_SEEDS     = 1,
+    HERB_SEEDS      = 2,
+    GRAIN_SEEDS     = 3,
+    VEGETABLE_SEEDS = 4,
+    CACTUS_STEMS    = 5,
+    TREE_CUTTINGS   = 6,
+    TREE_SAPLINGS   = 7,
+    WILDGRASS_SEEDS = 8,
+}

--- a/scripts/specs/test/CClientEntityPair.lua
+++ b/scripts/specs/test/CClientEntityPair.lua
@@ -30,6 +30,12 @@ end
 function CClientEntityPair:gotoZone(zoneId, pos)
 end
 
+---Zone into the player's own Mog House in the given zone
+---@param zoneId xi.zone Zone whose Mog House to enter
+---@return nil
+function CClientEntityPair:gotoMogHouse(zoneId)
+end
+
 ---Check if the client is currently waiting for a zone change
 ---@nodiscard
 ---@return boolean

--- a/scripts/specs/test/CClientEntityPairActions.lua
+++ b/scripts/specs/test/CClientEntityPairActions.lua
@@ -222,3 +222,48 @@ end
 ---@return nil
 function CClientEntityPairActions:craft(crystal, ingredients)
 end
+
+---Sow a seed or feed a crystal to a gardening pot. Pot and add item must be in a mog safe.
+---@param potContainer xi.inventoryLocation Container holding the flowerpot
+---@param potSlot integer Flowerpot slot index
+---@param addContainer xi.inventoryLocation Container holding the seed or crystal
+---@param addSlot integer Seed or crystal slot index
+---@return nil
+function CClientEntityPairActions:plantAdd(potContainer, potSlot, addContainer, addSlot)
+end
+
+---Examine a plant; resets its wilt timer.
+---@param potContainer xi.inventoryLocation Container holding the flowerpot
+---@param potSlot integer Flowerpot slot index
+---@return nil
+function CClientEntityPairActions:plantCheck(potContainer, potSlot)
+end
+
+---Harvest a mature plant; uproot clears the pot instead.
+---@param potContainer xi.inventoryLocation Container holding the flowerpot
+---@param potSlot integer Flowerpot slot index
+---@param uproot? boolean Uproot instead of harvesting (default false)
+---@return nil
+function CClientEntityPairActions:plantHarvest(potContainer, potSlot, uproot)
+end
+
+---Dry a plant so it stops growing and won't wilt.
+---@param potContainer xi.inventoryLocation Container holding the flowerpot
+---@param potSlot integer Flowerpot slot index
+---@return nil
+function CClientEntityPairActions:plantDry(potContainer, potSlot)
+end
+
+---Install a furnishing on the 1st floor at grid cell (x, z).
+---@param container xi.inventoryLocation Container holding the furnishing
+---@param slot integer Furnishing slot index
+---@param x integer Grid x cell
+---@param z integer Grid z cell
+---@return nil
+function CClientEntityPairActions:placeFurniture(container, slot, x, z)
+end
+
+---Finish placing furniture; recomputes the active moghancement.
+---@return nil
+function CClientEntityPairActions:finishFurnishing()
+end

--- a/scripts/specs/test/CSimulation.lua
+++ b/scripts/specs/test/CSimulation.lua
@@ -67,6 +67,12 @@ end
 function CSimulation:skipToNextVanaDay()
 end
 
+---Advance Vana'diel time forward by whole days (does not tick).
+---@param days integer
+---@return nil
+function CSimulation:skipVanaDays(days)
+end
+
 ---Returns mobs in a spawn slot as a table
 ---@param zoneId xi.zone
 ---@param slotId integer

--- a/scripts/tests/systems/exdata.lua
+++ b/scripts/tests/systems/exdata.lua
@@ -530,7 +530,6 @@ describe('Exdata', function()
                 z          = 0,
                 y          = 10,
                 rotation   = 3,
-                order      = 1,
             })
 
         local ex = item:getExData()
@@ -540,7 +539,6 @@ describe('Exdata', function()
         assert(ex.z == 0)
         assert(ex.y == 10)
         assert(ex.rotation == 3)
-        assert(ex.order == 1)
     end)
 
     it('can get and set FlowerPot exdata', function()

--- a/scripts/tests/systems/gardening.lua
+++ b/scripts/tests/systems/gardening.lua
@@ -1,0 +1,197 @@
+local function mogItem(player, itemId)
+    local item = player:findItem(itemId, xi.inv.MOGSAFE)
+    assert(item, string.format('expected item %d in mog safe', itemId))
+
+    return item
+end
+
+-- Add to inventory, then move into the mog safe.
+local function stockSafe(player, itemId)
+    player:addItem(itemId)
+
+    local item = player:findItem(itemId, xi.inv.INVENTORY)
+    assert(item, string.format('expected item %d in inventory', itemId))
+
+    player.actions:moveItem(xi.inv.INVENTORY, item:getSlotID(), xi.inv.MOGSAFE, 1)
+end
+
+-- Sow a seed into the pot; returns the pot handle.
+local function plant(player, seedId)
+    stockSafe(player, seedId)
+
+    local pot = mogItem(player, xi.item.EARTHEN_FLOWERPOT)
+    player.actions:plantAdd(xi.inv.MOGSAFE, pot:getSlotID(), xi.inv.MOGSAFE, mogItem(player, seedId):getSlotID())
+
+    return pot
+end
+
+-- Feed a crystal to the pot at a crystal stage.
+local function feed(player, crystalId)
+    stockSafe(player, crystalId)
+
+    local pot = mogItem(player, xi.item.EARTHEN_FLOWERPOT)
+    player.actions:plantAdd(xi.inv.MOGSAFE, pot:getSlotID(), xi.inv.MOGSAFE, mogItem(player, crystalId):getSlotID())
+end
+
+-- Check the plant (resets wilt), pass a stage's worth of days, then tick to grow until targetStep.
+-- 120 days clears the longest non-mature stage (Tree Saplings @ 108).
+local function growUntil(player, pot, targetStep)
+    for _ = 1, 20 do
+        if pot:getExData().step >= targetStep then
+            return
+        end
+
+        player.actions:plantCheck(xi.inv.MOGSAFE, pot:getSlotID())
+        xi.test.world:skipVanaDays(120)
+        xi.test.world:tickEntity(player)
+    end
+end
+
+-- Herb seed results with no crystal feed
+local herbCrops =
+{
+    xi.item.CHUNK_OF_ROCK_SALT,
+    xi.item.AMARYLLIS,
+    xi.item.GREEN_ROCK,
+    xi.item.KING_TRUFFLE,
+}
+
+local oreFeeds =
+{
+    { element = 'fire',      crystal = xi.item.FIRE_CRYSTAL,      ore = xi.item.CHUNK_OF_FIRE_ORE },
+    { element = 'ice',       crystal = xi.item.ICE_CRYSTAL,       ore = xi.item.CHUNK_OF_ICE_ORE },
+    { element = 'wind',      crystal = xi.item.WIND_CRYSTAL,      ore = xi.item.CHUNK_OF_WIND_ORE },
+    { element = 'earth',     crystal = xi.item.EARTH_CRYSTAL,     ore = xi.item.CHUNK_OF_EARTH_ORE },
+    { element = 'lightning', crystal = xi.item.LIGHTNING_CRYSTAL, ore = xi.item.CHUNK_OF_LIGHTNING_ORE },
+    { element = 'water',     crystal = xi.item.WATER_CRYSTAL,     ore = xi.item.CHUNK_OF_WATER_ORE },
+    { element = 'dark',      crystal = xi.item.DARK_CRYSTAL,      ore = xi.item.CHUNK_OF_DARK_ORE },
+}
+
+describe('Gardening', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.WINDURST_WOODS })
+        if player:isInEvent() then
+            player.events:finish()
+        end
+
+        player:gotoMogHouse(xi.zone.WINDURST_WOODS)
+        stockSafe(player, xi.item.EARTHEN_FLOWERPOT)
+    end)
+
+    it('grows a planted seed to maturity when tended', function()
+        local pot = plant(player, xi.item.BAG_OF_HERB_SEEDS)
+
+        assert(pot:getExData().kind == xi.gardening.plant.HERB_SEEDS, 'expected pot to be planted with herbs')
+        assert(pot:getExData().step == xi.gardening.stage.INITIAL, 'expected freshly sown seed to be at the initial stage')
+
+        growUntil(player, pot, xi.gardening.stage.MATURE_PLANT)
+
+        assert(pot:getExData().step == xi.gardening.stage.MATURE_PLANT,
+            string.format('expected plant to be mature (got stage %d)', pot:getExData().step))
+    end)
+
+    it('yields a crop when a mature plant is harvested', function()
+        local pot = plant(player, xi.item.BAG_OF_HERB_SEEDS)
+
+        growUntil(player, pot, xi.gardening.stage.MATURE_PLANT)
+        assert(pot:getExData().step == xi.gardening.stage.MATURE_PLANT)
+
+        player.actions:plantHarvest(xi.inv.MOGSAFE, pot:getSlotID())
+
+        -- Pot is emptied after harvest.
+        assert(pot:getExData().step == xi.gardening.stage.EMPTY, 'expected pot to be empty after harvest')
+        assert(pot:getExData().kind == xi.gardening.plant.NONE)
+
+        -- One of the herb crops lands in the mog safe.
+        local gotCrop = false
+        for _, cropId in ipairs(herbCrops) do
+            if player:findItem(cropId, xi.inv.MOGSAFE) then
+                gotCrop = true
+                break
+            end
+        end
+
+        assert(gotCrop, 'expected harvest to produce a herb crop')
+    end)
+
+    it('wilts a plant left unexamined for too long', function()
+        local pot = plant(player, xi.item.BAG_OF_HERB_SEEDS)
+
+        -- Leave it unchecked well past the wilt window.
+        xi.test.world:skipVanaDays(200)
+        xi.test.world:tickEntity(player)
+
+        assert(pot:getExData().step == xi.gardening.stage.WILTED, 'expected neglected plant to wilt')
+    end)
+
+    it('records crystal feeds at each crystal stage', function()
+        local pot = plant(player, xi.item.BAG_OF_FRUIT_SEEDS)
+        assert(pot:getExData().kind == xi.gardening.plant.FRUIT_SEEDS, 'expected fruit seeds to grow a tree')
+
+        -- First crystal stage: feed a fire crystal.
+        growUntil(player, pot, xi.gardening.stage.FIRST_SPROUTS_CRYSTAL)
+        assert(pot:getExData().step == xi.gardening.stage.FIRST_SPROUTS_CRYSTAL)
+
+        feed(player, xi.item.FIRE_CRYSTAL)
+        assert(pot:getExData().crystal1 == xi.element.FIRE, 'expected fire crystal to be recorded as the extra feed')
+        assert(pot:getExData().step == xi.gardening.stage.SECOND_SPROUTS, 'expected feeding a crystal to advance the stage')
+
+        -- Second crystal stage: feed an ice crystal.
+        growUntil(player, pot, xi.gardening.stage.SECOND_SPROUTS_CRYSTAL)
+        assert(pot:getExData().step == xi.gardening.stage.SECOND_SPROUTS_CRYSTAL)
+
+        feed(player, xi.item.ICE_CRYSTAL)
+        assert(pot:getExData().crystal2 == xi.element.ICE, 'expected ice crystal to be recorded as the common feed')
+
+        growUntil(player, pot, xi.gardening.stage.MATURE_PLANT)
+        assert(pot:getExData().step == xi.gardening.stage.MATURE_PLANT)
+    end)
+
+    it('dries a growing plant so it stops advancing', function()
+        local pot = plant(player, xi.item.BAG_OF_HERB_SEEDS)
+
+        growUntil(player, pot, xi.gardening.stage.SECOND_SPROUTS_2)
+        local driedStage = pot:getExData().step
+
+        player.actions:plantDry(xi.inv.MOGSAFE, pot:getSlotID())
+        assert(pot:getExData().dried, 'expected plant to be marked dried')
+
+        -- Dried plants no longer grow or wilt.
+        player.actions:plantCheck(xi.inv.MOGSAFE, pot:getSlotID())
+        xi.test.world:skipVanaDays(200)
+        xi.test.world:tickEntity(player)
+
+        assert(pot:getExData().step == driedStage, 'expected dried plant to not change stage')
+    end)
+
+    describe('yields', function()
+        for _, feedEntry in ipairs(oreFeeds) do
+            it(string.format('a %s-fed tree sapling yields %s ore', feedEntry.element, feedEntry.element), function()
+                -- Ore is the rarest bucket, so grow and harvest until one drops.
+                local gotOre = false
+                for _ = 1, 40 do
+                    local pot = plant(player, xi.item.BAG_OF_TREE_SAPLINGS)
+
+                    growUntil(player, pot, xi.gardening.stage.FIRST_SPROUTS_CRYSTAL)
+                    feed(player, feedEntry.crystal)
+
+                    growUntil(player, pot, xi.gardening.stage.SECOND_SPROUTS_CRYSTAL)
+                    feed(player, feedEntry.crystal)
+
+                    growUntil(player, pot, xi.gardening.stage.MATURE_PLANT)
+                    player.actions:plantHarvest(xi.inv.MOGSAFE, pot:getSlotID())
+
+                    if player:findItem(feedEntry.ore, xi.inv.MOGSAFE) then
+                        gotOre = true
+                        break
+                    end
+                end
+
+                assert(gotOre, string.format('expected %s feed to yield %s ore', feedEntry.element, feedEntry.element))
+            end)
+        end
+    end)
+end)

--- a/scripts/tests/systems/moghancement.lua
+++ b/scripts/tests/systems/moghancement.lua
@@ -1,0 +1,35 @@
+describe('Moghancement', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.WINDURST_WOODS })
+
+        if player:isInEvent() then
+            player.events:finish()
+        end
+
+        player:gotoMogHouse(xi.zone.WINDURST_WOODS)
+    end)
+
+    it('breaks an aura tie by highest moghancement id', function()
+        -- Both Water/aura 2: Armor Box gives Water (517), Water Cask gives Gardening (521).
+        for _, itemId in ipairs({ xi.item.ARMOR_BOX, xi.item.WATER_CASK }) do
+            player:addItem(itemId)
+            player.actions:moveItem(xi.inv.INVENTORY, player:findItem(itemId, xi.inv.INVENTORY):getSlotID(), xi.inv.MOGSAFE, 1)
+        end
+
+        local box  = player:findItem(xi.item.ARMOR_BOX, xi.inv.MOGSAFE)
+        local cask = player:findItem(xi.item.WATER_CASK, xi.inv.MOGSAFE)
+        assert(box)
+        assert(cask)
+
+        -- Place cask first to prove "most recently placed furniture" tiebreaking isn't a thing.
+        player.actions:placeFurniture(xi.inv.MOGSAFE, cask:getSlotID(), 0, 0)
+        player.actions:placeFurniture(xi.inv.MOGSAFE, box:getSlotID(), 3, 0)
+        player.actions:finishFurnishing()
+
+        assert(player:hasKeyItem(xi.ki.MOGHANCEMENT_GARDENING), 'expected higher id (521) to win')
+        assert(not player:hasKeyItem(xi.ki.MOGHANCEMENT_WATER), 'expected lower id (517) to not be granted')
+    end)
+end)

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2563,7 +2563,6 @@ void CCharEntity::UpdateMoghancement()
 
     // Determine which moghancement to use from the dominant element
     uint8  bestAura          = 0;
-    uint8  bestOrder         = 255;
     uint16 newMoghancementID = 0;
     if (!hasTiedElements && dominantAura > 0)
     {
@@ -2576,13 +2575,16 @@ void CCharEntity::UpdateMoghancement()
                 if (PItem != nullptr && PItem->isType(ITEM_FURNISHING))
                 {
                     CItemFurnishing* PFurniture = static_cast<CItemFurnishing*>(PItem);
-                    // If aura is tied then use whichever furniture was placed most recently
-                    if (PFurniture->isInstalled() && !PFurniture->getOn2ndFloor() && PFurniture->getElement() == dominantElement &&
-                        (PFurniture->getAura() > bestAura || (PFurniture->getAura() == bestAura && PFurniture->getOrder() < bestOrder)))
+                    // Highest aura wins, ties broken by highest moghancement id.
+                    if (PFurniture->isInstalled() && !PFurniture->getOn2ndFloor() && PFurniture->getElement() == dominantElement)
                     {
-                        bestAura          = PFurniture->getAura();
-                        bestOrder         = PFurniture->getOrder();
-                        newMoghancementID = PFurniture->getMoghancement();
+                        const uint8  aura         = PFurniture->getAura();
+                        const uint16 moghancement = PFurniture->getMoghancement();
+                        if (aura > bestAura || (aura == bestAura && moghancement > newMoghancementID))
+                        {
+                            bestAura          = aura;
+                            newMoghancementID = moghancement;
+                        }
                     }
                 }
             }

--- a/src/map/items/exdata/furniture.cpp
+++ b/src/map/items/exdata/furniture.cpp
@@ -29,7 +29,6 @@ void Exdata::Furniture::toTable(sol::table& table) const
     table["z"]          = this->Z;
     table["y"]          = this->Y;
     table["rotation"]   = this->Rotation;
-    table["order"]      = this->Order;
     table["signature"]  = Exdata::decodeSignature(this->Signature);
 }
 
@@ -41,7 +40,6 @@ void Exdata::Furniture::fromTable(const sol::table& data)
     this->Z          = Exdata::get_or<uint8_t>(data, "z", this->Z);
     this->Y          = Exdata::get_or<uint8_t>(data, "y", this->Y);
     this->Rotation   = Exdata::get_or<uint8_t>(data, "rotation", this->Rotation);
-    this->Order      = Exdata::get_or<uint8_t>(data, "order", this->Order);
 
     if (sol::optional<std::string> sig = data["signature"])
     {

--- a/src/map/items/exdata/furniture.h
+++ b/src/map/items/exdata/furniture.h
@@ -30,19 +30,18 @@ namespace Exdata
 
 struct Furniture
 {
-    uint8_t Header;
-    uint8_t On2ndFloor : 1;
-    uint8_t padding00 : 5;
-    uint8_t Installed : 1;
-    uint8_t padding01 : 1;
-    uint8_t Order; // LSB-only: placement order for moghancement tiebreaking. Not present on retail.
-    uint8_t padding02[3];
-    uint8_t X;
-    uint8_t Z;
-    uint8_t Y;
-    uint8_t Rotation;
-    uint8_t Signature[12];
-    uint8_t padding03[2];
+    uint8_t  Header;
+    uint8_t  On2ndFloor : 1;
+    uint8_t  padding00 : 5;
+    uint8_t  Installed : 1;
+    uint8_t  padding01 : 1;
+    uint32_t padding02;
+    uint8_t  X;
+    uint8_t  Z;
+    uint8_t  Y;
+    uint8_t  Rotation;
+    uint8_t  Signature[12];
+    uint8_t  padding03[2];
 
     void toTable(sol::table& table) const;
     void fromTable(const sol::table& data);

--- a/src/map/items/item_furnishing.cpp
+++ b/src/map/items/item_furnishing.cpp
@@ -171,16 +171,6 @@ uint8 CItemFurnishing::getRotation()
     return this->exdata<Exdata::Furniture>().Rotation;
 }
 
-void CItemFurnishing::setOrder(uint8 order)
-{
-    this->exdata<Exdata::Furniture>().Order = order;
-}
-
-uint8 CItemFurnishing::getOrder()
-{
-    return this->exdata<Exdata::Furniture>().Order;
-}
-
 void CItemFurnishing::setMannequinRace(uint8 race)
 {
     this->exdata<Exdata::Mannequin>().Race = race;

--- a/src/map/items/item_furnishing.h
+++ b/src/map/items/item_furnishing.h
@@ -121,7 +121,6 @@ public:
     uint8 getRow();
     uint8 getLevel();
     uint8 getRotation();
-    uint8 getOrder(); // Gets Placement order with 0 being the most recently placed furniture
 
     void setInstalled(bool installed);
     void setStorage(uint8 storage);
@@ -136,7 +135,6 @@ public:
     void setRow(uint8 row);
     void setLevel(uint8 level);
     void setRotation(uint8 rotation);
-    void setOrder(uint8 order);
 
     void  setMannequinRace(uint8 race);
     uint8 getMannequinRace();

--- a/src/map/packets/c2s/0x0fa_myroom_layout.cpp
+++ b/src/map/packets/c2s/0x0fa_myroom_layout.cpp
@@ -309,46 +309,6 @@ void GP_CLI_COMMAND_MYROOM_LAYOUT::process(MapSession* PSession, CCharEntity* PC
         PItem->setLevel(this->y);
         PItem->setRotation(this->v);
 
-        constexpr auto maxContainerSize = MAX_CONTAINER_SIZE * 2;
-
-        // Update installed furniture placement orders
-        // First we place the furniture into placed items using the order number as the index
-        std::array<CItemFurnishing*, maxContainerSize> placedItems = { nullptr };
-        for (auto safeMyroomCategory : { LOC_MOGSAFE, LOC_MOGSAFE2 })
-        {
-            CItemContainer* PContainer = PChar->getStorage(safeMyroomCategory);
-            for (int slotIndex = 1; slotIndex <= PContainer->GetSize(); ++slotIndex)
-            {
-                if (this->MyroomItemIndex == slotIndex && this->MyroomCategory == safeMyroomCategory)
-                {
-                    continue;
-                }
-
-                CItem* PContainerItem = PContainer->GetItem(slotIndex);
-                if (PContainerItem != nullptr && PContainerItem->isType(ITEM_FURNISHING))
-                {
-                    if (auto PFurniture = static_cast<CItemFurnishing*>(PContainerItem); PFurniture->isInstalled())
-                    {
-                        placedItems[PFurniture->getOrder()] = PFurniture;
-                    }
-                }
-            }
-        }
-
-        // Update the item's order number
-        for (int32 i = 0; i < MAX_CONTAINER_SIZE * 2; ++i)
-        {
-            // We can stop updating the order numbers once we hit an empty order number
-            if (placedItems[i] == nullptr)
-            {
-                break;
-            }
-            placedItems[i]->setOrder(placedItems[i]->getOrder() + 1);
-        }
-
-        // Set this item to being the most recently placed item
-        PItem->setOrder(0);
-
         PItem->setSubType(ITEM_LOCKED);
 
         PChar->pushPacket<GP_SERV_COMMAND_MYROOM_OPERATION>(PItem, static_cast<CONTAINER_ID>(this->MyroomCategory), this->MyroomItemIndex);

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
@@ -34,7 +34,10 @@
 #include "lua/lua_spy.h"
 #include "map/ability.h"
 #include "map/ai/controllers/player_controller.h"
+#include "map/entities/char_entity.h"
 #include "map/enums/party_kind.h"
+#include "map/item_container.h"
+#include "map/items/item.h"
 #include "map/lua/lua_base_entity.h"
 #include "map/packets/c2s/0x01a_action.h"
 #include "map/packets/c2s/0x028_item_dump.h"
@@ -53,6 +56,11 @@
 #include "map/packets/c2s/0x0ab_guild_buylist.h"
 #include "map/packets/c2s/0x0ac_guild_sell.h"
 #include "map/packets/c2s/0x0ad_guild_selllist.h"
+#include "map/packets/c2s/0x0fa_myroom_layout.h"
+#include "map/packets/c2s/0x0fc_myroom_plant_add.h"
+#include "map/packets/c2s/0x0fd_myroom_plant_check.h"
+#include "map/packets/c2s/0x0fe_myroom_plant_crop.h"
+#include "map/packets/c2s/0x0ff_myroom_plant_stop.h"
 #include "map/packets/c2s/0x102_extended_job.h"
 #include "map/spell.h"
 #include "map/status_effect_container.h"
@@ -833,6 +841,135 @@ void CLuaClientEntityPairActions::craft(const uint16 crystalItemId, const sol::t
     parent_->packets().sendBasicPacket(*packet);
 }
 
+namespace
+{
+
+auto storageItemNo(CCharEntity* PChar, const uint8 container, const uint8 slot) -> uint16
+{
+    CItemContainer* PContainer = PChar->getStorage(container);
+    CItem*          PItem      = PContainer ? PContainer->GetItem(slot) : nullptr;
+
+    return PItem ? PItem->getID() : 0;
+}
+
+} // namespace
+
+/************************************************************************
+ *  Function: plantAdd()
+ *  Purpose : Sow a seed or feed a crystal into a gardening pot.
+ *  Notes   : Pot and add item must both be in a mog safe.
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::plantAdd(const uint8 potContainer, const uint8 potSlot, const uint8 addContainer, const uint8 addSlot) const
+{
+    auto* PChar = parent_->testChar()->entity();
+
+    const auto packet       = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_PLANT_ADD>();
+    auto*      p            = packet->as<GP_CLI_COMMAND_MYROOM_PLANT_ADD>();
+    p->MyroomPlantItemNo    = storageItemNo(PChar, potContainer, potSlot);
+    p->MyroomAddItemNo      = storageItemNo(PChar, addContainer, addSlot);
+    p->MyroomPlantItemIndex = potSlot;
+    p->MyroomAddItemIndex   = addSlot;
+    p->MyroomPlantCategory  = potContainer;
+    p->MyroomAddCategory    = addContainer;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
+ *  Function: plantCheck()
+ *  Purpose : Examine a plant, resetting its wilt timer.
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::plantCheck(const uint8 potContainer, const uint8 potSlot) const
+{
+    auto* PChar = parent_->testChar()->entity();
+
+    const auto packet       = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_PLANT_CHECK>();
+    auto*      p            = packet->as<GP_CLI_COMMAND_MYROOM_PLANT_CHECK>();
+    p->MyroomPlantItemNo    = storageItemNo(PChar, potContainer, potSlot);
+    p->MyroomPlantItemIndex = potSlot;
+    p->MyroomPlantCategory  = potContainer;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
+ *  Function: plantHarvest()
+ *  Purpose : Harvest a mature plant; uproot clears the pot instead.
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::plantHarvest(const uint8 potContainer, const uint8 potSlot, const sol::optional<bool> uproot) const
+{
+    auto* PChar = parent_->testChar()->entity();
+
+    const auto packet       = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_PLANT_CROP>();
+    auto*      p            = packet->as<GP_CLI_COMMAND_MYROOM_PLANT_CROP>();
+    p->MyroomPlantItemNo    = storageItemNo(PChar, potContainer, potSlot);
+    p->MyroomPlantItemIndex = potSlot;
+    p->MyroomPlantCategory  = potContainer;
+    p->CancellFlg           = uproot.value_or(false) ? 1 : 0;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
+ *  Function: plantDry()
+ *  Purpose : Dry a plant so it stops growing and won't wilt.
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::plantDry(const uint8 potContainer, const uint8 potSlot) const
+{
+    auto* PChar = parent_->testChar()->entity();
+
+    const auto packet       = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_PLANT_STOP>();
+    auto*      p            = packet->as<GP_CLI_COMMAND_MYROOM_PLANT_STOP>();
+    p->MyroomPlantItemNo    = storageItemNo(PChar, potContainer, potSlot);
+    p->MyroomPlantItemIndex = potSlot;
+    p->MyroomPlantCategory  = potContainer;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
+ *  Function: placeFurniture()
+ *  Purpose : Install a furnishing on the 1st floor at grid cell (x, z).
+ *  Example : player.actions:placeFurniture(xi.inv.MOGSAFE, slot, 0, 0)
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::placeFurniture(const uint8 container, const uint8 slot, const uint8 x, const uint8 z) const
+{
+    auto* PChar = parent_->testChar()->entity();
+
+    const auto packet  = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_LAYOUT>();
+    auto*      p       = packet->as<GP_CLI_COMMAND_MYROOM_LAYOUT>();
+    p->MyroomItemNo    = storageItemNo(PChar, container, slot);
+    p->MyroomItemIndex = slot;
+    p->MyroomCategory  = container;
+    p->MyroomFloorFlg  = 0;
+    p->x               = x;
+    p->z               = z;
+    p->y               = 0;
+    p->v               = 0;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
+ *  Function: finishFurnishing()
+ *  Purpose : Finish placing furniture; recomputes the active moghancement.
+ *  Example : player.actions:finishFurnishing()
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::finishFurnishing() const
+{
+    const auto packet = parent_->packets().createPacket<GP_CLI_COMMAND_MYROOM_LAYOUT>();
+    auto*      p      = packet->as<GP_CLI_COMMAND_MYROOM_LAYOUT>();
+    p->MyroomItemNo   = 0;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
 void CLuaClientEntityPairActions::Register()
 {
     SOL_USERTYPE("CClientEntityPairActions", CLuaClientEntityPairActions);
@@ -867,4 +1004,10 @@ void CLuaClientEntityPairActions::Register()
     SOL_REGISTER("dropItem", CLuaClientEntityPairActions::dropItem);
     SOL_REGISTER("setLockstyle", CLuaClientEntityPairActions::setLockstyle);
     SOL_REGISTER("craft", CLuaClientEntityPairActions::craft);
+    SOL_REGISTER("plantAdd", CLuaClientEntityPairActions::plantAdd);
+    SOL_REGISTER("plantCheck", CLuaClientEntityPairActions::plantCheck);
+    SOL_REGISTER("plantHarvest", CLuaClientEntityPairActions::plantHarvest);
+    SOL_REGISTER("plantDry", CLuaClientEntityPairActions::plantDry);
+    SOL_REGISTER("placeFurniture", CLuaClientEntityPairActions::placeFurniture);
+    SOL_REGISTER("finishFurnishing", CLuaClientEntityPairActions::finishFurnishing);
 }

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.h
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.h
@@ -70,6 +70,14 @@ public:
     void setLockstyle(uint8 mode, sol::optional<sol::table> items) const;
     void craft(uint16 crystalItemId, const sol::table& ingredients) const;
 
+    void plantAdd(uint8 potContainer, uint8 potSlot, uint8 addContainer, uint8 addSlot) const;
+    void plantCheck(uint8 potContainer, uint8 potSlot) const;
+    void plantHarvest(uint8 potContainer, uint8 potSlot, sol::optional<bool> uproot) const;
+    void plantDry(uint8 potContainer, uint8 potSlot) const;
+
+    void placeFurniture(uint8 container, uint8 slot, uint8 x, uint8 z) const;
+    void finishFurnishing() const;
+
     static void Register();
 
 private:

--- a/src/test/lua/lua_client_entity_pair.cpp
+++ b/src/test/lua/lua_client_entity_pair.cpp
@@ -90,6 +90,23 @@ void CLuaClientEntityPair::tick()
 
 void CLuaClientEntityPair::gotoZone(ZONEID zoneId, sol::optional<sol::table> pos)
 {
+    doGotoZone(zoneId, std::move(pos), false);
+}
+
+/************************************************************************
+ *  Function: gotoMogHouse()
+ *  Purpose : Zone the player into their own Mog House in the given zone.
+ *  Example : player:gotoMogHouse(xi.zone.WINDURST_WOODS)
+ *  Notes   : Errors if the player is in an event.
+ ************************************************************************/
+
+void CLuaClientEntityPair::gotoMogHouse(ZONEID zoneId)
+{
+    doGotoZone(zoneId, sol::nullopt, true);
+}
+
+void CLuaClientEntityPair::doGotoZone(ZONEID zoneId, sol::optional<sol::table> pos, bool mogHouse)
+{
     // Check if player is in an event
     if (testChar_->entity()->isInEvent())
     {
@@ -108,7 +125,10 @@ void CLuaClientEntityPair::gotoZone(ZONEID zoneId, sol::optional<sol::table> pos
     charutils::removeCharFromZone(testChar_->entity());
     packets().sendZonePackets(); // Send zone in packets, reload PChar
 
-    // If position provided, set it and tick
+    // Set on the reloaded entity so it sticks through the zone-in.
+    testChar_->entity()->m_moghouseID = mogHouse ? testChar_->entity()->id : 0;
+
+    // If position provided, set it
     if (pos.has_value())
     {
         auto*      entity   = GetBaseEntity();
@@ -124,9 +144,12 @@ void CLuaClientEntityPair::gotoZone(ZONEID zoneId, sol::optional<sol::table> pos
         entity->loc.p.y        = y;
         entity->loc.p.z        = z;
         entity->loc.p.rotation = rot;
+    }
 
-        // After setting position on zone-in, we MUST perform these ticks in sequence
-        // Events will not be set if we don't!
+    // After zone-in we MUST perform these ticks in sequence, or events won't be
+    // set and the Mog House state won't settle.
+    if (pos.has_value() || mogHouse)
+    {
         simulation_->tick(TickType::ZoneTick);
         simulation_->tick(TickType::TriggerAreas);
     }
@@ -343,6 +366,7 @@ void CLuaClientEntityPair::Register()
     SOL_USERTYPE_INHERIT("CClientEntityPair", CLuaClientEntityPair, CLuaTestEntity, CLuaBaseEntity);
     SOL_REGISTER("tick", CLuaClientEntityPair::tick);
     SOL_REGISTER("gotoZone", CLuaClientEntityPair::gotoZone);
+    SOL_REGISTER("gotoMogHouse", CLuaClientEntityPair::gotoMogHouse);
     SOL_REGISTER("isPendingZone", CLuaClientEntityPair::isPendingZone);
     SOL_REGISTER("getItemInvSlot", CLuaClientEntityPair::getItemInvSlot);
     SOL_REGISTER("claimAndKillMob", CLuaClientEntityPair::claimAndKillMob);

--- a/src/test/lua/lua_client_entity_pair.h
+++ b/src/test/lua/lua_client_entity_pair.h
@@ -46,6 +46,7 @@ public:
 
     void tick();
     void gotoZone(ZONEID zoneId, sol::optional<sol::table> pos);
+    void gotoMogHouse(ZONEID zoneId);
     auto isPendingZone() const -> bool;
     auto getItemInvSlot(uint16 itemId, uint8 quantity) const -> Maybe<uint16>;
     void claimAndKillMob(const sol::object& mobQuery, sol::optional<sol::table> params);
@@ -65,6 +66,8 @@ public:
     static void Register();
 
 private:
+    void doGotoZone(ZONEID zoneId, sol::optional<sol::table> pos, bool mogHouse);
+
     std::unique_ptr<TestChar> testChar_;
     CLuaSimulation*           simulation_;
     MapEngine*                engine_;

--- a/src/test/lua/lua_simulation.cpp
+++ b/src/test/lua/lua_simulation.cpp
@@ -206,6 +206,20 @@ void CLuaSimulation::skipToNextVanaDay() const
 }
 
 /************************************************************************
+ *  Function: skipVanaDays()
+ *  Purpose : Advances Vana'diel time by whole days.
+ *  Example : sim:skipVanaDays(30)
+ *  Notes   : Vana'diel time only (like setVanaTime); does not tick.
+ ************************************************************************/
+
+void CLuaSimulation::skipVanaDays(const uint32 days) const
+{
+    ShowInfoFmt("Skipping {} Vana'diel days", days);
+
+    earth_time::add_offset(std::chrono::duration_cast<earth_time::duration>(xi::vanadiel_clock::days(days)));
+}
+
+/************************************************************************
  *  Function: setRegionOwner()
  *  Purpose : Sets a specific region to be controlled by given nation.
  *  Example : sim:setRegionOwner(xi.region.XXX, xi.nation.YYY)
@@ -615,6 +629,7 @@ void CLuaSimulation::Register()
     SOL_REGISTER("setVanaTime", CLuaSimulation::setVanaTime);
     SOL_REGISTER("setVanaDay", CLuaSimulation::setVanaDay);
     SOL_REGISTER("skipToNextVanaDay", CLuaSimulation::skipToNextVanaDay);
+    SOL_REGISTER("skipVanaDays", CLuaSimulation::skipVanaDays);
     SOL_REGISTER("setRegionOwner", CLuaSimulation::setRegionOwner);
     SOL_REGISTER("setSeed", CLuaSimulation::setSeed);
     SOL_REGISTER("seed", CLuaSimulation::seed);

--- a/src/test/lua/lua_simulation.h
+++ b/src/test/lua/lua_simulation.h
@@ -66,6 +66,7 @@ public:
     void setVanaTime(uint8 vanaHour, uint8 vanaMinute) const;
     void setVanaDay(uint8 day) const;
     void skipToNextVanaDay() const;
+    void skipVanaDays(uint32 days) const;
     void setRegionOwner(REGION_TYPE region, NATION_TYPE nation) const;
     void setSeed(uint64 seed) const;
     void seed() const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Infrastructure and basic tests for both gardening and moghancements.
- Deprecates existing tie-breaking mechanism for moghancements of same element/aura strength (placement order saved in exdata) in favor of selecting the highest moghancement ID.

### Rationale
- The order that's being stored in the exdata isn't a thing on retail
- It conflicts with Crystal1 field on flowerpots which I suspect (but have not conclusively proven) causes certain issues with planted pots
- Testing has shown "last placed furniture wins" is not a thing on retail

I tested several permutations of furnishing pieces with the hypothesis that the tie breaking was due to one of the following factor:
- Placement order (the existing LSB mechanic)
- Lower/Higher Item ID
- Location on the Mog House grid
- Lower/Higher Moghancement ID
- Furniture footprint

| Test | Aura | Furniture | Item id | Mog id | Moghancement | Size | Won |
  |:---:|:---:|---|:---:|:---:|---|:---:|:---:|
  | 1 | Dark / 3  | Semainier                     | 428 | 516 | Dark | 5*1 |   |
  | 1 | Dark / 3  | Rep. Legionnaire's Bedding    | 350 | 520 | Experience | 4*6 | ✓ |
  | 2 | Dark / 2  | Pile of Chocobo Bedding       | 1   | 520 | Experience | 5*5 |   |
  | 2 | Dark / 2  | Millionaire Desk              | 33  | 532 | Conquest   | 5*2 | ✓ |
  | 3 | Earth / 4 | Yellow Tarutaru Desk          | 396 | 515 | Earth      | 4*2 |   |
  | 3 | Earth / 4 | Tarutaru Desk                 | 26  | 521 | Gardening  | 4*2 | ✓ |
  | 4 | Water / 2 | Armor Box                     | 46  | 517 | Water      | 2*2 |   |
  | 4 | Water / 2 | Water Cask                    | 93  | 521 | Gardening  | 1*1 | ✓ |

As you can see, the only hypothesis that survived all the tests is the highest moghancement ID having priority.

## Steps to test these changes
Tests included

<!-- Clear and detailed steps to test your changes here -->
