### PR TITLE
[lua] Sandy 8-2 Fixes

### DIFF
--- a/scripts/missions/sandoria/8_2_Lightbringer.lua
+++ b/scripts/missions/sandoria/8_2_Lightbringer.lua
@@ -185,6 +185,8 @@ mission.sections =
                             return mission:messageSpecial(uggalepihID.text.BEGINS_TO_QUIVER, xi.ki.CRYSTAL_DOWSER)
                         end
                     end
+
+                    return mission:messageSpecial(uggalepihID.text.YOU_CANNOT_OPEN_THIS_DOOR)
                 end,
             },
 
@@ -270,6 +272,9 @@ mission.sections =
             {
                 [65] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 6)
+                    player:delKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY1)
+                    player:delKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY2)
+                    player:delKeyItem(xi.ki.PIECE_OF_A_BROKEN_KEY3)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request makes two changes to Sandy 8-2, including:

1. Added checks to remove the three "Piece of a broken key" temporary key items, [per retail](https://youtu.be/rGwWZ1PxE-A?t=3614).
2. Adds flavor dialogue for the cutscene/NM spawn door when you don't need the requirements to progress, [per retail.](https://youtu.be/rGwWZ1PxE-A?t=2651)

## Steps to test these changes

!addmission 0 21 and play it out. You will see the key items be deleted and the flavor text is present.