### PR TITLE
[lua] Attachment Burden Penalties

### DIFF
--- a/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
+++ b/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
@@ -99,8 +99,46 @@ end)
 -----------------------------------
 -- Ice Maker - Reduces Magic Attack Bonus from Ice Maker, and consumes all Ice Maneuvers on magic attack execution. https://wiki.ffo.jp/html/11198.html
 -----------------------------------
+local validIceMakerSpells = set
+{
+    xi.magic.spell.FIRE,
+    xi.magic.spell.FIRE_II,
+    xi.magic.spell.FIRE_III,
+    xi.magic.spell.FIRE_IV,
+    xi.magic.spell.FIRE_V,
+    xi.magic.spell.BLIZZARD,
+    xi.magic.spell.BLIZZARD_II,
+    xi.magic.spell.BLIZZARD_III,
+    xi.magic.spell.BLIZZARD_IV,
+    xi.magic.spell.BLIZZARD_V,
+    xi.magic.spell.AERO,
+    xi.magic.spell.AERO_II,
+    xi.magic.spell.AERO_III,
+    xi.magic.spell.AERO_IV,
+    xi.magic.spell.AERO_V,
+    xi.magic.spell.STONE,
+    xi.magic.spell.STONE_II,
+    xi.magic.spell.STONE_III,
+    xi.magic.spell.STONE_IV,
+    xi.magic.spell.STONE_V,
+    xi.magic.spell.THUNDER,
+    xi.magic.spell.THUNDER_II,
+    xi.magic.spell.THUNDER_III,
+    xi.magic.spell.THUNDER_IV,
+    xi.magic.spell.THUNDER_V,
+    xi.magic.spell.WATER,
+    xi.magic.spell.WATER_II,
+    xi.magic.spell.WATER_III,
+    xi.magic.spell.WATER_IV,
+    xi.magic.spell.WATER_V,
+}
+
 m:addOverride('xi.actions.abilities.pets.attachments.ice_maker.onEquip', function(pet, attachment)
     pet:addListener('MAGIC_USE', 'AUTO_ICE_MAKER_USE', function(automaton, target, spell, action)
+        if not validIceMakerSpells[spell:getID()] then
+            return
+        end
+
         local master = automaton:getMaster()
 
         if not master then
@@ -125,7 +163,7 @@ m:addOverride('xi.actions.abilities.pets.attachments.ice_maker.onUnequip', funct
 end)
 
 -----------------------------------
--- Replicator - Reduces amount of absorbs granted by Replicator, and changes them to Blink from Utsusemi. https://wiki.ffo.jp/html/12225.html
+-- Replicator - Reduces amount of absorbs granted by Replicator, and changes them to Blink from Utsusemi. Also consumes Wind Maneuvers. https://wiki.ffo.jp/html/12225.html
 -----------------------------------
 local shadowTable =
 {
@@ -147,6 +185,8 @@ m:addOverride('xi.actions.abilities.pets.automaton.replicator.onAutomatonAbility
     for i = 1, windManeuvers do
         master:delStatusEffectSilent(xi.effect.WIND_MANEUVER)
     end
+
+    master:updateAttachments()
 
     if
         shadows and
@@ -441,6 +481,26 @@ m:addOverride('xi.actions.abilities.pets.automaton.eraser.onAutomatonAbility', f
     end
 
     return effectsRemoved
+end)
+
+-----------------------------------
+-- Economizer - Changes Economizer to consume all Dark Maneuvers on activation. : https://wiki.ffo.jp/html/10435.html
+-----------------------------------
+m:addOverride('xi.actions.abilities.pets.automaton.economizer.onAutomatonAbility', function(target, automaton, skill, master, action)
+    automaton:addRecast(xi.recast.ABILITY, skill:getID(), 180)
+
+    local darkManeuvers = master:countEffect(xi.effect.DARK_MANEUVER)
+    local mpRecovered   = math.floor(automaton:getMaxMP() * 0.2 * darkManeuvers)
+
+    for _ = 1, darkManeuvers do
+        master:delStatusEffectSilent(xi.effect.DARK_MANEUVER)
+    end
+
+    master:updateAttachments()
+
+    skill:setMsg(xi.msg.basic.SKILL_RECOVERS_MP)
+
+    return automaton:addMP(mpRecovered)
 end)
 
 return m

--- a/scripts/actions/abilities/pets/attachments/flame_holder.lua
+++ b/scripts/actions/abilities/pets/attachments/flame_holder.lua
@@ -2,16 +2,64 @@
 -- Attachment: Flame Holder
 -- Description : Adds fire maneuver burden to increase weapon skill damage.
 -- 25% at 0, 100% at 1, 175% at 2, and 250% at 3. Ex. at 3 fire maneuvers, 10 fTP will be 25 fTP.
+-- Applies 7/14/21 Fire Burden per Maneuver active when a weaponskill is executed.
+-- https://wiki.ffo.jp/html/11183.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local validFlameHolderSkills = set
+{
+    xi.mobSkill.ARCUBALLISTA_AUTOMATON,
+    xi.mobSkill.ARMOR_PIERCER_AUTOMATON,
+    xi.mobSkill.ARMOR_SHATTERER_AUTOMATON,
+    xi.mobSkill.BONE_CRUSHER_AUTOMATON,
+    xi.mobSkill.CANNIBAL_BLADE_AUTOMATON,
+    xi.mobSkill.CHIMERA_RIPPER_AUTOMATON,
+    xi.mobSkill.DAZE_AUTOMATON,
+    xi.mobSkill.KNOCKOUT_AUTOMATON,
+    xi.mobSkill.MAGIC_MORTAR_AUTOMATON,
+    xi.mobSkill.SLAPSTICK_AUTOMATON,
+    xi.mobSkill.STRING_CLIPPER_AUTOMATON,
+    xi.mobSkill.STRING_SHREDDER_AUTOMATON,
+}
+
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 attachmentObject.onEquip = function(pet, attachment)
+    pet:addListener('WEAPONSKILL_STATE_EXIT', 'AUTO_FLAME_HOLDER_END', function(automaton, skillId, wasExecuted)
+        if
+            not validFlameHolderSkills[skillId] or
+            not wasExecuted
+        then
+            return
+        end
+
+        local master = automaton:getMaster()
+
+        if not master then
+            return
+        end
+
+        local fireManeuvers = master:countEffect(xi.effect.FIRE_MANEUVER)
+        local burdenAmount  = burdenApplied[fireManeuvers]
+
+        if burdenAmount then
+            master:addBurden(xi.element.FIRE - 1, burdenAmount)
+        end
+    end)
+
     xi.automaton.onAttachmentEquip(pet, attachment)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
+    pet:removeListener('AUTO_FLAME_HOLDER_END')
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)

--- a/scripts/actions/abilities/pets/attachments/ice_maker.lua
+++ b/scripts/actions/abilities/pets/attachments/ice_maker.lua
@@ -2,17 +2,79 @@
 -- Attachment: Ice Maker
 -- Description : Adds ice maneuver burden to increase magic damage.
 -- 50% at 1, 75% at 2, and 100% at 3. Works as a coefficient increase to magic attack bonus.
+-- Applies 7/14/21 Ice Burden per Maneuver active when a spell is cast.
 -- https://wiki.ffo.jp/html/11198.html
 -----------------------------------
 ---@type TAttachment
 local attachmentObject = {}
 
+local validIceMakerSpells = set
+{
+    xi.magic.spell.FIRE,
+    xi.magic.spell.FIRE_II,
+    xi.magic.spell.FIRE_III,
+    xi.magic.spell.FIRE_IV,
+    xi.magic.spell.FIRE_V,
+    xi.magic.spell.BLIZZARD,
+    xi.magic.spell.BLIZZARD_II,
+    xi.magic.spell.BLIZZARD_III,
+    xi.magic.spell.BLIZZARD_IV,
+    xi.magic.spell.BLIZZARD_V,
+    xi.magic.spell.AERO,
+    xi.magic.spell.AERO_II,
+    xi.magic.spell.AERO_III,
+    xi.magic.spell.AERO_IV,
+    xi.magic.spell.AERO_V,
+    xi.magic.spell.STONE,
+    xi.magic.spell.STONE_II,
+    xi.magic.spell.STONE_III,
+    xi.magic.spell.STONE_IV,
+    xi.magic.spell.STONE_V,
+    xi.magic.spell.THUNDER,
+    xi.magic.spell.THUNDER_II,
+    xi.magic.spell.THUNDER_III,
+    xi.magic.spell.THUNDER_IV,
+    xi.magic.spell.THUNDER_V,
+    xi.magic.spell.WATER,
+    xi.magic.spell.WATER_II,
+    xi.magic.spell.WATER_III,
+    xi.magic.spell.WATER_IV,
+    xi.magic.spell.WATER_V,
+}
+
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 attachmentObject.onEquip = function(pet, attachment)
+    pet:addListener('MAGIC_USE', 'AUTO_ICE_MAKER_USE', function(automaton, target, spell, action)
+        if not validIceMakerSpells[spell:getID()] then
+            return
+        end
+
+        local master = automaton:getMaster()
+
+        if not master then
+            return
+        end
+
+        local iceManeuvers = master:countEffect(xi.effect.ICE_MANEUVER)
+        local burdenAmount = burdenApplied[iceManeuvers]
+
+        if burdenAmount then
+            master:addBurden(xi.element.ICE - 1, burdenAmount)
+        end
+    end)
+
     xi.automaton.onAttachmentEquip(pet, attachment)
 end
 
 attachmentObject.onUnequip = function(pet, attachment)
     xi.automaton.onAttachmentUnequip(pet, attachment)
+    pet:removeListener('AUTO_ICE_MAKER_USE')
 end
 
 attachmentObject.onManeuverGain = function(pet, attachment, maneuvers)

--- a/scripts/actions/abilities/pets/automaton/barrage_turbine.lua
+++ b/scripts/actions/abilities/pets/automaton/barrage_turbine.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Barrage Turbine
--- https://www.bg-wiki.com/ffxi/Barrage_Turbine
+-- Fires a number of projectiles based on the number of active Wind Maneuvers
+-- Applies 7/14/21 Wind Burden per Maneuver active when activated.
 -- https://wiki.ffo.jp/html/23698.html
 -- TODO : Find out if shots from this do not return full TP.
 -----------------------------------
@@ -15,6 +16,13 @@ local shotCount =
     [3] = 9,
 }
 
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
     return 0
 end
@@ -23,6 +31,11 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 180)
 
     local windManeuvers = master:countEffect(xi.effect.WIND_MANEUVER)
+    local burdenAmount  = burdenApplied[windManeuvers]
+
+    if burdenAmount then
+        master:addBurden(xi.element.WIND - 1, burdenAmount)
+    end
 
     local params = {}
 

--- a/scripts/actions/abilities/pets/automaton/economizer.lua
+++ b/scripts/actions/abilities/pets/automaton/economizer.lua
@@ -2,10 +2,18 @@
 -- Economizer
 -- Recovers a percentage of missing MP based on dark maneuvers.
 -- Activation threshold is 30% MP, increasing by 10% per dark maneuver.
+-- Applies 7/14/21 Dark Burden per Maneuver active when activated.
 -- https://wiki.ffo.jp/html/10435.html
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
+
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
 
 abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
     return 0
@@ -15,7 +23,12 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 180)
 
     local darkManeuvers = master:countEffect(xi.effect.DARK_MANEUVER)
