### PR TITLE
[C++, lua] Make player invisible to self during zone-in events and transport events

### DIFF
--- a/scripts/globals/barge.lua
+++ b/scripts/globals/barge.lua
@@ -422,6 +422,7 @@ xi.barge.onTransportEvent = function(player, zoneId, transportId)
             [0] = 0,
             [1] = xi.ki.BARGE_TICKET,
             [2] = 0, -- Important to be set to 0
+            isHidden = true,
             flags = bit.bor(
                 xi.cutsceneFlag.UNKNOWN_1,
                 xi.cutsceneFlag.NO_PCS,
@@ -444,6 +445,7 @@ xi.barge.onTransportEvent = function(player, zoneId, transportId)
             [0] = usesLeft,     -- Not actually used by CS but passed in
             [1] = xi.ki.BARGE_MULTI_TICKET,
             [2] = usesLeft + 1, -- This expects the number of uses before it get decremented
+            isHidden = true,
             flags = bit.bor(
                 xi.cutsceneFlag.UNKNOWN_1,
                 xi.cutsceneFlag.NO_PCS,

--- a/scripts/globals/manaclipper.lua
+++ b/scripts/globals/manaclipper.lua
@@ -157,9 +157,9 @@ xi.manaclipper.onZoneIn = function(player, prevZone)
 
         -- game client updates player's position
         if eventId == 13 then
-            return 13
+            return { 13, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         else
-            return 12
+            return { 12, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
     end
 
@@ -174,7 +174,14 @@ xi.manaclipper.onTransportEvent = function(player, prevZoneId, transportId)
     if aboard == 1 then
         if player:hasKeyItem(xi.ki.MANACLIPPER_TICKET) then
             player:delKeyItem(xi.ki.MANACLIPPER_TICKET)
-            player:startEvent(14)
+            player:startEvent(14, {
+                flags = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_4,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
         elseif player:hasKeyItem(xi.ki.MANACLIPPER_MULTI_TICKET) then
             local uses = player:getCharVar('Manaclipper_Ticket') - 1
 
@@ -187,7 +194,14 @@ xi.manaclipper.onTransportEvent = function(player, prevZoneId, transportId)
             end
 
             player:setCharVar('Manaclipper_Ticket', uses)
-            player:startEvent(14)
+            player:startEvent(14, {
+                flags = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_4,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
         else
             player:messageSpecial(ID.text.NO_BILLET, xi.ki.MANACLIPPER_TICKET)
             player:setPos(489, -3, 713, 200) -- kicked off Manaclipper, returned to Sunset Docks
@@ -195,6 +209,12 @@ xi.manaclipper.onTransportEvent = function(player, prevZoneId, transportId)
 
     -- leaving Purgonorgo Isle. must be standing in trigger area 2. no ticket required.
     elseif aboard == 2 then
-        player:startEvent(16)
+        player:startEvent(16, {
+            flags = bit.bor(
+                xi.cutsceneFlag.UNKNOWN_1,
+                xi.cutsceneFlag.NO_PCS,
+                xi.cutsceneFlag.UNKNOWN_7
+            ),
+        })
     end
 end

--- a/scripts/missions/cop/1_1_The_Rites_of_Life.lua
+++ b/scripts/missions/cop/1_1_The_Rites_of_Life.lua
@@ -56,7 +56,7 @@ mission.sections =
                 -- pattern should also change in section 3
                 [22] = function(player, csid, option, npc)
                     if option == 1 then
-                        player:startEvent(36)
+                        player:startEvent(36, { isHidden = true })
                     else
                         local lowerDelkfuttsIDs = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
 
@@ -68,15 +68,15 @@ mission.sections =
                 end,
 
                 [36] = function(player, csid, option, npc)
-                    player:startEvent(37)
+                    player:startEvent(37, { isHidden = true })
                 end,
 
                 [37] = function(player, csid, option, npc)
-                    player:startEvent(38)
+                    player:startEvent(38, { isHidden = true })
                 end,
 
                 [38] = function(player, csid, option, npc)
-                    player:startEvent(39)
+                    player:startEvent(39, { isHidden = true })
                 end,
 
                 [39] = function(player, csid, option, npc)

--- a/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/Zone.lua
@@ -28,13 +28,13 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         if prevZone == xi.zone.OPEN_SEA_ROUTE_TO_AL_ZAHBI then
             player:setPos(-11, 2, -142, 192)
-            return 201
+            return { 201, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         elseif
             prevZone == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI or
             prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU
         then
             player:setPos(11, 2, 142, 64)
-            return 204
+            return { 204, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
     end
 
@@ -73,7 +73,10 @@ zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
         prevZoneId == xi.zone.OPEN_SEA_ROUTE_TO_MHAURA
     then
         if player:hasKeyItem(xi.ki.FERRY_TICKET) then
-            player:startEvent(200)
+            player:startEvent(200, {
+                isHidden = true,
+                flags    = bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.UNKNOWN_7),
+            })
         else
             player:setPos(-11, 2, -142, 192)
         end
@@ -84,7 +87,10 @@ zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
         prevZoneId == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI
     then
         if player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) then
-            player:startEvent(203)
+            player:startEvent(203, {
+                isHidden = true,
+                flags    = bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.UNKNOWN_7),
+            })
         else
             player:setPos(11, 2, 142, 64)
         end

--- a/scripts/zones/Bibiki_Bay/Zone.lua
+++ b/scripts/zones/Bibiki_Bay/Zone.lua
@@ -10,21 +10,21 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
-
     if
         player:getXPos() == 0 and
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
-        cs = xi.manaclipper.onZoneIn(player, prevZone)
+        local cs = xi.manaclipper.onZoneIn(player, prevZone)
 
         if cs == -1 then
             player:setPos(669.917, -23.138, 911.655, 111)
         end
+
+        return cs
     end
 
-    return cs
+    return -1
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
@@ -51,9 +51,15 @@ end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
     if csid == 12 then
-        player:startEvent(10) -- arrive at Sunset Docks CS
+        player:startEvent(10, {
+            isHidden = true,
+            flags    = bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS),
+        }) -- arrive at Sunset Docks CS
     elseif csid == 13 then
-        player:startEvent(11) -- arrive at Purgonorgo Isle CS
+        player:startEvent(11, {
+            isHidden = true,
+            flags    = bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS),
+        }) -- arrive at Purgonorgo Isle CS
     elseif csid == 14 or csid == 16 then
         player:setPos(0, 0, 0, 0, xi.zone.MANACLIPPER)
     end

--- a/scripts/zones/Kazham/Zone.lua
+++ b/scripts/zones/Kazham/Zone.lua
@@ -14,7 +14,7 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { }
 
     if
         player:getXPos() == 0 and
@@ -22,7 +22,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getZPos() == 0
     then
         if prevZone == xi.zone.KAZHAM_JEUNO_AIRSHIP then
-            cs = 10002
+            cs = { 10002, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
 
         player:setPos(-4.000, -3.000, 14.000, 66)
@@ -32,7 +32,14 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(10000)
+    player:startEvent(10000, {
+        isHidden = true,
+        flags    = bit.bor(
+            xi.cutsceneFlag.UNKNOWN_1,
+            xi.cutsceneFlag.UNKNOWN_3,
+            xi.cutsceneFlag.UNKNOWN_7
+        ),
+    })
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -29,7 +29,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { }
 
     if
         player:getXPos() == 0 and
@@ -42,7 +42,7 @@ zoneObject.onZoneIn = function(player, prevZone)
             prevZone == xi.zone.OPEN_SEA_ROUTE_TO_MHAURA or
             prevZone == xi.zone.SHIP_BOUND_FOR_MHAURA_PIRATES)
         then
-            cs = 202
+            cs = { 202, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
             player:setPos(14.960, -3.430, 18.423, 192)
         else
             player:setPos(0.003, -6.252, 117.971, 65)
@@ -70,14 +70,28 @@ zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
             player:hasKeyItem(xi.ki.BOARDING_PERMIT) and
             player:hasKeyItem(xi.ki.FERRY_TICKET)
         then
-            player:startEvent(200)
+            player:startEvent(200, {
+                isHidden = true,
+                flags    = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
         else
             player:startEvent(204)
             player:messageSpecial(ID.text.DO_NOT_POSSESS, xi.ki.BOARDING_PERMIT)
         end
     else
         if player:hasKeyItem(xi.ki.FERRY_TICKET) then
-            player:startEvent(200)
+            player:startEvent(200, {
+                isHidden = true,
+                flags    = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
         else
             player:startEvent(204)
         end

--- a/scripts/zones/Nashmau/Zone.lua
+++ b/scripts/zones/Nashmau/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { }
 
     if
         player:getXPos() == 0 and
@@ -20,7 +20,7 @@ zoneObject.onZoneIn = function(player, prevZone)
             player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) and
             prevZone == xi.zone.SILVER_SEA_ROUTE_TO_NASHMAU
         then
-            cs = 201
+            cs = { 201, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
             player:setPos(11, 2, -102, 128)
         else
             player:setPos(40.658, -7.527, -24.001, 128)
@@ -39,7 +39,14 @@ end
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     if prevZoneId == xi.zone.SILVER_SEA_ROUTE_TO_AL_ZAHBI then
         if player:hasKeyItem(xi.ki.SILVER_SEA_FERRY_TICKET) then
-            player:startEvent(200)
+            player:startEvent(200, {
+                isHidden = true,
+                flags    = bit.bor(
+                    xi.cutsceneFlag.UNKNOWN_1,
+                    xi.cutsceneFlag.NO_PCS,
+                    xi.cutsceneFlag.UNKNOWN_7
+                ),
+            })
         else
             player:setPos(11, 2, -102, 128)
         end

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -40,7 +40,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         if prevZone == xi.zone.BASTOK_JEUNO_AIRSHIP then
             player:setPos(-36.000, 7.000, -58.000, 194)
-            return 73
+            return { 73, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
     end
 
@@ -54,7 +54,15 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(71)
+    player:startEvent(71, {
+        isHidden = true,
+        flags    = bit.bor(
+            xi.cutsceneFlag.UNKNOWN_1,
+            xi.cutsceneFlag.NO_PCS,
+            xi.cutsceneFlag.UNKNOWN_3,
+            xi.cutsceneFlag.UNKNOWN_7
+        ),
+    })
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -26,18 +26,20 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:getYPos() == 0 and
         player:getZPos() == 0
     then
+        local arrivalFlags = bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS)
+
         if prevZone == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
             player:setPos(-87.000, 12.000, 116.000, 128)
-            return 10018
+            return { 10018, -1, arrivalFlags }
         elseif prevZone == xi.zone.BASTOK_JEUNO_AIRSHIP then
             player:setPos(-50.000, 12.000, -116.000, 0)
-            return 10020
+            return { 10020, -1, arrivalFlags }
         elseif prevZone == xi.zone.WINDURST_JEUNO_AIRSHIP then
             player:setPos(16.000, 12.000, -117.000, 0)
-            return 10019
+            return { 10019, -1, arrivalFlags }
         elseif prevZone == xi.zone.KAZHAM_JEUNO_AIRSHIP then
             player:setPos(-24.000, 12.000, 116.000, 128)
-            return 10021
+            return { 10021, -1, arrivalFlags }
         end
     end
 
@@ -49,14 +51,16 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
+    local boardingFlags = bit.bor(xi.cutsceneFlag.NO_PCS, xi.cutsceneFlag.UNKNOWN_3, xi.cutsceneFlag.UNKNOWN_7)
+
     if prevZoneId == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
-        player:startEvent(10010)
+        player:startEvent(10010, { isHidden = true, flags = boardingFlags })
     elseif prevZoneId == xi.zone.BASTOK_JEUNO_AIRSHIP then
-        player:startEvent(10012)
+        player:startEvent(10012, { isHidden = true, flags = boardingFlags })
     elseif prevZoneId == xi.zone.WINDURST_JEUNO_AIRSHIP then
-        player:startEvent(10011)
+        player:startEvent(10011, { isHidden = true, flags = boardingFlags })
     elseif prevZoneId == xi.zone.KAZHAM_JEUNO_AIRSHIP then
-        player:startEvent(10013)
+        player:startEvent(10013, { isHidden = true, flags = boardingFlags })
     end
 end
 

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -18,7 +18,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         if prevZone == xi.zone.SAN_DORIA_JEUNO_AIRSHIP then
             player:setPos(-1.000, 0.000, 44.000, 128)
-            return 702
+            return { 702, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
     end
 
@@ -37,7 +37,7 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(700)
+    player:startEvent(700, { isHidden = true, flags = xi.cutsceneFlag.UNKNOWN_7 })
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -18,7 +18,7 @@ zoneObject.onZoneIn = function(player, prevZone)
     then
         if prevZone == xi.zone.WINDURST_JEUNO_AIRSHIP then
             player:setPos(228.000, -3.000, 76.000, 160)
-            return 10004
+            return { 10004, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
         end
     end
 
@@ -30,7 +30,14 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(10002)
+    player:startEvent(10002, {
+        isHidden = true,
+        flags    = bit.bor(
+            xi.cutsceneFlag.UNKNOWN_1,
+            xi.cutsceneFlag.UNKNOWN_3,
+            xi.cutsceneFlag.UNKNOWN_7
+        ),
+    })
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Selbina/Zone.lua
+++ b/scripts/zones/Selbina/Zone.lua
@@ -23,7 +23,7 @@ zoneObject.onZoneTick = function(zone)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
-    local cs = -1
+    local cs = { }
 
     if
         player:getXPos() == 0 and
@@ -35,7 +35,7 @@ zoneObject.onZoneIn = function(player, prevZone)
             (prevZone == xi.zone.SHIP_BOUND_FOR_SELBINA or
             prevZone == xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES)
         then
-            cs = 202
+            cs = { 202, -1, bit.bor(xi.cutsceneFlag.UNKNOWN_1, xi.cutsceneFlag.NO_PCS) }
             player:setPos(32.500, -2.500, -45.500, 192)
         else
             player:setPos(17.981, -16.806, 99.83, 64)
@@ -46,7 +46,7 @@ zoneObject.onZoneIn = function(player, prevZone)
         player:hasKeyItem(xi.ki.SEANCE_STAFF) and
         player:getCharVar('Enagakure_Killed') == 1
     then
-        cs = 1101
+        cs = { 1101 }
     end
 
     return cs
@@ -63,7 +63,14 @@ zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
     end
 
     if player:hasKeyItem(xi.ki.FERRY_TICKET) then
-        player:startEvent(200)
+        player:startEvent(200, {
+            isHidden = true,
+            flags    = bit.bor(
+                xi.cutsceneFlag.UNKNOWN_1,
+                xi.cutsceneFlag.NO_PCS,
+                xi.cutsceneFlag.UNKNOWN_7
+            ),
+        })
     else
         player:startEvent(204)
     end

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/Zone.lua
@@ -42,14 +42,14 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(1025)
+    player:startEvent(1028)
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 1025 then
+    if csid == 1028 then
         player:setPos(0, 0, 0, 0, xi.zone.AHT_URHGAN_WHITEGATE)
     end
 end

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/Zone.lua
@@ -39,7 +39,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportId)
-    player:startEvent(1025)
+    player:startEvent(1028)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
@@ -49,7 +49,7 @@ zoneObject.onEventUpdate = function(player, csid, option, npc)
 end
 
 zoneObject.onEventFinish = function(player, csid, option, npc)
-    if csid == 1025 then
+    if csid == 1028 then
         player:setPos(0, 0, 0, 0, xi.zone.NASHMAU)
     end
 end

--- a/src/map/packets/char_status.cpp
+++ b/src/map/packets/char_status.cpp
@@ -242,10 +242,10 @@ CCharStatusPacket::CCharStatusPacket(CCharEntity* PChar)
     // flags 0 starts at 0x28
     charStatusFlags::flags0_t flags0 = {};
 
-    flags0.HideFlag        = false; // This hides your UI. Probably used for the Live Vanadiel streams.
-    flags0.SleepFlag       = false; // Hides the player, probably also used for Live Vanadiel
-    flags0.GroundFlag      = false; // Do not ignore collision
-    flags0.CliPosInitFlag  = false; // Ready to render?
+    flags0.HideFlag        = PChar->m_isPCHidden; // Hides the player from themselves.
+    flags0.SleepFlag       = false;               // Hides the player, probably also used for Live Vanadiel
+    flags0.GroundFlag      = false;               // Do not ignore collision
+    flags0.CliPosInitFlag  = false;               // Ready to render?
     flags0.LfgFlag         = PChar->isSeekingParty();
     flags0.CfhFlag         = false; // Orange name for CFH, players don't currently use this?
     flags0.AwayFlag        = PChar->isAway();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Players are not invisible to other players during transport depart events or CoP 1-1 intro cutscene. Additionally, players are visible in their own cutscenes when they shouldn't be in CoP 1-1 with the ocean and transport events. This fixes those things.

C++ Change: The captures show that the player also receives a the HideFlag during cutscenes where the player is supposed to be hidden from the world. This fixes that issue. Previously, I only checked other observers.
CoP 1-1: I updated the CoP 1-1 intro events to mark the player as hidden. This plus the C++ change stops the player from appearing in the cutscene.
Transport: I audited all transport events to mark them as hidden when needed as well as add cutscene flags.

### Captures
Airships/Boats: https://drive.google.com/file/d/1E-MZ2lJoKidxjg8Y05CVXJdM937fv_1_/view?usp=drive_link
Pirates: https://www.dropbox.com/scl/fi/wjkefpvvu96ljjyxpujq0/Pirate-Ship.zip?rlkey=dbd4yzhtteglbz227m8l4n7z7&e=1&dl=0
Barge: https://drive.google.com/file/d/1SZrahPnuwUjqAoLGTEnkhGv5KVhzSxLA/view
Manaclipper: https://drive.google.com/file/d/1fBbpp9AVt6LT0djW0Ranh1NMKo5C6nCU/view?usp=drive_link
CoP 1-1: https://drive.google.com/file/d/1ayJsS1jUy60fPpP2UrRddwbBLZcnFoZh

## Steps to test these changes

I tested Airship events as well as several missions with zone-in events, even ones where the player is supposed to appear in them.
