### PR TITLE
[core] Tighten lockstyle checks

### DIFF
--- a/src/map/enums/packet_s2c.h
+++ b/src/map/enums/packet_s2c.h
@@ -175,6 +175,7 @@ enum class PacketS2C : uint16_t
     GP_SERV_COMMAND_CURRENCIES_2      = 0x118,
     GP_SERV_COMMAND_ABIL_RECAST       = 0x119,
     GP_SERV_COMMAND_EMOTE_LIST        = 0x11A,
+    GP_SERV_COMMAND_LOCKSTYLE_ERROR   = 0x11C,
     GP_SERV_COMMAND_PARTYREQ          = 0x11D,
     GP_SERV_COMMAND_JUMP              = 0x11E,
 };

--- a/src/map/packets/c2s/0x053_lockstyle.cpp
+++ b/src/map/packets/c2s/0x053_lockstyle.cpp
@@ -111,6 +111,18 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                     failedItemIds.push_back(itemId);
                     itemId = 0;
                 }
+                else if (!charutils::canEquipItemOnAnyJob(PChar, PItem)) // owned but no leveled job can equip it
+                {
+                    failedItemIds.push_back(itemId);
+                    itemId = 0;
+                }
+                else if ((item.EquipKind == SLOT_MAIN || item.EquipKind == SLOT_SUB || item.EquipKind == SLOT_RANGED) &&
+                         !charutils::hasValidStyle(PChar, PChar->getEquip(static_cast<SLOTTYPE>(item.EquipKind)), PItem))
+                {
+                    // A weapon appearance can only be locked over a weapon of the same skill type
+                    failedItemIds.push_back(itemId);
+                    itemId = 0;
+                }
 
                 PChar->styleItems[item.EquipKind] = itemId;
 

--- a/src/map/packets/c2s/0x053_lockstyle.cpp
+++ b/src/map/packets/c2s/0x053_lockstyle.cpp
@@ -26,8 +26,11 @@
 #include "packets/char_sync.h"
 #include "packets/s2c/0x009_message.h"
 #include "packets/s2c/0x051_grap_list.h"
+#include "packets/s2c/0x11c_lockstyle_error.h"
 #include "utils/charutils.h"
 #include "utils/itemutils.h"
