### PR TITLE
[lua] Perform intro event on nation swap

### DIFF
--- a/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
+++ b/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
@@ -56,6 +56,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.BASTOK, true))
                 end,
             },
         },
@@ -86,6 +88,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.BASTOK, true))
                 end,
             },
         },
@@ -116,6 +120,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.BASTOK, true))
                 end,
             },
         },
@@ -147,6 +153,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
                 end,
             },
         },
@@ -178,6 +186,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
                 end,
             },
         },
@@ -209,6 +219,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
                 end,
             },
         },
@@ -252,6 +264,8 @@ quest.sections =
                     player:setPos(-40.611, -5, 102.5, 57) -- Move back to CS exit position
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))
                 end,
             },
         },
@@ -283,6 +297,8 @@ quest.sections =
                     player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))
                 end,
             },
         },
@@ -315,6 +331,8 @@ quest.sections =
 
                     player:setPos(-140, -7, 172, 32)
                     quest:setVar(player, 'notSeen', 0)
+                    local nationsSeen = quest:getVar(player, 'nations')
+                    quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))
                 end,
             },
         },

--- a/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
@@ -7,6 +7,13 @@
 ---@type TNpcEntity
 local entity = {}
 
+local newCharCutsceneLocations =
+{
+    [1] = { x = -140,     y = -7, z =  172,   rot =  32, zone = xi.zone.PORT_WINDURST   },
+    [2] = { x =  -40.611, y = -5, z =  102.5, rot =  57, zone = xi.zone.WINDURST_WATERS },
+    [3] = { x =   30,     y =  2, z =  -40,   rot = 128, zone = xi.zone.WINDURST_WOODS  },
+}
+
 entity.onTrigger = function(player, npc)
     local newNation = xi.nation.WINDURST
     local oldNation = player:getNation()
@@ -59,6 +66,16 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         -- Remove Expeditionary Force insignias
         xi.expeditionaryForce.disposeInsigniaNationSwap(player)
+
+        -- Handle New Character Cutscene
+        local nationsSeen = player:getCharVar('HQuest[newCharacterCS]nations')
+        if utils.mask.getBit(nationsSeen, newNation) then
+            return
+        end
+
+        player:setCharVar('HQuest[newCharacterCS]notSeen', 1)
+        local loc = newCharCutsceneLocations[math.randomInt(1, 3)]
+        player:setPos(loc.x, loc.y, loc.z, loc.rot, loc.zone)
     end
 end
 

--- a/scripts/zones/Metalworks/npcs/Mythily.lua
+++ b/scripts/zones/Metalworks/npcs/Mythily.lua
@@ -7,6 +7,13 @@
 ---@type TNpcEntity
 local entity = {}
 
+local newCharCutsceneLocations =
+{
+    [1] = { x = -280, y = -12,   z = -90, rot =   0, zone = xi.zone.BASTOK_MARKETS },
+    [2] = { x =  -45, y =   0,   z =  25, rot = 192, zone = xi.zone.BASTOK_MINES   },
+    [3] = { x =  134, y =   8.5, z = -11, rot =  96, zone = xi.zone.PORT_BASTOK    },
+}
+
 entity.onTrigger = function(player, npc)
     local newNation = xi.nation.BASTOK
     local oldNation = player:getNation()
@@ -59,6 +66,16 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         -- Remove Expeditionary Force insignias
         xi.expeditionaryForce.disposeInsigniaNationSwap(player)
+
+        -- Handle New Character Cutscene
+        local nationsSeen = player:getCharVar('HQuest[newCharacterCS]nations')
+        if utils.mask.getBit(nationsSeen, newNation) then
+            return
+        end
+
+        player:setCharVar('HQuest[newCharacterCS]notSeen', 1)
+        local loc = newCharCutsceneLocations[math.randomInt(1, 3)]
+        player:setPos(loc.x, loc.y, loc.z, loc.rot, loc.zone)
     end
 end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
@@ -7,6 +7,13 @@
 ---@type TNpcEntity
 local entity = {}
 
+local newCharCutsceneLocations =
+{
+    [1] = { x =    0, y =  0, z =  -12, rot = 192, zone = xi.zone.NORTHERN_SAN_DORIA },
+    [2] = { x = -100, y = -8, z = -125, rot = 224, zone = xi.zone.PORT_SAN_DORIA     },
+    [3] = { x = -100, y =  1, z =  -40, rot = 224, zone = xi.zone.SOUTHERN_SAN_DORIA },
+}
+
 entity.onTrigger = function(player, npc)
     local newNation = xi.nation.SANDORIA
     local oldNation = player:getNation()
@@ -59,6 +66,16 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         -- Remove Expeditionary Force insignias
         xi.expeditionaryForce.disposeInsigniaNationSwap(player)
+
+        -- Handle New Character Cutscene
+        local nationsSeen = player:getCharVar('HQuest[newCharacterCS]nations')
+        if utils.mask.getBit(nationsSeen, newNation) then
+            return
+        end
+
+        player:setCharVar('HQuest[newCharacterCS]notSeen', 1)
+        local loc = newCharCutsceneLocations[math.randomInt(1, 3)]
+        player:setPos(loc.x, loc.y, loc.z, loc.rot, loc.zone)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When you swap to a nation for the first time, you are supposed to receive the intro cutscene for that nation. If you swap to a nation for the second time, you don't. This PR implements that change.

One note: on retail the screen is black when zoning in until the event starts. With this implementation, your screen is not black and you see your character, frozen, while you wait for the event to load. I think this is an issue with all zone-in events, but it's only obvious here because the introductory cutscenes take a long time to load. I could not figure the issue out. I had looked through the 0x00a_login.cpp packet and tested the packet.SendCount (sometimes it is not 1) and  packet.PosHead.flags2 as these were both discrepancies from my capture; that did not fix the issue. Regardless, I think that is a separate issue and separate PR from this quest change.

Video of nation swap: https://youtu.be/Lcw7DhtaExY?t=611
Capture: https://drive.google.com/file/d/1A6-QsEDFtK9Wzifk_juDU4_M55AXlU_V/view?usp=drive_link

## Steps to test these changes

Change nations repeatedly.
