### PR TITLE
[lua] Fix Automaton Healing Calculations

### DIFF
--- a/scripts/effects/healing.lua
+++ b/scripts/effects/healing.lua
@@ -57,7 +57,20 @@ effectObject.onEffectTick = function(target, effect)
             not target:hasStatusEffect(xi.effect.CURSE_II)
         then
             local healHP = 0
-            if
+            local healMP = 12 + ((healtime - 2) * (1 + target:getMod(xi.mod.CLEAR_MIND))) + target:getMod(xi.mod.MPHEAL)
+
+            if target:isAutomaton() then
+                -- TODO: Check lower level Automatons
+                local mainLevel = target:getMainLvl()
+                local hpBase    = 10 + 3 * math.floor((mainLevel - 1) / 10)
+                local mpBase    = math.min(33, 9 + 3 * math.floor(mainLevel / 10))
+                local hpRate    = math.min(5, 1 + math.floor(target:getMaxHP() / 300))
+                local mpRate    = math.min(4, 1 + math.floor(target:getMaxMP() / 300))
+
+                target:addTP(xi.settings.main.HEALING_TP_CHANGE)
+                healHP = hpBase + (healtime - 2) * hpRate
+                healMP = mpBase + (healtime - 2) * mpRate
+            elseif
                 target:getContinentID() == 1 and
                 target:hasStatusEffect(xi.effect.SIGNET)
             then
@@ -80,7 +93,7 @@ effectObject.onEffectTick = function(target, effect)
 
             target:addHPLeaveSleeping(healHP)
             target:updateEnmityFromCure(target, healHP)
-            target:addMP(12 + ((healtime - 2) * (1 + target:getMod(xi.mod.CLEAR_MIND))) + target:getMod(xi.mod.MPHEAL))
+            target:addMP(healMP)
         end
     end
 end


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes HP/MP Resting Calculations for Automatons.

Checked Lv50, Lv75, Lv99 - Everything matches up. 

## Capture
[Lv50AutomatonRest.txt](https://github.com/user-attachments/files/29933969/Lv50AutomatonRest.txt)
[Lv75AutomatonRest.txt](https://github.com/user-attachments/files/29933970/Lv75AutomatonRest.txt)
https://youtu.be/U4QBTEp034o

## Steps to test these changes

Summon an automaton, rest.