### PR TITLE
[sql, lua] Fix Windurst Mission 6-1 Jack Cardians

### DIFF
--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Batons.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Batons.lua
@@ -9,11 +9,40 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar('popTime', GetSystemTime())
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
 end
 
 entity.onMobRoam = function(mob)
-    if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
-        DespawnMob(mob:getID())
+    -- If it's home.
+    if mob:getMobMod(xi.mobMod.NO_MOVE) == 1 then
+        if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
+            DespawnMob(mob:getID())
+        end
+
+        return
+    end
+
+    -- Check if at home and adjust behavior.
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    if spawnPos.x == pos.x and spawnPos.z == pos.z then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+        mob:setRotation(spawnPos.rot)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
+entity.onMobDisengage = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- If not at spawn position, path back to it
+    if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+        mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
     end
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Coins.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Coins.lua
@@ -9,11 +9,40 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar('popTime', GetSystemTime())
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
 end
 
 entity.onMobRoam = function(mob)
-    if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
-        DespawnMob(mob:getID())
+    -- If it's home.
+    if mob:getMobMod(xi.mobMod.NO_MOVE) == 1 then
+        if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
+            DespawnMob(mob:getID())
+        end
+
+        return
+    end
+
+    -- Check if at home and adjust behavior.
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    if spawnPos.x == pos.x and spawnPos.z == pos.z then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+        mob:setRotation(spawnPos.rot)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
+entity.onMobDisengage = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- If not at spawn position, path back to it
+    if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+        mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
     end
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Cups.lua
@@ -9,11 +9,40 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar('popTime', GetSystemTime())
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
 end
 
 entity.onMobRoam = function(mob)
-    if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
-        DespawnMob(mob:getID())
+    -- If it's home.
+    if mob:getMobMod(xi.mobMod.NO_MOVE) == 1 then
+        if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
+            DespawnMob(mob:getID())
+        end
+
+        return
+    end
+
+    -- Check if at home and adjust behavior.
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    if spawnPos.x == pos.x and spawnPos.z == pos.z then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+        mob:setRotation(spawnPos.rot)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
+entity.onMobDisengage = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- If not at spawn position, path back to it
+    if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+        mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
     end
 end
 

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Swords.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Jack_of_Swords.lua
@@ -9,11 +9,40 @@ local entity = {}
 
 entity.onMobSpawn = function(mob)
     mob:setLocalVar('popTime', GetSystemTime())
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
 end
 
 entity.onMobRoam = function(mob)
-    if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
-        DespawnMob(mob:getID())
+    -- If it's home.
+    if mob:getMobMod(xi.mobMod.NO_MOVE) == 1 then
+        if GetSystemTime() - mob:getLocalVar('popTime') > 180 then
+            DespawnMob(mob:getID())
+        end
+
+        return
+    end
+
+    -- Check if at home and adjust behavior.
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    if spawnPos.x == pos.x and spawnPos.z == pos.z then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+        mob:setRotation(spawnPos.rot)
+    end
+end
+
+entity.onMobEngage = function(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+end
+
+entity.onMobDisengage = function(mob)
+    local spawnPos = mob:getSpawnPos()
+    local pos      = mob:getPos()
+
+    -- If not at spawn position, path back to it
+    if spawnPos.x ~= pos.x or spawnPos.z ~= pos.z then
+        mob:pathThrough({ spawnPos.x, spawnPos.y, spawnPos.z })
     end
 end
 

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -72459,10 +72459,10 @@ INSERT INTO `mob_spawn_points` VALUES (17572193,0,'Balloon','Balloon',52,8,10,50
 INSERT INTO `mob_spawn_points` VALUES (17572194,80,'Goblin_Weaver','Goblin Weaver',58,4,7,532.532,-0.041,-692.563,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572195,0,'Balloon','Balloon',52,8,10,496.000,-1.000,-737.000,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572196,80,'Goblin_Weaver','Goblin Weaver',58,4,7,540.000,-1.000,-687.000,11,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17572197,0,'Jack_of_Cups','Jack of Cups',60,62,62,-291.000,0.001,-662.000,129,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17572197,0,'Jack_of_Cups','Jack of Cups',60,62,62,-291.000,0.001,-663.000,129,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572198,0,'Jack_of_Batons','Jack of Batons',61,62,62,-291.000,0.001,-657.000,126,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17572199,0,'Jack_of_Swords','Jack of Swords',62,62,62,-295.000,0.001,-659.000,130,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17572200,0,'Jack_of_Coins','Jack of Coins',63,62,62,-291.000,0.001,-659.000,127,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17572199,0,'Jack_of_Swords','Jack of Swords',62,62,62,-291.000,0.001,-659.000,130,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17572200,0,'Jack_of_Coins','Jack of Coins',63,62,62,-291.000,0.001,-661.000,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572201,0,'Queen_of_Swords','Queen of Swords',64,72,72,-422.000,0.001,618.000,239,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572202,0,'Queen_of_Coins','Queen of Coins',65,72,72,-422.000,0.001,621.000,16,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572203,0,'Thunder_Elemental','Thunder Elemental',66,75,75,-576.613,-1.014,739.999,0,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adresses some of the issues with Windurst Mission 6-1 Jack of (x) Cardians in Outer Horutoto Ruins.

- Fix spawn positioning to line them up properly again
- Don't randomly roam, but return to spawn location
- Jack NMs don't link with eachother
- Cardians in the room will link onto Jacks

Retail Capture: https://www.youtube.com/live/jyGgAtMpYnA?si=LLy39Wahd6SGR9TY&t=304

Known issue: Jacks don't link onto other Cardians.

Dev notes:
Setting mob_pool linking to 0 isn't sufficient, because other cardians will no longer link onto Jacks either. mobMod.NO_LINK still allows reverse linking.

## Steps to test these changes

!addmission 2 16
!zone Port Windurst
!gotoname Hakkuru-Rinkuru 2
Talk to Hakkuru-Rinkuru for Cutscene
!zone Outer Horutoto
!pos -291 0 -659 194

Cast Sneak on Self
Talk to Gate: Magical Gizmo
Verify Jacks don't aggro
Ranged pull one of the Jacks
Other Jacks should not engage
Pull Jack into nearby other Cardian
Cardian should link onto Jack

!goto me
Jack should path to original spawnpoint and rotation