### PR TITLE
[core] Tweak Paralyze message; Consume Blood Pact CD on paralyze

### DIFF
--- a/scripts/items/flask_of_paralyze_potion.lua
+++ b/scripts/items/flask_of_paralyze_potion.lua
@@ -12,7 +12,7 @@ end
 
 itemObject.onItemUse = function(target, user)
     if not target:hasStatusEffect(xi.effect.PARALYSIS) then
-        target:addStatusEffect(xi.effect.PARALYSIS, { power = 20, duration = 180, origin = user })
+        target:addStatusEffect(xi.effect.PARALYSIS, { power = 100, duration = 180, origin = user })
     else
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end

--- a/scripts/tests/packets/s2c/0x028_battle2/abilities.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/abilities.lua
@@ -94,62 +94,30 @@ local packets =
 
         expected =
         {
+            m_uID   = ph.TEST_CHAR,
+            trg_sum = 1,
+            res_sum = 0,
+            cmd_no  = xi.action.category.MAGIC_FINISH,
+            cmd_arg = 0,
+            info    = 0,
+            target  =
             {
-                m_uID   = ph.TEST_CHAR,
-                trg_sum = 1,
-                res_sum = 0,
-                cmd_no  = xi.action.category.MAGIC_FINISH,
-                cmd_arg = 0,
-                info    = 0,
-                target  =
                 {
+                    m_uID      = ph.TEST_MOB,
+                    result_sum = 1,
+                    result     =
                     {
-                        m_uID      = ph.TEST_CHAR,
-                        result_sum = 1,
-                        result     =
                         {
-                            {
-                                miss      = 0,
-                                kind      = 0,
-                                sub_kind  = 508,
-                                info      = 0,
-                                scale     = 0,
-                                value     = 0,
-                                message   = xi.msg.basic.IS_PARALYZED_2,
-                                bit       = 0,
-                                has_proc  = false,
-                                has_react = false,
-                            },
-                        },
-                    },
-                },
-            },
-            {
-                m_uID   = ph.TEST_CHAR,
-                trg_sum = 1,
-                res_sum = 0,
-                cmd_no  = xi.action.category.MAGIC_FINISH,
-                cmd_arg = 0,
-                info    = 0,
-                target  =
-                {
-                    {
-                        m_uID      = ph.TEST_MOB,
-                        result_sum = 1,
-                        result     =
-                        {
-                            {
-                                miss      = 0,
-                                kind      = 0,
-                                sub_kind  = 508,
-                                info      = 0,
-                                scale     = 0,
-                                value     = 0,
-                                message   = xi.msg.basic.IS_PARALYZED_2,
-                                bit       = 0,
-                                has_proc  = false,
-                                has_react = false,
-                            },
+                            miss      = 0,
+                            kind      = 0,
+                            sub_kind  = 508,
+                            info      = 0,
+                            scale     = 0,
+                            value     = 0,
+                            message   = xi.msg.basic.IS_PARALYZED_2,
+                            bit       = 0,
+                            has_proc  = false,
+                            has_react = false,
                         },
                     },
                 },

--- a/src/map/action/interrupts.cpp
+++ b/src/map/action/interrupts.cpp
@@ -422,25 +422,7 @@ void AttackIntimidated(CBattleEntity* PEntity, const CBattleEntity* PTarget)
 
 void AbilityParalyzed(CBattleEntity* PEntity, const CBattleEntity* PTarget)
 {
-    // 1. Generic MagicFinish with Paralyzed message
-    auto magicFinishSelfAction = action_t{
-        .actorId    = PEntity->id,
-        .actiontype = ActionCategory::MagicFinish,
-        .targets    = {
-            {
-                .actorId = PEntity->id,
-                .results = {
-                    {
-                        .animation = ActionAnimation::SkillInterrupt,
-                        .messageID = MsgBasic::IsParalyzed2,
-                    },
-                },
-            },
-        },
-    };
-
-    // 2. Generic MagicFinish with Paralyzed message
-    auto magicFinishTargetAction = action_t{
+    auto magicFinishAction = action_t{
         .actorId    = PEntity->id,
         .actiontype = ActionCategory::MagicFinish,
         .targets    = {
@@ -456,8 +438,7 @@ void AbilityParalyzed(CBattleEntity* PEntity, const CBattleEntity* PTarget)
         },
     };
 
-    PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(magicFinishSelfAction));
-    PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(magicFinishTargetAction));
+    PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(magicFinishAction));
 }
 
 void ItemInterrupt(CBattleEntity* PEntity)

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -1806,6 +1806,8 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
         auto* charge         = ability::GetCharge(this, static_cast<uint16>(PAbility->getRecastId()));
         auto  baseChargeTime = 0ns; // this can be reduced with merits/job point gifts. NOT the same as Recast- gear (so far...)
 
+        timer::duration bloodPactRecast = 0s;
+
         if (charge && PAbility->getID() != ABILITY_SIC)
         {
             auto chargesUsed = timer::count_seconds(PAbility->getRecastTime()); // charge cost is stored in the recast...
@@ -1852,9 +1854,12 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
 
             int16 bloodPactDelayReduction = favorReduction + std::min<int16>(bloodPact_I_Reduction + bloodPact_II_Reduction + bloodPact_III_Reduction, 30);
 
+            // Snapshot BP recast here so we can carry it into Paralyze check
+            bloodPactRecast = std::max<timer::duration>(0s, action.recast - std::chrono::seconds(bloodPactDelayReduction));
+
             // Localvar will set the BP ability timer when the move consumes MP
             // The delay is snapshot when the player uses the ability: https://www.bg-wiki.com/ffxi/Blood_Pact_Ability_Delay
-            this->SetLocalVar("bpRecastTime", static_cast<uint16>(timer::count_seconds(std::max<timer::duration>(0s, action.recast - std::chrono::seconds(bloodPactDelayReduction)))));
+            this->SetLocalVar("bpRecastTime", static_cast<uint16>(timer::count_seconds(bloodPactRecast)));
 
             // Recast is actually triggered when the bp goes off (no recast packet at all on using a bp and the target moving out of range of the pet)
             action.recast = 0s;
@@ -1867,7 +1872,8 @@ void CCharEntity::OnAbility(CAbilityState& state, action_t& action)
             const auto recastId = PAbility->getRecastId();
             if (recastId != Recast::Special && recastId != Recast::Special2)
             {
-                charutils::ApplyAbilityRecast(this, PAbility, charge, baseChargeTime, action.recast);
+                const bool isBloodPact = recastId == Recast::BloodPactRage || recastId == Recast::BloodPactWard;
+                charutils::ApplyAbilityRecast(this, PAbility, charge, baseChargeTime, isBloodPact ? bloodPactRecast : action.recast);
             }
 
             ActionInterrupts::AbilityParalyzed(this, PTarget);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Reduce paralyze procs to a single action packet, I don't know why I did 2 messages before.
- Apply cooldown when Blood Pact gets paralyzed
- Bumps Paralyze Potion potency to 100%, I've used these several times for paralyze message purposes and I've never actually seen paralyze not proc

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
<img width="3374" height="1076" alt="Screenshot 2026-07-10 182134" src="https://github.com/user-attachments/assets/6c23841e-8288-4d2f-bcc3-265672ca7181" />


<!-- Clear and detailed steps to test your changes here -->
