### PR TITLE
[lua] Fix mob fstr lower bounds

### DIFF
--- a/scripts/combat/physical_utilities.lua
+++ b/scripts/combat/physical_utilities.lua
@@ -285,7 +285,7 @@ xi.combat.physical.calculateMeleeStatFactor = function(actor, target)
         end
 
         fSTR = math.floor(fSTR)
-        fSTR = utils.clamp(fSTR, math.floor(mLvl / 5) - 1, math.floor(mLvl / 5) + 5)
+        fSTR = utils.clamp(fSTR, -1 - math.floor(mLvl / 5), math.floor(mLvl / 5) + 5)
 
         return fSTR
     end

--- a/scripts/combat/physical_utilities.lua
+++ b/scripts/combat/physical_utilities.lua
@@ -332,6 +332,7 @@ end
 -- 'fSTR2' in English Wikis. 'SV function' in JP wiki and Studio Gobli.
 -- BG wiki: https://www.bg-wiki.com/ffxi/FSTR
 -- Gobli Wiki: https://w-atwiki-jp.translate.goog/studiogobli/pages/14.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp
+-- https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=224123492#gid=224123492&range=A53
 xi.combat.physical.calculateRangedStatFactor = function(actor, target)
     local fSTR = 0 -- The variable we want to calculate.
     local mLvl = actor:getMainLvl()
@@ -373,7 +374,7 @@ xi.combat.physical.calculateRangedStatFactor = function(actor, target)
         end
 
         fSTR = math.floor(fSTR)
-        fSTR = utils.clamp(fSTR, math.floor((mLvl / 5 - 1) * 2), math.floor((mLvl / 5 + 5) * 2))
+        fSTR = utils.clamp(fSTR, math.floor((-1 - (mLvl / 5)) * 2), math.floor((mLvl / 5 + 5) * 2))
 
         return fSTR
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Looks like we got the lower bounds wrong for mob fSTR

per the source:
<img width="182" height="45" alt="image" src="https://github.com/user-attachments/assets/6902064e-a7c2-4a6d-ad6c-180a1e30b155" />

## Steps to test these changes

have high VIT and mobs have lower base damage
