### PR TITLE
[c++] Change Pet getMobHP() to int32

### DIFF
--- a/src/map/lua/lua_petskill.cpp
+++ b/src/map/lua/lua_petskill.cpp
@@ -111,7 +111,7 @@ float CLuaPetSkill::getTP()
     return static_cast<float>(m_PLuaPetSkill->getTP());
 }
 
-auto CLuaPetSkill::getMobHP() const -> uint8
+auto CLuaPetSkill::getMobHP() const -> int32
 {
     return m_PLuaPetSkill->getHP();
 }

--- a/src/map/lua/lua_petskill.h
+++ b/src/map/lua/lua_petskill.h
@@ -42,7 +42,7 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CLuaPetSkill& mobskill);
 
     float  getTP();
-    auto   getMobHP() const -> uint8;
+    auto   getMobHP() const -> int32;
     uint8  getMobHPP();
     uint16 getID();
     int16  getParam();


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
We received a bug report that the jug pet move Bubble Shower was doing 0 damage. Currently jug pet moves use a shim that feeds them through into mobskills and upon further inspection discovered that getMobHP() for pets was using a uint8 instead of a int32. 

## Steps to test these changes

Rebuild
Summon Courrier Carrie -> see Bubble Shower do damage.