-    local mpRecovered = math.floor(automaton:getMaxMP() * 0.2 * darkManeuvers)
+    local mpRecovered   = math.floor(automaton:getMaxMP() * 0.2 * darkManeuvers)
+    local burdenAmount  = burdenApplied[darkManeuvers]
+
+    if burdenAmount then
+        master:addBurden(xi.element.DARK - 1, burdenAmount)
+    end
 
     skill:setMsg(xi.msg.basic.SKILL_RECOVERS_MP)
 

--- a/scripts/actions/abilities/pets/automaton/eraser.lua
+++ b/scripts/actions/abilities/pets/automaton/eraser.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Eraser
 -- Removes up to 3 status effects from the Automaton or its Master based on the number of Light Maneuvers active.
+-- Applies 7/14/21 Light Burden per Maneuver active when activated regardless of the number of effects removed.
 -----------------------------------
 ---@type TAbilityAutomaton
 local abilityObject = {}
@@ -70,10 +71,22 @@ local removables =
     xi.effect.MAX_HP_DOWN
 }
 
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 30)
 
-    local maneuvers = master:countEffect(xi.effect.LIGHT_MANEUVER)
+    local maneuvers    = master:countEffect(xi.effect.LIGHT_MANEUVER)
+    local burdenAmount = burdenApplied[maneuvers]
+
+    if burdenAmount then
+        master:addBurden(xi.element.LIGHT - 1, burdenAmount)
+    end
 
     local effectsRemoved = 0
 

