### PR TITLE
[lua] Update Sticky Thread TP scaling duration

### DIFF
--- a/scripts/actions/mobskills/sticky_thread.lua
+++ b/scripts/actions/mobskills/sticky_thread.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = math.randomInt(300, 540)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 360)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, duration))
 
     return xi.effect.SLOW


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR updates sticky thread to use the same scaling as Sonic Boom.  At 1k, sticky thread's duration will always be exactly 3m.  This scales all the way to 3k, where the duration is 9m.

Every time its known that the crawler has a lot of TP, the duration shoots up dramatically, scaling with tp:

https://youtu.be/xtAhnsQ8_Og?t=50
https://youtu.be/jlsprgnCoZU?t=239
https://youtu.be/jlsprgnCoZU?t=287
https://youtu.be/jlsprgnCoZU?t=484

Every time the Crawler tps below 25%, where its known its TP is close to 1k, the duration will be 3m and some change, depending on the overflow of tp due to it scaling 1 for 1 with each extra tp.

https://youtu.be/xtAhnsQ8_Og?t=117
https://youtu.be/xtAhnsQ8_Og?t=225
https://youtu.be/xtAhnsQ8_Og?t=403
https://youtu.be/xtAhnsQ8_Og?t=507
https://youtu.be/jlsprgnCoZU?t=50
https://youtu.be/jlsprgnCoZU?t=310
https://youtu.be/jlsprgnCoZU?t=643
https://youtu.be/jlsprgnCoZU?t=758


## Steps to test these changes

Get a crawler to spin its white sticky thread all over you.

This is infinitely retestable on retail.
