### PR TITLE
[lua][sql] Create Expeditionary Force mobs and enable zones

### DIFF
--- a/scripts/globals/expeditionary_force.lua
+++ b/scripts/globals/expeditionary_force.lua
@@ -905,10 +905,11 @@ xi.expeditionaryForce.onBannerTrigger = function(player, banner)
 end
 
 -- Called from mob lua files. Fires once per alliance member in zone.
-xi.expeditionaryForce.onMobDeath = function(mob, player, optParams)
-    -- Early return: Only fires once for the killer or DoT
-    if not (optParams.isKiller or optParams.noKiller) then
-        return
+xi.expeditionaryForce.onMobDeath = function(mob, player)
+    -- Despawn pets.
+    local pet = mob:getPet()
+    if pet then
+        DespawnMob(pet:getID())
     end
 
     -- Remove NM from the zone list. When all NMs are accounted for, transition banner to CLEARED.
@@ -936,7 +937,6 @@ xi.expeditionaryForce.onMobDeath = function(mob, player, optParams)
     if allDefeated and banner:getLocalVar('State') == bannerState.ACTIVE then
         banner:setLocalVar('State', bannerState.CLEARED)
 
-        -- The banner will disappear after 60 seconds.
         banner:timer(60 * 1000, function(bannerArg)
             hideBanner(bannerArg)
         end)
@@ -1000,6 +1000,13 @@ end
 
 -- Fires on despawn. This is for if mobs despawn naturally without death. 3 minute despawn timer.
 xi.expeditionaryForce.onMobDespawn = function(mob)
+    -- Despawn pets.
+    local pet = mob:getPet()
+    if pet then
+        DespawnMob(pet:getID())
+    end
+
+    -- Handle expeditionary force completion.
     local zoneId = mob:getZoneID()
 
     local banner = GetNPCByID(zones[zoneId].npc.BEASTMENS_BANNER)
@@ -1015,10 +1022,8 @@ xi.expeditionaryForce.onMobDespawn = function(mob)
     end
 
     if banner:getLocalVar('State') == bannerState.ACTIVE then
-        -- Battle is cleared
         banner:setLocalVar('State', bannerState.CLEARED)
 
-        -- The banner will disappear after 60 seconds.
         banner:timer(60 * 1000, function(bannerArg)
             hideBanner(bannerArg)
         end)
@@ -1027,6 +1032,13 @@ end
 
 -- Pets called mid-fight (call beast, astral flow) miss the gate at spawn. Need to apply manually.
 xi.expeditionaryForce.gatePet = function(mob)
+    -- Non NMs share pet names with NMs. Only gate pets whose owner is gated.
+    -- Exclude astral flow mobs which are masterless pets.
+    local master = mob:getMaster()
+    if master and not master:hasStatusEffect(xi.effect.LEVEL_RESTRICTION) then
+        return
+    end
+
     mob:addStatusEffect(xi.effect.LEVEL_RESTRICTION, { power = zoneInfoTable[mob:getZoneID()].levelCap, origin = mob, flag = xi.effectFlag.CONFRONTATION })
 end
 

--- a/scripts/zones/Beaucedine_Glacier/DefaultActions.lua
+++ b/scripts/zones/Beaucedine_Glacier/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.BEAUCEDINE_GLACIER]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Goblin_Grenadier'] = { event = 509 },
     ['Leigon-Moigon']    = { event = 103 },
     ['Lonely_Evergreen'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },

