### PR TITLE
[Fix] Add back missing parameter to status AEs deleted on accident

### DIFF
--- a/scripts/combat/action_additional_effect_status.lua
+++ b/scripts/combat/action_additional_effect_status.lua
@@ -54,6 +54,7 @@ local function validateParameters(actor, target, fedData)
     params.subType         = fedData.subType or 0
     params.subPower        = fedData.subPower or 0
     params.tier            = fedData.tier or 0
+    params.resistRate      = fedData.resistRate or 0
 
     -- Action properties.
     params.element         = fedData.element or xi.element.NONE     -- None, Fire, Ice, Wind, Earth, Thunder, Water, Light, Dark.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds back a parameter that was deleted on accident in the effect AE system.

## Steps to test these changes
Have effect AEs work. Fight a mob that uses it, like Queen of Batons in Balga Dais
