### PR TITLE
[core] Add some more quick rejects for equipping gear

### DIFF
--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -3222,6 +3222,19 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         return;
     }
 
+    // Can't equip (job)
+    if (!(PItem->getJobs() & (1 << (PChar->GetMJob() - 1))))
+    {
+        return;
+    }
+
+    // gear sync disabled: can't equip based on current level
+    // gear sync enabled: can't equip based on real level
+    if (PItem->getReqLvl() > (settings::get<bool>("map.DISABLE_GEAR_SCALING") ? PChar->GetMLevel() : PChar->jobs.job[PChar->GetMJob()]))
+    {
+        return;
+    }
+
     // slotID of zero = unequip
     if (slotID > 0)
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: if you tried to equip stuff you couldn't you could reset your TP. retail doesn't do this.

## Steps to test these changes

/equipset with something you can't equip in ranged/ammo slot and see TP not reset
