### PR TITLE
[lua] Add Bartabaq outpost vendor to Oldton Movalpolos

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -704,6 +704,7 @@ local overseerOffsets =
         { offset =  1, nation = xi.nation.BASTOK   }, -- flag
         { offset =  2, nation = xi.nation.WINDURST }, -- flag
         { offset =  3, nation = xi.nation.BEASTMEN }, -- flag
+        { offset =  4, nation = xi.nation.OTHER    }, -- Bartabaq
     },
     [xi.region.TAVNAZIANARCH] =
     {

--- a/scripts/zones/Oldton_Movalpolos/DefaultActions.lua
+++ b/scripts/zones/Oldton_Movalpolos/DefaultActions.lua
@@ -1,7 +1,6 @@
 local ID = zones[xi.zone.OLDTON_MOVALPOLOS]
 
 return {
-    ['Bartabaq']           = { event = 32756 },
     ['Brakobrik']          = { text = ID.text.NO_FIRES_NO_BOMBS },
     ['GuZho_Thunderblade'] = { event = 60 },
     ['Koblakiq']           = { event = 13 },

--- a/scripts/zones/Oldton_Movalpolos/npcs/Bartabaq.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Bartabaq.lua
@@ -1,0 +1,32 @@
+-----------------------------------
+-- Area: Oldton Movalpolos
+--  NPC: Bartabaq
+-- Type: Outpost Vendor
+-- !pos -260 8 -49 11
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    xi.conquest.vendorOnTrigger(player, xi.region.MOVALPOLOS, 32756)
+end
+
+-- TODO: Implement evoliths trading.
+-- TODO: Check if you can trade equipment.
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if option == 1 then
+        local stock =
+        {
+            { xi.item.BOTTLE_OF_MOVALPOLOS_WATER, 800 },
+            { xi.item.GOBLIN_DOLL,                500 },
+            { xi.item.COPPER_NUGGET,              105 },
+            { xi.item.CORAL_FUNGUS,               755 },
+            { xi.item.CHUNK_OF_KOPPARNICKEL_ORE,  800 },
+        }
+
+        xi.shop.general(player, stock)
+    end
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The outpost vendor Bartabaq in Oldton Movalpolos does not exist. This adds that vendor.
The stock is shown below with prices.
I did not implement evolith trading (as I have on idea what that even is) nor equipment trading (unimplemented feature).

<img width="1902" height="996" alt="Bartabaq" src="https://github.com/user-attachments/assets/abfa66ea-f009-42d9-858b-b00a6913d63a" />

## Steps to test these changes

Control region, see she exists. Try and buy stuff. 
