### PR TITLE
[lua] Sandy 6-2 Aggro Fixes

### DIFF
--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Soffeil.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Ulbrig.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end

--- a/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
+++ b/scripts/zones/King_Ranperres_Tomb/mobs/Corrupted_Yorgos.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In my [recent PR](https://github.com/LandSandBoat/server/pull/10672), I forgot to make the spawned NMs always aggro. [Here is proof](https://youtu.be/6KJps4Egufs?t=772) that they aggro even at level 99 from Siknoz.

## Steps to test these changes

Do Sandy 6-2 or spawn the NMs and witness they now always aggro.
