### PR TITLE
[core] Adjust magic state interrupt

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -171,6 +171,14 @@ bool CMagicState::Update(timer::time_point tick)
             Complete();
             return false;
         }
+
+        auto& PSpell = m_PSpell;
+
+        // Bard songs do not get interrupted here
+        if (PSpell && PSpell->getSpellGroup() != SPELLGROUP_SONG && m_PEntity->StatusEffectContainer->HasPreventActionEffect())
+        {
+            m_interrupted = true;
+        }
     }
 
     if (tick > GetEntryTime() + m_castTime && !IsCompleted())
@@ -254,13 +262,9 @@ bool CMagicState::Update(timer::time_point tick)
         }
 
         // Slept/stunned/petrified/etc. at the moment of completion: the cast is interrupted.
-        // A prevent-action effect that lands mid-cast does not cancel the cast on retail;
-        // the interrupt is decided here, at the finish, mirroring CMobSkillState.
         if (m_PEntity->StatusEffectContainer->HasPreventActionEffect())
         {
-            m_PEntity->OnCastInterrupted(*this, action, msg, false);
-            Complete();
-            return false;
+            m_interrupted = true;
         }
 
         if (m_interrupted)


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Stun will interrupt non-song at the end of a cast.
Stun will interrupt songs only if stunned at the end of a cast.

## Steps to test these changes

<img width="558" height="119" alt="image" src="https://github.com/user-attachments/assets/aeabd32d-c300-4d87-a15c-5adfb2944060" />
<img width="503" height="106" alt="image" src="https://github.com/user-attachments/assets/8e5e7c36-c8f2-481c-9223-ecc745153b58" />
<img width="533" height="119" alt="image" src="https://github.com/user-attachments/assets/28e21588-6fa0-47c9-9635-615597b3ad58" />
