### PR TITLE
[lua] Appraisal: Don't lock items unless they will actually be taken

### DIFF
--- a/scripts/globals/appraisal.lua
+++ b/scripts/globals/appraisal.lua
@@ -1532,13 +1532,13 @@ xi.appraisal.appraisalItems =
 xi.appraisal.appraiseItem = function(player, npc, trade, gil, appraisalCsid)
     if player:getGil() >= gil then
         for _, tradedItem in pairs(xi.appraisal.unappraisedItems) do
-            if npcUtil.tradeHasExactly(trade, tradedItem) then
+            if trade:getItemQty(tradedItem) == 1 then
                 local tradeID        = trade:getItemId()
                 local info           = xi.appraisal.appraisalItems[tradeID]
                 local appraisalID    = trade:getItem():getAppraisalID()
                 local appraisedItem  = xi.appraisal.itemPick(player, info, appraisalID)
 
-                if appraisedItem ~= 0 then
+                if appraisedItem ~= 0 and trade:confirmItem(tradedItem) then
                     player:startEvent(appraisalCsid, 1, appraisedItem)
                     player:setLocalVar('Appraisal', appraisedItem) -- anticheat
                     player:confirmTrade()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Basically, it looks like if you traded more than one ??? item to the appraisers it would lock all the items. So we enforce only trading one at a time now

Note: I didn't check retail for this, so it may be possible that retail allows multiple. This is an anti-footgun PR.

## Steps to test these changes

trade ??? item to appraisers and see stuff work
