### PR TITLE
Fix Tutorial Quest Step 10 Copper A.M.A.N. Voucher reward

### DIFF
--- a/scripts/quests/hiddenQuests/Tutorial_Quest.lua
+++ b/scripts/quests/hiddenQuests/Tutorial_Quest.lua
@@ -926,7 +926,7 @@ quest.sections =
             onEventFinish =
             {
                 [715] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.WARP_RING) then
+                    if npcUtil.giveItem(player, xi.item.COPPER_AMAN_VOUCHER) then
                         quest:setVar(player, 'Prog', 11)
                     end
                 end,
@@ -949,7 +949,7 @@ quest.sections =
             onEventFinish =
             {
                 [3658] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.WARP_RING) then
+                    if npcUtil.giveItem(player, xi.item.COPPER_AMAN_VOUCHER) then
                         quest:setVar(player, 'Prog', 11)
                     end
                 end,
@@ -972,7 +972,7 @@ quest.sections =
             onEventFinish =
             {
                 [1006] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.WARP_RING) then
+                    if npcUtil.giveItem(player, xi.item.COPPER_AMAN_VOUCHER) then
                         quest:setVar(player, 'Prog', 11)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a copy-paste error in the Tutorial Quest Step 10 reward blocks to avoid getting the same Warp Ring reward that was in step 8. Step 10 should reward one Copper A.M.A.N Voucher.

## Steps to test these changes

x
