### PR TITLE
[lua] Event Audit: ToAU gates, Sandy 1-2, and THF AF3

### DIFF
--- a/scripts/missions/sandoria/1_2_Bat_Hunt.lua
+++ b/scripts/missions/sandoria/1_2_Bat_Hunt.lua
@@ -97,7 +97,7 @@ mission.sections =
             ['Tombstone_Upper'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(4)
+                    return mission:progressCutscene(4)
                 end,
             },
 

--- a/scripts/quests/windurst/THF_AF3_Hitting_the_Marquisate.lua
+++ b/scripts/quests/windurst/THF_AF3_Hitting_the_Marquisate.lua
@@ -47,7 +47,7 @@ local garlaigeQmOnTrigger = function(player, npc)
         quest:getVar(player, 'hagainProg') == qmData[1]
     then
         player:messageSpecial(garlaigeID.text.PRESENCE_FROM_CEILING)
-        return quest:progressEvent(qmData[2], xi.ki.BOMB_INCENSE)
+        return quest:progressCutscene(qmData[2], xi.ki.BOMB_INCENSE)
     end
 end
 
@@ -137,7 +137,7 @@ quest.sections =
                             player:hasKeyItem(xi.ki.BOMB_INCENSE)
                         then
                             player:messageSpecial(garlaigeID.text.HEAT_FROM_CEILING)
-                            return quest:progressEvent(56, xi.keyItem.BOMB_INCENSE)
+                            return quest:progressCutscene(56, xi.ki.BOMB_INCENSE)
                         end
                     end
                 end,

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20c.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20c.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > 80 then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(106)
+            player:startOptionalCutscene(106, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.NYZUL_ISLE_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(107)
+            player:startOptionalCutscene(107, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.NYZUL_ISLE_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
+++ b/scripts/zones/Alzadaal_Undersea_Ruins/npcs/_20d.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -40 then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(115)
+            player:startOptionalCutscene(115, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.NYZUL_ISLE_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_NYZUL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(114)
+            player:startOptionalCutscene(114, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.NYZUL_ISLE_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Arrapago_Reef/npcs/_jib.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/_jib.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getXPos() < 8 then
             player:messageSpecial(ID.text.STAGING_GATE_ILRUSI)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startOptionalCutscene(106)
+            player:startOptionalCutscene(106, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.ILRUSI_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_ILRUSI)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(107)
+            player:startOptionalCutscene(107, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.ILRUSI_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g0.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g0.lua
@@ -7,7 +7,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(502)
+    player:startOptionalCutscene(502, { cs_option = 0, canSkip = true })
 end
 
 entity.onEventFinish = function(player, csid, option, npc)

--- a/scripts/zones/Bhaflau_Thickets/npcs/_1g1.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/_1g1.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -761 then
             player:messageSpecial(ID.text.STAGING_GATE_MAMOOL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startOptionalCutscene(106)
+            player:startOptionalCutscene(106, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.MAMOOL_JA_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_MAMOOL)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(107)
+            player:startOptionalCutscene(107, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.MAMOOL_JA_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/_270.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_270.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() > -438 then
             player:messageSpecial(ID.text.STAGING_GATE_AZOUPH)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startOptionalCutscene(120)
+            player:startOptionalCutscene(120, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.LEUJAOAM_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_AZOUPH)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(121)
+            player:startOptionalCutscene(121, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.LEUJAOAM_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/_271.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/_271.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() < -78 then
             player:messageSpecial(ID.text.STAGING_GATE_DVUCCA)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startOptionalCutscene(122)
+            player:startOptionalCutscene(122, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.PERIQIA_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_DVUCCA)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(123)
+            player:startOptionalCutscene(123, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.PERIQIA_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Mount_Zhayolm/npcs/_1p0.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/_1p0.lua
@@ -13,11 +13,11 @@ entity.onTrigger = function(player, npc)
         if player:getZPos() < 332 then
             player:messageSpecial(ID.text.STAGING_GATE_HALVUNG)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startOptionalCutscene(106)
+            player:startOptionalCutscene(106, { cs_option = 0, canSkip = true })
         elseif not player:hasKeyItem(xi.ki.LEBROS_ASSAULT_ORDERS) then
             player:messageSpecial(ID.text.STAGING_GATE_HALVUNG)
             player:messageSpecial(ID.text.STAGING_GATE_INTERACT)
-            player:startEvent(107)
+            player:startOptionalCutscene(107, { cs_option = 0, canSkip = true })
         else
             player:messageSpecial(ID.text.CANNOT_LEAVE, xi.ki.LEBROS_ASSAULT_ORDERS)
         end

--- a/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
+++ b/scripts/zones/Wajaom_Woodlands/npcs/_1f0.lua
@@ -7,7 +7,7 @@
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    player:startEvent(502)
+    player:startOptionalCutscene(502, { cs_option = 0, canSkip = true })
 end
 
 entity.onEventFinish = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds progressOptionalCutscene with Event Skipped to ToAU gates.
Updates Sandy 1-2 and THF AF3 to drop aggro correctly.

THF AF: https://www.youtube.com/watch?v=Erp0_G8RKWo
Sandy 1-2: https://www.youtube.com/watch?v=JDclIiomt-U

## Steps to test these changes

Check each event with aggro.
