### PR TITLE
[C++] [lua] Add settings for Mog House options

### DIFF
--- a/scripts/globals/moghouse.lua
+++ b/scripts/globals/moghouse.lua
@@ -311,6 +311,7 @@ xi.moghouse.onMoghouseZoneIn = function(player, prevZone)
     -- Reset: !exec player:setMoghouseFlag(0)
     -- Complete quests: !exec player:setMoghouseFlag(7)
     if
+        xi.settings.main.ENABLE_MOG_HOUSE_2F == 1 and
         xi.moghouse.inMogHouseInHomeNation(player) and
         growingFlowers and
         aLadysHeart and

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -38,6 +38,10 @@ xi.settings.main =
     ENABLE_TVR       = 1,
     ENABLE_VOIDWATCH = 1, -- Not an expansion, but has its own storyline. (Not Implemented)
 
+    -- MOG HOUSE
+    ENABLE_MOG_HOUSE_2F = 1, -- Enables Access to Mog House 2F / Mog Safe 2.
+    ENABLE_MOG_GARDEN   = 1, -- Enables Access to Mog Garden, will send player to the area they entered from if disabled.
+
     -- FIELDS OF VALOR/Grounds of Valor settings
     ENABLE_FIELD_MANUALS  = 1, -- Enables Fields of Valor
     ENABLE_GROUNDS_TOMES  = 1, -- Enables Grounds of Valor

--- a/src/map/packets/c2s/0x029_item_move.cpp
+++ b/src/map/packets/c2s/0x029_item_move.cpp
@@ -21,6 +21,7 @@
 
 #include "0x029_item_move.h"
 
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "items.h"
 #include "packets/s2c/0x01d_item_same.h"
@@ -72,7 +73,7 @@ const auto validContainers = [](const CCharEntity* PChar) -> std::set<CONTAINER_
         allowedContainers.insert(LOC_MOGSAFE);
 
         // Bitflag indicating if Mog 2F is unlocked
-        if (PChar->profile.mhflag & 0x20)
+        if ((PChar->profile.mhflag & 0x20) && settings::get<bool>("main.ENABLE_MOG_HOUSE_2F"))
         {
             allowedContainers.insert(LOC_MOGSAFE2);
         }

--- a/src/map/packets/c2s/0x03b_subcontainer.cpp
+++ b/src/map/packets/c2s/0x03b_subcontainer.cpp
@@ -21,6 +21,7 @@
 
 #include "0x03b_subcontainer.h"
 
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "enums/item_lockflg.h"
 #include "items/item_furnishing.h"
@@ -55,7 +56,7 @@ const auto validContainers = [](const CCharEntity* PChar) -> std::set<CONTAINER_
     };
 
     // Bitflag indicating if Mog 2F is unlocked
-    if (PChar->profile.mhflag & 0x20)
+    if ((PChar->profile.mhflag & 0x20) && settings::get<bool>("main.ENABLE_MOG_HOUSE_2F"))
     {
         allowedContainers.insert(LOC_MOGSAFE2);
     }

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2025 LandSandBoat Dev Teams
@@ -23,6 +23,7 @@
 
 #include <string_view>
 
+#include "common/settings.h"
 #include "common/utils.h"
 #include "entities/char_entity.h"
 #include "enums/msg_std.h"
@@ -83,7 +84,18 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
         {
             uint16_t destinationZone = PChar->getZone();
 
-            switch (static_cast<GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE>(this->MyRoomExitMode))
+            auto exitDestination = static_cast<GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE>(this->MyRoomExitMode);
+
+            if (!settings::get<bool>("main.ENABLE_MOG_GARDEN"))
+            {
+                // If Mog Garden is disabled, send the request as a regular mog house exit.
+                if (exitDestination == GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::MogGarden)
+                {
+                    exitDestination = GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom;
+                }
+            }
+
+            switch (exitDestination)
             {
                 case GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom:
                     // Return to current zone
@@ -130,9 +142,9 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     break;
             }
 
-            bool moghouseExitRegular          = this->MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom) && PChar->inMogHouse();
-            bool requestedMoghouseFloorChange = startingZone == destinationZone && (this->MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog1F) || this->MyRoomExitMode == static_cast<uint8>(GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog2F));
-            bool moghouse2FUnlocked           = PChar->profile.mhflag & 0x20;
+            bool moghouseExitRegular          = exitDestination == GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::AreaEnteredFrom && PChar->inMogHouse();
+            bool requestedMoghouseFloorChange = startingZone == destinationZone && (exitDestination == GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog1F || exitDestination == GP_CLI_COMMAND_MAPRECT_MYROOMEXITMODE::Mog2F);
+            bool moghouse2FUnlocked           = (PChar->profile.mhflag & 0x20) && settings::get<bool>("main.ENABLE_MOG_HOUSE_2F");
             auto startingRegion               = zoneutils::GetCurrentRegion(startingZone);
             auto destinationRegion            = zoneutils::GetCurrentRegion(destinationZone);
             auto moghouseExitRegions          = { REGION_TYPE::SANDORIA, REGION_TYPE::BASTOK, REGION_TYPE::WINDURST, REGION_TYPE::JEUNO, REGION_TYPE::WEST_AHT_URHGAN, REGION_TYPE::ADOULIN_ISLANDS };


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds a setting to enable / disable Mog House 2F (and by extension safe 2)
* Adds a setting to enable / disable Mog Garden - sends player to the area they entered from when disabled.

Originally I was thinking about content tagging these as SOA but that felt overly restrictive for downstream servers who might care about these, I think a setting is a better approach.

## Steps to test these changes

Complete Mog Garden / 2F Requirements (Mog House exit quests, rank 3)
Set settings to 0 -> 2F / Mog Safe 2 Disabled
Choose to exit through Mog Garden -> Get Sent to the area you entered from.
