### PR TITLE
[cpp] Add USE_OLD_COUNTERSTANCE for era Counterstance DEF

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -248,6 +248,7 @@ xi.settings.main =
     SNEAK_INVIS_DURATION_MULTIPLIER = 1,     -- multiplies duration of sneak, invis, deodorize to reduce player torture. 1 = retail behavior.
     USE_OLD_CURE_FORMULA            = false, -- true/false. if true, uses older cure formula (3*MND + VIT + 3*(healing skill/5)) // cure 6 will use the newer formula
     USE_OLD_MAGIC_DAMAGE            = false, -- true/false. if true, uses older magic damage formulas
+    USE_OLD_COUNTERSTANCE           = false, -- true/false. if true, Counterstance DEF = 1 + VIT/2 (+ Minne); gear/Protect ignored
 
     -- CELEBRATIONS
     EXPLORER_MOOGLE_LV              = 10, -- Enables Explorer Moogle teleports and sets required level. Zero to disable.

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -1616,9 +1616,21 @@ uint16 CBattleEntity::DEF()
 
     DEF += getMod(Mod::DEF);
 
-    // TODO: support old style counterstance
     if (this->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Counterstance, 0))
     {
+        // https://ffxiclopedia.fandom.com/wiki/Talk:Counterstance: DEF = 1 + VIT/2; gear/Protect ignored; % mods apply
+        if (settings::get<bool>("main.USE_OLD_COUNTERSTANCE"))
+        {
+            DEF = 1 + VIT() / 2;
+
+            if (CStatusEffect* PMinne = this->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Minne))
+            {
+                DEF += PMinne->GetPower();
+            }
+
+            return std::max(1, DEF + (DEF * getMod(Mod::DEFP) / 100) + std::min<int16>((DEF * getMod(Mod::FOOD_DEFP) / 100), getMod(Mod::FOOD_DEF_CAP)));
+        }
+
         return DEF / 2;
     }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds `USE_OLD_COUNTERSTANCE` (default `false`) so era servers can use pre-WotG Counterstance DEF.

When enabled, Counterstance DEF is `1 + VIT/2`, plus Knight's Minne if present. Gear DEF and Protect are ignored. Percent DEF modifiers (Berserk, food, Defense Down) still apply.

When disabled, existing half-total-DEF behavior is unchanged.

Source: https://ffxiclopedia.fandom.com/wiki/Talk:Counterstance

https://wiki.ffo.jp/html/2848.html

## Steps to test these changes

1. Set `USE_OLD_COUNTERSTANCE = true` and rebuild/restart.
2. MNK75, strip armor, use Counterstance, note damage from the same mob autos.
3. Equip high DEF gear (same job/level), reapply Counterstance, fight the same mob.
4. Confirm taken damage does not drop from gear DEF alone.
5. Optionally confirm VIT gear / Minne still affect DEF under Counterstance, and that with the setting left `false` behavior matches current retail (`DEF / 2`).