### PR TITLE
[Chore] Make `xi.mobskills.calculateDuration` work like it claims it does

### DIFF
--- a/scripts/actions/mobskills/abominable_belch.lua
+++ b/scripts/actions/mobskills/abominable_belch.lua
@@ -12,9 +12,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 3, xi.mobskills.calculateDuration(skill:getTP(), 15, 45)))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 3, xi.mobskills.calculateDuration(skill:getTP(), 15, 75)))
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, duration))
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 25, 0, duration))
 

--- a/scripts/actions/mobskills/animating_wail.lua
+++ b/scripts/actions/mobskills/animating_wail.lua
@@ -16,7 +16,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power    = 3000
-    local duration = xi.mobskills.calculateDuration(mob:getTP(), 90, 120)
+    local duration = xi.mobskills.calculateDuration(mob:getTP(), 90, 150)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, power, 0, duration))
 
     return xi.effect.HASTE

--- a/scripts/actions/mobskills/aura_of_persistence.lua
+++ b/scripts/actions/mobskills/aura_of_persistence.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
     local power = 20
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, power, 0, duration))
 

--- a/scripts/actions/mobskills/binding_wave.lua
+++ b/scripts/actions/mobskills/binding_wave.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(mob:getTP(), 30, 60)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
 
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, duration))
 

--- a/scripts/actions/mobskills/blade_retsu.lua
+++ b/scripts/actions/mobskills/blade_retsu.lua
@@ -29,7 +29,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
         local power = utils.clamp(30 + 3 * (mob:getMainLvl() - target:getMainLvl()), 5, 35)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, power, 0, xi.mobskills.calculateDuration(skill:getTP(), 30, 120))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, power, 0, xi.mobskills.calculateDuration(skill:getTP(), 30, 210))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/blastbomb.lua
+++ b/scripts/actions/mobskills/blastbomb.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType, { breakBind = false })
 
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, duration)
     end
 

--- a/scripts/actions/mobskills/crippling_slam.lua
+++ b/scripts/actions/mobskills/crippling_slam.lua
@@ -29,7 +29,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 50, 0, duration)
     end
 

--- a/scripts/actions/mobskills/demoralizing_roar.lua
+++ b/scripts/actions/mobskills/demoralizing_roar.lua
@@ -15,7 +15,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power = 500
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 150)
 
     xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, power, 0, duration)
 end

--- a/scripts/actions/mobskills/feather_barrier.lua
+++ b/scripts/actions/mobskills/feather_barrier.lua
@@ -18,7 +18,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 600)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 1020)
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration))
 

--- a/scripts/actions/mobskills/fortifying_wail.lua
+++ b/scripts/actions/mobskills/fortifying_wail.lua
@@ -16,7 +16,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power = 60
-    local duration = xi.mobskills.calculateDuration(mob:getTP(), 120, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 240)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.PROTECT, power, 0, duration))
 
     return xi.effect.PROTECT

--- a/scripts/actions/mobskills/granite_skin.lua
+++ b/scripts/actions/mobskills/granite_skin.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     -- This is a special case where the defense boost prevents damage
     -- while the attacker is in front of the defender at the given subpower angle
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 90)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 120)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 0, 0, duration))
 
     local effect = mob:getStatusEffect(xi.effect.DEFENSE_BOOST)

--- a/scripts/actions/mobskills/hard_membrane.lua
+++ b/scripts/actions/mobskills/hard_membrane.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 300)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 420)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration))
 
     return xi.effect.EVASION_BOOST

--- a/scripts/actions/mobskills/herculean_slash.lua
+++ b/scripts/actions/mobskills/herculean_slash.lua
@@ -12,7 +12,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 300)
 
     params.baseDamage     = mob:getMainLvl() + 2
     params.fTP            = { 3.5, 3.5, 3.5 }

--- a/scripts/actions/mobskills/hypnic_lamp.lua
+++ b/scripts/actions/mobskills/hypnic_lamp.lua
@@ -16,7 +16,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 240)
     skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLEEP_I, 1, 0, duration))
 
     return xi.effect.SLEEP_I

--- a/scripts/actions/mobskills/hypnosis.lua
+++ b/scripts/actions/mobskills/hypnosis.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(mob:getTP(), 45, 90)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 45, 135)
 
     skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.SLEEP_I, 1, 0, duration))
 

