### PR TITLE
[core] Fix ghost item showing in ammo slot

### DIFF
--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -41,6 +41,7 @@
 #include "packets/s2c/0x033_eventstr.h"
 #include "packets/s2c/0x034_eventnum.h"
 #include "packets/s2c/0x036_talknum.h"
+#include "packets/s2c/0x04f_equip_clear.h"
 #include "packets/s2c/0x050_equip_list.h"
 #include "packets/s2c/0x051_grap_list.h"
 #include "packets/s2c/0x052_eventucoff.h"
@@ -1277,6 +1278,20 @@ void CCharEntity::flushEquipChanges()
     pushPacket<GP_SERV_COMMAND_COMMAND_DATA>(this);
 
     inventorySyncState_.clearEquipChanges();
+}
+
+void CCharEntity::resyncEquipment()
+{
+    // EQUIP_CLEAR + re-assert every equipped slot.
+    pushPacket<GP_SERV_COMMAND_EQUIP_CLEAR>();
+
+    for (uint8 slotID = 0; slotID < EquipSlotCount; ++slotID)
+    {
+        if (auto loc = equipLocation(slotID))
+        {
+            pushPacket<GP_SERV_COMMAND_EQUIP_LIST>(loc->Slot, static_cast<SLOTTYPE>(slotID), loc->Container);
+        }
+    }
 }
 
 auto CCharEntity::inventorySyncState() -> InventorySyncState&

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -637,6 +637,7 @@ public:
     timer::time_point m_LastRangedAttackTime{};
 
     void flushEquipChanges();
+    void resyncEquipment();
     auto inventorySyncState() -> InventorySyncState&;
 
     CHAR_SUBSTATE m_Substate;

--- a/src/map/inventory_sync_state.cpp
+++ b/src/map/inventory_sync_state.cpp
@@ -21,6 +21,8 @@
 
 #include "inventory_sync_state.h"
 
+#include <algorithm>
+
 #include "entities/char_entity.h"
 #include "items/item.h"
 #include "packets/s2c/0x020_item_attr.h"
@@ -62,6 +64,15 @@ void InventorySyncState::removeEquipChange(const CItem* item)
                   });
 }
 
+auto InventorySyncState::hasEquipChange(const CItem* item) const -> bool
+{
+    return std::ranges::any_of(pendingEquipChanges_,
+                               [&](const equip_change_t& x)
+                               {
+                                   return x.item == item;
+                               });
+}
+
 void InventorySyncState::clearEquipChanges()
 {
     pendingEquipChanges_.clear();
@@ -83,7 +94,7 @@ auto InventorySyncState::dirtyContainers() const -> const std::set<CONTAINER_ID>
     return dirtyContainers_;
 }
 
-void InventorySyncState::flushDirtyItems(CCharEntity* PChar)
+void InventorySyncState::flushDirtyItems(CCharEntity* PChar) const
 {
     for (uint8 loc = 0; loc < MAX_CONTAINER_ID; ++loc)
     {

--- a/src/map/inventory_sync_state.h
+++ b/src/map/inventory_sync_state.h
@@ -53,13 +53,14 @@ public:
     // Equipment change queue
     void queueEquipChange(CONTAINER_ID container, uint8 containerSlotId, SLOTTYPE equipSlot, CItem* item, Equipping equipping);
     void removeEquipChange(const CItem* item);
+    auto hasEquipChange(const CItem* item) const -> bool;
     void clearEquipChanges();
     auto hasPendingEquipChanges() const -> bool;
     auto pendingEquipChanges() const -> const std::vector<equip_change_t>&;
     auto dirtyContainers() const -> const std::set<CONTAINER_ID>&;
 
     // Dirty item exdata flush
-    void flushDirtyItems(class CCharEntity* PChar);
+    void flushDirtyItems(class CCharEntity* PChar) const;
 
 private:
     xi::bitset<MAX_CONTAINER_ID> syncedContainers_{};

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2014,8 +2014,12 @@ uint32 UpdateItem(CCharEntity* PChar, uint8 LocationID, uint8 slotID, int32 quan
 
         luautils::OnItemDrop(PChar, PItem);
 
-        // Remove soon to be stale PItem pointer from sync state
-        PChar->inventorySyncState().removeEquipChange(PItem);
+        // Equipped item consumed to 0: resync equipment.
+        if (PChar->inventorySyncState().hasEquipChange(PItem))
+        {
+            PChar->inventorySyncState().clearEquipChanges();
+            PChar->resyncEquipment();
+        }
     }
     return ItemID;
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Reorganizes a little bit how we send inventory/equipment packets when ammo gets to 0 to match retail

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
