### PR TITLE
[core] Skip animation lock if JA couldnt be fired

### DIFF
--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -202,23 +202,27 @@ bool CAbilityState::Update(timer::time_point tick)
 
     if (!IsCompleted() && tick > GetEntryTime() + m_castTime)
     {
-        if (CanUseAbility())
+        // A failed validity check exits immediately and doesn't serve out the animation lock.
+        if (!CanUseAbility())
         {
-            action_t action{};
-            m_PEntity->OnAbility(*this, action);
-            m_PEntity->PAI->EventHandler.triggerListener("ABILITY_USE", m_PEntity, GetTarget(), m_PAbility.get(), &action);
-            // Only send packet if action was populated (e.g. interrupts return early)
-            if (!action.targets.empty())
+            return true;
+        }
+
+        action_t action{};
+        m_PEntity->OnAbility(*this, action);
+        m_PEntity->PAI->EventHandler.triggerListener("ABILITY_USE", m_PEntity, GetTarget(), m_PAbility.get(), &action);
+        // Only send packet if action was populated (e.g. interrupts return early)
+        if (!action.targets.empty())
+        {
+            m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
+        }
+
+        for (auto& actionTarget : action.targets)
+        {
+            auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
+            if (PActionTarget)
             {
-                m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
-            }
-            for (auto& actionTarget : action.targets)
-            {
-                auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
-                if (PActionTarget)
-                {
-                    PActionTarget->PAI->EventHandler.triggerListener("ABILITY_TAKE", m_PEntity, PActionTarget, m_PAbility.get(), &action);
-                }
+                PActionTarget->PAI->EventHandler.triggerListener("ABILITY_TAKE", m_PEntity, PActionTarget, m_PAbility.get(), &action);
             }
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Ability state is being pushed at the top if you manage to pass early checks (cooldown mainly) but fail any subsequent check (LoS / lua driven onAbilityCheck etc). 
The JA would then not activate but keep the state on top for animation time (2s usually) and stop all basic attacks.

This PR simply backs out earlier if the JA doesn't activate for any reason.

## Steps to test these changes
Spam "Animated Flourish" with a macro, see basic attacks keep firing when you have no finishing moves.

<!-- Clear and detailed steps to test your changes here -->
