### PR TITLE
[lua] Phuabo AI breaks in disengage

### DIFF
--- a/scripts/mixins/families/phuabo.lua
+++ b/scripts/mixins/families/phuabo.lua
@@ -10,21 +10,18 @@ g_mixins.families.phuabo = function(phuaboMob)
         mob:hideName(true)
         mob:setUntargetable(true)
         mob:setAnimationSub(5)
-        mob:wait(2000)
     end)
 
     phuaboMob:addListener('ENGAGE', 'PHUABO_ENGAGE', function(mob, target)
         mob:hideName(false)
         mob:setUntargetable(false)
         mob:setAnimationSub(6)
-        mob:wait(2000)
     end)
 
     phuaboMob:addListener('DISENGAGE', 'PHUABO_DISENGAGE', function(mob, target)
         mob:hideName(true)
         mob:setUntargetable(true)
         mob:setAnimationSub(5)
-        mob:wait(2000)
     end)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an issue where the Phuabo mobs AI break (just freezes) whenever they disengage.

wait in a disengage listener breaks the AI. I couldn't find a good reason the wait was ever in there.

## Steps to test these changes

Zone to sea, aggro a shark, rezone to sea.
