### PR TITLE
[login] Set OTP features bit if account has OTP enabled

### DIFF
--- a/settings/default/login.lua
+++ b/settings/default/login.lua
@@ -55,7 +55,6 @@ xi.settings.login =
 
     -- Feature display on client's login screen. This does NOT effect in game content whatsoever!
     -- Mog wardrobes are per character, so anything custom will not be able to reflect per-account login screen.
-    SECURE_TOKEN   = false, -- 2FA not supported yet
     MOG_WARDROBE_3 = true,
     MOG_WARDROBE_4 = true,
     MOG_WARDROBE_5 = true,

--- a/src/login/login_helpers.cpp
+++ b/src/login/login_helpers.cpp
@@ -354,12 +354,11 @@ uint16 generateExpansionBitmask()
     return mask;
 }
 
-uint16 generateFeatureBitmask()
+uint16 generateFeatureBitmask(const bool& needsOTP)
 {
     uint16 mask = 0;
 
     std::map<std::string, uint16> features = {
-        { "login.SECURE_TOKEN", FEATURE_DISPLAY::SECURE_TOKEN }, // This needs to be broken out into auth calls once TOTP is supported
         { "login.MOG_WARDROBE_3", FEATURE_DISPLAY::MOG_WARDROBE_3 },
         { "login.MOG_WARDROBE_4", FEATURE_DISPLAY::MOG_WARDROBE_4 },
         { "login.MOG_WARDROBE_5", FEATURE_DISPLAY::MOG_WARDROBE_5 },
@@ -375,6 +374,11 @@ uint16 generateFeatureBitmask()
         {
             mask |= feature.second;
         }
+    }
+
+    if (needsOTP)
+    {
+        mask |= FEATURE_DISPLAY::SECURE_TOKEN;
     }
 
     return mask;

--- a/src/login/login_helpers.h
+++ b/src/login/login_helpers.h
@@ -95,7 +95,7 @@ void generateErrorMessage(uint8* packet, uint16 errorCode);
 
 uint16 generateExpansionBitmask();
 
-uint16 generateFeatureBitmask();
+uint16 generateFeatureBitmask(const bool& needsOTP);
 
 int32 saveCharacter(uint32 accid, uint32 charid, char_mini* createchar);
 

--- a/src/login/otp_helpers.h
+++ b/src/login/otp_helpers.h
@@ -35,7 +35,7 @@
 namespace otpHelpers
 {
 
-std::vector<uint8_t> base32Decode(const std::string& base32)
+inline std::vector<uint8_t> base32Decode(const std::string& base32)
 {
     static const std::array<int8_t, 256> lookup = []
     {
@@ -85,7 +85,7 @@ std::vector<uint8_t> base32Decode(const std::string& base32)
     return bytes;
 }
 
-std::string generateTOTP(const std::string& base32Secret, uint64_t epochSeconds, int digits = 6, int period = 30)
+inline std::string generateTOTP(const std::string& base32Secret, uint64_t epochSeconds, int digits = 6, int period = 30)
 {
     std::vector<uint8_t> key     = base32Decode(base32Secret);
     uint64_t             counter = epochSeconds / period;

--- a/src/login/view_session.cpp
+++ b/src/login/view_session.cpp
@@ -29,6 +29,7 @@
 #include <common/utils.h>
 
 #include "login_packets.h"
+#include "otp_helpers.h"
 
 void view_session::read_func()
 {
@@ -394,6 +395,8 @@ void view_session::read_func()
                 }
             }
 
+            bool needsOTP = otpHelpers::doesAccountNeedOTP(session.accountID, "TOTP");
+
             // https://github.com/atom0s/XiPackets/blob/main/lobby/S2C_0x0005_ResponseKey.md
             struct lpkt_key
             {
@@ -417,7 +420,7 @@ void view_session::read_func()
             packet.command        = 0x05;
             packet.key            = 0xAD5DE04F; // old magic key. May be able to replace with a randomized key some day...
             packet.excode_server  = loginHelpers::generateExpansionBitmask();
-            packet.excode_server2 = loginHelpers::generateFeatureBitmask();
+            packet.excode_server2 = loginHelpers::generateFeatureBitmask(needsOTP);
 
             std::memcpy(buffer_.data(), &packet, sizeof(lpkt_key));
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sets the OTP feature bit for OTP if the account has OTP enabled

## Steps to test these changes

Login with OTP enabled, at the main title where you can choose to select char, you will set the OTP token to the left. Without OTP enabled, you won't see it.
