### PR TITLE
[lua] Change Sunsand must zone check to ~= 0

### DIFF
--- a/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/qm1.lua
@@ -10,7 +10,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     -- NOTE: The NPC is despawned when weather is not up, we do NOT need to check weather.
-    if player:getCharVar('[qm1]mustZone') == 1 then
+    if player:getCharVar('[qm1]mustZone') ~= 0 then
         player:messageSpecial(ID.text.JUST_A_PILE_OF_SAND)
     elseif npcUtil.giveItem(player, xi.item.PINCH_OF_VALKURM_SUNSAND) then
         player:setCharVar('[qm1]mustZone', player:getZoneID())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`== 1` check would always fail since we set that variable to the zone ID

## Steps to test these changes

Get sunsand, try to get it again without zoning, fail, zone and come back and be able to get it again