### PR TITLE
[Cleanup] Stoneskin handling and usage

### DIFF
--- a/data/enums/mod.yaml
+++ b/data/enums/mod.yaml
@@ -440,7 +440,6 @@ values:
   elemental_debuff_effect: 1150 # Increase stat reduction by N, and DoT by N/2 HP per tick
   # Red Mage
   blink:             299  # Tracks blink shadows
-  stoneskin:         300  # Tracks stoneskin HP pool
   phalanx:           301  # Tracks direct damage reduction
   enf_mag_potency:   290  # Increases Enfeebling magic potency %
   enf_mag_duration:  1151 # Increases enfeebling magic duration %
@@ -1273,4 +1272,4 @@ values:
 
   # The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
   # 570 through 825 used by WS DMG mods these are not spares.
-  # SPARE IDs: 1212 and onward
+  # SPARE IDs: 300 and 1212 and onward

--- a/scripts/actions/abilities/pets/concentric_pulse.lua
+++ b/scripts/actions/abilities/pets/concentric_pulse.lua
@@ -21,11 +21,11 @@ abilityObject.onPetAbility = function(target, pet, petskill, master, action)
     end
 
     if dmgBoost > 0 then
-        dmg = dmg + (dmg * 0.01 * dmgBoost)
+        dmg = dmg + math.floor(dmg * dmgBoost / 100)
     end
 
     -- TODO: Affected by Phalanx, MDT, Magic Damage % modifiers, OneForAll?
-    dmg = utils.handleStoneskin(target, dmg)
+    dmg = utils.handleStoneskin(target, dmg, xi.attackType.MAGICAL)
 
     target:takeDamage(dmg, pet, xi.attackType.MAGICAL, xi.damageType.NONE)
 

--- a/scripts/actions/mobskills/arrogance_incarnate.lua
+++ b/scripts/actions/mobskills/arrogance_incarnate.lua
@@ -32,7 +32,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         return 0
     end
 
-    dmg = utils.handleStoneskin(target, dmg)
+    dmg = utils.handleStoneskin(target, dmg, xi.attackType.BREATH)
 
     if dmg > 0 then
         target:wakeUp()

--- a/scripts/actions/mobskills/frozen_mist.lua
+++ b/scripts/actions/mobskills/frozen_mist.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     -- Ice aura that provides special stoneskin that absorbs only physical damage
     skill:setFinalAnimationSub(1)
     mob:delStatusEffectSilent(xi.effect.STONESKIN)
-    mob:addStatusEffect(xi.effect.STONESKIN, { duration = 180, origin = mob, subType = 1, subPower = 1500 })
+    mob:addStatusEffect(xi.effect.STONESKIN, { power = 1500, duration = 180, subType = 1, origin = mob })
 
     return info.damage
 end

--- a/scripts/actions/mobskills/hydro_wave.lua
+++ b/scripts/actions/mobskills/hydro_wave.lua
@@ -34,7 +34,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     -- TODO: Make a new function to handle stoneskin types.
     skill:setFinalAnimationSub(2)
     mob:delStatusEffectSilent(xi.effect.STONESKIN)
-    mob:addStatusEffect(xi.effect.STONESKIN, { duration = 180, origin = mob, subType = 2, subPower = 1500 })
+    mob:addStatusEffect(xi.effect.STONESKIN, { power = 1500, duration = 180, subType = 2, origin = mob })
 
     return info.damage
 end

--- a/scripts/actions/spells/black/meteor.lua
+++ b/scripts/actions/spells/black/meteor.lua
@@ -46,7 +46,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     -- Handle Phalanx, One for All, Stoneskin.
     damage = utils.clamp(utils.handlePhalanx(target, damage), 0, 99999)
     damage = utils.clamp(utils.handleOneForAll(target, damage), 0, 99999)
-    damage = utils.clamp(utils.handleStoneskin(target, damage), -99999, 99999)
+    damage = utils.handleStoneskin(target, damage, xi.attackType.MAGICAL)
 
     -- Handle final adjustments. Most are located in core. TODO: Decide if we want core handling this.
     -- Check if the mob has a damage cap

