### PR TITLE
[core] Don't do silly calculations for no reason for base delay

### DIFF
--- a/src/map/items/item_weapon.cpp
+++ b/src/map/items/item_weapon.cpp
@@ -46,7 +46,7 @@ CItemWeapon::CItemWeapon(uint16 id)
     m_effect         = 0;
     m_dmgType        = xi::DamageType::None;
     m_delay          = 8000;
-    m_baseDelay      = 8000; // this should only be needed for mobs (specifically mnks)
+    m_baseDelay      = 480; // this should only be needed for mobs (specifically mnks)
     m_maxHit         = 0;
     m_DPS            = 0.0;
     m_ranged         = false;
@@ -319,52 +319,28 @@ uint16 CItemWeapon::getILvlMacc() const
     return m_iLvlMacc;
 }
 
-/************************************************************************
- *                                                                      *
- * Set the weapon delay time. Value in raw game delay units.            *
- * Converts to milliseconds: delay * 1000 / 60.                         *
- *                                                                      *
- ************************************************************************/
-
+// set delay used for milliseconds calculations (such as auto attack delay)
 void CItemWeapon::setDelay(uint16 delay)
 {
     m_delay = uint16(delay * 1000.0f / 60.0f);
 }
 
-/************************************************************************
- *                                                                      *
- * Get the weapon delay time. Value in milliseconds.                    *
- * All math operations are performed with integers which is why         *
- * the order of operations is important                                 *
- *                                                                      *
- ************************************************************************/
-
+// get delay used for milliseconds calculations (such as auto attack delay)
 uint16 CItemWeapon::getDelay() const
 {
     return m_delay;
 }
 
-/************************************************************************
- *                                                                      *
- *  Set the un-adjusted delay of the weapon. Value in raw game units.  *
- *  Converts to milliseconds: delay * 1000 / 60.                       *
- *                                                                      *
- ************************************************************************/
-
+// set real delay used by real people
 void CItemWeapon::setBaseDelay(uint16 delay)
 {
-    m_baseDelay = uint16(delay * 1000.0f / 60.0f);
+    m_baseDelay = delay;
 }
 
-/************************************************************************
- *                                                                       *
- * Get the un-adjusted base delay of the weapon. Value in raw game units.*
- *                                                                       *
- ************************************************************************/
-
+// get real delay used by real people
 uint16 CItemWeapon::getBaseDelay() const
 {
-    return uint16(m_baseDelay * 60.0f / 1000.0f);
+    return m_baseDelay;
 }
 
 /************************************************************************

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1789,7 +1789,9 @@ auto GetBaseDelay(CBattleEntity* PEntity) -> uint16
             else
             {
                 baseDelay = PMainWeapon->getBaseDelay();
-                if (PSubWeapon)
+
+                // Only add delay if subweapon isnt a grip
+                if (PSubWeapon && PSubWeapon->getSkillType() != xi::SkillType::None)
                 {
                     baseDelay += PSubWeapon->getBaseDelay();
                 }
@@ -1801,7 +1803,7 @@ auto GetBaseDelay(CBattleEntity* PEntity) -> uint16
         CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN]);
         if (PWeapon)
         {
-            baseDelay = PWeapon->getBaseDelay(); // there is some precision loss that results in delays of 319.98 instead of 320, etc, so round to nearest.
+            baseDelay = PWeapon->getBaseDelay();
         }
     }
 
@@ -1841,7 +1843,7 @@ auto GetBaseRangedDelay(CBattleEntity* PEntity) -> uint16
         CItemWeapon* PWeapon = dynamic_cast<CItemWeapon*>(PMobEntity->m_Weapons[SLOT_MAIN]);
         if (PWeapon)
         {
-            baseDelay = PWeapon->getBaseDelay(); // there is some precision loss that results in delays of 319.98 instead of 320, etc, so round to nearest.
+            baseDelay = PWeapon->getBaseDelay();
         }
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1) Amanomurakumo will now output 437 delay instead of 436 delay from GetBaseDelay
2) fixes grips adding delay to GetBaseDelay (why are grips even "Weapons?")
3) removes utterly pointless infuriating math that only serves to annoy us and cause 1)

## Steps to test these changes

check output of getBaseDelay with Amanomurakumo + a grip and have 437 delay.