### PR TITLE
Add Matamata mob skill list

### DIFF
--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1212,7 +1212,11 @@ INSERT INTO `mob_skill_lists` VALUES ('Serket',273,724);
 INSERT INTO `mob_skill_lists` VALUES ('KingV',274,354);
 INSERT INTO `mob_skill_lists` VALUES ('KingV',274,722);
 INSERT INTO `mob_skill_lists` VALUES ('KingV',274,723);
--- 275: Matamata
+INSERT INTO `mob_skill_lists` VALUES ('Matamata',275,2965);
+INSERT INTO `mob_skill_lists` VALUES ('Matamata',275,2966);
+INSERT INTO `mob_skill_lists` VALUES ('Matamata',275,2967);
+INSERT INTO `mob_skill_lists` VALUES ('Matamata',275,2968);
+INSERT INTO `mob_skill_lists` VALUES ('Matamata',275,2969);
 -- 276: Crepuscular Worm
 INSERT INTO `mob_skill_lists` VALUES ('Genbu',277,805);
 INSERT INTO `mob_skill_lists` VALUES ('Genbu',277,806);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing `mob_skill_lists` rows for Matamata skill list `275`, covering one focused slice of #5494.

Evidence used:
- `sql/mob_pools.sql` assigns eight Matamata-family pools to skill list `275`: `Skittish_Matamata`, `Matamata`, `Emberflash_Matamata`, `Volatile_Matamata`, `Groundstomp_Matamata`, `Disturbed_Matamata`, `Sinewy_Matamata`, and `Apex_Matamata`.
- `sql/mob_skill_lists.sql` had only the placeholder comment for `275` and no active rows.
- `sql/mob_skills.sql` already defines active Matamata skills `2965` through `2969`: `cranial_thrust`, `tail_thwack`, `embalming_earth`, `scalding_breath`, and `debilitating_spout`.
- Existing LSB skill list `348` already uses those same five Matamata skill IDs.
- Public wiki family pages list the same Matamata-family TP moves.

This PR is not claiming packet-capture or retail-capture verification; it is a data-only correction based on current LSB data plus public wiki support. No proprietary client data, DAT files, packet captures, or private materials were used.

## Steps to test these changes

Local checks run on Windows:

- Targeted static parser check confirming list `275` contains `2965,2966,2967,2968,2969` and all five referenced skill IDs are active in `mob_skills.sql`.
- `PYTHONUTF8=1 bash tools/ci/sanity_checks/sql.sh sql/mob_skill_lists.sql`
- `PYTHONUTF8=1 bash tools/ci/sanity_checks/general.sh sql/mob_skill_lists.sql`
- `PYTHONUTF8=1 bash tools/ci/sanity_checks/python.sh sql/mob_skill_lists.sql`
- `PYTHONUTF8=1 bash tools/ci/sanity_checks/lua.sh sql/mob_skill_lists.sql`
- `PYTHONUTF8=1 python tools/ci/sanity_checks/lua_stylecheck.py test`
- `git diff --check`
- Native MSVC/Ninja build using Visual Studio Build Tools 2022: passed after configuring `build-msvc-cl` with `cl.exe`.
- Temporary MariaDB 12.3 database import via `python tools/dbtool.py update full`: passed.
- DB query confirmed skill list `275` has the five intended skill rows and eight pools use list `275`.
- `python tools/ci/startup_checks.py`: passed; all server processes reached `ready to work`.

Local limitations:

- `PYTHONUTF8=1 bash tools/ci/sanity_checks.sh upstream/base` was attempted, but timed out locally while running the Lua sanity phase. The targeted per-file sanity scripts listed above passed.
- A direct `xi_test.exe` run was attempted separately, but it exited nonzero before producing a clean final summary in this Windows session; CI should provide the authoritative full test matrix.
