### PR TITLE
[core] Allow Blink/Utsusemi to negate knockback

### DIFF
--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -3078,7 +3078,8 @@ void CBattleEntity::OnMobSkillFinished(CMobSkillState& state, action_t& action)
         if (PSkill->getMsg() == MsgBasic::ShadowAbsorb) // Setting of shadow message is handled in mobskills.lua
         {
             result.resolution = ActionResolution::Miss;
-            result.param      = damage; // damage is the number of shadows consumed to display in chat log
+            result.param      = damage;          // damage is the number of shadows consumed to display in chat log
+            result.knockback  = Knockback::None; // Shadows negate knockback for most skills
         }
         else if (PSkill->hasMissMsg())
         {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Allows Blink/Utsusemi to negate knockback effects again if shadows absorbed all valid hits.

* Most skills follow this logic. If there are exceptions, they can be handled in mobskill scripts using: `action:knockback(target:getID(), xi.action.knockback.LEVEL1)`
 * This will override a skills knockback behavior.
 xi.action.knockback can be LEVEL0 to LEVEL7.

## Steps to test these changes

1. Cast Utsusemi on yourself.
2. Find a mob, use `target:useMobAbility(590, player)` to force a mob to use Goblin Rush on you(3 hit skill).
3. See that you are no longer knocked back if you absorb all hits that would have landed on you.