### PR TITLE
Fix Ankabut mob skill list

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -3400,7 +3400,7 @@ INSERT INTO `mob_skill_lists` VALUES ('NM_Rocs',1004,926); -- Stormwind
 INSERT INTO `mob_skill_lists` VALUES ('Nargun',1005,677); -- Thunder Break
 INSERT INTO `mob_skill_lists` VALUES ('Ignamoth',1006,1952);
 INSERT INTO `mob_skill_lists` VALUES ('Ignamoth',1006,1956);
-INSERT INTO `mob_skill_lists` VALUES ('Ankabut',1007,704);
+INSERT INTO `mob_skill_lists` VALUES ('Ankabut',1007,811);
 INSERT INTO `mob_skill_lists` VALUES ('White_Coney',1008,323); -- only Wild Carrot
 INSERT INTO `mob_skill_lists` VALUES ('Ophiotaurus',1009,2922); -- Soulshattering Roar
 INSERT INTO `mob_skill_lists` VALUES ('Ophiotaurus',1009,2923); -- Calcifying Claw


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #10387.

Updates Ankabut's mob skill list entry from mob skill `704` to `811`.

Evidence checked:
- `sql/mob_pools.sql` assigns Ankabut to skill list `1007`.
- `sql/mob_skill_lists.sql` had Ankabut list `1007` pointing at `704`.
- `sql/mob_skills.sql` has `704` only as a commented-out `counterstance_2` row.
- `sql/mob_skills.sql` defines `811` as `acid_spray`.
- BG Wiki currently lists Ankabut as using Acid Spray.

## Steps to test these changes

Ran locally from this branch:

```sh
PYTHONUTF8=1 /c/Program\ Files/Git/bin/bash.exe tools/ci/sanity_checks.sh upstream/base
```

Result: all sanity checks passed.

Also ran a targeted parser to confirm Ankabut has exactly one skill-list row and that it points to defined mob skill `811`.

Not run locally:
- Docker compose build/test/startup services, because Docker is not installed/on PATH in this Windows environment.
- Native CMake build, because CMake selects NMake but `nmake` and C/C++ compilers are not installed/on PATH.