### PR TITLE
[lua] Fix Chi Blast Boost multiplier

### DIFF
--- a/scripts/globals/job_utils/monk.lua
+++ b/scripts/globals/job_utils/monk.lua
@@ -31,7 +31,7 @@ end
 -- Ability Use Functions
 -----------------------------------
 xi.job_utils.monk.useBoost = function(player, target, ability)
-    local power = 12.5 + (0.10 * player:getMod(xi.mod.BOOST_EFFECT))
+    local power = 12.5 + player:getMod(xi.mod.BOOST_EFFECT) / 10
 
     if player:hasStatusEffect(xi.effect.BOOST) then
         local effect = player:getStatusEffect(xi.effect.BOOST)
@@ -82,15 +82,15 @@ xi.job_utils.monk.useChiBlast = function(player, target, ability)
         target:addStatusEffect(xi.effect.INHIBIT_TP, { power = 25, duration = penanceMerits, origin = player })
     end
 
-    local boost = player:getStatusEffect(xi.effect.BOOST)
-    local multiplier = 1.0
-    if boost ~= nil then
-        multiplier = (boost:getPower() / 100) * 4 -- power is the raw % atk boost
-    end
+    local boost           = player:getStatusEffect(xi.effect.BOOST)
+    local statMultiplier  = 0.5 + math.randomFloat(0, 1) / 2
+    local boostMultiplier = boost and 1 + 4 * boost:getPower() / 100 or 1
 
-    local dmg = math.floor(player:getStat(xi.mod.MND) * (0.5 + (math.randomFloat(0, 1) / 2))) * multiplier
+    local dmg = player:getStat(xi.mod.MND)
+    dmg       = math.floor(dmg * statMultiplier)
+    dmg       = math.floor(dmg * boostMultiplier)
+    dmg       = xi.ability.adjustDamage(dmg, player, ability, target, xi.attackType.BREATH, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
 
-    dmg = xi.ability.adjustDamage(dmg, player, ability, target, xi.attackType.BREATH, xi.damageType.ELEMENTAL, xi.mobskills.shadowBehavior.IGNORE_SHADOWS)
     target:takeDamage(dmg, player, xi.attackType.BREATH, xi.damageType.ELEMENTAL)
     target:updateClaim(player)
     player:delStatusEffect(xi.effect.BOOST)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes Chi Blast's Boost multiplier so Boost increases Chi Blast damage instead of reducing it.
The previous formula only applied the Boost portion of the multiplier and missed the base `1.0`.

## Current Behavior
0 Boost: normal baseline
1 Boost: bug makes Chi Blast ~ 0.5× baseline 
2 Boosts: bug makes it ~1.0× baseline
3 Boosts: bug makes it ~ 1.5× baseline
4 Boosts: bug makes it ~2.0× baseline

## Expected Behavior
1 Boost: ~ 1.5×
2 Boosts: ~ 2.0×
3 Boosts: ~ 2.5×
4 Boosts: ~3.0×

## Steps to test these changes
1. Use Chi Blast with no Boost and note the damage.
2. Use Boost once, then use Chi Blast on the same target.
3. Confirm the Boosted Chi Blast deals more damage than the unboosted Chi Blast.