### PR TITLE
[lua] Kamlanaut aggro range fix

### DIFF
--- a/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
+++ b/scripts/zones/Stellar_Fulcrum/mobs/Kamlanaut.lua
@@ -24,6 +24,11 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.DETECTION, xi.detects.HEARING)
+    mob:setMobMod(xi.mobMod.SOUND_RANGE, 15)
+end
+
 entity.onMobEngage = function(mob, target)
     mob:setLocalVar('nextEnSkill', GetSystemTime() + 10)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Kamlanaut's aggro so he doesn't aggro players loading into the fight.

Kamlanaut was aggroing so far that he was instantly aggroing anyone loading into the fight.

https://youtu.be/d0aHOvLZLfM?t=7

## Steps to test these changes

Have time to buff now. Then walk forward.