--- a/scripts/zones/Beaucedine_Glacier/Zone.lua
+++ b/scripts/zones/Beaucedine_Glacier/Zone.lua
@@ -9,6 +9,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
     xi.voidwalker.zoneOnInit(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Beastmaster.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Gigas Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 2, 'Gigass_Tiger')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Monk.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Gigas Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Ranger.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Gigas Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Warrior.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Gigas_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Gigas Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Gigass_Tiger.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Gigass_Tiger.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Gigas's Tiger
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Goblins_Tiger.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Goblins_Tiger.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Goblin's Tiger
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Tiger')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Beaucedine_Glacier/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Beaucedine Glacier
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/DefaultActions.lua
+++ b/scripts/zones/Buburimu_Peninsula/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.BUBURIMU_PENINSULA]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['qm1']              = { messageSpecial = ID.text.SHIP_SANK_NEAR_HERE },
     ['Song_Runes']       = { messageSpecial = ID.text.SONG_RUNES_DEFAULT },
     ['Stone_Monument']   = { event = 900 },

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -11,6 +11,8 @@ zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
 
     xi.helm.initZone(zone, xi.helmType.LOGGING)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Buburimu_Peninsula/mobs/Goblins_Rabbit.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Goblins_Rabbit.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Goblin's Rabbit
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Rabbit')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Bard.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Bard.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Bard
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Black_Mage.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Monk.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Ninja.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Ninja.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Ninja
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Samurai.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Samurai.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Samurai
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Summoner.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_Summoner.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo Summoner
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Yagudos_Elemental')
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 2)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_White_Mage.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Theoyagudo_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Theoyagudo White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/mobs/Yagudos_Avatar.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Yagudos_Avatar.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  Mob: Yagudo's Avatar
+-----------------------------------
+mixins = { require('scripts/mixins/families/avatar') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Buburimu_Peninsula/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Buburimu Peninsula
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/DefaultActions.lua
+++ b/scripts/zones/Cape_Teriggan/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.CAPE_TERIGGAN]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Cermet_Headstone'] = { messageSpecial = ID.text.CANNOT_REMOVE_FRAG },
     ['qm1']              = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Cape_Teriggan/Zone.lua
+++ b/scripts/zones/Cape_Teriggan/Zone.lua
@@ -8,6 +8,8 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Cape_Teriggan/mobs/Goblins_Rabbit.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Goblins_Rabbit.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Goblin's Rabbit
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Rabbit')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Cape_Teriggan/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Cape Teriggan
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/DefaultActions.lua
@@ -1,6 +1,3 @@
-local ID = zones[xi.zone.EASTERN_ALTEPA_DESERT]
-
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Lokpix'] = { event = 24 },
 }

--- a/scripts/zones/Eastern_Altepa_Desert/Zone.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/Zone.lua
@@ -9,6 +9,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
     xi.chocobo.initZone(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Black_Mage.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Contantican Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Paladin.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Paladin.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Contantican Paladin
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Ranger.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Contantican Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Warrior.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Contantican_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Contantican Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Goblins_Spider.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Goblins_Spider.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Goblin's Spider
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Spider')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Eastern Altepa Desert
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/DefaultActions.lua
+++ b/scripts/zones/Jugner_Forest/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.JUGNER_FOREST]
 
 return {
-    ['Beastmens_Banner']    = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Metallic_Hodgepodge'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Perevie']             = { event = 29 },
     ['qm1']                 = { messageSpecial = ID.text.DUG_UP },

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -14,6 +14,8 @@ zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helmType.LOGGING)
 
     xi.voidwalker.zoneOnInit(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Jugner_Forest/mobs/Goblins_Beetle.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Goblins_Beetle.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Goblin's Beetle
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Black_Mage.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Dark_Knight.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Dragoon.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Dragoon.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Dragoon
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Orcs_Wyvern')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Monk.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Paladin.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Paladin.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Paladin
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Ranger.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Halforc_Warrior.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Halforc_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Halforc Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Beetle')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/mobs/Orcs_Wyvern.lua
+++ b/scripts/zones/Jugner_Forest/mobs/Orcs_Wyvern.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  Mob: Orc's Wyvern
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Jugner_Forest/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Jugner Forest
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/DefaultActions.lua
+++ b/scripts/zones/Meriphataud_Mountains/DefaultActions.lua
@@ -1,7 +1,4 @@
-local ID = zones[xi.zone.MERIPHATAUD_MOUNTAINS]
-
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Muzeze']           = { event = 44 },
     ['Stone_Monument']   = { event = 900 },
 }

