### PR TITLE
[lua] Rewrite freshly summoned pet logic's return pos

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -791,10 +791,13 @@ xi.mob.callPets = function(mob, petIds, params)
             then
                 spawnedCount = spawnedCount + 1
                 -- spawn pet around owner
-                petToSummon:setSpawn(pos.x + math.randomInt(-2, 2), pos.y, pos.z + math.randomInt(-2, 2), pos.rot)
+                local randomX = math.randomInt(1, 100) <= 50 and 2 or -2
+                local randomZ = math.randomInt(1, 100) <= 50 and 2 or -2
+
+                petToSummon:setSpawn(pos.x + randomX, pos.y, pos.z + randomZ, pos.rot)
                 petToSummon:spawn()
                 -- set home to be the owner's home position
-                petToSummon:setSpawn(spawnPos.x, spawnPos.y, spawnPos.z, spawnPos.rot)
+                petToSummon:setSpawn(spawnPos.x + randomX, spawnPos.y, spawnPos.z + randomZ, spawnPos.rot)
 
                 local ownerRoamListenerName = fmt('OWNER_ASSIST_{}', petId)
                 if params.superLink then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR rewrites how pet home positions are handled, making battlefields less of a mess.

Co-Authored by @Xaver-DaRed 

## Steps to test these changes

Do BST Maat.  You can easily target his pet now.
