### PR TITLE
[lua] Fix fade-to-black nation change event

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Rakano-Marukano.lua
@@ -42,7 +42,8 @@ entity.onTrigger = function(player, npc)
             hasGil = 1
         end
 
-        player:startEvent(10002, 0, 1, player:getRank(newNation), newNation, hasGil, cost)
+        local wasCitizen = utils.mask.getBit(player:getCharVar('HQuest[newCharacterCS]nations'), newNation) and 1 or 0
+        player:startEvent(10002, 0, wasCitizen, player:getRank(newNation), newNation, hasGil, cost)
     end
 end
 

--- a/scripts/zones/Metalworks/npcs/Mythily.lua
+++ b/scripts/zones/Metalworks/npcs/Mythily.lua
@@ -42,7 +42,8 @@ entity.onTrigger = function(player, npc)
             hasGil = 1
         end
 
-        player:startEvent(360, 0, 1, player:getRank(newNation), newNation, hasGil, cost)
+        local wasCitizen = utils.mask.getBit(player:getCharVar('HQuest[newCharacterCS]nations'), newNation) and 1 or 0
+        player:startEvent(360, 0, wasCitizen, player:getRank(newNation), newNation, hasGil, cost)
     end
 end
 

--- a/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Beriphaule.lua
@@ -42,7 +42,8 @@ entity.onTrigger = function(player, npc)
             hasGil = 1
         end
 
-        player:startEvent(606, 0, 1, player:getRank(newNation), newNation, hasGil, cost)
+        local wasCitizen = utils.mask.getBit(player:getCharVar('HQuest[newCharacterCS]nations'), newNation) and 1 or 0
+        player:startEvent(606, 0, wasCitizen, player:getRank(newNation), newNation, hasGil, cost)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a mistake on PR #10736 where you need to set the second event parameter to 0 if you are going to trigger the intro cutscene to keep the fade-to-black screen.

## Steps to test these changes

Do nation swaps.
