### PR TITLE
[Combat] Rename `isRanged` to `ignoreEnSpell` and apply to Excalibur

### DIFF
--- a/scripts/combat/action_additional_effect_damage.lua
+++ b/scripts/combat/action_additional_effect_damage.lua
@@ -36,8 +36,8 @@ local function validateParameters(actor, target, fedData)
     -- Limit undead
     params.limitUndead     = fedData.limitUndead or false -- Default: Works on undead.
 
-    -- Source is ranged attack or melee? Skip en-spell check if so.
-    params.isRanged        = fedData.isRanged or false -- Assume melee.
+    -- Bypass regular En-Spell > AE > Daze priority.
+    params.ignoreEnSpell   = fedData.ignoreEnSpell or false -- Assume En-Spell takes priority.
 
     -- Base damage parameters.
     params.basePower       = fedData.basePower or 0
@@ -105,8 +105,8 @@ end
 xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     local params = validateParameters(actor, target, fedData)
 
-    -- Early return: En-spell overrides innate/weapon additional effects, except ranged attacks.
-    if not params.isRanged and hasEnspell(actor) then
+    -- Early return: En-spell override.
+    if not params.ignoreEnSpell and hasEnspell(actor) then
         return 0, 0, 0
     end
 

--- a/scripts/items/bloody_bolt.lua
+++ b/scripts/items/bloody_bolt.lua
@@ -13,7 +13,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 60 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.DARK,

--- a/scripts/items/darkling_bolt.lua
+++ b/scripts/items/darkling_bolt.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.DARK,

--- a/scripts/items/earth_arrow.lua
+++ b/scripts/items/earth_arrow.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.EARTH,

--- a/scripts/items/excalibur_119.lua
+++ b/scripts/items/excalibur_119.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_119_ii.lua
+++ b/scripts/items/excalibur_119_ii.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_119_iii.lua
+++ b/scripts/items/excalibur_119_iii.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_75.lua
+++ b/scripts/items/excalibur_75.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_80.lua
+++ b/scripts/items/excalibur_80.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_85.lua
+++ b/scripts/items/excalibur_85.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_90.lua
+++ b/scripts/items/excalibur_90.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_95.lua
+++ b/scripts/items/excalibur_95.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_99.lua
+++ b/scripts/items/excalibur_99.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/excalibur_99_ii.lua
+++ b/scripts/items/excalibur_99_ii.lua
@@ -10,6 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     local pTable =
     {
         chance          = 7,
+        ignoreEnSpell   = true,
         basePower       = math.floor(actor:getHP() / 4),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/fire_arrow.lua
+++ b/scripts/items/fire_arrow.lua
@@ -10,7 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     -- Unconfirmed power.
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = math.random(7, 10),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.FIRE,

--- a/scripts/items/grand_knights_arrow.lua
+++ b/scripts/items/grand_knights_arrow.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.FIRE,

--- a/scripts/items/holy_bolt.lua
+++ b/scripts/items/holy_bolt.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 40 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.LIGHT,

--- a/scripts/items/ice_arrow.lua
+++ b/scripts/items/ice_arrow.lua
@@ -10,7 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     -- Unconfirmed power.
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = math.random(7, 10),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.ICE,

--- a/scripts/items/lightning_arrow.lua
+++ b/scripts/items/lightning_arrow.lua
@@ -10,7 +10,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
     -- Unconfirmed power.
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = math.random(7, 10),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.THUNDER,

--- a/scripts/items/righteous_bolt.lua
+++ b/scripts/items/righteous_bolt.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 40 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.LIGHT,

--- a/scripts/items/scouts_bolt.lua
+++ b/scripts/items/scouts_bolt.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 40 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.LIGHT,

--- a/scripts/items/temple_knights_arrow.lua
+++ b/scripts/items/temple_knights_arrow.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.FIRE,

--- a/scripts/items/water_arrow.lua
+++ b/scripts/items/water_arrow.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.WATER,

--- a/scripts/items/wind_arrow.lua
+++ b/scripts/items/wind_arrow.lua
@@ -12,7 +12,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        isRanged        = true,
+        ignoreEnSpell   = true,
         basePower       = 10 + utils.clamp(dStat, -3, 8) + utils.clamp(math.floor((dStat - 8) / 2), 0, 8),
         attackType      = xi.attackType.MAGICAL,
         magicalElement  = xi.element.WIND,


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
What title sais.
Excalibur's additional effect is speccial, because of course it is, and bypasses en-spell effects. That is handled in core correctly, but the change is needed here aswell.

## Steps to test these changes
None.
