### PR TITLE
[lua] Restrict xp in Eco-Warrior and Garrison

### DIFF
--- a/scripts/globals/garrison.lua
+++ b/scripts/globals/garrison.lua
@@ -92,7 +92,12 @@ xi.garrison.addLevelCap = function(entity, definedCap)
     end
 
     -- Note the level restriction does not wear on death.
-    entity:addStatusEffect(xi.effect.LEVEL_RESTRICTION, { power = cap, origin = entity, flag = xi.effectFlag.ON_ZONE + xi.effectFlag.CONFRONTATION })
+    entity:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+        power = cap,
+        subPower = 1, -- exp uses actual level and not the restricted level.
+        origin = entity,
+        flag = xi.effectFlag.ON_ZONE + xi.effectFlag.CONFRONTATION,
+    })
 end
 
 -----------------------------------
@@ -259,6 +264,7 @@ xi.garrison.spawnMob = function(mobID, zoneData)
 
     xi.garrison.addLevelCap(mob, zoneData.levelCap)
     mob:setRoamFlags(xi.roamFlag.SCRIPTED)
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
     table.insert(zoneData.mobs, mobID)
 
     -- Death listener for tracking win/lose condition

--- a/scripts/zones/Gusgen_Mines/mobs/Pudding.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Pudding.lua
@@ -10,10 +10,8 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-end
-
-entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Gusgen_Mines/npcs/Degga.lua
+++ b/scripts/zones/Gusgen_Mines/npcs/Degga.lua
@@ -22,7 +22,12 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 13 and option == 1 then
-        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, { power = 25, origin = player })
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+            power    = 25,
+            subPower = 1, -- exp uses actual level and not the restricted level.
+            origin   = player,
+            flag     = xi.effectFlag.ON_ZONE
+        })
     elseif csid == 16 then
         player:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
         player:setCharVar('EcoStatus', 103)

--- a/scripts/zones/Maze_of_Shakhrami/mobs/Wyrmfly.lua
+++ b/scripts/zones/Maze_of_Shakhrami/mobs/Wyrmfly.lua
@@ -11,6 +11,7 @@ local entity = {}
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Maze_of_Shakhrami/npcs/Ahko_Mhalijikhari.lua
+++ b/scripts/zones/Maze_of_Shakhrami/npcs/Ahko_Mhalijikhari.lua
@@ -22,7 +22,12 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 62 and option == 1 then
-        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, { power = 25, origin = player })
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+            power    = 25,
+            subPower = 1, -- exp uses actual level and not the restricted level.
+            origin   = player,
+            flag     = xi.effectFlag.ON_ZONE
+        })
     elseif csid == 65 then
         player:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
         player:setCharVar('EcoStatus', 203)

--- a/scripts/zones/Ordelles_Caves/mobs/Necroplasm.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Necroplasm.lua
@@ -8,10 +8,8 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
-end
-
-entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180) -- 3 minutes
+    mob:setMobMod(xi.mobMod.EXP_BONUS, -100)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Ordelles_Caves/npcs/Rojaireaut.lua
+++ b/scripts/zones/Ordelles_Caves/npcs/Rojaireaut.lua
@@ -22,7 +22,12 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 51 and option == 1 then
-        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, { power = 25, origin = player })
+        player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+            power    = 25,
+            subPower = 1, -- exp uses actual level and not the restricted level.
+            origin   = player,
+            flag     = xi.effectFlag.ON_ZONE
+        })
     elseif csid == 54 then
         player:delStatusEffect(xi.effect.LEVEL_RESTRICTION)
         player:setCharVar('EcoStatus', 3)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes xp from the NMs in Eco-Warrior and Garrison
- Restricts xp gain to be based on actual level and not restricted level in Eco-Warrior and Garrison

Eco-Warrior: https://www.youtube.com/watch?v=5E-D74J1Dug and https://www.youtube.com/watch?v=81ltEpOVfNw
Garrison: https://youtu.be/rUynta2OYIU

## Steps to test these changes

Get level restriction and test xp gains.
