### PR TITLE
[lua] [sql] Trials Size Avatar Fight Res Override

### DIFF
--- a/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
+++ b/scripts/zones/Cloister_of_Flames/mobs/Ifrit_Prime_TSTBF.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
+++ b/scripts/zones/Cloister_of_Frost/mobs/Shiva_Prime_TSTBI.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Gales/mobs/Garuda_Prime_TSTBW.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
+++ b/scripts/zones/Cloister_of_Storms/mobs/Ramuh_Prime_TSTBL.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
+++ b/scripts/zones/Cloister_of_Tides/mobs/Leviathan_Prime_TSTBW.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
+++ b/scripts/zones/Cloister_of_Tremors/mobs/Titan_Prime_TSTBE.lua
@@ -28,6 +28,7 @@ entity.onMobSpawn = function(mob)
     -- online videos show that 24/27 SL were unresisted on retail
     -- this reduction in MEVA roughly gives roughly the correct resist rate
     mob:addMod(xi.mod.LIGHT_MEVA, -35)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 0)
 
     mob:addImmunity(xi.immunity.BLIND)
     mob:addImmunity(xi.immunity.SLOW)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -916,7 +916,7 @@ INSERT INTO `mob_skills` VALUES (884,586,'diamond_dust',1,0.0,30.0,600,3000,4,64
 INSERT INTO `mob_skills` VALUES (885,591,'shock_strike',0,0.0,10.0,608,3000,4,64,0,0,8,0,0); -- Impaction (8)
 INSERT INTO `mob_skills` VALUES (886,592,'thunder_ii',0,0.0,10.0,609,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (887,593,'rolling_thunder',1,0.0,10.0,610,3000,1,128,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (888,594,'thunderspark',1,0.0,10.0,611,3000,4,64,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (888,594,'thunderspark',1,0.0,20.0,611,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (889,595,'lightning_armor',1,0.0,10.0,612,3000,1,128,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (890,596,'thunder_iv',0,0.0,10.0,613,3000,4,64,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (891,597,'chaotic_strike',0,0.0,10.0,614,3000,4,64,0,0,12,1,0); -- Fragmentation (12) / Transfixion (1)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Recent changes to Avatar SQL res ranks had the unintended consequence of making the Mini fights harder than it should be.

This PR overrides the Light Res rank of the mini fight to 0 so Carbuncle can once again assist summoners in clearing the fight.
It's unknown if other elements also have similar rank, as nobody actually clears this fight with any other avatar.  I'll leave the change at just light.

While I was looking at caps however, I noticed the distance of mob Thunderspark is bonkers, so I adjusted that.

https://youtu.be/6LB_ORJ1Rvw?t=115

## Steps to test these changes

Clear a mini tuning fork fight using carbuncle 2hr like Tanaka intended.
