### PR TITLE
[lua] Block teleports while mounted

### DIFF
--- a/scripts/actions/spells/black/retrace.lua
+++ b/scripts/actions/spells/black/retrace.lua
@@ -6,7 +6,15 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
-    return xi.spells.enhancing.checkTeleportSpell(caster, target, spell)
+    if target:hasStatusEffect(xi.effect.MOUNTED) then
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
+    end
+
+    if target:getCampaignAllegiance() == 0 then
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
+    end
+
+    return 0
 end
 
 spellObject.onSpellCast = function(caster, target, spell)

--- a/scripts/actions/spells/black/warp_ii.lua
+++ b/scripts/actions/spells/black/warp_ii.lua
@@ -6,6 +6,10 @@
 local spellObject = {}
 
 spellObject.onMagicCastingCheck = function(caster, target, spell)
+    if target:hasStatusEffect(xi.effect.MOUNTED) then
+        return xi.msg.basic.MAGIC_CANNOT_BE_CAST
+    end
+
     return 0
 end
 

--- a/scripts/globals/spells/enhancing_teleport.lua
+++ b/scripts/globals/spells/enhancing_teleport.lua
@@ -34,33 +34,31 @@ local pTable =
     [xi.magic.spell.WARP_II       ] = { xi.teleport.id.WARP,    0,                              3, false },
 }
 
--- Check for "Retrace" Spell.
-xi.spells.enhancing.checkTeleportSpell = function(caster, target, spell)
-    if target:getCampaignAllegiance() > 0 then
-        return 0
-    else
-        return 48
-    end
-end
-
 -- Main function for Teleport / Warp / etc. Spells.
 xi.spells.enhancing.useTeleportSpell = function(caster, target, spell)
-    local spellId    = spell:getID()
-    local teleportId = pTable[spellId][column.TELEPORT_ID]
-    local keyItem    = pTable[spellId][column.TELEPORT_KEY_ITEM]
-    local duration   = pTable[spellId][column.TELEPORT_DURATION]
-    local campaign   = pTable[spellId][column.TELEPORT_CAMPAIGN]
+    spell:setMsg(xi.msg.basic.NONE)
 
-    if
-        target:getObjType() == xi.objType.PC and
-        (keyItem == 0 or (keyItem > 0 and target:hasKeyItem(keyItem))) and
-        (not campaign or (campaign and target:getCampaignAllegiance() > 0))
-    then
-        target:addStatusEffect(xi.effect.TELEPORT, { power = teleportId, duration = duration, origin = caster, icon = 0 })
-        spell:setMsg(xi.msg.basic.MAGIC_TELEPORT)
-    else
-        spell:setMsg(xi.msg.basic.NONE)
+    if target:getObjType() == xi.objType.PC then
+        return 0
     end
 
-    return 0
+    if target:hasStatusEffect(xi.effect.MOUNTED) then
+        return 0
+    end
+
+    local spellId = spell:getID()
+    local keyItem = pTable[spellId][column.TELEPORT_KEY_ITEM]
+    if keyItem > 0 and not target:hasKeyItem(keyItem) then
+        return 0
+    end
+
+    local campaign = pTable[spellId][column.TELEPORT_CAMPAIGN]
+    if campaign and target:getCampaignAllegiance() == 0 then
+        return 0
+    end
+
+    target:addStatusEffect(xi.effect.TELEPORT, { power = pTable[spellId][column.TELEPORT_ID], duration = pTable[spellId][column.TELEPORT_DURATION], origin = caster, icon = 0 })
+    spell:setMsg(xi.msg.basic.MAGIC_TELEPORT)
+
+    return xi.effect.TELEPORT
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Stops teleport spells from being cast on mounted players.

Retail captures show:
- No teleports
- Buffs work (Already works)
- AOE damage from mobs happen (Already implemented)

https://youtu.be/gJlhiGRPAbQ
Capture: https://drive.google.com/file/d/1--qKihRI8GXWGHud29dip6O6Dy58hOOI/view?usp=sharing

## Steps to test these changes

Mount chocobo. Have other player try to cast Warp II or any teleport.
