### PR TITLE
[core] Deny zoning with rental chocobo to non-riding zones

### DIFF
--- a/src/map/enums/msg_std.h
+++ b/src/map/enums/msg_std.h
@@ -60,7 +60,7 @@ enum class MsgStd : uint16_t
     MoogleDriesPlant             = 133, // Your moogle dries the plant in the <item>.
     MoogleUsesItemOnPLant        = 136, // Your moogle uses the <item> on the plant.
     MoghouseCantPickUp           = 137, // Kupo... I can't pick anything right now, kupo.
-    ChocoboRefusedToEnte         = 138, // The chocobo refused to enter the next area.
+    CannotEnterAreaWhileMounted  = 138, // You cannot enter the next area while mounted.
     CurrentPollResultsSystem     = 140, // Player Name's proposal - Current poll results:
     FinalPollResultsSystem       = 141, // Player Name's proposal - Final poll results:
     CannotUseCommandAtTheMoment  = 142, // You cannot use that command at the moment. Please try again later.

--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -29,13 +29,15 @@
 #include "enums/msg_std.h"
 #include "packets/s2c/0x053_systemmes.h"
 #include "packets/s2c/0x065_wpos2.h"
+#include "status_effect.h"
+#include "status_effect_container.h"
 #include "utils/charutils.h"
 #include "utils/zoneutils.h"
 
 namespace
 {
 
-const auto denyZone = [](CCharEntity* PChar)
+const auto denyZone = [](CCharEntity* PChar, MsgStd message = MsgStd::CouldNotEnter)
 {
     // TODO: Retail handling:
     // - Tripped poshack check: Placed somewhere on the corresponding 'exit' zoneline
@@ -43,10 +45,16 @@ const auto denyZone = [](CCharEntity* PChar)
     // - Invalid zoneline (observed in Kamihr): Placed on a different zoneline
     PChar->loc.p.rotation += 128;
 
-    PChar->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::CouldNotEnter);
+    PChar->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, message);
     PChar->pushPacket<GP_SERV_COMMAND_WPOS2>(PChar, PChar->loc.p, POSMODE::RESET);
 
     PChar->status = xi::Status::Normal;
+};
+
+const auto isRidingRentalChocobo = [](const CCharEntity* PChar) -> bool
+{
+    const auto* effect = PChar->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Mounted);
+    return effect != nullptr && effect->GetPower() == MOUNT_CHOCOBO && effect->GetSubPower() == 0;
 };
 
 } // namespace
@@ -245,6 +253,13 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                 if (!isMogHouseEntrance && zoneutils::IsZoneAtPlayerCap(PZoneLine->destinationZoneId, PChar->m_GMlevel > 0))
                 {
                     denyZone(PChar);
+                    return;
+                }
+
+                // A rental chocobo cannot be taken into a zone that does not permit riding.
+                if (isRidingRentalChocobo(PChar) && !zoneutils::CanZoneUseMisc(PZoneLine->destinationZoneId, xi::ZoneMisc::Mount))
+                {
+                    denyZone(PChar, MsgStd::CannotEnterAreaWhileMounted);
                     return;
                 }
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -1344,6 +1344,19 @@ auto GetZoneIPP(uint16 zoneId) -> uint64
     return ipp;
 }
 
+auto CanZoneUseMisc(uint16 zoneId, xi::ZoneMisc misc) -> bool
+{
+    const auto rset = db::preparedStmt("SELECT misc FROM zone_settings WHERE zoneid = ?", zoneId);
+    FOR_DB_SINGLE_RESULT(rset)
+    {
+        const auto mask = rset->get<xi::ZoneMisc>("misc");
+        return (mask & misc) == misc;
+    }
+
+    ShowCritical("zoneutils::CanZoneUseMisc: Cannot find zone %u", zoneId);
+    return false;
+}
+
 auto IsZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool
 {
     const auto cap = settings::get<uint16>("map.ZONE_PLAYER_CAP");

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -81,10 +81,11 @@ auto GetZonesAssignedToThisProcess(IPP mapIPP) -> std::vector<uint16>;
 auto IsZoneAssignedToThisProcess(IPP mapIPP, ZONEID zoneId) -> bool;
 void ForEachZone(FnRef<void(CZone*)> func);
 void ForEachZone(const std::vector<uint16>& zoneIds, FnRef<void(CZone*)> func);
-auto GetZoneIPP(uint16 zoneId) -> uint64;                    // returns IPP for zone ID
-auto IsZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool;    // returns true if the zone is at capacity and the entry should be denied
-auto IsResidentialArea(const CCharEntity* PChar) -> bool;    // returns whether or not the area is a residential zone
-auto IsAlwaysOutOfNationControl(REGION_TYPE region) -> bool; // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
+auto GetZoneIPP(uint16 zoneId) -> uint64;                      // returns IPP for zone ID
+auto CanZoneUseMisc(uint16 zoneId, xi::ZoneMisc misc) -> bool; // DB-backed misc check; works for zones on other processes
+auto IsZoneAtPlayerCap(uint16 zoneId, bool isGM) -> bool;      // returns true if the zone is at capacity and the entry should be denied
+auto IsResidentialArea(const CCharEntity* PChar) -> bool;      // returns whether or not the area is a residential zone
+auto IsAlwaysOutOfNationControl(REGION_TYPE region) -> bool;   // returns true if a region should never trigger "in areas outside own nation's control" latent effect; false otherwise.
 
 void AfterZoneIn(CBaseEntity* PEntity); // triggers after a player has finished zoning in
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Title. 

Still a thing on retail. Does not apply to mounts.


## Steps to test these changes
Port Jeuno, rent a chocobo.
Try to zone:
- Port Jeuno -> denied
- Garlaige Citadel -> denied
- Meriphataud -> allowed

Try with mounts, should work in all 3 cases.

<!-- Clear and detailed steps to test your changes here -->
