### PR TITLE
[lua] Don't lock Dhalmel Meat when not necessary

### DIFF
--- a/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
+++ b/scripts/quests/otherAreas/RQ1_Rycharde_the_Chef.lua
@@ -96,7 +96,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if npcUtil.tradeHasExactly(trade, { { xi.item.SLICE_OF_DHALMEL_MEAT, 2 } }) then
                         return quest:progressEvent(74) -- Quest completed dialog.
-                    elseif npcUtil.tradeHasExactly(trade, { { xi.item.SLICE_OF_DHALMEL_MEAT, 1 } }) then
+                    elseif trade:hasItemQty(xi.item.SLICE_OF_DHALMEL_MEAT, 1)  then
                         return quest:event(73) -- "That's not enough!" dialog.
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If you traded one meat it would lock it and could softlock you without zoning

## Steps to test these changes

trade 1 meat and then 2 to rycharde and see quest complete