--- a/scripts/zones/Meriphataud_Mountains/Zone.lua
+++ b/scripts/zones/Meriphataud_Mountains/Zone.lua
@@ -9,6 +9,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
     xi.voidwalker.zoneOnInit(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Meriphataud_Mountains/mobs/Goblins_Dragonfly.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Goblins_Dragonfly.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Goblin's Dragonfly
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Dragonfly')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Bard.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Bard.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Bard
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Black_Mage.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Monk.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Ninja.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Ninja.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Ninja
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Samurai.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Samurai.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Samurai
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Summoner.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_Summoner.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo Summoner
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Yagudos_Elemental')
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 2)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_White_Mage.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Theoyagudo_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Theoyagudo White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/mobs/Yagudos_Avatar.lua
+++ b/scripts/zones/Meriphataud_Mountains/mobs/Yagudos_Avatar.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  Mob: Yagudo's Avatar
+-----------------------------------
+mixins = { require('scripts/mixins/families/avatar') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Meriphataud_Mountains/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Meriphataud Mountains
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/DefaultActions.lua
+++ b/scripts/zones/Pashhow_Marshlands/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.PASHHOW_MARSHLANDS]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Luck_Rune']        = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Meh_Nbolo']        = { event = 27 },
     ['Odyssean_Passage'] = { messageSpecial = ID.text.NOTHING_HAPPENS },

--- a/scripts/zones/Pashhow_Marshlands/Zone.lua
+++ b/scripts/zones/Pashhow_Marshlands/Zone.lua
@@ -10,6 +10,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
     xi.voidwalker.zoneOnInit(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Pashhow_Marshlands/mobs/Goblins_Bee.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Goblins_Bee.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Goblin's Bee
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Bee')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Black_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Dark_Knight.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Paladin.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Paladin.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Paladin
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Red_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Thief.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Warrior.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_White_Mage.lua
+++ b/scripts/zones/Pashhow_Marshlands/mobs/Metaquadav_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  Mob: Metaquadav White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Pashhow_Marshlands/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Pashhow Marshlands
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/DefaultActions.lua
+++ b/scripts/zones/Qufim_Island/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.QUFIM_ISLAND]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Giant_Footprint']  = { messageSpecial = ID.text.GIGANTIC_FOOTPRINT },
     ['Luck_Rune']        = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Trodden_Snow']     = { messageSpecial = ID.text.ASA_SNOW },

--- a/scripts/zones/Qufim_Island/Zone.lua
+++ b/scripts/zones/Qufim_Island/Zone.lua
@@ -8,6 +8,8 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/Qufim_Island/mobs/Giant_Beastmaster.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Giant Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 2, 'Gigass_Leech')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Giant_High_Ranger.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_High_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Giant High Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Giant_Monk.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Giant Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Giant_Warrior.lua
+++ b/scripts/zones/Qufim_Island/mobs/Giant_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Giant Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Gigass_Leech.lua
+++ b/scripts/zones/Qufim_Island/mobs/Gigass_Leech.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Gigas's Leech
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Goblins_Leech.lua
+++ b/scripts/zones/Qufim_Island/mobs/Goblins_Leech.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Goblin's Leech
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Leech')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Qufim_Island/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Qufim Island
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Qufim_Island/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Qufim_Island/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Qufim Island
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/DefaultActions.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.THE_SANCTUARY_OF_ZITAH]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['qm1']              = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm2']              = { messageSpecial = ID.text.BEAUTIFUL_STURDY_BRANCH },
     ['qm3']              = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },

--- a/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/Zone.lua
@@ -8,6 +8,8 @@ local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Goblins_Leech.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Goblins_Leech.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Goblin's Leech
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Leech')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: The Sanctuary of ZiTah
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/DefaultActions.lua
+++ b/scripts/zones/Valkurm_Dunes/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.VALKURM_DUNES]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['qm2']              = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm3']              = { messageSpecial = ID.text.YOU_SENSE_AN_EVIL_PRESENCE },
     ['qm4']              = { messageSpecial = ID.text.MONSTERS_KILLED_ADVENTURERS },

--- a/scripts/zones/Valkurm_Dunes/Zone.lua
+++ b/scripts/zones/Valkurm_Dunes/Zone.lua
@@ -20,6 +20,8 @@ zoneObject.onInitialize = function(zone)
             qm2:setStatus(xi.status.DISAPPEAR)
         end
     end
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneTick = function(zone)