--- a/scripts/actions/abilities/pets/automaton/heat_capacitor.lua
+++ b/scripts/actions/abilities/pets/automaton/heat_capacitor.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- Heat Capacitor
 -- Increases TP based on the number of Fire Maneuvers and the attachments equipped.
+-- Applies 7/14/21 Fire Burden per Maneuver active when activated.
 -- https://wiki.ffo.jp/html/23696.html
 -----------------------------------
 ---@type TAbilityAutomaton
@@ -27,6 +28,13 @@ local tpTable =
     },
 }
 
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
     return 0
 end
@@ -40,6 +48,12 @@ abilityObject.onAutomatonAbility = function(target, automaton, skill, master, ac
 
     if not tpAmounts then
         return 0
+    end
+
+    local burdenAmount = burdenApplied[fireManeuvers]
+
+    if burdenAmount then
+        master:addBurden(xi.element.FIRE - 1, burdenAmount)
     end
 
     for attachment, tpAmount in pairs(tpAmounts) do

--- a/scripts/actions/abilities/pets/automaton/replicator.lua
+++ b/scripts/actions/abilities/pets/automaton/replicator.lua
@@ -5,6 +5,7 @@
 -- Amount of images increased on December 15th, 2011.
 -- Changed from Blink to Copy Image on August 5th, 2015.
 -- Changed to not consume Wind Maneuvers on August 6th, 2019.
+-- Applies 7/14/21 Wind Burden per Maneuver active when activated.
 -- https://wiki.ffo.jp/html/12225.html
 -----------------------------------
 ---@type TAbilityAutomaton
@@ -17,6 +18,13 @@ local shadowTable =
     [3] = 10,
 }
 