--- a/scripts/combat/action_additional_effect_damage.lua
+++ b/scripts/combat/action_additional_effect_damage.lua
@@ -168,7 +168,7 @@ xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     if damage > 0 then
         damage = utils.clamp(utils.handlePhalanx(params.aeTarget, damage), 0, 99999)
         damage = utils.clamp(utils.handleOneForAll(params.aeTarget, damage), 0, 99999)
-        damage = utils.clamp(utils.handleStoneskin(params.aeTarget, damage), 0, 99999)
+        damage = utils.handleStoneskin(params.aeTarget, damage, params.attackType)
     end
 
     -- Handle absorption.

--- a/scripts/combat/action_spikes_damage.lua
+++ b/scripts/combat/action_spikes_damage.lua
@@ -136,7 +136,7 @@ xi.combat.action.executeSpikesDamage = function(actor, target, fedData)
     if damage > 0 then
         damage = utils.clamp(utils.handlePhalanx(params.aeTarget, damage), 0, 99999)
         damage = utils.clamp(utils.handleOneForAll(params.aeTarget, damage), 0, 99999)
-        damage = utils.clamp(utils.handleStoneskin(params.aeTarget, damage), 0, 99999)
+        damage = utils.handleStoneskin(params.aeTarget, damage, params.attackType)
     end
 
     -- Drain HP, MP or TP

--- a/scripts/combat/basic/damage_additions.lua
+++ b/scripts/combat/basic/damage_additions.lua
@@ -18,12 +18,13 @@ xi.combat.damage.souleaterAddition = function(actor)
     local souleaterEffect        = actor:getMaxGearMod(xi.mod.SOULEATER_EFFECT) / 100
     local souleaterEffectII      = actor:getMod(xi.mod.SOULEATER_EFFECT_II) / 100
     local stalwartSoulMultiplier = 1 - actor:getMod(xi.mod.STALWART_SOUL) / 100
-    local bonusDamage            = math.floor(actor:getHP() * (0.1 + souleaterEffect + souleaterEffectII))
+    local soulEaterResistance    = 1 -- TODO: Add soul eater resistance for AV and others.
+    local bonusDamage            = math.floor(actor:getHP() * (0.1 + souleaterEffect + souleaterEffectII) * soulEaterResistance)
 
     if bonusDamage > 0 then
         local selfDamage = bonusDamage * stalwartSoulMultiplier
 
-        selfDamage = utils.handleStoneskin(actor, selfDamage)
+        selfDamage = utils.handleStoneskin(actor, selfDamage, xi.attackType.NONE)
 
         actor:delHP(selfDamage)
 

--- a/scripts/combat/skillchain.lua
+++ b/scripts/combat/skillchain.lua
@@ -141,7 +141,7 @@ xi.combat.skillchain.calculateSkillchainDamage = function(actor, target, baseDam
     if finalDamage > 0 then
         finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
         finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
-        finalDamage = utils.clamp(utils.handleStoneskin(target, finalDamage), 0, 99999)
+        finalDamage = utils.handleStoneskin(target, finalDamage, xi.attackType.SPECIAL)
         finalDamage = target:checkDamageCap(finalDamage)
 
         target:takeDamage(finalDamage, actor, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL + skillchainElement)

--- a/scripts/effects/bio.lua
+++ b/scripts/effects/bio.lua
@@ -19,7 +19,7 @@ effectObject.onEffectTick = function(target, effect)
     -- handle diabolos nightmare bio damage explicitly
     if effect:getTier() >= 11 then
         -- re-using logic from helix effect processing
-        local dmg = utils.handleStoneskin(target, effect:getPower())
+        local dmg = utils.handleStoneskin(target, effect:getPower(), xi.attackType.NONE)
 
         if dmg > 0 then
             target:takeDamage(dmg, nil, nil, nil, { wakeUp = false, breakBind = false })

--- a/scripts/effects/helix.lua
+++ b/scripts/effects/helix.lua
@@ -8,7 +8,7 @@ effectObject.onEffectGain = function(target, effect)
 end
 
 effectObject.onEffectTick = function(target, effect)
-    local dmg = utils.handleStoneskin(target, effect:getPower())
+    local dmg = utils.handleStoneskin(target, effect:getPower(), xi.attackType.NONE)
 
     if dmg > 0 then
         target:takeDamage(dmg)

--- a/scripts/effects/stoneskin.lua
+++ b/scripts/effects/stoneskin.lua
@@ -6,7 +6,6 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    effect:addMod(xi.mod.STONESKIN, effect:getPower())
 end
 
 effectObject.onEffectTick = function(target, effect)

--- a/scripts/effects/sublimation_activated.lua
+++ b/scripts/effects/sublimation_activated.lua
@@ -29,13 +29,14 @@ effectObject.onEffectTick = function(target, effect)
         target:getMerit(xi.merit.MAX_SUBLIMATION) * 10 + target:getJobPointLevel(xi.jp.SUBLIMATION_EFFECT) * 3
 
     if target:getHPP() >= 51 then
-        if target:hasStatusEffect(xi.effect.STONESKIN) then
-            local skin = target:getMod(xi.mod.STONESKIN)
-            if skin >= dmg then --absorb all damage
-                target:delMod(xi.mod.STONESKIN, dmg)
+        local stoneskin = target:getStatusEffect(xi.effect.STONESKIN)
+        if stoneskin then
+            local stoneskinPower = stoneskin:getPower()
+            if stoneskinPower > dmg then
+                stoneskin:setPower(stoneskinPower - dmg)
             else
                 target:delStatusEffect(xi.effect.STONESKIN)
-                target:takeDamage(dmg - skin)
+                target:takeDamage(dmg - stoneskinPower)
                 if target:getHPP() < 51 then
                     complete = true
                 end

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -92,7 +92,7 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage)
     damage            = math.floor(defender:handleSevereDamage(damage, false))
     damage            = utils.handlePhalanx(defender, damage)
     damage            = utils.handleOneForAll(defender, damage)
