### PR TITLE
[lua] Add TP Clamp to Aftermath handler

### DIFF
--- a/scripts/globals/aftermath.lua
+++ b/scripts/globals/aftermath.lua
@@ -557,6 +557,9 @@ xi.aftermath.addStatusEffect = function(player, tp, weaponSlot, aftermathType)
         return
     end
 
+    -- Ensures atleast 1000 TP is fed to AM handler, incase of TP Draining ability TODO: Check how this interaction works on retail.
+    tp = utils.clamp(tp, 1000, 3000)
+
     local weapon = player:getStorageItem(0, 0, weaponSlot)
     if not weapon then
         return


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Avoids a very niche race condition where a TP draining ability could reduce the players TP below 1000 while a weaponskill is executing. 

## Steps to test these changes

None
