### PR TITLE
[C++] [lua] Fix Maidens Virelai

### DIFF
--- a/scripts/enum/mob_mod.lua
+++ b/scripts/enum/mob_mod.lua
@@ -105,4 +105,5 @@ xi.mobMod =
     FOLLOW_LEASH_RANGE     = 94, -- Distance the leader can walk before their followers start moving. Applied to followers.
     FOLLOW_STOP_RANGE      = 95, -- Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
     TRUST_SHIELD_SIZE      = 96, -- TRUSTS ONLY: Set the size of the mob's shield. 3 = Default size, only used for trusts that use shields.
+    BODYGUARD              = 97, -- Charmed mob defends its master similar to an avatar. (Maidens Virelai)
 }

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -224,8 +224,11 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
 
     -- Virelai applies a charm. Quit early.
     elseif spellEffect == xi.effect.CHARM_I then
-        target:addStatusEffect(xi.effect.CHARM_I, { duration = duration, origin = caster })
-        caster:charm(target)
+        -- Should be tracking status effect here with : target:addStatusEffect(xi.effect.CHARM_I, { duration = duration, origin = caster })
+        -- Currently when applied it disables the mobs AI.
+        caster:charm(target, duration)
+        -- Makes charmed mob act as a bodyguard, like avatars.
+        target:setMobMod(xi.mobMod.BODYGUARD, 1)
         if caster:isPC() then
             spell:setMsg(xi.msg.basic.MAGIC_ENFEEB)
         else

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -231,31 +231,42 @@ void CMobController::TryLink()
         return;
     }
 
-    // handle pet behavior on the targets behalf (faster than in ai_pet_dummy)
-    // Avatars defend masters by attacking mobs if the avatar isn't attacking anything currently (bodyguard behavior)
-    // Alexander, Odin and Atomos are passive and do not protect the master.
+    // Handle pets that act as bodyguards for their master. Will defend the master if they are being attacked.
+    // Will not switch targets if they are already engaged.
+    // Atomos, Alexander, and Odin are exempt from this behavior.
     if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
     {
+        bool isBodyguard = false;
+
         if (PTarget->PPet->objtype == TYPE_PET)
         {
             const auto PPetEntity = static_cast<CPetEntity*>(PTarget->PPet);
-            if (PPetEntity->getPetType() == PET_TYPE::AVATAR &&
-                PPetEntity->petID() != PETID_ALEXANDER &&
-                PPetEntity->petID() != PETID_ODIN &&
-                PPetEntity->petID() != PETID_ATOMOS)
+
+            isBodyguard = PPetEntity->getPetType() == PET_TYPE::AVATAR &&
+                          PPetEntity->petID() != PETID_ALEXANDER &&
+                          PPetEntity->petID() != PETID_ODIN &&
+                          PPetEntity->petID() != PETID_ATOMOS;
+        }
+        else if (PTarget->PPet->objtype == TYPE_MOB)
+        {
+            const auto PPetMob = static_cast<CMobEntity*>(PTarget->PPet);
+
+            isBodyguard = PPetMob->isCharmed && PPetMob->getMobMod(MOBMOD_BODYGUARD);
+        }
+
+        if (isBodyguard)
+        {
+            if (PTarget->objtype == TYPE_PC)
             {
-                if (PTarget->objtype == TYPE_PC)
-                {
-                    auto* PChar = dynamic_cast<CCharEntity*>(PTarget);
-                    if (PChar && PChar->IsMobOwner(PMob))
-                    {
-                        petutils::AttackTarget(PTarget, PMob);
-                    }
-                }
-                else
+                auto* PChar = dynamic_cast<CCharEntity*>(PTarget);
+                if (PChar && PChar->IsMobOwner(PMob))
                 {
                     petutils::AttackTarget(PTarget, PMob);
                 }
+            }
+            else
+            {
+                petutils::AttackTarget(PTarget, PMob);
             }
         }
     }

--- a/src/map/mob_modifier.h
+++ b/src/map/mob_modifier.h
@@ -125,6 +125,7 @@ enum MOBMODIFIER : int
     MOBMOD_FOLLOW_LEASH_RANGE     = 94, // Distance the leader can walk before their followers start moving. Applied to followers.
     MOBMOD_FOLLOW_STOP_RANGE      = 95, // Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
     MOBMOD_TRUST_SHIELD_SIZE      = 96, // TRUSTS ONLY: Set the size of the mob's shield. 3 = Default size, only used for trusts that use shields.
+    MOBMOD_BODYGUARD              = 97, // Charmed mob defends its master similar to an avatar. (Maiden's Virelai)
 };
 
 #endif

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1444,6 +1444,8 @@ void DetachPet(CBattleEntity* PMaster)
         PMob->charmTime  = timer::time_point::min();
         PMob->PMaster    = nullptr;
 
+        PMob->setMobMod(MOBMOD_BODYGUARD, 0);
+
         PMob->PAI->SetController(std::make_unique<CMobController>(PMob));
 
         // clear all enmity towards a charmed mob when it is released


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes the charm effect from Maidens Virelai. Was causing enemies to not actually be charmed before and would just lock their AI up until the effect ended.

* Adds assist logic to Maidens Virelai with a capture linked below.

## Capture
https://youtu.be/kdn7gV_lnpQ

## Steps to test these changes

Cast the song, charm stuff, watch it defend you if you get attacked