-    damage            = utils.handleStoneskin(defender, damage)
+    damage            = utils.handleStoneskin(defender, damage, xi.attackType.MAGICAL)
     damage            = utils.clamp(damage, -99999, 99999)
 
     if damage < 0 then
@@ -102,87 +102,6 @@ xi.additionalEffect.calcDamage = function(attacker, element, defender, damage)
     end
 
     return damage
-end
-
-xi.additionalEffect.calcPhysDamage = function(attacker, defender, item, params)
-    params.isPhysical = params.isPhysical or false
-    params.isRanged   = params.isRanged or false
-    params.isBreath   = params.isBreath or false
-    params.damageType = params.damageType or xi.damageType.NONE
-    params.damage     = math.floor(params.damage) or 0
-
-    if params.damage == 0 then
-        return 0
-    end
-
-    -- Check nullification
-    if math.randomInt(1, 100) <= defender:getMod(xi.mod.NULL_DAMAGE) then
-        return 0
-    end
-
-    if
-        params.isPhysical and
-        math.randomInt(1, 100) <= defender:getMod(xi.mod.NULL_PHYSICAL_DAMAGE)
-    then
-        return 0
-    end
-
-    if
-        params.isRanged and
-        math.randomInt(1, 100) <= defender:getMod(xi.mod.NULL_RANGED_DAMAGE)
-    then
-        return 0
-    end
-
-    if
-        params.isBREATH and
-        math.randomInt(1, 100) <= defender:getMod(xi.mod.NULL_BREATH_DAMAGE)
-    then
-        return 0
-    end
-
-    -- Check absorbs
-    -- Absorb: All damage.
-    if math.randomInt(1, 100) <= defender:getMod(xi.mod.ABSORB_DMG_CHANCE) then
-        return params.damage * -1
-    end
-
-    -- Absorb: ranged or phys
-    if
-        (params.isPhysical or params.isRanged) and
-        math.randomInt(1, 100) <= defender:getMod(xi.mod.PHYS_ABSORB)
-    then
-        return params.damage * -1
-    end
-
-    params.damage = params.damage * xi.combat.damage.calculateDamageAdjustment(defender, params.isPhysical, false, params.isRanged, params.isBreath)
-
-    -- multiplicative
-    switch (params.damageType) : caseof
-    {
-        [xi.damageType.PIERCING] = function()
-            params.damage = params.damage * (1 + defender:getMod(xi.mod.PIERCE_SDT) / 10000)
-        end,
-
-        [xi.damageType.SLASHING] = function()
-            params.damage = params.damage * (1 + defender:getMod(xi.mod.SLASH_SDT) / 10000)
-        end,
-
-        [xi.damageType.BLUNT] = function() -- aka IMPACT
-            params.damage = params.damage * (1 + defender:getMod(xi.mod.IMPACT_SDT) / 10000)
-        end,
-
-        [xi.damageType.HAND_TO_HAND] = function()
-            params.damage = params.damage * (1 + defender:getMod(xi.mod.HTH_SDT) / 10000)
-        end,
-    }
-
-    params.damage = math.floor(params.damage)
-
-    params.damage = utils.handlePhalanx(defender, params.damage)
-    params.damage = utils.handleStoneskin(defender, params.damage)
-
-    return params.damage
 end
 
 xi.additionalEffect.procType =
