### PR TITLE
Add Acrolith mob skill list

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -22,6 +22,11 @@ CREATE TABLE IF NOT EXISTS `mob_skill_lists` (
 --
 
 -- 1: Acrolith
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2070);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2071);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2072);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2073);
+INSERT INTO `mob_skill_lists` VALUES ('Acrolith',1,2074);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,804);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,805);
 INSERT INTO `mob_skill_lists` VALUES ('Adamantoise',2,806);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Part of #5494.

Adds the missing Acrolith mob skill list rows for `skill_list_id` 1. On current `base`, pool 39 (`Acrolith`) already points at `skill_list_id` 1, but `mob_skill_lists.sql` only had the `-- 1: Acrolith` section marker and no active rows for that list.

The new list uses the five active Acrolith skill definitions already present in `mob_skills.sql` and already used by the existing Wulgaru Acrolith list: `dismemberment`, `dire_straight`, `earth_shatter`, `sinker_drill`, and `detonating_grip`.

Evidence used:
- Existing LSB data: Wulgaru list 302 already maps to skill IDs 2070-2074.
- Public wiki evidence: BG Wiki and FFXIclopedia list the same Acrolith-family TP moves.
- No proprietary client assets, DAT files, private captures, or leaked materials were used.

## Steps to test these changes

Targeted static validation:
- Confirmed pool 39 (`Acrolith`) uses `skill_list_id` 1.
- Confirmed list 1 now contains skill IDs 2070-2074.
- Confirmed all five skill IDs exist in `mob_skills.sql`.
- Confirmed the #5494 missing-list condition no longer matches Acrolith.

Local checks run:
- `tools/ci/sanity_checks/sql.sh sql/mob_skill_lists.sql`
- `tools/ci/sanity_checks/general.sh sql/mob_skill_lists.sql` with `PYTHONUTF8=1`
- `tools/ci/sanity_checks/python.sh sql/mob_skill_lists.sql`
- `tools/ci/sanity_checks/lua.sh sql/mob_skill_lists.sql` with `PYTHONUTF8=1`
- `python tools/ci/sanity_checks/lua_stylecheck.py test`
- `tools/ci/sanity_checks.sh upstream/base` with `PYTHONUTF8=1`
- `git diff --check`

Local limitations:
- Docker compose/build/DB startup checks were not run locally. Docker Desktop and WSL2 are not installed/enabled on this Windows host, and enabling them would require OS feature changes and likely a reboot.