### PR TITLE
[C++] Fix caster check in mob utils

### DIFF
--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1046,11 +1046,11 @@ void SetupJob(CMobEntity* PMob)
     JOBTYPE sJob = PMob->GetSJob();
     JOBTYPE job{};
 
-    if (grade::GetJobGrade(mJob, 1) > 0 || mJob == JOB_NIN) // check if mainjob gives mp or is NIN
+    if (grade::GetJobGrade(mJob, 1) > 0 || mJob == JOB_NIN || mJob == JOB_BRD) // Check if main job is a caster.
     {
         job = mJob;
     }
-    else // if mainjob had no MP (and isn't NIN), use subjob in switch cases.
+    else // If main job is not a caster, check sub job.
     {
         job = sJob;
     }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This check was poorly written, causing certain job combinations to trigger a false warning. (Like BRD/WAR for instance.)
This adds BRD to the initial check so that they no longer warn falsely. 

## Steps to test these changes

Go kill a Yagudo Conductor - don't get this error. 

<img width="533" height="192" alt="image" src="https://github.com/user-attachments/assets/86ace526-17e1-4f33-b543-8de0e5051580" />


