### PR TITLE
[core] Don't block REQSUBMAPNUM during CS

### DIFF
--- a/scripts/missions/windurst/9_2_Moon_Reading.lua
+++ b/scripts/missions/windurst/9_2_Moon_Reading.lua
@@ -213,7 +213,14 @@ mission.sections =
         {
             onZoneIn = function(player, prevZone)
                 if player:getMissionStatus(mission.areaId) == 4 then
-                    return 443
+                    player:setPos(0, -16.750, 130, 64)
+
+                    local cutsceneFlags = bit.bor(
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.UNKNOWN_2
+                    )
+
+                    return { 443, -1, cutsceneFlags }
                 end
             end,
 

--- a/src/map/packets/c2s/0x0eb_reqsubmapnum.cpp
+++ b/src/map/packets/c2s/0x0eb_reqsubmapnum.cpp
@@ -26,9 +26,7 @@
 
 auto GP_CLI_COMMAND_REQSUBMAPNUM::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
-    // No parameter to validate.
-    return PacketValidator(PChar)
-        .blockedBy({ BlockedState::InEvent });
+    return PacketValidator(PChar);
 }
 
 void GP_CLI_COMMAND_REQSUBMAPNUM::process(MapSession* PSession, CCharEntity* PChar) const


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Packet is used for certain CS swapping maps/rooms and the event VM stalls without response.

Tweaks 9-2 CS parameters to be retail accurate but shouldn't change much.

## Steps to test these changes
!cs 443 in Walls
<!-- Clear and detailed steps to test your changes here -->
