### PR TITLE
[lua] Silk Caterpillar Despawn Fixes

### DIFF
--- a/scripts/zones/Rolanberry_Fields/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields/Zone.lua
@@ -50,8 +50,8 @@ zoneObject.onGameHour = function(zone)
         VanadielHour() % 6 == 3 and
         not GetMobByID(ID.mob.SILK_CATERPILLAR):isSpawned()
     then
-        -- Despawn set to 210 seconds (3.5 minutes, approx when the Jeuno-Bastok airship is flying back over to Bastok).
-        SpawnMob(ID.mob.SILK_CATERPILLAR, 210)
+        -- Despawn is handled by xi.mobMod.IDLE_DESPAWN in the mob's script.
+        SpawnMob(ID.mob.SILK_CATERPILLAR)
     end
 end
 

--- a/scripts/zones/Rolanberry_Fields/mobs/Silk_Caterpillar.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Silk_Caterpillar.lua
@@ -27,6 +27,11 @@ entity.spawnPoints =
     { x = 380.297, y = -0.248, z = 167.144 },
 }
 
+entity.onMobInitialize = function(mob)
+    -- Despawns 3.5 minutes after spawning, approximately when the Jeuno-Bastok airship departs Jeuno to fly back over towards Bastok.
+    mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 210)
+end
+
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The old despawn code was outdated and not firing. I updated it so it despawns based on the times witnessed in [retail captures](https://youtu.be/-v7fNheHJR8) (which matches up with airship arrival and departure).

## Steps to test these changes

Go camp Silk Caterpillar and watch it spawn/despawn like it is supposed to. Note that it will be off sync if someone claims it... as per retail.
