### PR TITLE
[ci] Remove built exes from build cache

### DIFF
--- a/.github/workflows/runner_build.yml
+++ b/.github/workflows/runner_build.yml
@@ -242,6 +242,15 @@ jobs:
             xi_*
             tracy.tar.gz
 
+      - name: Remove exes from build cache
+        if: ${{ inputs.save_cache && env.SKIP_BUILD != 'true' && steps.restore_build.outputs.cache-hit != 'true' }}
+        run: |
+          rm -f build/src/login/xi_connect*
+          rm -f build/src/map/xi_map*
+          rm -f build/src/search/xi_search*
+          rm -f build/src/test/xi_test*
+          rm -f build/src/world/xi_world*
+
       - name: Cache build
         if: ${{ inputs.save_cache && env.SKIP_BUILD != 'true' && steps.restore_build.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v5


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes built executables from the build directory. Saves ~2GB from the GHA cache, which we're currently very close to the cap of 10GB.

## Steps to test these changes

[Successful build](https://github.com/cocosolos/server/actions/runs/29356527634)
[My cache](https://github.com/cocosolos/server/actions/caches) (6.5GB)
[LSB cache](https://github.com/LandSandBoat/server/actions/caches)  (8.89GB)
