### PR TITLE
[C++] Account for if conquest setting is reduced midweek

### DIFF
--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -123,12 +123,16 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
         rset->get<int>("beastmen_influence"),
     };
 
+    const int total = influences[0] + influences[1] + influences[2] + influences[3];
+
     // Read from main settings. Protect against 0 or too high of number.
     // Restricted by a factor of 100 because of packet lines in 0x05e_conquest.cpp
-    const int32 influenceCap = std::clamp<int32>(settings::get<int32>("main.CONQUEST_INFLUENCE_CAP"), 1, 20000000);
+    const int32 influenceCapSetting = std::clamp<int32>(settings::get<int32>("main.CONQUEST_INFLUENCE_CAP"), 1, 20000000);
 
-    int total = influences[0] + influences[1] + influences[2] + influences[3];
-    int room  = influenceCap - total;
+    // Account for situation where influenceCapSetting was reduced midweek.
+    const int32 influenceCap = std::max<int32>(influenceCapSetting, total);
+
+    const int room = influenceCap - total;
 
     if (points <= room) // Pool is not capped and there is space. Straight add.
     {
@@ -138,11 +142,12 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
     {
         // Fill the remaining room first, then redistribute the overflow.
         influences[nation] += room;
-        int overflow = points - room;
 
         // Do not adjust anything if the nation is already at the pool maximum.
         if (influences[nation] < influenceCap)
         {
+            const int overflow = points - room;
+
             auto lost = 0;
             for (auto i = 0u; i < 4; ++i)
             {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

If a server lowers the CONQUEST_INFLUENCE_CAP setting mid week, room can become negative. If that happens, the next nation to gain influence goes to the cap regardless of who is leading. I missed this case when coding PR #10266 

The fix is if total is greater than CONQUEST_INFLUENCE_CAP to use total as the cap until the weekly reset.

I also added const to many of the variables.

## Steps to test these changes

This is how I tested it:
Have setting at 250k. Set one region to have a total of 250k points between the nations. 
Change the setting down to 5k and go increase the influence of one of the nations.
Go to a fresh region and set one nation to 5k influence. Set another nation to 2.5k influence. Add another 2.5k influence.