### PR TITLE
[lua] Fix KS99 Wyrm Remove All Miss on Spawn

### DIFF
--- a/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Tiamat.lua
@@ -64,7 +64,7 @@ entity.spawnPoints =
 -----------------------------------
 local function enterFlight(mob)
     mob:setMobSkillAttack(730)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
     mob:setLocalVar('flightTime', GetSystemTime() + 120)

--- a/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Wyrm.lua
@@ -19,7 +19,7 @@ local entity = {}
 local function enterFlight(mob)
     mob:setMobSkillAttack(1146)
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
 end

--- a/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
+++ b/scripts/zones/Monarch_Linn/mobs/Ouryu.lua
@@ -26,7 +26,7 @@ end
 
 local function fly(mob)
     mob:setAnimationSub(allFlightPhaseAnimationSub)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setMobSkillAttack(731)
     setNextPhaseTriggers(mob, subsequentPhaseDuration)
 end
@@ -48,9 +48,6 @@ entity.onMobSpawn = function(mob)
     mob:setMobSkillAttack(0)
     -- subanim 0 is only used when it spawns until first flight
     mob:setAnimationSub(initialGroundPhaseAnimationSub)
-    if mob:hasStatusEffect(xi.effect.ALL_MISS) then
-        mob:delStatusEffect(xi.effect.ALL_MISS)
-    end
 
     -- 54 + 2 + 14 = 70 total damage (the 14 dmg accounts for a 25% boost)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MODIFIER, 14)

--- a/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ouryu.lua
@@ -35,7 +35,7 @@ local addTable =
 -----------------------------------
 local function enterFlight(mob)
     mob:setMobSkillAttack(425)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
 end

--- a/scripts/zones/Riverne-Site_B01/mobs/Jormungand_bv2.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Jormungand_bv2.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 local function enterFlight(mob)
     mob:setMobSkillAttack(732)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
 end

--- a/scripts/zones/Riverne-Site_B01/mobs/Ouryu_bv2.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Ouryu_bv2.lua
@@ -30,7 +30,7 @@ local addTable =
 -----------------------------------
 local function enterFlight(mob)
     mob:setMobSkillAttack(425)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
 end

--- a/scripts/zones/Riverne-Site_B01/mobs/Tiamat_bv2.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Tiamat_bv2.lua
@@ -8,7 +8,7 @@ local entity = {}
 
 local function enterFlight(mob)
     mob:setMobSkillAttack(730)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setAnimationSub(1)
 end

--- a/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Jormungand.lua
@@ -61,7 +61,7 @@ entity.spawnPoints =
 
 local function enterFlight(mob)
     mob:setMobSkillAttack(732)
-    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, origin = mob, icon = 0 })
+    mob:addStatusEffect(xi.effect.ALL_MISS, { power = 1, duration = 7200, origin = mob, icon = 0 })
     mob:setBehavior(bit.band(mob:getBehavior(), bit.bnot(xi.behavior.NO_TURN)))
     mob:setLocalVar('flightTime', GetSystemTime() + 30)
     mob:setLocalVar('changeHP', math.max(0, mob:getHP() - 6000))


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Removes all Miss on Spawn to ensure it can be hit if a group wipes while flying.

## Steps to test these changes

Run KS99 Wyrm -> !hp 25000 -> see it fly -> warp out -> enter again -> see all miss gone and can hit them
