### PR TITLE
[lua, sql] NIN Unlock Quest Audits

### DIFF
--- a/scripts/quests/bastok/Ayame_and_Kaede.lua
+++ b/scripts/quests/bastok/Ayame_and_Kaede.lua
@@ -18,6 +18,7 @@ quest.reward =
 {
     fame     = 30,
     fameArea = xi.fameArea.BASTOK,
+    keyItem  = xi.ki.JOB_GESTURE_NINJA,
     title    = xi.title.SHADOW_WALKER,
 }
 
@@ -92,7 +93,7 @@ quest.sections =
                                 SpawnMob(nmId):updateClaim(player)
                             end
 
-                            return quest:messageSpecial(korrolokaID.text.SENSE_OF_FOREBODING)
+                            return quest:messageText(korrolokaID.text.HAIR_STANDS_ON_END)
                         end
                     end
                 end,
@@ -183,6 +184,7 @@ quest.sections =
 
                 [246] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:delKeyItem(xi.ki.SEALED_DAGGER)
                         player:unlockJob(xi.job.NIN)
                         player:messageSpecial(portBastokID.text.UNLOCK_NINJA)
                     end

--- a/scripts/zones/Korroloka_Tunnel/IDs.lua
+++ b/scripts/zones/Korroloka_Tunnel/IDs.lua
@@ -25,6 +25,7 @@ zones[xi.zone.KORROLOKA_TUNNEL] =
         ENTERED_SPRING                = 7348,  -- The water in this spring is pleasant and tepid. This looks like a nice place to warm yourself up.
         LEFT_SPRING_EARLY             = 7349,  -- You are not warm enough yet. You will need to spend more time than that in the spring to get your body heated up.
         LEFT_SPRING_CLEAN             = 7350,  -- Your whole body is piping hot, and the smell of the Rafflesia pollen is gone!
+        HAIR_STANDS_ON_END            = 7352,  -- The hair on the back of your neck begins to stand on end!
         MORION_WORM_1                 = 7353,  -- It appears to be a hole made by some kind of animal. Fragments of iron ore are scattered around the area...
         FILL_FLASK                    = 7356,  -- You carefully draw the water stored in the clam into <keyitem>.
         STILL_LIGHT                   = 7357,  -- The flask still feels light...

--- a/scripts/zones/Korroloka_Tunnel/mobs/Korroloka_Leech.lua
+++ b/scripts/zones/Korroloka_Tunnel/mobs/Korroloka_Leech.lua
@@ -8,6 +8,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.IDLE_DESPAWN, 180)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
 end
 
 entity.onMobSpawn = function(mob)

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -12484,7 +12484,7 @@ INSERT INTO `mob_groups` VALUES (24,1587,173,'Gigas_Stonegrinder',300,0,988,0,0,
 INSERT INTO `mob_groups` VALUES (25,1563,173,'Gigas_Foreman',300,0,988,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,1593,173,'Gigass_Spider',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (27,4831,173,'Thoon',3600,0,3020,3000,0,0,'WOTG');
-INSERT INTO `mob_groups` VALUES (28,2283,173,'Korroloka_Leech',0,128,0,250,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (28,2283,173,'Korroloka_Leech',0,128,0,400,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,2748,173,'Morion_Worm',0,128,1739,2100,2100,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,2633,173,'Metallic_Slime',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (31,1642,173,'Goblin_Bounty_Hunter',300,0,1030,0,0,0,NULL);

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -65024,9 +65024,9 @@ INSERT INTO `mob_spawn_points` VALUES (17486183,24,'Gigas_Stonecarrier','Gigas S
 INSERT INTO `mob_spawn_points` VALUES (17486184,24,'Gigas_Stonegrinder','Gigas Stonegrinder',24,35,37,-272.000,-0.500,0.500,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17486185,24,'Gigas_Foreman','Gigas Foreman',25,35,37,-198.000,-0.500,0.500,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17486186,0,'Gigass_Spider','Gigas\'s Spider',26,28,30,1.000,1.000,1.000,0,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17486187,0,'Korroloka_Leech','Korroloka Leech',28,32,32,-212.000,-9.000,179.000,247,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17486188,0,'Korroloka_Leech','Korroloka Leech',28,32,32,-209.000,-9.000,172.000,246,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17486189,0,'Korroloka_Leech','Korroloka Leech',28,32,32,-215.000,-10.000,167.000,114,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17486187,0,'Korroloka_Leech','Korroloka Leech',28,15,15,-212.000,-9.000,179.000,247,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17486188,0,'Korroloka_Leech','Korroloka Leech',28,15,15,-209.000,-9.000,172.000,246,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17486189,0,'Korroloka_Leech','Korroloka Leech',28,15,15,-215.000,-10.000,167.000,114,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17486190,0,'Morion_Worm','Morion Worm',29,28,28,255.652,-6.039,20.878,0,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17486191,0,'Metallic_Slime','Metallic Slime',30,24,30,0.000,0.000,0.000,0,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17486192,0,'Goblin_Bounty_Hunter','Goblin Bounty Hunter',31,10,10,-48.364,-4.866,106.168,64,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request audits the NIN unlock quest "Ayame and Kaede" [per retail captures](https://youtu.be/ddvb2yjJHFs) and does all of the following:

- Adds missing Job Gesture: Ninja key item reward.
- Properly removed the temporary key item "Sealed Dagger" at the end of the quest chain.
- Corrects messaging upon spawning Korroloka Leeeches to be retail accurate.
- Adjust level range of Korroloka Leeches.
- Adjusted HP of Korroloka Leeches.
- Added always aggro modifier because they aggro level 99 characters.

## Steps to test these changes

Do the quest and witness all the changes.