@@ -202,7 +121,6 @@ xi.additionalEffect.procType =
     SELF_BUFF     = 12,
     DEATH         = 13,
     NM_SPECIFIC   = 14,
-    PHYS_DAMAGE   = 15,
 }
 
 -- TODO: add resistance check for params.element
@@ -495,30 +413,6 @@ xi.additionalEffect.procFunctions[xi.additionalEffect.procType.HPMPTP_DRAIN] = f
     }
 
     return xi.additionalEffect.procFunctions[drainFuncs[drainRoll]](attacker, defender, item, params)
-end
-
--- Script only for now
-xi.additionalEffect.procFunctions[xi.additionalEffect.procType.PHYS_DAMAGE] = function(attacker, defender, item, params)
-    local subEffect = params.subEffect
-    local msgID     = 0
-    local msgParam  = 0
-
-    local damage = xi.additionalEffect.calcPhysDamage(attacker, defender, item, params)
-    msgID  = xi.msg.basic.ADD_EFFECT_DMG
-
-    if damage < 0 then
-        msgID = xi.msg.basic.ADD_EFFECT_HEAL
-
-        damage = damage * -1
-
-        defender:addHP(damage)
-    else
-        defender:delHP(damage)
-    end
-
-    msgParam = damage
-
-    return subEffect, msgID, msgParam
 end
 
 -- NM-specific additional effects configuration table

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -507,7 +507,7 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     -- Handle Phalanx, One for All, Stoneskin and target HP (Cant be higher than current HP)
     finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
     finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
-    finalDamage = utils.clamp(utils.handleStoneskin(target, finalDamage), -99999, 99999)
+    finalDamage = utils.handleStoneskin(target, finalDamage, xi.attackType.MAGICAL)
     finalDamage = utils.clamp(finalDamage, 0, target:getHP())
 
     -- Check if the mob has a damage cap
@@ -600,7 +600,7 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
     if dmg > 0 then
         dmg = utils.clamp(utils.handlePhalanx(target, dmg), 0, 99999)
         dmg = utils.clamp(utils.handleOneForAll(target, dmg), 0, 99999)
-        dmg = utils.clamp(utils.handleStoneskin(target, dmg), -99999, 99999)
+        dmg = utils.handleStoneskin(target, dmg, attackType)
         dmg = utils.clamp(dmg, 0, target:getHP())
         dmg = target:checkDamageCap(dmg)
     end
@@ -646,7 +646,7 @@ xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, t
     end
 
     dmg = utils.handlePhalanx(target, dmg)
-    dmg = utils.handleStoneskin(target, dmg)
+    dmg = utils.handleStoneskin(target, dmg, attackType)
 
     -- Check if the mob has a damage cap
     dmg = target:checkDamageCap(dmg)

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -436,7 +436,7 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
         local applyLevelCorrection = xi.data.levelCorrection.isLevelCorrectedZone(player)
         local baseDmg              = weaponDamage + xi.combat.physical.calculateMeleeStatFactor(player, target)
         local pdif                 = xi.combat.physical.calculateMeleePDIF(player, target, weaponType, 1.0, false, applyLevelCorrection, false, 0.0, false, xi.slot.MAIN, false)
-        local dmg                  = baseDmg * pdif
+        local dmg                  = math.floor(baseDmg * pdif)
 
         dmg = utils.handleStoneskin(target, dmg, xi.attackType.PHYSICAL)
         target:takeDamage(dmg, player, xi.attackType.PHYSICAL, player:getWeaponDamageType(xi.slot.MAIN))

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -438,7 +438,7 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
         local pdif                 = xi.combat.physical.calculateMeleePDIF(player, target, weaponType, 1.0, false, applyLevelCorrection, false, 0.0, false, xi.slot.MAIN, false)
         local dmg                  = baseDmg * pdif
 
