### PR TITLE
Fix PUP Module Repair Message

### DIFF
--- a/modules/era/lua/globals/job_utils/puppetmaster.lua
+++ b/modules/era/lua/globals/job_utils/puppetmaster.lua
@@ -36,9 +36,107 @@ m:addOverride('xi.job_utils.puppetmaster.onAbilityCheckRepair', function(player,
     return msg, param
 end)
 
--- Oils: Remove the initial burst heal, leaving only the Regen effect
-for _, oilData in pairs(xi.job_utils.puppetmaster.oilData) do
-    oilData.initialHealPercent = 0
+local removableEffects =
+{
+    -- Songs
+    xi.effect.ELEGY,
+    xi.effect.REQUIEM,
+    xi.effect.THRENODY,
+
+    -- Enfeebling
+    xi.effect.BLINDNESS,
+    xi.effect.PARALYSIS,
+    xi.effect.SILENCE,
+    xi.effect.CURSE_I,
+    xi.effect.CURSE_II,
+    xi.effect.DISEASE,
+    xi.effect.PLAGUE,
+    xi.effect.WEIGHT,
+    xi.effect.BIND,
+    xi.effect.ADDLE,
+    xi.effect.SLOW,
+    xi.effect.PETRIFICATION,
+
+    -- DoTs
+    xi.effect.BIO,
+    xi.effect.DIA,
+    xi.effect.POISON,
+    xi.effect.BURN,
+    xi.effect.FROST,
+    xi.effect.CHOKE,
+    xi.effect.RASP,
+    xi.effect.SHOCK,
+    xi.effect.DROWN,
+
+    -- Main Stat Downs
+    xi.effect.STR_DOWN,
+    xi.effect.DEX_DOWN,
+    xi.effect.VIT_DOWN,
+    xi.effect.AGI_DOWN,
+    xi.effect.INT_DOWN,
+    xi.effect.MND_DOWN,
+    xi.effect.CHR_DOWN,
+
+    -- Combat Stat Downs
+    xi.effect.ACCURACY_DOWN,
+    xi.effect.ATTACK_DOWN,
+    xi.effect.EVASION_DOWN,
+    xi.effect.DEFENSE_DOWN,
+
+    -- Magic Stat Downs
+    xi.effect.MAGIC_ACC_DOWN,
+    xi.effect.MAGIC_ATK_DOWN,
+    xi.effect.MAGIC_EVASION_DOWN,
+    xi.effect.MAGIC_DEF_DOWN,
+
+    -- HP/MP/TP Stat Downs
+    xi.effect.MAX_TP_DOWN,
+    xi.effect.MAX_MP_DOWN,
+    xi.effect.MAX_HP_DOWN
+}
+
+local function removeStatusEffects(pet, amountToRemove)
+    local effectsRemoved = 0
+
+    for _, effectId in ipairs(removableEffects) do
+        if effectsRemoved >= amountToRemove then
+            break
+        end
+
+        if pet:delStatusEffect(effectId) then
+            effectsRemoved = effectsRemoved + 1
+        end
+    end
+
+    return effectsRemoved
 end
+
+-- Repair: Remove the initial burst heal, leaving only the Regen and status removal effects
+m:addOverride('xi.job_utils.puppetmaster.onAbilityUseRepair', function(player, target, ability, action)
+    local pet = player:getPet()
+    if not pet then
+        return
+    end
+
+    -- Self-cast ability but reports on pet
+    action:ID(player:getID(), pet:getID())
+
+    local oilEquipped = xi.job_utils.puppetmaster.oilData[player:getEquipID(xi.slot.AMMO)]
+    local regenAmount = oilEquipped.regen
+    local regenTime   = oilEquipped.duration
+
+    removeStatusEffects(pet, player:getMod(xi.mod.REPAIR_EFFECT))
+
+    local bonus = 1 + player:getMerit(xi.merit.REPAIR_EFFECT) / 100 + player:getMod(xi.mod.REPAIR_POTENCY) / 100
+    regenAmount = regenAmount * bonus
+
+    pet:wakeUp()
+
+    pet:delStatusEffect(xi.effect.REGEN)
+    pet:addStatusEffect(xi.effect.REGEN, { power = regenAmount, duration = regenTime, origin = player, tick = 3 }) -- 3 = tick, each 3 seconds.
+    player:removeAmmo(1)
+
+    ability:setMsg(xi.msg.basic.USES_JA)
+end)
 
 return m


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the Repair message for the era PUP Module , now just says "Uses Repair" instead of displaying 0 HP recovered

## Steps to test these changes

Use it
