### PR TITLE
[core] [lua] Extend charvar to 64 characters, add size check msg

### DIFF
--- a/sql/char_vars.sql
+++ b/sql/char_vars.sql
@@ -12,7 +12,7 @@ SET SQL_MODE="NO_AUTO_VALUE_ON_ZERO";
 DROP TABLE IF EXISTS `char_vars`;
 CREATE TABLE IF NOT EXISTS `char_vars` (
   `charid` int(10) unsigned NOT NULL,
-  `varname` varchar(30) NOT NULL,
+  `varname` varchar(64) NOT NULL,
   `value` int(11) NOT NULL,
   `expiry` int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (`charid`,`varname`)

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -3070,6 +3070,11 @@ void CCharEntity::setLocked(bool locked)
 
 auto CCharEntity::getCharVar(const std::string& varName) const -> int32
 {
+    if (varName.length() > 64)
+    {
+        ShowErrorFmt("CCharEntity::getCharVar: Charvar '{}' longer than 60 characters. Please shorten your variable name.", varName);
+    }
+
     if (auto charVar = charVarCache.find(varName); charVar != charVarCache.end())
     {
         std::pair cachedVarData = charVar->second;
@@ -3148,6 +3153,11 @@ auto CCharEntity::getCharVarsWithSuffix(const std::string& suffix) -> std::vecto
 
 void CCharEntity::setCharVar(const std::string& charVarName, int32 value, uint32 expiry /* = 0 */)
 {
+    if (charVarName.length() > 64)
+    {
+        ShowErrorFmt("CCharEntity::setCharVar: Charvar '{}' longer than 60 characters. Please shorten your variable name.", charVarName);
+    }
+
     charVarCache[charVarName] = { value, expiry };
     charutils::PersistCharVar(this->id, charVarName, value, expiry);
 }

--- a/tools/migrations/057_extend_charvar_length.py
+++ b/tools/migrations/057_extend_charvar_length.py
@@ -1,0 +1,30 @@
+import mariadb
+
+
+def migration_name():
+    return "Adjusting char_var default varname size to 64"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    # check
+    cur.execute(
+        "show columns from char_vars where field = 'varname' and type = 'varchar(30)';"
+    )
+    if cur.fetchone():
+        return True
+    return False
+
+
+def migrate(cur, db):
+    pass
+    try:
+        cur.execute(
+            "ALTER TABLE char_vars MODIFY varname varchar(64);"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Justification:
If you make a hidden quest with a not so unreasonable name such as "newCharacterCS" it actually has variables that look like this on the backend:
`HQuest[newCharacterCS]var`. The current limit is 30 characters, of which a variable named `var` to that quest would take up 26 of the 30. To the lua user, this is not obvious that it's a problem.

Additionally, I believe this quest var (I didn't look for more) is broken in our existing code:
quests/otherAreas/An_Explorers_Footsteps.lua:
`quest:setVar(player, '[EF]TargetMonument', i)`
It claims to be quest ID 19, log ID 4 which would be represented as 
`Quest[4][19][EF]TargetMonument` which is 31 characters.

Therefore, increasing the length to reduce footguns seems in order. But if we increase the length, does it actually increase storage on the backend?


Per the mariadb documentation:

```
MariaDB stores VARCHAR values as a one-byte or two-byte length prefix plus data. The length prefix indicates the number of bytes in the value. A VARCHAR column uses one length byte if values require no more than 255 bytes, two length bytes if values may require more than 255 bytes.
```

If we use a value <= 255, the answer is no. No length change is observed. So in that light, I think a change to varchar(255) is reasonable. At the same time, I will add length checks to get/set charvar and loudly complain if you are going over the limit.

## Steps to test these changes

run mariadb, run some quests and see things work.