+
+#include <vector>
 
 namespace
 {
@@ -79,6 +82,9 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
             // TODO: Missing a handful of retail checks here
             charutils::SetStyleLock(PChar, true);
 
+            // Any items that we fail to lockstyle will be reported to the client
+            std::vector<uint16_t> failedItemIds;
+
             // Build new lockstyle
             for (int i = 0; i < this->Count; i++)
             {
@@ -100,12 +106,17 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                 {
                     itemId = 0;
                 }
+                else if (!charutils::HasItem(PChar, itemId, IncludeRecycleBin::No)) // valid for the slot but not owned
+                {
+                    failedItemIds.push_back(itemId);
+                    itemId = 0;
+                }
 
                 PChar->styleItems[item.EquipKind] = itemId;
 
-                if (i == SLOT_MAIN)
+                if (i == SLOT_MAIN && itemId != 0)
                 {
-                    if (const CItemWeapon* PItemWeapon = dynamic_cast<const CItemWeapon*>(PItem); PItemWeapon)
+                    if (auto* PItemWeapon = dynamic_cast<const CItemWeapon*>(PItem); PItemWeapon)
                     {
                         if (PItemWeapon->isHandToHand())
                         {
@@ -165,6 +176,12 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
             }
 
             charutils::UpdateRemovedSlotsLookForLockStyle(PChar);
+
+            if (!failedItemIds.empty())
+            {
+                PChar->pushPacket<GP_SERV_COMMAND_LOCKSTYLE_ERROR>(failedItemIds);
+            }
+
             PChar->RequestPersist(CHAR_PERSIST::EQUIP);
             updateClientAppearance(PChar);
         }

--- a/src/map/packets/s2c/0x11c_lockstyle_error.cpp
+++ b/src/map/packets/s2c/0x11c_lockstyle_error.cpp
@@ -1,0 +1,36 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "0x11c_lockstyle_error.h"
+
+#include <algorithm>
+#include <iterator>
+
+GP_SERV_COMMAND_LOCKSTYLE_ERROR::GP_SERV_COMMAND_LOCKSTYLE_ERROR(const std::vector<uint16_t>& failedItemIds)
+{
+    auto& packet = this->data();
+
+    packet.Count = static_cast<uint8_t>(std::min(failedItemIds.size(), std::size(packet.ItemNo)));
+    for (size_t i = 0; i < packet.Count; ++i)
+    {
+        packet.ItemNo[i] = failedItemIds[i];
+    }
+}

--- a/src/map/packets/s2c/0x11c_lockstyle_error.h
+++ b/src/map/packets/s2c/0x11c_lockstyle_error.h
@@ -1,0 +1,42 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "base.h"
+
+#include <vector>
+
+// https://github.com/atom0s/XiPackets/tree/main/world/server/0x011C
+// This packet is sent by the server in response to the client locking their style.
+// (This packet was intended to work similar to packet 0x0117 to inform the client when a piece of gear could not be style locked.)
+class GP_SERV_COMMAND_LOCKSTYLE_ERROR final : public GP_SERV_PACKET<PacketS2C::GP_SERV_COMMAND_LOCKSTYLE_ERROR, GP_SERV_COMMAND_LOCKSTYLE_ERROR>
+{
+public:
+    struct PacketData
+    {
+        uint8_t  Count;        // PS2: (New; did not exist.)
+        uint8_t  padding05[3]; // PS2: (New; did not exist.)
+        uint16_t ItemNo[16];   // PS2: (New; did not exist.)
+    };
+
+    GP_SERV_COMMAND_LOCKSTYLE_ERROR(const std::vector<uint16_t>& failedItemIds);
+};

--- a/src/map/packets/s2c/CMakeLists.txt
+++ b/src/map/packets/s2c/CMakeLists.txt
@@ -294,6 +294,8 @@ set(PACKET_S2C_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/0x119_abil_recast.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x11a_emote_list.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x11a_emote_list.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x11c_lockstyle_error.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/0x11c_lockstyle_error.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/0x11d_partyreq.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x11e_jump.h
     ${CMAKE_CURRENT_SOURCE_DIR}/0x11e_jump.cpp

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1796,7 +1796,7 @@ auto AddItem(CCharEntity* PChar, uint8 LocationID, std::unique_ptr<CItem> PItem,
  *                                                                       *
  ************************************************************************/
 
-bool HasItem(CCharEntity* PChar, uint16 ItemID)
+bool HasItem(CCharEntity* PChar, uint16 ItemID, IncludeRecycleBin includeRecycleBin)
 {
     if (ItemID == 0)
     {
@@ -1804,6 +1804,11 @@ bool HasItem(CCharEntity* PChar, uint16 ItemID)
     }
     for (uint8 LocID = 0; LocID < CONTAINER_ID::MAX_CONTAINER_ID; ++LocID)
     {
+        if (!includeRecycleBin && LocID == LOC_RECYCLEBIN)
+        {
+            continue;
+        }
+
         if (PChar->getStorage(LocID)->SearchItem(ItemID) != ERROR_SLOTID)
         {
             return true;
@@ -2007,37 +2012,6 @@ uint32 UpdateItem(CCharEntity* PChar, uint8 LocationID, uint8 slotID, int32 quan
         auto PRemoved = PChar->getStorage(LocationID)->RemoveItem(slotID);
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_ATTR>(nullptr, static_cast<CONTAINER_ID>(LocationID), slotID);
 
-        if (PChar->getStyleLocked() && !HasItem(PChar, ItemID))
-        {
-            if (PItem->isType(ITEM_WEAPON))
-            {
-                if (PChar->styleItems[SLOT_MAIN] == ItemID)
-                {
-                    charutils::UpdateWeaponStyle(PChar, SLOT_MAIN, (CItemWeapon*)PChar->getEquip(SLOT_MAIN));
-                }
-                else if (PChar->styleItems[SLOT_SUB] == ItemID)
-                {
-                    charutils::UpdateWeaponStyle(PChar, SLOT_SUB, (CItemWeapon*)PChar->getEquip(SLOT_SUB));
-                }
-            }
-            else if (PItem->isType(ITEM_EQUIPMENT))
-            {
-                auto equipSlotID = ((CItemEquipment*)PItem)->getSlotType();
-                if (PChar->styleItems[equipSlotID] == ItemID)
-                {
-                    switch (equipSlotID)
-                    {
-                        case SLOT_HEAD:
-                        case SLOT_BODY:
-                        case SLOT_HANDS:
-                        case SLOT_LEGS:
-                        case SLOT_FEET:
-                            charutils::UpdateArmorStyle(PChar, equipSlotID);
-                            break;
-                    }
-                }
-            }
-        }
         luautils::OnItemDrop(PChar, PItem);
 
         // Remove soon to be stale PItem pointer from sync state

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -27,7 +27,8 @@
 
 #include "entities/char_entity.h"
 
-using Recalculate = xi::Flag<struct RecalculateTag>;
+using Recalculate       = xi::Flag<struct RecalculateTag>;
+using IncludeRecycleBin = xi::Flag<struct IncludeRecycleBinTag>;
 
 struct Charge_t;
 enum class MissionLog : uint8_t;
@@ -123,7 +124,7 @@ void DoTrade(CCharEntity* PChar, CCharEntity* PTarget);
 bool CanTrade(CCharEntity* PChar, CCharEntity* PTarget);
 
 void   CheckWeaponSkill(CCharEntity* PChar, uint8 skill);
-bool   HasItem(CCharEntity* PChar, uint16 ItemID);
+bool   HasItem(CCharEntity* PChar, uint16 ItemID, IncludeRecycleBin includeRecycleBin = IncludeRecycleBin::Yes);
 uint32 getItemCount(CCharEntity* PChar, uint16 ItemID);
 auto   AddItem(CCharEntity* PChar, uint8 LocationID, std::unique_ptr<CItem> PItem, bool silence = false) -> uint8;
 uint8  AddItem(CCharEntity* PChar, uint8 LocationID, uint16 itemID, uint32 quantity = 1, bool silence = false);

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -143,6 +143,8 @@ void   CheckUnarmedWeapon(CCharEntity* PChar);
 void   SetStyleLock(CCharEntity* PChar, bool isStyleLocked);
 void   UpdateWeaponStyle(CCharEntity* PChar, uint8 equipSlotID, CItemEquipment* PItem);
 void   UpdateArmorStyle(CCharEntity* PChar, uint8 equipSlotID);
+auto   canEquipItemOnAnyJob(CCharEntity* PChar, const CItemEquipment* PItem) -> bool;
+auto   hasValidStyle(CCharEntity* PChar, const CItemEquipment* PItem, const CItemEquipment* AItem) -> bool;
 void   UpdateRemovedSlotsLookForLockStyle(CCharEntity* PChar);
 void   UpdateRemovedSlotsLook(CCharEntity* PChar);
 void   AddItemToRecycleBin(CCharEntity* PChar, uint32 container, uint8 slotID, uint8 quantity);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Closes a few loopholes:
- Items no longer owned cannot be applied as lockstyle
  - This also blocks weird glitches with missing limbs
- Players must meet requirements to equip the item on _any_ of their job.
  - For example, you need DRK levelled to 70 to equip a Vampire Cloak
- Weapons need exact same skill type to be applied
  - Sword to sword, shield to shield, bow to bow etc.

Drops a tiny bit of logic that immediately updated player model on dropping an item. Retail does not do that.
Adds the retail accurate error packet for error paths.

## Steps to test these changes
See this message appear in various conditions

<img width="1526" height="70" alt="image" src="https://github.com/user-attachments/assets/1c13960e-2355-49c7-984f-c5b78bdf2484" />

<!-- Clear and detailed steps to test your changes here -->
