### PR TITLE
[lua] Move fomorParty superlink to onMobInit

### DIFF
--- a/scripts/mixins/fomor_party.lua
+++ b/scripts/mixins/fomor_party.lua
@@ -112,7 +112,9 @@ local zoneParties =
         patrol =
         {
             { leader = sacrariumID.mob.FOMOR_WARRIOR[5], followers = 1 },
-            { leader = sacrariumID.mob.FOMOR_BARD[6],    followers = 3 },
+            { leader = sacrariumID.mob.FOMOR_BARD[6],    followers = 2 },
+            { leader = sacrariumID.mob.FOMOR_THIEF[4],   followers = 1 },
+            { leader = sacrariumID.mob.FOMOR_MONK[5],    followers = 1 },
         },
 
         guard =

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Bard.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Beastmaster.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Beastmaster.lua
@@ -13,11 +13,8 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bat')
-end
-
-entity.onMobSpawn = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
+    xi.pet.setMobPet(mob, 1, 'Fomors_Bat')
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Black_Mage.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Black_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Dark_Knight.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Dark_Knight.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Dragoon.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Dragoon.lua
@@ -13,12 +13,11 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Wyvern')
 end
 
 entity.onMobSpawn = function(mob)
-    xi.mix.fomorParty.onPartySpawn(mob)
-
     -- Summon wyvern immediately on spawn
     mob:useMobAbility(xi.mobSkill.CALL_WYVERN_1)
 end

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Monk.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Monk.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Ninja.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Ninja.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Paladin.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Ranger.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Ranger.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Red_Mage.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Red_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Samurai.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Samurai.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Summoner.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Summoner.lua
@@ -13,11 +13,8 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Elemental')
-end
-
-entity.onMobSpawn = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
+    xi.pet.setMobPet(mob, 1, 'Fomors_Elemental')
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Thief.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Lufaise_Meadows/mobs/Fomor_Warrior.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Fomor_Warrior.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Bard.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Black_Mage.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Black_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Dark_Knight.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Dark_Knight.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Dragoon.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Dragoon.lua
@@ -13,12 +13,11 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Wyvern')
 end
 
 entity.onMobSpawn = function(mob)
-    xi.mix.fomorParty.onPartySpawn(mob)
-
     -- Summon wyvern immediately on spawn
     mob:useMobAbility(xi.mobSkill.CALL_WYVERN_1)
 end

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Monk.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Monk.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Ninja.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Ninja.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Paladin.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Ranger.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Ranger.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Red_Mage.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Red_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Samurai.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Samurai.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Summoner.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Summoner.lua
@@ -13,11 +13,8 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 2, 'Fomors_Elemental')
-end
-
-entity.onMobSpawn = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
+    xi.pet.setMobPet(mob, 2, 'Fomors_Elemental')
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Thief.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Fomor_Warrior.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Fomor_Warrior.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Bard.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Beastmaster.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Beastmaster.lua
@@ -2,13 +2,29 @@
 -- Area: Phomiuna_Aqueducts
 --  Mob: Fomor Beastmaster
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Bat')
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
 end
 
 return entity

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Black_Mage.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Black_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dark_Knight.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dark_Knight.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dragoon.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Dragoon.lua
@@ -13,12 +13,11 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Wyvern')
 end
 
 entity.onMobSpawn = function(mob)
-    xi.mix.fomorParty.onPartySpawn(mob)
-
     -- Summon wyvern immediately on spawn
     mob:useMobAbility(xi.mobSkill.CALL_WYVERN_1)
 end

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Monk.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Monk.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ninja.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ninja.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Paladin.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ranger.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Ranger.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Red_Mage.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Red_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Samurai.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Samurai.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Summoner.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Summoner.lua
@@ -13,11 +13,8 @@ mixins =
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Elemental')
-end
-
-entity.onMobSpawn = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
+    xi.pet.setMobPet(mob, 1, 'Fomors_Elemental')
 end
 
 entity.onMobRoam = function(mob)

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Thief.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Warrior.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Fomor_Warrior.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/IDs.lua
+++ b/scripts/zones/Sacrarium/IDs.lua
@@ -49,6 +49,7 @@ zones[xi.zone.SACRARIUM] =
         FOMOR_RANGER            = GetTableOfIDs('Fomor_Ranger'),
         FOMOR_RED_MAGE          = GetTableOfIDs('Fomor_Red_Mage'),
         FOMOR_SAMURAI           = GetTableOfIDs('Fomor_Samurai'),