-        dmg = utils.handleStoneskin(target, dmg)
+        dmg = utils.handleStoneskin(target, dmg, xi.attackType.PHYSICAL)
         target:takeDamage(dmg, player, xi.attackType.PHYSICAL, player:getWeaponDamageType(xi.slot.MAIN))
         target:updateEnmityFromDamage(player, dmg)
         action:recordDamage(target, xi.attackType.PHYSICAL, dmg)

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -378,15 +378,13 @@ xi.job_utils.dragoon.useSpiritLink = function(player, target, ability, action)
 
     -- Handle Stoneskin.
     local stoneskinPower = 0
-
-    if player:hasStatusEffect(xi.effect.STONESKIN) then
-        stoneskinPower = player:getMod(xi.mod.STONESKIN)
+    local stoneskin      = player:getStatusEffect(xi.effect.STONESKIN)
+    if stoneskin then
+        stoneskinPower = stoneskin:getPower()
 
         -- If stoneskin is more powerfull than the amount to be drained.
         if stoneskinPower > drainamount then
-            local effect = player:getStatusEffect(xi.effect.STONESKIN)
-            effect:setPower(effect:getPower() - drainamount) -- Fixes the status effect so when it ends it uses the new power instead of old.
-            player:delMod(xi.mod.STONESKIN, drainamount)     -- Removes the amount from the mod.
+            stoneskin:setPower(stoneskinPower - drainamount) -- Fixes the status effect so when it ends it uses the new power instead of old.
 
         -- If stoneskin is as powerful or less than the amount to be drained.
         else

--- a/scripts/globals/job_utils/ninja.lua
+++ b/scripts/globals/job_utils/ninja.lua
@@ -53,7 +53,7 @@ xi.job_utils.ninja.useMijinGakure = function(player, target, ability, action)
     dmg = math.floor(dmg * resist)
     dmg = math.floor(dmg * tmdaFactor)
     dmg = math.floor(dmg * jpFactor)
-    dmg = utils.handleStoneskin(target, dmg)
+    dmg = utils.handleStoneskin(target, dmg, xi.attackType.SPECIAL)
 
     target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
     player:setLocalVar('MijinGakure', 1)

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -223,7 +223,7 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
     -- Randomize damage
     local randomizer = 1 + math.randomInt(1, 5) / 100
 
-    damage = damage * randomizer
+    damage = math.floor(damage * randomizer)
     damage = utils.handleStoneskin(target, damage, xi.attackType.PHYSICAL)
 
     target:takeDamage(damage, player, xi.attackType.PHYSICAL, xi.damageType.BLUNT)

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -221,10 +221,10 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
     end
 
     -- Randomize damage
-    local randomizer = 1 + (math.randomInt(1, 5) / 100)
+    local randomizer = 1 + math.randomInt(1, 5) / 100
 
     damage = damage * randomizer
