### PR TITLE
[lua] Require Astral Candescence for certain shop items; Hagakoff shop

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -98,6 +98,22 @@ xi.besieged.getAstralCandescence = function()
     return 1 -- Hardcoded to 1 for now
 end
 
+---Send shop dialog to a player after removing items requiring the Astral Candescence if it is missing
+---@param player CBaseEntity
+---@param stock { [1]: xi.item, [2]: integer, astralCandescence: boolean? }[] Entries flagged `astralCandescence = true` are hidden without the AC
+xi.besieged.shop = function(player, stock)
+    local hasAstralCandescence = xi.besieged.getAstralCandescence() == 1
+    local available            = {}
+
+    for _, entry in ipairs(stock) do
+        if not entry.astralCandescence or hasAstralCandescence then
+            available[#available + 1] = entry
+        end
+    end
+
+    xi.shop.general(player, available)
+end
+
 xi.besieged.badges =
 {
     xi.ki.PSC_WILDCAT_BADGE,

--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hagakoff.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Hagakoff.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Area: Aht Urhgan Whitegate
 --  NPC: Hagakoff
--- TODO: Stock needs to be modified based on
---       status of Astral Candescence
 -----------------------------------
 local ID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 -----------------------------------
@@ -12,27 +10,26 @@ local entity = {}
 entity.onTrigger = function(player, npc)
     local stock =
     {
-        { xi.item.KATARS,            15448, }, -- (Requires Astral Candescence)
-        { xi.item.DARKSTEEL_KATARS,  67760, },
-        { xi.item.PATAS,             45760, }, -- (Requires Astral Candescence)
-        { xi.item.BRONZE_DAGGER,       156, },
-        { xi.item.DAGGER,             2030, },
-        { xi.item.SAPARA,              776, },
-        { xi.item.SCIMITAR,           4525, },
-        { xi.item.TULWAR,            38800, }, -- (Requires Astral Candescence)
-        { xi.item.TABAR,              6600, },
-        { xi.item.DARKSTEEL_TABAR,  124305, }, -- (Requires Astral Candescence)
-        { xi.item.BUTTERFLY_AXE,       672, },
-        { xi.item.GREATAXE,           4550, }, -- (Requires Astral Candescence)
-        { xi.item.BRONZE_ZAGHNAL,      344, },
-        { xi.item.ZAGHNAL,           12540, }, -- (Requires Astral Candescence)
-        { xi.item.ASH_CLUB,             72, },
-        { xi.item.CHESTNUT_CLUB,      1740, }, -- (Requires Astral Candescence)
-        { xi.item.ANGON,               238, },
+        { xi.item.ANGON,               248, astralCandescence = false },
+        { xi.item.DARKSTEEL_KATARS,  67760, astralCandescence = false },
+        { xi.item.PATAS,             45760, astralCandescence = true  },
+        { xi.item.BRONZE_DAGGER,       156, astralCandescence = false },
+        { xi.item.DAGGER,             2030, astralCandescence = false },
+        { xi.item.SAPARA,              776, astralCandescence = false },
+        { xi.item.SCIMITAR,           4525, astralCandescence = false },
+        { xi.item.TULWAR,            38800, astralCandescence = true  },
+        { xi.item.TABAR,             66000, astralCandescence = false },
+        { xi.item.DARKSTEEL_TABAR,  124305, astralCandescence = true  },
+        { xi.item.BUTTERFLY_AXE,       672, astralCandescence = false },
+        { xi.item.GREATAXE,           4550, astralCandescence = true  },
+        { xi.item.BRONZE_ZAGHNAL,      344, astralCandescence = false },
+        { xi.item.ZAGHNAL,           12540, astralCandescence = true  },
+        { xi.item.ASH_CLUB,             72, astralCandescence = false },
+        { xi.item.CHESTNUT_CLUB,      1740, astralCandescence = true  },
     }
 
     player:showText(npc, ID.text.HAGAKOFF_SHOP_DIALOG)
-    xi.shop.general(player, stock)
+    xi.besieged.shop(player, stock)
 end
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds a new function filtering a shop stock before handing it off to the real function, based on astralCandescence being true/false (or missing)

Reorder Hagakoff shop to match retail + fix prices

## Steps to test these changes
Without AC
<img width="855" height="680" alt="image" src="https://github.com/user-attachments/assets/bcb5cdfa-2d55-4c42-ad73-d27704760865" />

With AC
<img width="815" height="586" alt="image" src="https://github.com/user-attachments/assets/19777382-1d3e-4692-a9c1-ffe63b8da191" />

<!-- Clear and detailed steps to test your changes here -->
