### PR TITLE
[lua] Reduce Ranged Attack to 1.0 fTP

### DIFF
--- a/scripts/actions/mobskills/ranged_attack.lua
+++ b/scripts/actions/mobskills/ranged_attack.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1
-    params.fTP            = { 1.5, 1.5, 1.5 } -- TODO: Mobs get more base damage on their ranged weapon slot already. Do we need the 1.5 fTP?
+    params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.RANGED
     params.damageType     = xi.damageType.PIERCING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reduces Ranged Attack from 1.5 fTP to 1.0 fTP. Recently ranged attack stats were finally hooked up properly for ranged attacks and this left over compensation is resulting in mobs hitting for a severe excess in comparison to retail.

You can see in this screenshot here that a ranged attack does about the same damage as a melee hit :

<img width="732" height="177" alt="image" src="https://github.com/user-attachments/assets/67441048-f2bf-443d-babe-e65ef766be66" />

Using the same stats as Thris, same mob, level, job, VIT, everything - significantly higher damage than melee hit.

<img width="471" height="46" alt="image" src="https://github.com/user-attachments/assets/c7ab4a94-cbc1-430e-821f-bd852dc67103" />

Post adjustment - Very close damage to a melee hit, with the ranged attack being slightly higher.

<img width="580" height="56" alt="image" src="https://github.com/user-attachments/assets/12275b58-766d-4e70-8113-159d880a6ccd" />


## Steps to test these changes

Get ranged attacked, see less damage. 