+        FOMOR_THIEF             = GetTableOfIDs('Fomor_Thief'),
         FOMOR_WARRIOR           = GetTableOfIDs('Fomor_Warrior'),
         OLD_PROFESSOR_MARISELLE = GetFirstID('Old_Professor_Mariselle'),
         SWIFT_BELT_NM_OFFSET    = GetFirstID('Balor'),

--- a/scripts/zones/Sacrarium/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Bard.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Beastmaster.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Beastmaster.lua
@@ -2,13 +2,29 @@
 -- Area: Sacrarium
 --  Mob: Fomor Beastmaster
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
 end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Black_Mage.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Black_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Dark_Knight.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Dark_Knight.lua
@@ -2,9 +2,28 @@
 -- Area: Sacrarium
 --  Mob: Fomor Dark Knight
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
+end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Dragoon.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Dragoon.lua
@@ -2,18 +2,34 @@
 -- Area: Sacrarium
 --  Mob: Fomor Dragoon
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Wyvern')
 end
 
 entity.onMobSpawn = function(mob)
     -- Summon wyvern immediately on spawn
     mob:useMobAbility(xi.mobSkill.CALL_WYVERN_1)
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
 end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Monk.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Monk.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Ninja.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Ninja.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Paladin.lua
@@ -2,9 +2,28 @@
 -- Area: Sacrarium
 --  Mob: Fomor Paladin
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
+end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Ranger.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Ranger.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Red_Mage.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Red_Mage.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Samurai.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Samurai.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 

--- a/scripts/zones/Sacrarium/mobs/Fomor_Summoner.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Summoner.lua
@@ -2,13 +2,29 @@
 -- Area: Sacrarium
 --  Mob: Fomor Summoner
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Elemental')
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
 end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Thief.lua
@@ -2,9 +2,28 @@
 -- Area: Sacrarium
 --  Mob: Fomor Thief
 -----------------------------------
-mixins = { require('scripts/mixins/fomor_hate') }
+mixins =
+{
+    require('scripts/mixins/follow'),
+    require('scripts/mixins/fomor_hate'),
+    require('scripts/mixins/fomor_party'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
+
+entity.onMobInitialize = function(mob)
+    xi.mix.fomorParty.onPartySpawn(mob)
+end
+
+entity.onMobRoam = function(mob)
+    xi.mix.fomorParty.onPartyRoam(mob)
+end
+
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        xi.mix.fomorParty.onPartyDeath(mob)
+    end
+end
 
 return entity

--- a/scripts/zones/Sacrarium/mobs/Fomor_Warrior.lua
+++ b/scripts/zones/Sacrarium/mobs/Fomor_Warrior.lua
@@ -12,7 +12,7 @@ mixins =
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobSpawn = function(mob)
+entity.onMobInitialize = function(mob)
     xi.mix.fomorParty.onPartySpawn(mob)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Moves fomorParty.onPartySpawn (which contains superLink logic) from onMobSpawn to onMobInitialize so it can properly build mob groups
- Adds two missing Fomor Parties to Sacrarium
- Adds blanket mixins and onMobInit logic to all basic job fomors. They don't strictly all need it, but as we investigate Fomor party composition further, it's easier to add/fix parties and mob file layout is consistent. 

## Steps to test these changes

!gotoid 16892022
Provoke Fomor Thief (16892022)
Fomor Samurai (16892023) should join the fight

Tested all Sacrarium parties. Smoketested some Lufaise / Misareaux.