--- a/scripts/actions/mobskills/hypnotic_sway.lua
+++ b/scripts/actions/mobskills/hypnotic_sway.lua
@@ -13,7 +13,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power = 1
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 60)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
 
     skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.AMNESIA, power, 0, duration))
     return xi.effect.AMNESIA

--- a/scripts/actions/mobskills/ice_break.lua
+++ b/scripts/actions/mobskills/ice_break.lua
@@ -26,7 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType, { breakBind = false })
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 120, 180))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 120, 240))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/ice_break_2128.lua
+++ b/scripts/actions/mobskills/ice_break_2128.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType, { breakBind = false })
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 120, 180))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BIND, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 120, 240))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/leaping_cleave.lua
+++ b/scripts/actions/mobskills/leaping_cleave.lua
@@ -31,7 +31,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(mob:getTP(), 15, 30)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 15, 45)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, duration)
     end
 

--- a/scripts/actions/mobskills/level_5_petrify.lua
+++ b/scripts/actions/mobskills/level_5_petrify.lua
@@ -14,7 +14,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if target:getMainLvl() % 5 == 0 then
-        local duration = xi.mobskills.calculateDuration(mob:getTP(), 15, 60)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 15, 105)
 
         skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PETRIFICATION, 1, 0, duration))
     else

--- a/scripts/actions/mobskills/lightning_spear.lua
+++ b/scripts/actions/mobskills/lightning_spear.lua
@@ -26,7 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(30, 120)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 210)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.AMNESIA, 1, 0, duration) -- TODO: Capture power of Amnesia
     end

--- a/scripts/actions/mobskills/mind_blast.lua
+++ b/scripts/actions/mobskills/mind_blast.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
         -- TODO: Capture Paralysis power. Sources say its extremely potent.
         -- TODO: More captures for duration to account for effect resistance.
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, xi.mobskills.calculateDuration(skill:getTP(), 15, 45))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 20, 0, xi.mobskills.calculateDuration(skill:getTP(), 15, 75))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/numbing_shot.lua
+++ b/scripts/actions/mobskills/numbing_shot.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, xi.mobskills.calculateDuration(skill:getTP(), 60, 180))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PARALYSIS, 30, 0, xi.mobskills.calculateDuration(skill:getTP(), 60, 300))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/parry.lua
+++ b/scripts/actions/mobskills/parry.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 600, 1020)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 600, 1440)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 25, 0, duration))
 
     return xi.effect.DEFENSE_BOOST

--- a/scripts/actions/mobskills/rhino_guard.lua
+++ b/scripts/actions/mobskills/rhino_guard.lua
@@ -12,7 +12,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 480)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 780)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration))
 
     return xi.effect.EVASION_BOOST

--- a/scripts/actions/mobskills/rotten_stench.lua
+++ b/scripts/actions/mobskills/rotten_stench.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     -- TODO Confirm actual power
     local power        = 50
-    local duration     = xi.mobskills.calculateDuration(skill:getTP(), 90, 120)
+    local duration     = xi.mobskills.calculateDuration(skill:getTP(), 90, 150)
     local accuracyDown = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, power, 0, duration)
     local magicAccDown = xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.MAGIC_ACC_DOWN, power, 0, duration)
     local typeEffect   = 0

--- a/scripts/actions/mobskills/rumble.lua
+++ b/scripts/actions/mobskills/rumble.lua
@@ -13,7 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 45, 210)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 45, 375)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 10, 0, duration))
 
     return xi.effect.EVASION_DOWN

--- a/scripts/actions/mobskills/shell_guard.lua
+++ b/scripts/actions/mobskills/shell_guard.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 600, 1080)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 600, 1560)
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 25, 0, duration))
 
     return xi.effect.DEFENSE_BOOST

--- a/scripts/actions/mobskills/shijin_spiral.lua
+++ b/scripts/actions/mobskills/shijin_spiral.lua
@@ -27,7 +27,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 18, 24)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 18, 30)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 5, 3, duration)
     end
 

