### PR TITLE
[core] Skip grid check on UpdateEntityPacket for always relevant npc

### DIFF
--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1437,6 +1437,14 @@ void CZoneEntities::UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, 
         }
     }
 
+    if (PEntity->objtype == TYPE_NPC)
+    {
+        if (static_cast<CNpcEntity*>(PEntity)->alwaysRelevant())
+        {
+            alwaysInclude = true;
+        }
+    }
+
     // Grid-accelerated recipient selection for the common ENTITY_UPDATE case: instead of scanning
     // every player in the zone (O(P) per broadcast -> O(P^2)/tick), query the spatial hash for the
     // players near the entity.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes out of range "always relevant" npcs being... not relevant.

## Steps to test these changes

1) set south side of bastok bridge to be impassable via barrier
2) warp to flaco
3) set south side of bastok bridge to be passable, walk back and be able to go through
<img width="469" height="92" alt="image" src="https://github.com/user-attachments/assets/5f99129c-7583-46d4-9f34-b078aa4d195d" />