### PR TITLE
[sql] Faf/Nidhogg removal of immunities in SQL

### DIFF
--- a/sql/mob_resistances.sql
+++ b/sql/mob_resistances.sql
@@ -298,10 +298,10 @@ INSERT INTO `mob_resistances` VALUES (256,'Weeper',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
 INSERT INTO `mob_resistances` VALUES (257,'Wivre',0,0,0,0,0,0,0,0,0,0,0,0,0,0,-2,-2,3,1,-1,-1,-1,-2,-2,-2,3,-1,-1,-1,-1);
 INSERT INTO `mob_resistances` VALUES (258,'Worm',0,0,0,0,0,0,0,0,0,0,0,0,0,-2,-2,-3,2,-2,-2,-3,0,-2,-2,-3,2,-2,-3,0,0);
 INSERT INTO `mob_resistances` VALUES (259,'Wyrm-Ouryu',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-2,11,11,0,0,0,0,0,-2,11,0,0,0,0);
-INSERT INTO `mob_resistances` VALUES (260,'Wyrm-Fafnir',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,-2,0,11,11,0,0,-2,6,6,0);
+INSERT INTO `mob_resistances` VALUES (260,'Wyrm-Fafnir',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,-2,0,0,0,0,0,-2,6,6,0);
 INSERT INTO `mob_resistances` VALUES (261,'Wyrm-Cynoprosopi',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,-2,0,11,11,0,0,-2,-2,0,0);
 INSERT INTO `mob_resistances` VALUES (262,'Wyrm',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,0,0,11,11,0,0,-2,0,0,0);
-INSERT INTO `mob_resistances` VALUES (263,'Wyrm-Nidhogg',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,-2,0,11,11,0,0,-2,6,6,0);
+INSERT INTO `mob_resistances` VALUES (263,'Wyrm-Nidhogg',0,0,0,0,0,0,0,0,0,0,0,0,0,11,11,0,0,0,-2,-2,0,0,0,0,0,-2,6,6,0);
 INSERT INTO `mob_resistances` VALUES (264,'Unused',0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
 INSERT INTO `mob_resistances` VALUES (265,'Wyvern-Simorg',0,0,0,0,0,0,0,0,0,0,0,0,0,4,1,0,0,-2,-2,-2,-3,1,1,0,0,-2,-2,-3,-3);
 INSERT INTO `mob_resistances` VALUES (266,'Wyvern',0,0,0,0,0,0,0,0,0,0,0,0,0,4,1,0,0,-2,-2,-2,-3,1,1,0,0,-2,-2,-3,-3);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Faf/Nidhogg had overlooked immunities to bind/paralyze in SQL.

These mobs have already been thoroughly researched and their immunities have been added to lua

## Steps to test these changes

Land Paralyze on Fafnir and rejoice
