### PR TITLE
[lua] Add in store tp merit to tp return calc

### DIFF
--- a/scripts/combat/basic/tp.lua
+++ b/scripts/combat/basic/tp.lua
@@ -135,7 +135,7 @@ xi.combat.tp.getSingleMeleeHitTPReturn = function(actor, isZanshin)
         tpReturn = tpReturn + actor:getMerit(xi.merit.IKISHOTEN) -- https://www.bg-wiki.com/ffxi/Ikishoten
     end
 
-    local storeTPModifier = 1 + actor:getMod(xi.mod.STORETP) / 100
+    local storeTPModifier = 1 + (actor:getMod(xi.mod.STORETP) + actor:getMerit(xi.merit.STORE_TP_EFFECT)) / 100
 
     return math.floor(tpReturn * storeTPModifier)
 end

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -73,7 +73,7 @@ local function performWSJump(player, target, action, params, abilityID)
     end
 
     -- Jumps add JUMP_TP_BONUS regardless of 0 dmg or miss and is affected by Store TP but not the target's subtle blow
-    local storeTPModifier = (100 + player:getMod(xi.mod.STORETP)) / 100
+    local storeTPModifier = (100 + player:getMod(xi.mod.STORETP) + player:getMerit(xi.merit.STORE_TP_EFFECT)) / 100
     local extraTP         = player:getMod(xi.mod.JUMP_TP_BONUS)
 
     -- Spirit jump specific TP bonus

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -966,7 +966,7 @@ xi.weaponskills.takeWeaponskillDamage = function(defender, attacker, wsParams, p
     end
 
     -- Core does not modify the TP for the 10 TP/hit like it should, so we're doing it here
-    local storeTPModifier = 1 + attacker:getMod(xi.mod.STORETP) / 100 -- TODO, make a global function to get this (inhibit TP is not accounted for properly in core)
+    local storeTPModifier = 1 + (attacker:getMod(xi.mod.STORETP) + attacker:getMerit(xi.merit.STORE_TP_EFFECT)) / 100 -- TODO, make a global function to get this (inhibit TP is not accounted for properly in core)
     local extraHitsTP     = (wsResults.extraHitsLanded * 10 * storeTPModifier) + wsResults.bonusTP
 
     -- Extra hits return 0 TP while under the effect of Meikyo Shisui


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently, we were not adding in store tp merit to store tp calculations. Whoops.
These are the only instances of fetching store tp in the codebase (zero in c++)

## Steps to test these changes

jump, ws, auto attack on SAM with STP merits with correct stp