-    damage = utils.handleStoneskin(target, damage)
+    damage = utils.handleStoneskin(target, damage, xi.attackType.PHYSICAL)
 
     target:takeDamage(damage, player, xi.attackType.PHYSICAL, xi.damageType.BLUNT)
     target:updateEnmityFromDamage(player, damage)

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -558,7 +558,7 @@ local function calculateSwipeLungeDamage(player, target, skillModifier, gearBonu
     if damage > 0 then
         damage = utils.clamp(utils.handlePhalanx(target, damage), 0, 99999)
         damage = utils.clamp(utils.handleOneForAll(target, damage), 0, 99999)
-        damage = utils.clamp(utils.handleStoneskin(target, damage), -99999, 99999)
+        damage = utils.handleStoneskin(target, damage, xi.attackType.MAGICAL)
     end
 
     return damage

--- a/scripts/globals/job_utils/white_mage.lua
+++ b/scripts/globals/job_utils/white_mage.lua
@@ -117,7 +117,7 @@ xi.job_utils.white_mage.useDevotion = function(player, target, ability, action)
     local damageHP   = math.floor(player:getHP() * 0.25)
 
     -- If stoneskin is present, it should absorb damage
-    damageHP = utils.handleStoneskin(player, damageHP)
+    damageHP = utils.handleStoneskin(player, damageHP, xi.attackType.MAGICAL)
 
     local healMP = player:getHP() * mpPercent
     healMP = utils.clamp(healMP, 0, target:getMaxMP() - target:getMP())
@@ -153,7 +153,7 @@ xi.job_utils.white_mage.useMartyr = function(player, target, ability, action)
     healHP = utils.clamp(healHP, 0, target:getMaxHP() - target:getHP())
 
     -- If stoneskin is present, it should absorb damage
-    damageHP = utils.handleStoneskin(player, damageHP)
+    damageHP = utils.handleStoneskin(player, damageHP, xi.attackType.MAGICAL)
     player:delHP(damageHP)
     target:addHP(healHP)
 

--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -563,7 +563,7 @@ local addEffectImmediate = function(mob, target, damage, ae, params)
         power = math.floor(target:handleSevereDamage(power, false))
         power = utils.handlePhalanx(target, power)
         power = utils.handleOneForAll(target, power)
-        power = utils.handleStoneskin(target, power)
+        power = utils.handleStoneskin(target, power, xi.attackType.MAGICAL)
         power = utils.clamp(power, -99999, 99999)
 
         if power < 0 then

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -356,11 +356,16 @@ local function handleSinglePhysicalHit(mob, target, baseHitDamage, params)
     -- TODO: Fan Dance Reduction
 
     -- Pre phalanx check - if stoneskin breaks we can get TP from shield mastery
-    if
-        blockedWithShieldMastery and
-        math.max(hitDamage - target:getMod(xi.mod.STONESKIN), 0) > 0
-    then
-        target:addTP(target:getMod(xi.mod.SHIELD_MASTERY_TP))
+    if blockedWithShieldMastery then
+        local stoneskin      = target:getStatusEffect(xi.effect.STONESKIN)
+        local stoneskinPower = 0
+        if stoneskin then
+            stoneskinPower = stoneskin:getPower()
+        end
+
+        if hitDamage - stoneskinPower > 0 then
+            target:addTP(target:getMod(xi.mod.SHIELD_MASTERY_TP))
+        end
     end
 
     hitDamage = utils.handlePhalanx(target, hitDamage)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -1772,7 +1772,7 @@ xi.mobskills.handleHybridDamage = function(mob, target, physicalDamage, element)
     magicDamage = math.floor(magicDamage * 0.5)
 
     magicDamage = utils.handleOneForAll(target, magicDamage)
-    magicDamage = utils.handleStoneskin(target, magicDamage)
+    magicDamage = utils.handleStoneskin(target, magicDamage, xi.attackType.MAGICAL)
 
     return magicDamage
 end

--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -152,7 +152,7 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
     if modAbsorbed == xi.mod.HP then
         finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
         finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
-        finalDamage = utils.clamp(utils.handleStoneskin(target, finalDamage), -99999, 99999)
+        finalDamage = utils.handleStoneskin(target, finalDamage, xi.attackType.MAGICAL)
         finalDamage = utils.clamp(finalDamage, 0, targetPoints)
         finalDamage = target:checkDamageCap(finalDamage)
 

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -1186,7 +1186,7 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     -- Handle Phalanx, One for All, Stoneskin.
     finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
     finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
-    finalDamage = utils.clamp(utils.handleStoneskin(target, finalDamage), 0, 99999)
+    finalDamage = utils.handleStoneskin(target, finalDamage, xi.attackType.MAGICAL)
 
     -- Handle final adjustments. Most are located in core. TODO: Decide if we want core handling this.
     -- Check if the mob has a damage cap

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -258,7 +258,7 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
     if magicdmg > 0 then -- handle nonzero damage if previous function does not absorb or nullify
         magicdmg = utils.handlePhalanx(target, magicdmg)
         magicdmg = utils.handleOneForAll(target, magicdmg)
-        magicdmg = utils.handleStoneskin(target, magicdmg)
+        magicdmg = utils.handleStoneskin(target, magicdmg, xi.attackType.MAGICAL)
     end
 
     return math.floor(magicdmg)
@@ -895,7 +895,7 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
 
         dmg = utils.handlePhalanx(target, dmg)
         dmg = utils.handleOneForAll(target, dmg)
-        dmg = utils.handleStoneskin(target, dmg)
+        dmg = utils.handleStoneskin(target, dmg, xi.attackType.MAGICAL)
 
         dmg = dmg * xi.settings.main.WEAPON_SKILL_POWER -- Add server bonus
     else

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -287,7 +287,11 @@ end
 -- luacheck: ignore 561
 xi.weaponskills.calculateRawWSDmg = function(attacker, target, wsID, tp, action, wsParams, calcParams)
     local targetLvl = target:getMainLvl()
-    local targetHp  = target:getHP() + target:getMod(xi.mod.STONESKIN)
+    local targetHp  = target:getHP()
+    local stoneskin = target:getStatusEffect(xi.effect.STONESKIN)
+    if stoneskin then
+        targetHp = targetHp + stoneskin:getPower()
+    end
 
     -- Obtains alpha, used for working out WSC on legacy servers. Retail has no alpha anymore as of 2014 Weaponskill functions
     local alpha = 1

--- a/scripts/mixins/families/morbol_toau.lua
+++ b/scripts/mixins/families/morbol_toau.lua
@@ -99,7 +99,7 @@ g_mixins.families.morbol_toau = function(morbolToAUMob)
             local drainPercent = drainVar > 0 and drainVar or 0.01
             local drainPotency = math.floor(target:getMaxHP() * drainPercent)
 
-            drainPotency = utils.handleStoneskin(target, drainPotency)
+            drainPotency = utils.handleStoneskin(target, drainPotency, xi.attackType.MAGICAL)
 
             action:additionalEffect(targetID, xi.subEffect.HP_DRAIN)
             action:addEffectMessage(targetID, xi.msg.basic.ADD_EFFECT_HP_DRAIN)

--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -272,21 +272,20 @@ function utils.handleStoneskin(actor, damage, attackType)
     end
 
     -- Early return: Stoneskin can't mitigate any more damage.
-    local stoneskinRemaining = actor:getMod(xi.mod.STONESKIN)
+    local stoneskinRemaining = effect:getPower()
     if stoneskinRemaining <= 0 then
         return damage
     end
 
     -- Absorb all damage.
     if stoneskinRemaining > damage then
-        actor:delMod(xi.mod.STONESKIN, damage)
+        effect:setPower(stoneskinRemaining - damage)
 
         return 0
 
     -- Wear off if mitigated damage exceeds stoneskin.
     else
         actor:delStatusEffect(xi.effect.STONESKIN)
-        actor:setMod(xi.mod.STONESKIN, 0)
 
         return utils.clamp(damage - stoneskinRemaining, 0, 99999)
     end

--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -241,39 +241,43 @@ end
 ---@param attackType xi.attackType?
 ---@return integer
 function utils.handleStoneskin(actor, damage, attackType)
+    -- Early return: No damage to mitigate.
     if damage <= 0 then
         return damage
     end
 
-    if attackType ~= nil and attackType ~= xi.attackType.NONE then
-        local effect = actor:getStatusEffect(xi.effect.STONESKIN)
-        if effect then
-            local stoneskinType = effect:getSubType()
-            if stoneskinType == 2 then
-                if
-                    attackType == xi.attackType.PHYSICAL or
-                    attackType == xi.attackType.RANGED
-                then
-                    return damage
-                end
-            elseif stoneskinType == 1 then
-                if
-                    attackType == xi.attackType.MAGICAL or
-                    attackType == xi.attackType.BREATH or
-                    attackType == xi.attackType.SPECIAL
-                then
-                    return damage
-                end
-            end
+    -- Early return: No effect present.
+    local effect = actor:getStatusEffect(xi.effect.STONESKIN)
+    if not effect then
+        return damage
+    end
+
+    -- Early return: Stoneskin type doesn't mitigate damage type.
+    local stoneskinType = effect:getSubType()
+    if stoneskinType == 2 then
+        if
+            attackType == xi.attackType.PHYSICAL or
+            attackType == xi.attackType.RANGED
+        then
+            return damage
+        end
+    elseif stoneskinType == 1 then
+        if
+            attackType == xi.attackType.MAGICAL or
+            attackType == xi.attackType.BREATH or
+            attackType == xi.attackType.SPECIAL
+        then
+            return damage
         end
     end
 
+    -- Early return: Stoneskin can't mitigate any more damage.
     local stoneskinRemaining = actor:getMod(xi.mod.STONESKIN)
     if stoneskinRemaining <= 0 then
         return damage
     end
 
-    -- Absorb all damage
+    -- Absorb all damage.
     if stoneskinRemaining > damage then
         actor:delMod(xi.mod.STONESKIN, damage)
 
@@ -284,7 +288,7 @@ function utils.handleStoneskin(actor, damage, attackType)
         actor:delStatusEffect(xi.effect.STONESKIN)
         actor:setMod(xi.mod.STONESKIN, 0)
 
-        return damage - stoneskinRemaining
+        return utils.clamp(damage - stoneskinRemaining, 0, 99999)
     end
 end
 

--- a/src/map/modifier.h
+++ b/src/map/modifier.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
   Copyright (c) 2010-2015 Darkstar Dev Teams
   This program is free software: you can redistribute it and/or modify

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1660,10 +1660,6 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
             else if (PStatusEffect->GetStatusID() == xi::StatusEffect::Blink)
             {
                 PStatusEffect->SetPower(m_POwner->getMod(xi::Mod::BLINK));
-            }
-            else if (PStatusEffect->GetStatusID() == xi::StatusEffect::Stoneskin)
-            {
-                PStatusEffect->SetPower(m_POwner->getMod(xi::Mod::STONESKIN));
             }
 
             uint32 duration = 0;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -2096,12 +2096,20 @@ auto TakePhysicalDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, PHYS
             }
 
             // Shield Mastery
