### PR TITLE
[cpp] Adds extra logging for ITEM_TRANSFER packet on reserved items

### DIFF
--- a/src/map/packets/c2s/0x036_item_transfer.cpp
+++ b/src/map/packets/c2s/0x036_item_transfer.cpp
@@ -99,13 +99,13 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
 
         if (PItem == nullptr || PItem->getQuantity() < quantity)
         {
-            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with invalid item!", PChar->getName(), PNpc->getName());
+            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with invalid item {} ({})!", PChar->getName(), PNpc->getName(), PItem->getName(), PItem->getID());
             return;
         }
 
         if (PItem->getReserve() > 0)
         {
-            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with reserved item!", PChar->getName(), PNpc->getName());
+            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with reserved item {} ({})!", PChar->getName(), PNpc->getName(), PItem->getName(), PItem->getID());
             return;
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
When trading a reserved item to an NPC we currently get this error:
```
GP_CLI_COMMAND_ITEM_TRANSFER: Aria trying to trade NPC Hut_Door with reserved item!
```

This simply just adds what that reserved item is, both its name and the ID.

New:
```
[map][error] GP_CLI_COMMAND_ITEM_TRANSFER: Test trying to trade NPC BC_Entrance with reserved item moon_orb (1130)! (GP_CLI_COMMAND_ITEM_TRANSFER::process:108)
```
<img width="1119" height="25" alt="image" src="https://github.com/user-attachments/assets/2c02824c-c501-458d-bcd0-718f5d295779" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Easiest way to do this at the time of this pr:
!additem moon_orb
!zone balga's Dais
Trade the moon or to the bcnm and wait for the menu to come up
Close the menu
Try to trade the orb back -> error
<!-- Clear and detailed steps to test your changes here -->
