### PR TITLE
[lua] Reset mission status for failed Windurst 2-2

### DIFF
--- a/scripts/missions/windurst/2_2_A_Testing_Time.lua
+++ b/scripts/missions/windurst/2_2_A_Testing_Time.lua
@@ -73,6 +73,7 @@ local failMission = function(player, csid, option, npc)
     mission:setVar(player, 'EndTime', 0)
     mission:setVar(player, 'KillCount', 0)
     player:delKeyItem(xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
+    player:setMissionStatus(mission.areaId, 0)
     player:delMission(mission.areaId, mission.missionId)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Failing Windurst 2-2 doesn't reset the mission status, so then when going into 2-3, events are skipped.

Mission status is set to 0 on ```mission:complete(player)``` which is why clearing the mission correctly doesn't cause this issue.

## Steps to test these changes

Fail Windurst 2-2, start Windurst 2-3 and verify you get the event with Kupipi.
