### PR TITLE
Increase constexpr steps limit for clang builds

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -43,6 +43,14 @@ set(SOURCES
     test_suite.cpp
 )
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Apple")
+    set_source_files_properties(
+        tests/rng_spread_tests.cpp
+        PROPERTIES
+            COMPILE_OPTIONS "-fconstexpr-steps=2097152"
+    )
+endif()
+
 if(UNIX)
     set(resource "")
 else()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Double Clang's default constexpr evaluation step limit so the compile-time RNG distribution tests compile reliably with Release build configurations.

```
#23 2372.8 /server/src/test/tests/rng_spread_tests.cpp:128:15: error: static assertion expression is not an integral constant expression
#23 2372.8   128 | static_assert(spreadWithin<10, kIntSamples>(0xDEADBEEF, 90), "integer spread too skewed");           // within 9%
#23 2372.8       |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#23 2372.8 /server/src/test/tests/rng_spread_tests.cpp:68:5: note: constexpr evaluation hit maximum step limit; possible infinite loop?
#23 2372.8    68 |     {
#23 2372.8       |     ^
#23 2372.8 /server/src/test/tests/rng_spread_tests.cpp:103:12: note: in call to 'maxBucketDeviation<10U, 24000U, Squirrel5>(3735928559)'
#23 2372.8   103 |     return maxBucketDeviation<Buckets, Samples, Engine>(seed) <= allowed;
#23 2372.8       |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#23 2372.8 /server/src/test/tests/rng_spread_tests.cpp:128:15: note: in call to 'spreadWithin<10U, 24000U, Squirrel5>(3735928559, 90)'
#23 2372.8   128 | static_assert(spreadWithin<10, kIntSamples>(0xDEADBEEF, 90), "integer spread too skewed");           // within 9%
#23 2372.8       |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#23 2372.8 1 error generated.
```

## Steps to test these changes

https://github.com/cocosolos/server/actions/runs/28992481674