### PR TITLE
[lua] Assault exit event bug fix and event skipped

### DIFF
--- a/scripts/globals/assault/container.lua
+++ b/scripts/globals/assault/container.lua
@@ -407,7 +407,14 @@ xi.assault.onInstanceFailure = function(instance)
         entity:messageSpecial(zones[zoneID].text.MISSION_FAILED, 10, 10)
         entity:setCharVar('assaultEntered', 0)
         entity:setCharVar('AssaultFailed', 1)
-        entity:startEvent(102)
+        if entity:isInEvent() then
+            entity:release()
+            entity:timer(1, function(entityArg)
+                entityArg:startEvent(102)
+            end)
+        else
+            entity:startEvent(102)
+        end
     end
 end
 
@@ -457,7 +464,14 @@ local function awardCompletionPoints(player, instance)
 
             member:setCharVar('assaultEntered', 0)
             member:setCharVar('Assault_Armband', 0)
-            member:startEvent(102)
+            if member:getID() ~= player:getID() and member:isInEvent() then -- Player is finishing Rune of Release event: do not interrupt.
+                member:release()
+                member:timer(1, function(memberArg)
+                    memberArg:startEvent(102)
+                end)
+            else
+                member:startEvent(102)
+            end
         end
     end
 

--- a/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Ilrusi_Atoll/npcs/Rune_of_Release.lua
@@ -10,7 +10,7 @@ entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
     if instance and instance:completed() then
-        player:startEvent(100, 4)
+        player:startOptionalCutscene(100, { [0] = 4, cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Lebros_Cavern/npcs/Rune_of_Release.lua
@@ -8,7 +8,7 @@ entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
     if instance and instance:completed() then
-        player:startEvent(100, 2)
+        player:startOptionalCutscene(100, { [0] = 2, cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Leujaoam_Sanctum/npcs/Rune_of_Release.lua
@@ -9,7 +9,7 @@ entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
     if instance and instance:completed() then
-        player:startEvent(100, 0)
+        player:startOptionalCutscene(100, { [0] = 0, cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Rune_of_Release.lua
@@ -8,7 +8,7 @@ entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
     if instance and instance:completed() then
-        player:startEvent(100, 1)
+        player:startOptionalCutscene(100, { [0] = 1, cs_option = 0, canSkip = true })
     end
 end
 

--- a/scripts/zones/Periqia/npcs/Rune_of_Release.lua
+++ b/scripts/zones/Periqia/npcs/Rune_of_Release.lua
@@ -10,7 +10,7 @@ entity.onTrigger = function(player, npc)
     local instance = npc:getInstance()
 
     if instance and instance:completed() then
-        player:startEvent(100, 3)
+        player:startOptionalCutscene(100, { [0] = 3, cs_option = 0, canSkip = true })
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. In the new Assault framework, if the Assault ends by a teammate OR through the timeout, if the player is in the event, the exit event doesn't fire until the player leaves their current event. This PR will instead have the player quit the event, wait 2 seconds (retail delay), and then fire the exit event.

The way I implemented this is a :release() then a 2 second wait until the exit event to mimic the retail delay. If I didn't have that 2 second wait, the exit event never fires and you are stuck in the assault. With this implementation, technically, the player can spam "enter" to re-enter the event. I think a future PR will also need to freeze or lock the player during all of this.

2. Adds event skipped to the rune of release.

Video of ending Assault while in an event: https://youtu.be/-1ZAWkKUkQc
Video of Event Skipped: https://youtu.be/YHvsnZkPV50

## Steps to test these changes

Go into one of the new assaults, beat it, sit at the rune of release until the timer runs out in that event.