--- a/scripts/zones/Valkurm_Dunes/mobs/Goblins_Dragonfly.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Goblins_Dragonfly.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Goblin's Dragonfly
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Black_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Dark_Knight.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Dragoon.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Dragoon.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Dragoon
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Orcs_Wyvern')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Monk.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Paladin.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Paladin.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Paladin
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Ranger.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Halforc_Warrior.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Halforc_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Halforc Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Dragonfly')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Black_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Dark_Knight.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Paladin.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Paladin.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Paladin
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Red_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Thief.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Warrior.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_White_Mage.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Metaquadav_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Metaquadav White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/mobs/Orcs_Wyvern.lua
+++ b/scripts/zones/Valkurm_Dunes/mobs/Orcs_Wyvern.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  Mob: Orc's Wyvern
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Valkurm_Dunes/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Valkurm Dunes
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/DefaultActions.lua
+++ b/scripts/zones/Xarcabard/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.XARCABARD]
 
 return {
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Luck_Rune']        = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Option_One']       = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Option_Two']       = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },

--- a/scripts/zones/Xarcabard/Zone.lua
+++ b/scripts/zones/Xarcabard/Zone.lua
@@ -7,6 +7,8 @@ local zoneObject = {}
 zoneObject.onInitialize = function(zone)
     xi.conquest.setRegionalConquestOverseers(zone:getRegionID())
     xi.voidwalker.zoneOnInit(zone)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Xarcabard/mobs/Gigas_Beastmaster.lua
+++ b/scripts/zones/Xarcabard/mobs/Gigas_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Gigas Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 2, 'Gigass_Tiger')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Gigas_Monk.lua
+++ b/scripts/zones/Xarcabard/mobs/Gigas_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Gigas Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Gigas_Ranger.lua
+++ b/scripts/zones/Xarcabard/mobs/Gigas_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Gigas Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Gigas_Warrior.lua
+++ b/scripts/zones/Xarcabard/mobs/Gigas_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Gigas Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Gigass_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Gigass_Tiger.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Gigas's Tiger
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Goblins_Tiger.lua
+++ b/scripts/zones/Xarcabard/mobs/Goblins_Tiger.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Goblin's Tiger
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Tiger')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Xarcabard/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Xarcabard
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Xarcabard/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Xarcabard/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Xarcabard
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/DefaultActions.lua
+++ b/scripts/zones/Yhoator_Jungle/DefaultActions.lua
@@ -2,5 +2,4 @@ local ID = zones[xi.zone.YHOATOR_JUNGLE]
 
 return {
     ['qm2']              = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
 }

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -15,6 +15,8 @@ zoneObject.onInitialize = function(zone)
     xi.chocobo.initZone(zone)
 
     xi.beastmenTreasure.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onGameDay = function()

--- a/scripts/zones/Yhoator_Jungle/mobs/Goblins_Bee.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Goblins_Bee.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Goblin's Bee
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Bee')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Black_Mage.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Black_Mage.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Noctonberry Black Mage
+-----------------------------------
+mixins =
+{
+    require('scripts/mixins/families/tonberry'),
+    require('scripts/mixins/job_special')
+}
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Ninja.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Ninja.lua
@@ -11,8 +11,19 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
 entity.onMobDeath = function(mob, player, optParams)
-    xi.regime.checkRegime(player, mob, 133, 1, xi.regime.type.FIELDS)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
 end
 
 return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Summoner.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Summoner.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Noctonberry Summoner
