### PR TITLE
[lua] Enable Bostaunieux trap doors

### DIFF
--- a/scripts/zones/Bostaunieux_Oubliette/IDs.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/IDs.lua
@@ -49,6 +49,7 @@ zones[xi.zone.BOSTAUNIEUX_OUBLIETTE] =
     },
     npc =
     {
+        TRAP_DOOR_OFFSET = GetFirstID('_mn0'), -- Pressure plate trap doors, 25 of them.
     },
 }
 

--- a/scripts/zones/Bostaunieux_Oubliette/Zone.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/Zone.lua
@@ -7,6 +7,14 @@ local ID = zones[xi.zone.BOSTAUNIEUX_OUBLIETTE]
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    local doorCount = 25 -- _mn0 to _mns
+    local trapRadius = 1.5
+    for i = 1, doorCount do
+        local door = GetNPCByID(ID.npc.TRAP_DOOR_OFFSET + i - 1)
+        if door ~= nil then
+            zone:registerCylindricalTriggerArea(i, door:getXPos(), door:getZPos(), trapRadius)
+        end
+    end
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
@@ -28,6 +36,16 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
+    local doorCount = 25
+    local triggerAreaID = triggerArea:getTriggerAreaID()
+    if triggerAreaID >= 1 and triggerAreaID <= doorCount then
+        local door = GetNPCByID(ID.npc.TRAP_DOOR_OFFSET + triggerAreaID - 1)
+        if door ~= nil then
+            door:timer(800, function(doorArg)
+                doorArg:openDoor(6) -- opens for 6s, then auto-closes
+            end)
+        end
+    end
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fairly accurate trap doors in Bostaunieux Oubliette

## Steps to test these changes
https://youtu.be/bjGMXIVt2Xc Retail in PIP
