### PR TITLE
[lua] Sandy 6-1 & 6-2 Key Item Fix

### DIFF
--- a/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
+++ b/scripts/missions/sandoria/6_2_Ranperres_Final_Rest.lua
@@ -213,6 +213,7 @@ mission.sections =
 
                 [8] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.ANCIENT_SAN_DORIAN_BOOK)
+                    player:delKeyItem(xi.ki.PIECE_OF_PAPER)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

During Sandy 6-1 you obtain a "Piece of Paper" temporary key item. It is supposed to be deleted during one of the final cutscenes of Sandy 6-2. [However the deletion is silent to players and only visible in the packets](https://www.youtube.com/watch?v=4c-h6Zv65D0). This PR implements that correct retail behavior instead of having players keep a temporary key item they are supposed to lose.

## Steps to test these changes

!addmission 0 17 and then do the mission and see you can still properly complete it but you also lose the Piece of Paper temporary key item per retail.