### PR TITLE
[lua] Adjust BLU quest tradehas order to not lock item accidentally

### DIFF
--- a/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
+++ b/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
@@ -111,8 +111,8 @@ quest.sections =
                     local requiredItem = quest:getVar(player, 'Option')
 
                     if
-                        npcUtil.tradeHasExactly(trade, requiredItemList[requiredItem]) and
-                        quest:getVar(player, 'Prog') == 1
+                        quest:getVar(player, 'Prog') == 1 and
+                        npcUtil.tradeHasExactly(trade, requiredItemList[requiredItem])
                     then
                         return quest:progressEvent(67, requiredItemList[requiredItem])
                     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

You can serially lock the quest items if you trade Wauod him at the wrong stage

## Steps to test these changes

finish the quest properly after trading a bunch of crap