### PR TITLE
[Fix] Add check for CoP 8-2 to disallow entering The garden of Ru'Hmet

### DIFF
--- a/scripts/missions/cop/8_2_A_Fate_Decided.lua
+++ b/scripts/missions/cop/8_2_A_Fate_Decided.lua
@@ -24,6 +24,13 @@ mission.sections =
 
         [xi.zone.GRAND_PALACE_OF_HUXZOI] =
         {
+            ['_iya'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:messageSpecial(huxoiID.text.DOES_NOT_RESPOND):setPriority(1000)
+                end,
+            },
+
             ['_iyq'] =
             {
                 onTrigger = function(player, npc)

--- a/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/npcs/_iya.lua
@@ -12,7 +12,7 @@ end
 
 entity.onEventFinish = function(player, csid, option, npc)
     if csid == 52 and option == 1 then
-        player:setPos(-419.995, 0, 248.483, 191, 35) -- To The Garden of RuHmet
+        player:setPos(-419.995, 0, 248.483, 191, xi.zone.THE_GARDEN_OF_RUHMET)
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
There was no check in place while mission 8-2 was active.

## Steps to test these changes
Be on CoP 8-2 and try to use the door. Now complete the mission and be able to use it.
