### PR TITLE
[lua] Faust Aggro Fixes

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Faust.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Faust.lua
@@ -45,6 +45,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.GIL_MIN, 18000)
     mob:setMobMod(xi.mobMod.GIL_MAX, 18000)
     mob:setMobMod(xi.mobMod.SIGHT_RANGE, 30)
+    mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.MAGIC, xi.detects.SIGHT)) -- Aggros to magic and sight (30 yalms).
     mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.ELEGY)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Faust is supposed to aggro by sight at a long (30 yalms) range, pursuant to [retail captures](https://youtu.be/mblnrETIQDg?t=42). It was not hooked up correctly. This PR fixes that.

## Steps to test these changes

Spawn Faust and see that he now properly aggros sight from 30y and magic from 20y.