-            if (std::max(damage - PDefender->getMod(xi::Mod::STONESKIN), 0) > 0 &&
-                PDefender->getMod(xi::Mod::SHIELD_MASTERY_TP))
+            if (PDefender->getMod(xi::Mod::SHIELD_MASTERY_TP))
             {
-                // If the attack was blocked and has shield mastery, add shield mastery TP bonus
-                // unblocked damage (before block but as if affected by phalanx) must be greater than zero
-                PDefender->addTP(PDefender->getMod(xi::Mod::SHIELD_MASTERY_TP));
+                int32 stoneskinPower = 0;
+                if (PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Stoneskin))
+                {
+                    stoneskinPower = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Stoneskin)->GetPower();
+                }
+
+                if (damage - stoneskinPower > 0)
+                {
+                    // If the attack was blocked and has shield mastery, add shield mastery TP bonus
+                    // unblocked damage (before block but as if affected by phalanx) must be greater than zero
+                    PDefender->addTP(PDefender->getMod(xi::Mod::SHIELD_MASTERY_TP));
+                }
             }
 
             if (const auto PChar = dynamic_cast<CCharEntity*>(PDefender))
@@ -4618,6 +4626,16 @@ int32 HandleOneForAll(CBattleEntity* PDefender, int32 damage)
 
 int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, xi::AttackType attackType)
 {
+    if (damage <= 0)
+    {
+        return damage;
+    }
+
+    if (!PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Stoneskin))
+    {
+        return damage;
+    }
+
     // subType 1 = physical/ranged only, 2 = magical only (frozen_mist / hydro_wave / Rampart)
     if (attackType != xi::AttackType::None)
     {
@@ -4641,20 +4659,15 @@ int32 HandleStoneskin(CBattleEntity* PDefender, int32 damage, xi::AttackType att
         }
     }
 
-    int16 skin = PDefender->getMod(xi::Mod::STONESKIN);
-    if (damage > 0 && skin > 0)
+    int16 stoneskinPower = PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Stoneskin)->GetPower();
+    if (stoneskinPower > damage)
     {
-        if (skin > damage)
-        {
-            PDefender->delModifier(xi::Mod::STONESKIN, damage);
-            return 0;
-        }
-
-        PDefender->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Stoneskin);
-        return damage - skin;
+        PDefender->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Stoneskin)->SetPower(stoneskinPower - damage);
+        return 0;
     }
 
-    return damage;
+    PDefender->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Stoneskin);
+    return damage - stoneskinPower;
 }
 
 auto HandleSevereDamage(CBattleEntity* PDefender, int32 damage, bool isPhysical) -> int32


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
What title sais.
- Moves clamping to inside stoneskin util, and removes all clamping from wherever the utils was used, which was severely inconsistent.
- Adds attack type to all stoneskin uses. Because being consistent is important.
- Removes unused code in old additional effect code.
- Removes old method to track stoneskin power. Because it was stupid.

## Steps to test these changes
Review each commit separately.
No changes should be observed.