+local burdenApplied =
+{
+    [1] = 7,
+    [2] = 14,
+    [3] = 21,
+}
+
 abilityObject.onAutomatonAbilityCheck = function(target, automaton, skill)
     return 0
 end
@@ -24,6 +32,11 @@ end
 abilityObject.onAutomatonAbility = function(target, automaton, skill, master, action)
     local windManeuvers = master:countEffect(xi.effect.WIND_MANEUVER)
     local shadows       = shadowTable[windManeuvers]
+    local burdenAmount  = burdenApplied[windManeuvers]
+
+    if burdenAmount then
+        master:addBurden(xi.element.WIND - 1, burdenAmount)
+    end
 
     automaton:addRecast(xi.recast.ABILITY, skill:getID(), 60)
 

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3168,7 +3168,6 @@ end
 function CBaseEntity:isTandemActive()
 end
 
----@nodiscard
 ---@param element integer
 ---@param burden integer
 ---@return integer


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In 2019, many attachments that used to consume maneuvers were converted to no longer consume maneuvers and instead place burden of that element on the master when used. This PR adds 7/14/21 burden to those attachments when used per maneuver active.

Did all the math in game, take a look at the capture if you're interested but all attachments showed the same burden values.

Oh and just incase anyone asks, I did test both Heat Capacitors together with 3 Fire Maneuvers, still the same burden applied. 

Also includes some other bug fixes I found along the way for my PUP module, and also adds a override for Economizer I was missing. 

## Capture
https://www.youtube.com/watch?v=fLrHLIK3htQ
https://1drv.ms/u/c/a1ac08c33d8c8146/IQCpclSILVSaT7N6UGpNe2jLAf9GSaXoNzb1I6FgyY890TY?e=eHFPo7

## Steps to test these changes

Use any of the changed attachments, feel burdened. 
