### PR TITLE
[lua] Allow purchase of exp ring with voucher

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1542,7 +1542,7 @@ local function handlePurchuase(player, option, pNation, pRank, guardNation, mOff
         return
     end
 
-    local isEXPRing = option <= 32933 and option >= 32935
+    local isEXPRing = option >= 32933 and option <= 32935
     if isEXPRing and not canBuyExpRing(player, stock.item) then
         return
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where the EXP Ring check option was reversed. 

## Steps to test these changes

Set your cp to 0 using !cp -#
!addkeyitem conquest_promotion_voucher
Go attempt to purchase a ring.
