### PR TITLE
[core, lua] Fix Rampart Magic Shield absorbing physical damage

### DIFF
--- a/modules/era/lua/globals/job_utils/paladin.lua
+++ b/modules/era/lua/globals/job_utils/paladin.lua
@@ -15,7 +15,6 @@ if not xi.module.isContentEnabled('ROV') then
         local defense     = player:getMainLvl() == 75 and 23 or 21
 
         -- Apply STONESKIN effect but display as RAMPART icon
-        -- TODO: subType 2 not yet implemented for magical only stoneskin
         target:addStatusEffect(xi.effect.STONESKIN, { power = defense, duration = duration, origin   = player, icon = xi.effect.RAMPART, subType  = 2, subPower = stoneskinHP })
 
         return xi.effect.RAMPART

--- a/scripts/globals/ability.lua
+++ b/scripts/globals/ability.lua
@@ -90,7 +90,7 @@ xi.ability.adjustDamage = function(dmg, attacker, skill, target, skilltype, skil
         dmg = utils.handleOneForAll(target, dmg)
     end
 
-    dmg = utils.handleStoneskin(target, dmg)
+    dmg = utils.handleStoneskin(target, dmg, skilltype)
 
     if dmg > 0 then
         target:wakeUp()

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -366,7 +366,7 @@ local function handleSinglePhysicalHit(mob, target, baseHitDamage, params)
     hitDamage = utils.handlePhalanx(target, hitDamage)
 
     if not params.skipStoneskin then
-        hitDamage = utils.handleStoneskin(target, hitDamage)
+        hitDamage = utils.handleStoneskin(target, hitDamage, xi.attackType.PHYSICAL)
     end
 
     hitDamage = math.floor(target:checkDamageCap(hitDamage))
@@ -473,7 +473,7 @@ local function handleSingleRangedHit(mob, target, baseHitDamage, params)
     hitDamage = utils.handlePhalanx(target, hitDamage)
 
     if not params.skipStoneskin then
-        hitDamage = utils.handleStoneskin(target, hitDamage)
+        hitDamage = utils.handleStoneskin(target, hitDamage, xi.attackType.RANGED)
     end
 
     if hitDamage > 0 then
@@ -1225,8 +1225,7 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
     damage = utils.handleOneForAll(target, damage)
 
     if not skipStoneskin then
-        -- TODO: Some Stoneskin effects only absorb certain damage types.
-        damage = utils.handleStoneskin(target, damage)
+        damage = utils.handleStoneskin(target, damage, attackType)
     end
 
     target:handleAfflatusMiseryDamage(damage)
@@ -1414,8 +1413,7 @@ xi.mobskills.mobBreathMove = function(mob, target, skill, action, skillParams)
     damage = utils.handleOneForAll(target, damage)
 
     if not skipStoneskin then
-        -- TODO: Some Stoneskin effects only absorb certain damage types.
-        damage = utils.handleStoneskin(target, damage)
+        damage = utils.handleStoneskin(target, damage, attackType)
     end
 
     target:handleAfflatusMiseryDamage(damage)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -225,7 +225,7 @@ local function modifyMeleeHitDamage(attacker, target, attackTbl, wsParams, rawDa
     adjustedDamage = adjustedDamage + xi.combat.damage.souleaterAddition(attacker)
 
     adjustedDamage = utils.handlePhalanx(target, adjustedDamage)
-    adjustedDamage = utils.handleStoneskin(target, adjustedDamage)
+    adjustedDamage = utils.handleStoneskin(target, adjustedDamage, xi.attackType.PHYSICAL)
 
     return adjustedDamage
 end

--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -232,13 +232,39 @@ function utils.handleOneForAll(actor, damage)
 end
 
 -- Calculates Stoneskin damage reduction.
+-- Optional attackType: subType 1 = physical/ranged only, 2 = magical only (frozen_mist / hydro_wave / Rampart).
+-- Omitting attackType preserves previous absorb-all behavior.
 ---@nodiscard
 ---@param actor CBaseEntity
 ---@param damage integer
+---@param attackType xi.attackType?
 ---@return integer
-function utils.handleStoneskin(actor, damage)
+function utils.handleStoneskin(actor, damage, attackType)
     if damage <= 0 then
         return damage
+    end
+
+    if attackType ~= nil and attackType ~= xi.attackType.NONE then
+        local effect = actor:getStatusEffect(xi.effect.STONESKIN)
+        if effect then
+            local stoneskinType = effect:getSubType()
+            if stoneskinType == 2 then
+                if
+                    attackType == xi.attackType.PHYSICAL or
+                    attackType == xi.attackType.RANGED
+                then
+                    return damage
+                end
+            elseif stoneskinType == 1 then
+                if
+                    attackType == xi.attackType.MAGICAL or
+                    attackType == xi.attackType.BREATH or
+                    attackType == xi.attackType.SPECIAL
+                then
+                    return damage
+                end
+            end
+        end
     end
 
     local stoneskinRemaining = actor:getMod(xi.mod.STONESKIN)

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2143,7 +2143,7 @@ auto TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYS
     {
         damage = std::max(damage - PDefender->getMod(Mod::PHALANX), 0);
 
-        damage = HandleStoneskin(PDefender, damage);
+        damage = HandleStoneskin(PDefender, damage, attackType);
         HandleAfflatusMiseryDamage(PDefender, damage);
     }
     damage = std::clamp(damage, -99999, 99999);
@@ -2301,7 +2301,7 @@ auto TakeWeaponskillDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, i
     if (damage > 0)
     {
         damage = std::max(damage - PDefender->getMod(Mod::PHALANX), 0);
-        damage = HandleStoneskin(PDefender, damage);
+        damage = HandleStoneskin(PDefender, damage, attackType);
     }
 
     if (!isRanged)
@@ -4646,8 +4646,31 @@ int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage)
     return damage;
 }
 
