### PR TITLE
[core] Spawn, but hide content tagged NPCs

### DIFF
--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -308,13 +308,6 @@ auto LoadNPCList(Scheduler& scheduler, const std::vector<uint16>& zoneIds) -> Ta
                         {
                             while (rset->next())
                             {
-                                // If there is no content tag, the NPC will always be loaded
-                                const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
-                                if (!luautils::IsContentEnabled(contentTag))
-                                {
-                                    continue;
-                                }
-
                                 const auto NpcID = rset->get<uint32>("npcid");
 
                                 if (!((PZone->GetTypeMask() & xi::ZoneType::Instanced) != xi::ZoneType::Unknown))
@@ -349,6 +342,21 @@ auto LoadNPCList(Scheduler& scheduler, const std::vector<uint16>& zoneIds) -> Ta
 
                                     PNpc->name_prefix = rset->get<uint8>("name_prefix");
                                     PNpc->setWidescan(rset->get<uint8>("widescan"));
+
+                                    // If there is no content tag, the NPC will be loaded but not spawned
+                                    // We load them because certain CS require NPCs that may be flagged as content tagged and the client may request them through a CHARREQ packet
+                                    const auto contentTag = rset->getOrDefault<std::string>("content_tag", "");
+                                    if (!luautils::IsContentEnabled(contentTag))
+                                    {
+                                        // TODO: set some invisible flags so the client can't render them?
+                                        PNpc->loc.p.x = 0.f;
+                                        PNpc->loc.p.y = 0.f;
+                                        PNpc->loc.p.z = 0.f;
+
+                                        PNpc->status = xi::Status::Disappear;
+
+                                        PNpc->setWidescan(false);
+                                    }
 
                                     PZone->InsertNPC(PNpc);
                                 }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Apparently, some cutscenes contain NPCs in different content tags, such as WoTG NPCs now appearing in a pre WoTG CS because they are in town now

This will allow the client to request info on those NPCs and the server will reply with their look etc.

## Steps to test these changes

This can only be tested without the default settings.

Enable content restriction and restrict everything after ToAU, try to talk to Collet in Upper Jeuno to start her quest (A Clock Most Delicate) and see it not freeze.
