### PR TITLE
[lua] Delete KIs at the correct prog for Early Bird Catches the Bookworm

### DIFF
--- a/scripts/quests/windurst/Early_Bird_Catches_the_Bookworm.lua
+++ b/scripts/quests/windurst/Early_Bird_Catches_the_Bookworm.lua
@@ -113,6 +113,7 @@ quest.sections =
 
                 [395] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 1)
+                    player:delKeyItem(xi.ki.OVERDUE_BOOK_NOTIFICATIONS_EARLY_BIRD)
                 end,
 
                 [398] = function(player, csid, option, npc)
@@ -122,7 +123,7 @@ quest.sections =
                 [400] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:setLocalVar('Quest[2][13]mustZone', 1)
-                        player:delKeyItem(xi.ki.OVERDUE_BOOK_NOTIFICATIONS_EARLY_BIRD)
+                        player:delKeyItem(xi.ki.ART_FOR_EVERYONE)
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR correctly deletes KIs for the correct progs for Early Bird Catches the Bookworm.

https://youtu.be/ruZLYtnRF-0

## Steps to test these changes

Do the quest, you no longer have KI's when you don't need them.
