### PR TITLE
[lua] Expeditionary Force - Award Influence

### DIFF
--- a/scripts/globals/expeditionary_force.lua
+++ b/scripts/globals/expeditionary_force.lua
@@ -19,6 +19,14 @@ local bannerState =
 -- Tables
 -----------------------------------
 
+local regionPointsEarned =
+{
+    [0] =  500, -- No standing
+    [1] =  500,
+    [2] =  750,
+    [3] = 1000,
+}
+
 local zoneInfoTable =
 {
     [xi.zone.BEAUCEDINE_GLACIER    ] = { levelCap = 40 },
@@ -966,8 +974,7 @@ xi.expeditionaryForce.onMobDeath = function(mob, player)
     end
 
     -- Award Influence
-    -- TODO: Implement this
-    -- player:gainConquestInfluence(xi.settings.main.EXP_FORCE_MOBKILL_INFLUENCE)
+    player:gainConquestInfluence(regionPointsEarned[GetNationRank(creditNation)])
 
     -- SEND ZONE MESSAGE
     for _, person in pairs(mob:getZone():getPlayers()) do
@@ -1070,8 +1077,8 @@ xi.expeditionaryForce.onChestOpen = function(player)
     local participation = player:getCharVar('[ExpForce]Participation')
     player:setCharVar('[ExpForce]Participation', bit.bor(participation, bit.lshift(1, currentRegion)))
 
-    -- TODO: Award influence.
-    -- player:gainConquestInfluence(xi.settings.main.EXP_FORCE_TREASURE_INFLUENCE)
+    -- Award influence
+    player:gainConquestInfluence(regionPointsEarned[GetNationRank(playerNation)])
 
     -- TODO: Never tested if opening a chest granted the EF title.
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds region point gain for Expeditionary Force for killing NMs and opening treasure caskets based on current nation rank.

## Steps to test these changes

Give yourself the EF KI, kill NMs, open a coffer.

## Justification

All data was collected as a nation in rank 3. From analyzing all the data, it was determined to set the region point gain for the nation in 3rd to 1000 for both an NM kill and opening a treasure. Based on patch notes from July 17, 2003 ( https://www.playonline.com/comnews/200307172028.html ), region point gain is based on the nation's rank. Setting rank 2 and rank 1 nations to 750 and 500 region points respectively were based on the idea that the 1st place nation should gain influence about equivalent to a 6 person party leveling. Setting treasure openings to be equivalent to NM kills is based off of data presented in Fig. 1 of the attached document.

A more thorough analysis has been attached.
[Expeditionary Force Influence Justification.pdf](https://github.com/user-attachments/files/30064947/Expeditionary.Force.Influence.Justification.pdf)

Fig. 2 was generated using the Google Sheet file located here: https://docs.google.com/spreadsheets/d/1amU-bAwu0adLvVrXMisvcxCRWpSNTZ7fYc7bZ3R2IGo/edit?usp=sharing

## Captures

Treasure Chests - The Maze
Capture: https://drive.google.com/file/d/1hyVWyHZlIXIS3AdvgmXi_0yh6vpy7bE8/view?usp=drive_link
Video: https://youtu.be/3DX6PpWwin0

Expeditionary Force (Bastok) - Valkurm Dunes + Xarcabard from a non-Bastok (for half) player
https://youtu.be/lBNlgznk_xM
Capture: https://drive.google.com/file/d/1PtyPYbbVMKLeLgUShDYWsG91Ur4gYk_6/view?usp=drive_link

Expeditionary Force (Bastok) - Beaucedine Glacier + Cape Terrigan
Capture: https://drive.google.com/file/d/112OqWeZc27rpHqe71SJUDkxF0dnLW8Jl/view?usp=drive_link
https://youtu.be/1cwPNbnQqwY