--- a/scripts/actions/mobskills/shockwave.lua
+++ b/scripts/actions/mobskills/shockwave.lua
@@ -12,7 +12,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 300)
 
     params.baseDamage     = mob:getWeaponDmg()
     params.numHits        = 1

--- a/scripts/actions/mobskills/shoulder_tackle.lua
+++ b/scripts/actions/mobskills/shoulder_tackle.lua
@@ -26,7 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 2, 6)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 2, 10)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, duration)
     end
 

--- a/scripts/actions/mobskills/slipstream.lua
+++ b/scripts/actions/mobskills/slipstream.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 120, 240)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ACCURACY_DOWN, 25, 0, duration))
 
     return xi.effect.ACCURACY_DOWN

--- a/scripts/actions/mobskills/sonic_boom.lua
+++ b/scripts/actions/mobskills/sonic_boom.lua
@@ -15,7 +15,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if target:hasStatusEffect(xi.effect.ATTACK_DOWN) then
         skill:setMsg(xi.msg.basic.SKILL_NO_EFFECT)
     else
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 360)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
 
         skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ATTACK_DOWN, 25, 0, duration))
 

--- a/scripts/actions/mobskills/tartarus_torpor.lua
+++ b/scripts/actions/mobskills/tartarus_torpor.lua
@@ -11,7 +11,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 180)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 60, 300)
 
     -- params.str_wSC = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.
     -- params.int_wSC = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/thermal_pulse.lua
+++ b/scripts/actions/mobskills/thermal_pulse.lua
@@ -30,7 +30,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 90)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 30, 150)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 100, 0, duration)
     end
 

--- a/scripts/actions/mobskills/tourbillion.lua
+++ b/scripts/actions/mobskills/tourbillion.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         -- TODO: Capture power/duration
-        local duration = xi.mobskills.calculateDuration(mob:getTP(), 20, 60)
+        local duration = xi.mobskills.calculateDuration(skill:getTP(), 20, 100)
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.DEFENSE_DOWN, 20, 0, duration)
     end
 

--- a/scripts/actions/mobskills/vile_belch.lua
+++ b/scripts/actions/mobskills/vile_belch.lua
@@ -12,8 +12,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 3, xi.mobskills.calculateDuration(skill:getTP(), 15, 45)))
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 30, 60)))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.PLAGUE, 10, 3, xi.mobskills.calculateDuration(skill:getTP(), 15, 75)))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 30, 90)))
 
     return xi.effect.PLAGUE
 end

--- a/scripts/actions/mobskills/wind_wall.lua
+++ b/scripts/actions/mobskills/wind_wall.lua
@@ -19,7 +19,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 15, 60)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 15, 105)
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 200, 0, duration))
 

--- a/scripts/actions/mobskills/wrath_of_zeus.lua
+++ b/scripts/actions/mobskills/wrath_of_zeus.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, xi.mobskills.calculateDuration(30, 60))
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, xi.mobskills.calculateDuration(skill:getTP(), 30, 90))
     end
 
     return info.damage

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -1631,11 +1631,10 @@ xi.mobskills.mobHealMove = function(target, healAmount)
 end
 
 xi.mobskills.calculateDuration = function(tp, minimum, maximum)
-    if tp <= 1000 then
-        return minimum
-    end
+    local midpoint = (minimum + maximum) / 2
+    local duration = minimum + (midpoint - minimum) * (tp - 1000) / 1000
 
-    return minimum + (maximum - minimum) * (tp - 1000) / 1000
+    return utils.clamp(duration, minimum, maximum)
 end
 
 -- Used for mobskills that remove player equipment.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
The function claims to be fed a tp value, a min duration and a max duration.

In practice, this isn't true. The "maximum" is a midpoint. In other words, the minimum value + a range which determines ACTUAL duration.

This changes the function and the definition to actually work with a min and a max.
- No reall changes where made to durations. I just recalculated what the maximum would be (assuming the function was actually used correctly, no matter the claim, which I doubt. Im pretty sure ppl in some cases were feeding it an actual max)
- Fixes some uses where no tp was being defined. So they were broken. This has the side effect of fixing them.
- I also changed all cases where we were fetching mobs current tp instead of the skill tp (AKA the tp value the mob had when it used the skill)

## Steps to test these changes
None. No real changes were made other than the few fixes.