### PR TITLE
[lua] Zoredonite Bug Fixes

### DIFF
--- a/scripts/actions/mobskills/venom_shell.lua
+++ b/scripts/actions/mobskills/venom_shell.lua
@@ -18,6 +18,10 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power = math.floor(mob:getMainLvl() / 2) - 2
     power = math.max(power, 16) -- Floor of 16 damage per tick
 
+    if mob:getPool() == xi.mobPool.ZOREDONITE then
+        power = 30 -- Retail capture: Zoredonite's Venom Shell ticks for 30
+    end
+
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, power, 0, 120))
 
     return xi.effect.POISON

--- a/scripts/enum/mob_pool.lua
+++ b/scripts/enum/mob_pool.lua
@@ -46,6 +46,7 @@ xi.mobPool =
     THRONE_ROOM_VOLKER     = 4249, -- Throne Room BC, Volker
     WREAKER                = 4382, -- Wreaker (CoP 1-3 Spire Battle)
     ZIZZY_ZILLAH           = 4509, -- Zizzy Zillah (Mamook NM)
+    ZOREDONITE             = 4519, -- Zoredonite (Manaclipper NM) Venom Shell 30/tick poison
     QNAERN_WHM             = 4651, -- Qn'Aern WHM benediction check
     GROUNDSKEEPER_WALL     = 5128, -- Groundskeepers in wall that aggro
     AMNAF_PSYCHEFLAYER     = 5310, -- Reset enmity on sleepga

--- a/scripts/zones/Manaclipper/mobs/Zoredonite.lua
+++ b/scripts/zones/Manaclipper/mobs/Zoredonite.lua
@@ -1,6 +1,5 @@
--- Note: Zoredonite not despawning when the boat docks is correct to retail behavior. He will respawn on the boat when it takes off again. As long as he is claimed when the boat docks, he will always respawn on the next boat ride.
--- To Do: Venom Shell poison tick rate is 30/HP per tick based on retail captures.
--- To Do: Fix uragnite family mixin. Right now, they do not go into their shells to heal.
+-- Note: Zoredonite persists on the boat across rides until killed.
+-- On death he goes on a 12 hour cooldown before he can spawn again.
 -----------------------------------
 -- Area: Manaclipper
 --   NM: Zoredonite
@@ -18,8 +17,9 @@ entity.onMobEngage = function(mob, player)
     mob:setLocalVar('[uragnite]inShellRegen', 100)
 end
 
-entity.onMobDespawn = function(mob)
-    mob:setLocalVar('respawn', GetSystemTime() + 43200) -- 12 hour respawn
+entity.onMobDeath = function(mob, player, optParams)
+    mob:setLocalVar('respawn', GetSystemTime() + 43200) -- When killed: 12 hour respawn timer.
+    mob:setRespawnTime(0)                               -- Cancel auto-respawn.
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes multiple bugs with [Zoredonite](https://youtu.be/8u9EmxfVrAA) (ID: 16789518), including:

- Zoredonite no longer can spawn twice on the same boat.
- Zoredonite now actually goes on cooldown when he dies.
- Addressed old to do by me and tuned his venom shell.
- Cleaned up other now outdated comments.

## Steps to test these changes

Ride the boat. See him pop sometime after server restart. Then kill him. Then see him not pop until he is supposed to many hours later. See he also doesn't pop multiple times on the same ride.
