### PR TITLE
[sql][module] Adds module to revert Tiamat to drop Herald's Gaiters

### DIFF
--- a/modules/soa/sql/mob_droplist_adjust.sql
+++ b/modules/soa/sql/mob_droplist_adjust.sql
@@ -1,0 +1,8 @@
+-----------------------------------
+-- Mob drop list item adjustment module
+-- This module removes or adds items for the SoA era
+-----------------------------------
+
+-- Replace Crier's Gaiters with Herald's Gaiters from Tiamat
+-- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
+UPDATE mob_droplist SET itemId = 15322 WHERE itemId = 27456 and dropId = 2416;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Tiamat should drop Herald's Gaiters before SoA. This adds a module to revert that.

## Steps to test these changes

- Load module, check Tiamat's drop table in mob_droplist table
- See she has Herald's gaiters
