### PR TITLE
[lua] Fix RSE Quest Dialogue 

### DIFF
--- a/scripts/quests/jeuno/The_Goblin_Tailor.lua
+++ b/scripts/quests/jeuno/The_Goblin_Tailor.lua
@@ -56,7 +56,7 @@ quest.sections =
                         player:getMainLvl() >= 10 and
                         player:getFameLevel(xi.fameArea.JEUNO) >= 3
                     then
-                        return quest:progressEvent(10016)
+                        return quest:progressEvent(10016, VanadielRSELocation(), VanadielRSERace())
                     else
                         return quest:event(10020)
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes the dialogue for the RSE quest when you pick it up the first time by passing the current race in the progress event - that way the goblin doesnt tell you to "find a magical pattern for nobody" This is only a bug you can replicate when talking to him the first time.
<img width="1467" height="110" alt="image" src="https://github.com/user-attachments/assets/dd82ce09-237e-4709-869b-f93140f55b62" />

## Steps to test these changes

Go to Lower Jeuno
!setfamelevel 3 9
Talk to Guttrix on Level 30+ job
 Get this instead :
 
<img width="1191" height="110" alt="image" src="https://github.com/user-attachments/assets/c7d481d9-24f6-4377-adb3-1ee9c0e76d5d" />