+-----------------------------------
+mixins =
+{
+    require('scripts/mixins/families/tonberry'),
+    require('scripts/mixins/job_special')
+}
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Tonberrys_Elemental')
+    mob:setMobMod(xi.mobMod.ASTRAL_PET_OFFSET, 2)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Thief.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Noctonberry_Thief.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Noctonberry Thief
+-----------------------------------
+mixins =
+{
+    require('scripts/mixins/families/tonberry'),
+    require('scripts/mixins/job_special')
+}
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/mobs/Tonberrys_Avatar.lua
+++ b/scripts/zones/Yhoator_Jungle/mobs/Tonberrys_Avatar.lua
@@ -1,0 +1,14 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  Mob: Tonberry's Avatar
+-----------------------------------
+mixins = { require('scripts/mixins/families/avatar') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Yhoator_Jungle/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Yhoator Jungle
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/DefaultActions.lua
+++ b/scripts/zones/Yuhtunga_Jungle/DefaultActions.lua
@@ -2,7 +2,6 @@ local ID = zones[xi.zone.YUHTUNGA_JUNGLE]
 
 return {
     ['qm11']             = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['Beastmens_Banner'] = { messageSpecial = ID.text.BEASTMEN_BANNER },
     ['Cermet_Headstone'] = { messageSpecial = ID.text.CANNOT_REMOVE_FRAG },
     ['LuckRune']         = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -17,6 +17,8 @@ zoneObject.onInitialize = function(zone)
     xi.helm.initZone(zone, xi.helmType.LOGGING)
 
     xi.beastmenTreasure.updatePeddlestox(xi.zone.YUHTUNGA_JUNGLE, ID.npc.PEDDLESTOX)
+
+    xi.expeditionaryForce.initZone(zone)
 end
 
 zoneObject.onGameDay = function()

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Bard.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Bard.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Demisahagin Bard
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Dragoon.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Dragoon.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Demisahagin Dragoon
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Sahagins_Wyvern')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Monk.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Demisahagin_Monk.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Demisahagin Monk
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Demishagin_White_Mage.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Demishagin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Demishagin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Goblins_Bee.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Goblins_Bee.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Goblin's Bee
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Beastmaster.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Beastmaster.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Beastmaster
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.pet.setMobPet(mob, 1, 'Goblins_Bee')
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Black_Mage.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Black_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Black Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Dark_Knight.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Dark_Knight.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Dark Knight
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Ranger.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Ranger.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Ranger
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Red_Mage.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Red_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Red Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Thief.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Thief.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Thief
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Warrior.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_Warrior.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin Warrior
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_White_Mage.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Hobgoblin_White_Mage.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Hobgoblin White Mage
+-----------------------------------
+mixins = { require('scripts/mixins/job_special') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.NO_DESPAWN, 1)
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.expeditionaryForce.onMobDeath(mob, player)
+    end
+end
+
+entity.onMobDespawn = function(mob)
+    xi.expeditionaryForce.onMobDespawn(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Sahagins_Wyvern.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Sahagins_Wyvern.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  Mob: Sahagin's Wyvern
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    xi.expeditionaryForce.gatePet(mob)
+end
+
+return entity

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Beastmens_Banner.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Beastmens_Banner.lua
@@ -1,0 +1,12 @@
+-----------------------------------
+-- Area: Yuhtunga Jungle
+--  NPC: Beastmen's Banner
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.expeditionaryForce.onBannerTrigger(player, npc)
+end
+
+return entity

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -46814,7 +46814,7 @@ INSERT INTO `mob_spawn_points` VALUES (17281477,0,'Demisahagin_Monk','Demisahagi
 INSERT INTO `mob_spawn_points` VALUES (17281478,0,'Demishagin_White_Mage','Demishagin White Mage',43,40,43,1.000,1.000,1.000,0,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17281479,0,'Demisahagin_Bard','Demisahagin Bard',44,40,43,1.000,1.000,1.000,0,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17281480,0,'Demisahagin_Dragoon','Demisahagin Dragoon',45,40,43,1.000,1.000,1.000,0,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17281481,0,'Sahagins_Wyvern','Sahagin\'s Wyvern',46,38,40,0.000,0.000,0.000,0,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17281481,0,'Sahagins_Wyvern','Sahagin\'s Wyvern',46,38,40,1.000,1.000,1.000,0,NULL,NULL);
 
 -- Garrison
 INSERT INTO `mob_spawn_points` VALUES (17281482,0,'Brook_Sahagin','Brook Sahagin',47,40,45,-224.851,0.483,-392.204,95,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
If you want me to split this PR by zone let me know! Each zone is pretty much repeats, there are just a lot of EF mobs.

For all 13 zones in EF, this PR:
- Removes Beastmen's Banner from default actions and creates it's own lua file.
- Initializes Expeditionary Force in the Zone.lua file.
- Adds lua files for all EF NMs and pets (Beastmaster pet, Wyvern, Elemental, and Avatar). All EF NMs are standard beastmen mobs with 2-hour abilities.

Some Beastmaster NM's pets also exist in the zone (Cape Teriggan) so this PR adds a check in expeditionary_force.lua gatePet.

One EF mob was missed in the mob_spawn_pools.sql file, so that was corrected.

Notes: Pets despawn on death or despawn of owner, whichever comes first which is why that code is in both.

## Steps to test these changes

Add key item for expeditionary force

## Known EF issues
A PR is going to be made to correct some of the EF mob models. Several were discovered when testing.
A PR is going to enable influence gain through EF chests and mob kills.