### PR TITLE
[fix] Handle TOTD despawning differently in sleeping zones

### DIFF
--- a/src/map/spawn_handler.cpp
+++ b/src/map/spawn_handler.cpp
@@ -21,6 +21,7 @@
 
 #include "spawn_handler.h"
 
+#include "ai/ai_container.h"
 #include "common/timer.h"
 #include "common/vana_time.h"
 #include "entities/mob_entity.h"
@@ -240,13 +241,23 @@ void SpawnHandler::Tick(const timer::time_point now)
 // Despawn mobs now outside their spawn window. Not tied to 30s task.
 void SpawnHandler::onGameHour(const uint32 hour) const
 {
+    const bool zoneActive = zone_->IsZoneActive();
+
     zone_->ForEachMob(
-        [hour](CMobEntity* PMob)
+        [zoneActive, hour](CMobEntity* PMob)
         {
             const auto window = spawnWindowOf(PMob);
             if (window.has_value() && PMob->isAlive() && !hourInWindow(hour, window->spawnHour, window->despawnHour))
             {
-                PMob->SetDespawnTime(1ms);
+                if (zoneActive)
+                {
+                    PMob->SetDespawnTime(1ms);
+                }
+                else
+                {
+                    // Sleeping zone -> process the despawn immediately since AI doesnt tick on its own
+                    PMob->PAI->Despawn();
+                }
             }
         });
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Little bit of a speculative fix with regards to sleeping zones possibly not processing TOTD despawns correctly since the AI doesn't tick.
I believe this is what's causing TOTD mobs to not be up when a player zones into a sleeping zone.

Mandatory mention that I hate the concept of sleeping zones to begin with.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
