### PR TITLE
[lua] Fix Tateeya Attachment Trade

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Tateeya.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Tateeya.lua
@@ -20,6 +20,7 @@ entity.onTrade = function(player, npc, trade)
                     player:startEventString(651, automatonName, automatonName, automatonName, automatonName, subid) --unlock attachment event
                     if trade:confirmSlot(i) then
                         player:confirmTrade()
+                        break
                     end
                 else
                     player:startEvent(652) --already unlocked event


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a simple break to prevent more than one attachment from being accepted. Verified on retail this was accurate behavior.

## Steps to test these changes

Trade 2 attachments at once, see 1 accepted