### PR TITLE
[lua] Correct Utsusemi Effect Wear Message

### DIFF
--- a/scripts/utils/combat_utils.lua
+++ b/scripts/utils/combat_utils.lua
@@ -153,6 +153,7 @@ function utils.shadowAbsorb(target, shadowsToRemove)
         local effect = target:getStatusEffect(xi.effect.COPY_IMAGE)
         if effect then
             if targetShadows == 0 then
+                effect:setIcon(xi.effect.COPY_IMAGE)
                 target:delStatusEffect(xi.effect.COPY_IMAGE)
             elseif targetShadows == 1 then
                 effect:setIcon(xi.effect.COPY_IMAGE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Corrects a small issue with Copy Image effect's wear message where the amount of shadows was listed in the effect wear messaging. (Sets the effect icon back to base before deleting it)

Examples:

Retail (Correct Messaging)
<img width="499" height="251" alt="image" src="https://github.com/user-attachments/assets/8e019102-cc94-4d2b-93d3-f06a1361a37a" />

Current (Incorrect messaging)
<img width="341" height="19" alt="image" src="https://github.com/user-attachments/assets/34fee704-75a8-4434-a44f-2e4449d6acf6" />


## Steps to test these changes
1. Cast Utsusemi: Ichi on self
2. Use `!exec target:useMobAbility(590, player)` to force a mob to use a mobskill on you.
3. See that the message no longer displays the amount of shadows in the effect wear message.
