### PR TITLE
[C++] Set scent tracking mobs to deaggro on m_Locked

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -182,7 +182,7 @@ auto CMobController::CheckLock(CBattleEntity* PTarget) const -> bool
             const auto* PChar = dynamic_cast<CCharEntity*>(PTarget);
             if (PChar && PChar->m_Locked)
             {
-                return !CanPursueTarget(PTarget);
+                return true;
             }
         }
         else if (PTarget->objtype == TYPE_PET)
@@ -201,7 +201,7 @@ auto CMobController::CheckLock(CBattleEntity* PTarget) const -> bool
 
             if (PChar->m_Locked)
             {
-                return !CanPursueTarget(PTarget);
+                return true;
             }
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

All mobs, even those who track by scent, are supposed to deaggro during a cutscene event that sets m_Locked = true. This PR fixes the issue where mobs that detect by scent do not deaggro.

Video: https://youtu.be/rgGLtrokfiw

## Steps to test these changes

Aggro a mob that tracks by scent, trigger a Cutscene event, watch aggro drop.
