### PR TITLE
[lua] Fix Queen Jelly Spawn HP

### DIFF
--- a/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
+++ b/scripts/zones/Waughroon_Shrine/mobs/Princess_Jelly.lua
@@ -147,8 +147,7 @@ entity.onMobFight = function(mob, target)
         end
 
         SpawnMob(queenJellyID)
-        queenJelly:setMaxHP(queenHP)
-        queenJelly:setHP(queenJelly:getMaxHP())
+        queenJelly:setHP(queenHP)
     end
 end
 


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Makes it so a Queen Jelly will spawn with missing HP instead of appearing to have full HP to reflect retail accuracy.

## Capture
[BCNM 40 Royal Jelly (BST duo)](https://www.youtube.com/watch?v=V2dkkutDxZI)

## Steps to test these changes

Run It!