### PR TITLE
[C++] Add hidden option for event

### DIFF
--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -115,10 +115,10 @@ CCharEntity::CCharEntity()
     eventPreparation = new EventPrep();
     currentEvent     = new EventInfo();
 
-    inSequence       = false;
-    gotMessage       = false;
-    m_Locked         = false;
-    m_zoneInCutscene = false;
+    inSequence   = false;
+    gotMessage   = false;
+    m_Locked     = false;
+    m_isPCHidden = false;
 
     accid        = 0;
     m_GMlevel    = 0;
@@ -2916,8 +2916,8 @@ void CCharEntity::endCurrentEvent()
     currentEvent->reset();
     eventPreparation->reset();
     setLocked(false);
-    m_zoneInCutscene = false;
-    m_Substate       = CHAR_SUBSTATE::SUBSTATE_NONE;
+    m_isPCHidden = false;
+    m_Substate   = CHAR_SUBSTATE::SUBSTATE_NONE;
     tryStartNextEvent();
 }
 
@@ -2998,6 +2998,9 @@ void CCharEntity::tryStartNextEvent()
 
     // If it's a cutscene, we lock the player immediately
     setLocked(currentEvent->type == CUTSCENE);
+
+    // Set hidden status based on event data
+    m_isPCHidden = currentEvent->isHidden;
 
     if (currentEvent->strings.empty())
     {

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -743,8 +743,8 @@ public:
 
     void clearCharVarsWithPrefix(const std::string& prefix);
 
-    bool m_Locked{};         // Is the player locked in a cutscene
-    bool m_zoneInCutscene{}; // Is the player currently in a zone-in cutscene
+    bool m_Locked{};     // Is the player locked in a cutscene
+    bool m_isPCHidden{}; // Is the player currently hidden from other players
 
     // Starts a synth with skillType X
     bool startSynth(xi::SkillType synthSkill);

--- a/src/map/event_info.h
+++ b/src/map/event_info.h
@@ -64,6 +64,7 @@ struct EventInfo : EventPrep
     uint16             interruptText = 0;
     uint32             eventFlags    = 0;
     bool               canSkip       = false;
+    bool               isHidden      = false;
 
     bool hasCutsceneOption(int32 _option)
     {
@@ -82,6 +83,7 @@ struct EventInfo : EventPrep
         eventFlags = 0;
         type       = NORMAL;
         canSkip    = false;
+        isHidden   = false;
     }
 };
 

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -1274,6 +1274,7 @@ EventInfo* CLuaBaseEntity::ParseEvent(int32 EventID, sol::variadic_args va, Even
         eventToStart->interruptText = table.get_or<int16>("interrupt_text", 0);
         eventToStart->eventFlags    = table.get_or<uint32>("flags", 0);
         eventToStart->canSkip       = table.get_or("canSkip", false);
+        eventToStart->isHidden      = table.get_or("isHidden", false);
 
         sol::object csOption = table["cs_option"];
         if (csOption.is<int32>())

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2277,7 +2277,7 @@ void OnZoneIn(CCharEntity* PChar)
         return;
     }
 
-    PChar->m_zoneInCutscene = false;
+    PChar->m_isPCHidden = false;
 
     CZone*      prevZone    = zoneutils::GetZone(PChar->loc.prevzone);
     std::string prevZoneStr = "Unknown";
@@ -2320,7 +2320,7 @@ void OnZoneIn(CCharEntity* PChar)
     if (PChar->currentEvent->eventId >= 0)
     {
         PChar->currentEvent->type = CUTSCENE;
-        PChar->m_zoneInCutscene   = true;
+        PChar->m_isPCHidden       = true;
         PChar->setLocked(true);
     }
 }

--- a/src/map/packets/char_update.cpp
+++ b/src/map/packets/char_update.cpp
@@ -284,7 +284,7 @@ void CCharUpdatePacket::updateWith(CCharEntity* PChar, ENTITYUPDATE type, uint8 
         packet->ModelHitboxSize = static_cast<uint8_t>(PChar->modelHitboxSize * 10); // TODO: verify this value and if it changes (Monstrosity?)
 
         packet->Flags1.MonsterFlag = false; // TODO: Is this ever set for Monstrosity PVP?
-        packet->Flags1.HideFlag    = PChar->m_zoneInCutscene;
+        packet->Flags1.HideFlag    = PChar->m_isPCHidden;
         packet->Flags1.SleepFlag   = 0;                                                                         // Something to do with events. // TODO: figure out when/if this is set. Probably when you're in a cutscene?
         packet->Flags1.unknown_0_3 = PChar->loc.zone ? PChar->loc.zone->CanUseMisc(xi::ZoneMisc::Treasure) : 0; // Set global treasure pool
         packet->Flags1.unknown_0_4 = 0;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Renames a variable to be more generic (my old code) and adds an event parameter to set PC to hidden.

When examining transport events, it is observed that the Flags1.HideFlag is sent to nearby players (picture below) at the start of the event. So, there needs to be a way to set this flag for events. Transport events and CoP 1-1 intro events will need this event flag. After this change, we can call events like ```player:startEvent(37, { isHidden = true })``` to hide the player.
<img width="479" height="40" alt="image" src="https://github.com/user-attachments/assets/c1cc42d0-0f6e-4335-b872-f779d3834ca8" />

Capture: https://drive.google.com/file/d/1Uz57tYQWPVpF1l9_OVewT9JpeQFgTWww/view?usp=sharing
https://youtu.be/F_q-GCukmZc

## Steps to test these changes

Add the isHidden check to and event and verify the player disappears.
