### PR TITLE
[lua] Stardust quest repeatable mustZone and Accept

### DIFF
--- a/scripts/quests/bastok/Stardust.lua
+++ b/scripts/quests/bastok/Stardust.lua
@@ -38,7 +38,7 @@ quest.sections =
 
     {
         check = function(player, status, vars)
-            return status ~= xi.questStatus.QUEST_AVAILABLE
+            return status == xi.questStatus.QUEST_ACCEPTED
         end,
 
         [xi.zone.METALWORKS] =
@@ -57,6 +57,7 @@ quest.sections =
                 [555] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:confirmTrade()
+                        quest:setMustZone(player)
                     end
                 end,
             },
@@ -67,6 +68,51 @@ quest.sections =
             ['Drangord'] = quest:event(97),
         },
     },
+
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.METALWORKS] =
+        {
+            ['Baldric'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        quest:getVar(player, 'Prog') == 1 and
+                        npcUtil.tradeHasExactly(trade, xi.item.PINCH_OF_VALKURM_SUNSAND)
+                    then
+                        return quest:progressEvent(555)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if
+                        quest:getVar(player, 'Prog') == 0 and
+                        not quest:getMustZone(player)
+                    then
+                        return quest:progressEvent(554)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [554] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
+                [555] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:confirmTrade()
+                        quest:setMustZone(player)
+                    end
+                end,
+            },
+        },
+    },
+
 }
 
 return quest


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Player must Zone after delivering Sunsand
- On repeating quest, player must have heard the request for Sunsand again. Baldric should not blindly accept Sunsand.
- Baldric should only say the request for Sunsand once. When interacting again, should say standard interaction. ("Designing new products isn't easy").

Retail capture: https://youtube.com/live/f5Ab5pdKwzI

## Steps to test these changes

**First Time**
!zone Metalworks
!gotoname Baldric
Trade Sunsand to Baldric. Should not accept.
Talk to Baldric. Request for Sunsand, quest gets automatically accepted.
Talk to Baldric. Standard interaction "Designing new products isn't easy".
Trade Sunsand to Baldric. Should complete.
Talk to Baldric. Standard interaction "Designing new products isn't easy".
Trade Sunsand to Baldric. Should not accept.

**Repeat**
!zone Port Bastok
!zone Metalworks
!gotoname Baldric
Trade Sunsand to Baldric. Should not accept.
Talk to Baldric. Request for Sunsand. (No quest accepted since already completed, but Prog var set to keep track)
Talk to Baldric. Standard interaction "Designing new products isn't easy".
Trade Sunsand to Baldric. Should complete.
Talk to Baldric. Standard interaction "Designing new products isn't easy".
Trade Sunsand to Baldric. Should not accept.