-int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage)
+int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, xi::AttackType attackType)
 {
+    // subType 1 = physical/ranged only, 2 = magical only (frozen_mist / hydro_wave / Rampart)
+    if (attackType != xi::AttackType::None)
+    {
+        if (auto* PEffect = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Stoneskin))
+        {
+            const uint32 stoneskinType = PEffect->GetSubID();
+            if (stoneskinType == 2)
+            {
+                if (attackType == xi::AttackType::Physical || attackType == xi::AttackType::Ranged)
+                {
+                    return damage;
+                }
+            }
+            else if (stoneskinType == 1)
+            {
+                if (attackType == xi::AttackType::Magical || attackType == xi::AttackType::Breath || attackType == xi::AttackType::Special)
+                {
+                    return damage;
+                }
+            }
+        }
+    }
+
     int16 skin = PDefender->getMod(Mod::STONESKIN);
     if (damage > 0 && skin > 0)
     {

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -225,7 +225,7 @@ void HandleTacticalGuard(CBattleEntity* PEntity);
 void BindBreakCheck(CBattleEntity* PAttacker, CBattleEntity* PDefender);
 
 // returns damage taken
-int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage);
+int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, xi::AttackType attackType = xi::AttackType::None);
 int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage);
 int32 HandleFanDance(CBattleEntity* PDefender, int32 damage);
 void  HandleScarletDelirium(CBattleEntity* PDefender, int32 damage);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Rampart (and other typed stoneskins) already apply `STONESKIN` with `subType` 1/2 (`frozen_mist`, `hydro_wave`, Rampart), but absorption ignored attack type, so Rampart's Magic Shield zeroed physical melee.

- Teach `HandleStoneskin` / `utils.handleStoneskin` to skip absorb only when attack type is known incompatible with `subType` 1 (physical/ranged only) or `2` (magical only)
- Pass `attackType` on physical / weaponskill / mobskill / ability paths that already know it
- Omitting `attackType` keeps previous absorb-all behavior for untouched call sites
- Remove the Rampart TODO now that `subType` 2 is honored

Addresses #9665.

## Steps to test these changes

**Rampart Magic Shield:**
1. PLD75, note DEF/VIT, engage a mob that hits for real damage
2. Confirm auto-attacks deal normal non-zero damage
3. Use Rampart (DEF should rise, e.g. +23 at 75)
4. Confirm auto-attacks still deal damage (slightly reduced by DEF, **not** 0)
5. Take magical damage while Rampart is up and confirm the Magic Shield still absorbs it
6. Confirm normal `Stoneskin` still absorbs both physical and magical damage

**Optional (typed stoneskin callers):**
- Ruszor `Frozen Mist` (`subType` 1): physical absorbed, magical not
- Ruszor `Hydro Wave` (`subType` 2): magical/breath absorbed, physical not