### PR TITLE
[lua] Adjust Maat Mnk's accuracy

### DIFF
--- a/scripts/zones/Balgas_Dais/mobs/Maat_mnk.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Maat_mnk.lua
@@ -30,6 +30,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setUnkillable(true)
     mob:setBaseSpeed(60)
+    mob:setMod(xi.mod.ACC, 229)
 
     -- Reset mob.
     xi.combat.behavior.enableAllActions(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Maat Mnk's accuracy to observed levels and should give players the fighting chance they need.

<img width="933" height="175" alt="image" src="https://github.com/user-attachments/assets/1acbc1a9-8d8f-42d6-a97d-652c266f6a72" />

Subtracted 7 hits on trusts, errored in favor of Maat.

<img width="175" height="30" alt="image" src="https://github.com/user-attachments/assets/377cd1f7-7e25-4fe5-83b7-429e202e98d9" />


## Steps to test these changes

Fight Maat Mnk, your Monk levels of evasion should actually do something.