### PR TITLE
Core: Own our own network buffers

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -3,6 +3,7 @@
 # add_subdirectory(zmq) # Handled globally
 # add_subdirectory(openssl) # Handled globally
 add_subdirectory(concurrentqueue)
+add_subdirectory(SPSCQueue)
 add_subdirectory(sol)
 
 # CPM Modules
@@ -311,6 +312,7 @@ set(SHARED_EXTERNAL_LIBS
     fmt::fmt
     spdlog
     concurrentqueue
+    spscqueue
     mariadbclient
     sol2_single
     argparse

--- a/ext/SPSCQueue/CMakeLists.txt
+++ b/ext/SPSCQueue/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(spscqueue INTERFACE)
+target_sources(spscqueue INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/rigtorp/SPSCQueue.h)
+target_include_directories(spscqueue SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include/)

--- a/ext/SPSCQueue/include/rigtorp/SPSCQueue.h
+++ b/ext/SPSCQueue/include/rigtorp/SPSCQueue.h
@@ -1,0 +1,237 @@
+/*
+Copyright (c) 2020 Erik Rigtorp <erik@rigtorp.se>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <memory> // std::allocator
+#include <new>    // std::hardware_destructive_interference_size
+#include <stdexcept>
+#include <type_traits> // std::enable_if, std::is_*_constructible
+
+#ifdef __has_cpp_attribute
+#if __has_cpp_attribute(nodiscard)
+#define RIGTORP_NODISCARD [[nodiscard]]
+#endif
+#endif
+#ifndef RIGTORP_NODISCARD
+#define RIGTORP_NODISCARD
+#endif
+
+namespace rigtorp {
+
+template <typename T, typename Allocator = std::allocator<T>> class SPSCQueue {
+
+#if defined(__cpp_if_constexpr) && defined(__cpp_lib_void_t)
+  template <typename Alloc2, typename = void>
+  struct has_allocate_at_least : std::false_type {};
+
+  template <typename Alloc2>
+  struct has_allocate_at_least<
+      Alloc2, std::void_t<typename Alloc2::value_type,
+                          decltype(std::declval<Alloc2 &>().allocate_at_least(
+                              size_t{}))>> : std::true_type {};
+#endif
+
+public:
+  explicit SPSCQueue(const size_t capacity,
+                     const Allocator &allocator = Allocator())
+      : capacity_(capacity), allocator_(allocator) {
+    // The queue needs at least one element
+    if (capacity_ < 1) {
+      capacity_ = 1;
+    }
+    capacity_++; // Needs one slack element
+    // Prevent overflowing size_t
+    if (capacity_ > SIZE_MAX - 2 * kPadding) {
+      capacity_ = SIZE_MAX - 2 * kPadding;
+    }
+
+#if defined(__cpp_if_constexpr) && defined(__cpp_lib_void_t)
+    if constexpr (has_allocate_at_least<Allocator>::value) {
+      auto res = allocator_.allocate_at_least(capacity_ + 2 * kPadding);
+      slots_ = res.ptr;
+      capacity_ = res.count - 2 * kPadding;
+    } else {
+      slots_ = std::allocator_traits<Allocator>::allocate(
+          allocator_, capacity_ + 2 * kPadding);
+    }
+#else
+    slots_ = std::allocator_traits<Allocator>::allocate(
+        allocator_, capacity_ + 2 * kPadding);
+#endif
+
+    static_assert(alignof(SPSCQueue<T>) == kCacheLineSize, "");
+    static_assert(sizeof(SPSCQueue<T>) >= 3 * kCacheLineSize, "");
+    assert(reinterpret_cast<char *>(&readIdx_) -
+               reinterpret_cast<char *>(&writeIdx_) >=
+           static_cast<std::ptrdiff_t>(kCacheLineSize));
+  }
+
+  ~SPSCQueue() {
+    while (front()) {
+      pop();
+    }
+    std::allocator_traits<Allocator>::deallocate(allocator_, slots_,
+                                                 capacity_ + 2 * kPadding);
+  }
+
+  // non-copyable and non-movable
+  SPSCQueue(const SPSCQueue &) = delete;
+  SPSCQueue &operator=(const SPSCQueue &) = delete;
+
+  template <typename... Args>
+  void emplace(Args &&...args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const writeIdx = writeIdx_.load(std::memory_order_relaxed);
+    auto nextWriteIdx = writeIdx + 1;
+    if (nextWriteIdx == capacity_) {
+      nextWriteIdx = 0;
+    }
+    while (nextWriteIdx == readIdxCache_) {
+      readIdxCache_ = readIdx_.load(std::memory_order_acquire);
+    }
+    new (&slots_[writeIdx + kPadding]) T(std::forward<Args>(args)...);
+    writeIdx_.store(nextWriteIdx, std::memory_order_release);
+  }
+
+  template <typename... Args>
+  RIGTORP_NODISCARD bool try_emplace(Args &&...args) noexcept(
+      std::is_nothrow_constructible<T, Args &&...>::value) {
+    static_assert(std::is_constructible<T, Args &&...>::value,
+                  "T must be constructible with Args&&...");
+    auto const writeIdx = writeIdx_.load(std::memory_order_relaxed);
+    auto nextWriteIdx = writeIdx + 1;
+    if (nextWriteIdx == capacity_) {
+      nextWriteIdx = 0;
+    }
+    if (nextWriteIdx == readIdxCache_) {
+      readIdxCache_ = readIdx_.load(std::memory_order_acquire);
+      if (nextWriteIdx == readIdxCache_) {
+        return false;
+      }
+    }
+    new (&slots_[writeIdx + kPadding]) T(std::forward<Args>(args)...);
+    writeIdx_.store(nextWriteIdx, std::memory_order_release);
+    return true;
+  }
+
+  void push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  void push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    emplace(std::forward<P>(v));
+  }
+
+  RIGTORP_NODISCARD bool
+  try_push(const T &v) noexcept(std::is_nothrow_copy_constructible<T>::value) {
+    static_assert(std::is_copy_constructible<T>::value,
+                  "T must be copy constructible");
+    return try_emplace(v);
+  }
+
+  template <typename P, typename = typename std::enable_if<
+                            std::is_constructible<T, P &&>::value>::type>
+  RIGTORP_NODISCARD bool
+  try_push(P &&v) noexcept(std::is_nothrow_constructible<T, P &&>::value) {
+    return try_emplace(std::forward<P>(v));
+  }
+
+  RIGTORP_NODISCARD T *front() noexcept {
+    auto const readIdx = readIdx_.load(std::memory_order_relaxed);
+    if (readIdx == writeIdxCache_) {
+      writeIdxCache_ = writeIdx_.load(std::memory_order_acquire);
+      if (writeIdxCache_ == readIdx) {
+        return nullptr;
+      }
+    }
+    return &slots_[readIdx + kPadding];
+  }
+
+  void pop() noexcept {
+    static_assert(std::is_nothrow_destructible<T>::value,
+                  "T must be nothrow destructible");
+    auto const readIdx = readIdx_.load(std::memory_order_relaxed);
+    assert(writeIdx_.load(std::memory_order_acquire) != readIdx &&
+           "Can only call pop() after front() has returned a non-nullptr");
+    slots_[readIdx + kPadding].~T();
+    auto nextReadIdx = readIdx + 1;
+    if (nextReadIdx == capacity_) {
+      nextReadIdx = 0;
+    }
+    readIdx_.store(nextReadIdx, std::memory_order_release);
+  }
+
+  RIGTORP_NODISCARD size_t size() const noexcept {
+    std::ptrdiff_t diff = writeIdx_.load(std::memory_order_acquire) -
+                          readIdx_.load(std::memory_order_acquire);
+    if (diff < 0) {
+      diff += capacity_;
+    }
+    return static_cast<size_t>(diff);
+  }
+
+  RIGTORP_NODISCARD bool empty() const noexcept {
+    return writeIdx_.load(std::memory_order_acquire) ==
+           readIdx_.load(std::memory_order_acquire);
+  }
+
+  RIGTORP_NODISCARD size_t capacity() const noexcept { return capacity_ - 1; }
+
+private:
+#ifdef __cpp_lib_hardware_interference_size
+  static constexpr size_t kCacheLineSize =
+      std::hardware_destructive_interference_size;
+#else
+  static constexpr size_t kCacheLineSize = 64;
+#endif
+
+  // Padding to avoid false sharing between slots_ and adjacent allocations
+  static constexpr size_t kPadding = (kCacheLineSize - 1) / sizeof(T) + 1;
+
+private:
+  size_t capacity_;
+  T *slots_;
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(no_unique_address)
+  Allocator allocator_ [[no_unique_address]];
+#else
+  Allocator allocator_;
+#endif
+
+  // Align to cache line size in order to avoid false sharing
+  // readIdxCache_ and writeIdxCache_ is used to reduce the amount of cache
+  // coherency traffic
+  alignas(kCacheLineSize) std::atomic<size_t> writeIdx_ = {0};
+  alignas(kCacheLineSize) size_t readIdxCache_ = 0;
+  alignas(kCacheLineSize) std::atomic<size_t> readIdx_ = {0};
+  alignas(kCacheLineSize) size_t writeIdxCache_ = 0;
+};
+} // namespace rigtorp

--- a/src/common/types/box.h
+++ b/src/common/types/box.h
@@ -1,7 +1,7 @@
 /*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,30 +21,22 @@
 
 #pragma once
 
-#include <common/cbasetypes.h>
-#include <common/ipp.h>
-#include <common/types/box.h>
+#include <memory>
+#include <utility>
 
-#include <map/socket.h>
+// namespace xi
+// {
 
-class Scheduler;
-class MapStatistics;
+//
+// Box<T>
+//
+template <typename T>
+using Box = std::unique_ptr<T>;
 
-// MapSocket owns a dedicated networking thread. That thread does nothing but drain the OS
-// receive buffer as fast as the kernel will hand us datagrams (pushing them into a lockless
-// ingress ring) and drain our egress ring back out to the wire.
-class MapSocket final : public Socket
+template <typename T, typename... Args>
+auto makeBox(Args&&... args) -> Box<T>
 {
-public:
-    MapSocket(Scheduler& scheduler, MapStatistics& mapStatistics, uint16 port, ReceiveFn onReceiveFn);
-    ~MapSocket() override;
+    return std::make_unique<T>(std::forward<Args>(args)...);
+}
 
-    DISALLOW_COPY_AND_MOVE(MapSocket);
-
-    void send(const IPP& ipp, ByteSpan buffer) override;
-    void flushDiagnostics() override;
-
-private:
-    struct Impl;
-    Box<Impl> impl_;
-};
+// } // namespace xi

--- a/src/common/xi.h
+++ b/src/common/xi.h
@@ -31,14 +31,15 @@
 #include <utility>
 #include <vector>
 
-#include "earth_time.h"
-#include "tracy.h"
-#include "vanadiel_clock.h"
+#include <common/earth_time.h>
+#include <common/tracy.h>
+#include <common/vanadiel_clock.h>
 
-#include "types/flag.h"
-#include "types/fn.h"
-#include "types/maybe.h"
-#include "types/variant.h"
+#include <common/types/box.h>
+#include <common/types/flag.h>
+#include <common/types/fn.h>
+#include <common/types/maybe.h>
+#include <common/types/variant.h>
 
 namespace xi
 {

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -754,14 +754,14 @@ void MapNetworking::flushStatistics()
 
     mapStatistics_.set(MapStatistics::Key::DynamicTargIdUsagePercent, static_cast<int64>(percent));
 
-    // This also zeroes out all the stats
-    mapStatistics_.flush();
-
     // Null on test servers, which don't open a socket
     if (socket_)
     {
         socket_->flushDiagnostics();
     }
+
+    // This also zeroes out all the stats
+    mapStatistics_.flush();
 }
 
 auto MapNetworking::ipp() const -> IPP

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -279,7 +279,11 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
 
             std::ignore = langID;
 
-            auto rset = db::preparedStmt("SELECT accid FROM chars WHERE charid = ? LIMIT 1", packetCharID);
+            auto rset = db::preparedStmt("SELECT c.accid, s.session_key "
+                                         "FROM chars c "
+                                         "LEFT JOIN accounts_sessions s ON s.charid = c.charid "
+                                         "WHERE c.charid = ? LIMIT 1",
+                                         packetCharID);
             if (!rset || rset->rowsCount() == 0 || !rset->next())
             {
                 ShowError("recv_parse: Cannot load char %u (no such charid)", packetCharID);
@@ -288,8 +292,7 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
 
             accountID = rset->get<uint32>("accid");
 
-            rset = db::preparedStmt("SELECT session_key FROM accounts_sessions WHERE charid = ? LIMIT 1", packetCharID);
-            if (rset && rset->rowsCount() && rset->next())
+            if (!rset->isNull("session_key"))
             {
                 db::extractFromBlob(rset, "session_key", PSession->blowfish.key);
                 PSession->initBlowfish();

--- a/src/map/map_socket.cpp
+++ b/src/map/map_socket.cpp
@@ -62,6 +62,7 @@ struct Datagram
     Datagram(const IPP& ipp, ByteSpan bytes)
     : ipp(ipp)
     , length(static_cast<uint16>(std::min<std::size_t>(bytes.size(), kMaxBufferSize)))
+    , data{}
     {
         std::memcpy(data.data(), bytes.data(), length);
     }
@@ -209,7 +210,7 @@ MapSocket::Impl::Impl(Scheduler& scheduler, MapStatistics& mapStatistics, const 
     armReceive();
 
     netThread_ = std::jthread(
-        [this](std::stop_token stopToken)
+        [this](const std::stop_token& stopToken)
         {
             TracySetThreadName("Map Network Thread");
             const auto stopOnRequest = std::stop_callback(

--- a/src/map/map_socket.cpp
+++ b/src/map/map_socket.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2025 LandSandBoat Dev Teams
@@ -22,136 +22,423 @@
 #include "map_socket.h"
 
 #include <common/logging.h>
+#include <common/scheduler.h>
+#include <common/tracy.h>
+#include <common/types/error_or.h>
 
-MapSocket::MapSocket(Scheduler& scheduler, MapStatistics& mapStatistics, const uint16 port, ReceiveFn onReceiveFn)
+#include <map/map_constants.h>
+#include <map/map_statistics.h>
+
+#include <asio/io_context.hpp>
+#include <asio/ip/udp.hpp>
+#include <asio/post.hpp>
+#include <asio/socket_base.hpp>
+#include <asio/ts/buffer.hpp>
+
+#include <rigtorp/SPSCQueue.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <mutex>
+#include <set>
+#include <stop_token>
+#include <system_error>
+#include <thread>
+
+namespace
+{
+
+constexpr auto kIngressRingCapacity = 4096uz;
+constexpr auto kEgressRingCapacity  = 4096uz;
+
+constexpr auto kSocketBufferBytes = 4 * 1024 * 1024;
+
+// A single datagram parked in a ring. Fixed-size so slots never allocate. Constructed
+// in-place in the ring slot via SPSCQueue::try_emplace, copying the payload exactly once.
+// TODO: Should we bother with a no-copy design at some point? It's such a small memcpy...
+struct Datagram
+{
+    Datagram(const IPP& ipp, ByteSpan bytes)
+    : ipp(ipp)
+    , length(static_cast<uint16>(std::min<std::size_t>(bytes.size(), kMaxBufferSize)))
+    {
+        std::memcpy(data.data(), bytes.data(), length);
+    }
+
+    IPP           ipp;
+    uint16        length;
+    NetworkBuffer data;
+};
+
+auto endpointToIPP(const asio::ip::udp::endpoint& endpoint) -> IPP
+{
+    // NOTE: ASIO returns the address in host byte order, but we store it in network byte
+    //     : order, so we convert it back.
+    const auto ip   = htonl(endpoint.address().to_v4().to_uint());
+    const auto port = endpoint.port();
+    return IPP(ip, port);
+}
+
+auto ippToEndpoint(const IPP& ipp) -> asio::ip::udp::endpoint
+{
+    // Inverse of endpointToIPP(): ASIO wants host byte order, we store network byte order.
+    const auto ip = ntohl(ipp.getIP());
+    return asio::ip::udp::endpoint(asio::ip::address_v4(ip), ipp.getPort());
+}
+
+} // namespace
+
+struct MapSocket::Impl
+{
+    using Key = MapStatistics::Key;
+
+    Impl(Scheduler& scheduler, MapStatistics& mapStatistics, uint16 port, Socket::ReceiveFn onReceiveFn);
+    ~Impl();
+
+    DISALLOW_COPY_AND_MOVE(Impl);
+
+    //
+    // Ingress: network thread -> main thread
+    //
+
+    void armReceive();
+    void scheduleMainDrain();
+    void drainIngress();
+
+    //
+    // Egress: main thread -> network thread
+    //
+
+    void send(const IPP& ipp, ByteSpan buffer);
+    void drainEgress();
+    auto sendOne(const Datagram& d) -> ErrorOr<std::size_t, std::error_code>;
+    void recordSendError(const std::error_code& ec);
+
+    //
+    // Diagnostics
+    //
+
+    void flushDiagnostics();
+
+    //
+    // Members
+    //
+
+    Scheduler&     scheduler_;
+    MapStatistics& mapStatistics_;
+    ReceiveFn      onReceiveFn_;
+    uint16         port_;
+
+    // The network thread owns this context and the socket bound to it. The main thread never
+    // touches the socket; it only posts onto netContext_ (thread-safe) to wake the drain.
+    asio::io_context        netContext_;
+    asio::ip::udp::socket   socket_;
+    asio::ip::udp::endpoint remoteEndpoint_; // network thread only
+
+    rigtorp::SPSCQueue<Datagram> ingress_; // net produces, main consumes
+    rigtorp::SPSCQueue<Datagram> egress_;  // main produces, net consumes
+
+    // Network thread only: ASIO receives into this, then the bytes are copied into an ingress slot.
+    // TODO: Could we be pooling and swapping ingress slot buffers out, so that each packet owns
+    //     : it's own buffer for the whole operation, then returns it to the pool?
+    NetworkBuffer recvBuffer_{};
+
+    //
+    // Stats
+    //
+
+    std::atomic<bool> ingressDrainScheduled_{ false };
+    std::atomic<bool> egressDrainScheduled_{ false };
+
+    std::atomic<int64> ingressDropped_{ 0 };
+    std::atomic<int64> recvErrors_{ 0 };
+    std::atomic<int64> egressDropped_{ 0 };
+    std::atomic<int64> egressBlocked_{ 0 };
+    std::atomic<int64> egressErrors_{ 0 };
+    std::atomic<int64> egressBytesSent_{ 0 };
+    std::atomic<int64> maxEgressDepth_{ 0 };
+
+    std::mutex                diagMutex_; // guards the reason sets (touched only on the error path)
+    std::set<std::error_code> blockedReasons_;
+    std::set<std::error_code> droppedReasons_;
+
+    // Declared last so it is destroyed first
+    std::jthread netThread_;
+};
+
+MapSocket::Impl::Impl(Scheduler& scheduler, MapStatistics& mapStatistics, const uint16 port, Socket::ReceiveFn onReceiveFn)
 : scheduler_(scheduler)
 , mapStatistics_(mapStatistics)
-, port_(port)
-, inFlightSends_(0)
-, sendsBlockedThisTick_(0)
-, sendsDroppedThisTick_(0)
-, socket_(scheduler_.mainContext())
-, buffer_{}
 , onReceiveFn_(std::move(onReceiveFn))
+, port_(port)
+, netContext_()
+, socket_(netContext_)
+, ingress_(kIngressRingCapacity)
+, egress_(kEgressRingCapacity)
 {
     TracyZoneScoped;
 
     ShowInfoFmt("MapSocket: Starting on port {}", port_);
 
-    asio::ip::udp::endpoint listen_endpoint(asio::ip::udp::v4(), port_);
-    socket_.open(listen_endpoint.protocol());
-    socket_.bind(listen_endpoint);
+    asio::ip::udp::endpoint listenEndpoint(asio::ip::udp::v4(), port_);
+    socket_.open(listenEndpoint.protocol());
+    socket_.bind(listenEndpoint);
 
-    receive(); // begin receiving loop
-}
+    std::error_code ec;
 
-MapSocket::~MapSocket()
-{
-    TracyZoneScoped;
-
-    if (socket_.is_open())
+    socket_.set_option(asio::socket_base::receive_buffer_size(kSocketBufferBytes), ec);
+    if (ec)
     {
-        socket_.close();
+        ShowWarningFmt("MapSocket: failed to set receive buffer to {} bytes: {}", kSocketBufferBytes, ec.message());
     }
-}
 
-void MapSocket::receive()
-{
-    TracyZoneScoped;
+    socket_.set_option(asio::socket_base::send_buffer_size(kSocketBufferBytes), ec);
+    if (ec)
+    {
+        ShowWarningFmt("MapSocket: failed to set send buffer to {} bytes: {}", kSocketBufferBytes, ec.message());
+    }
 
-    socket_.async_receive_from(
-        asio::buffer(buffer_), remoteEndpoint_, [this](const std::error_code& ec, std::size_t bytesRecvd)
+    socket_.non_blocking(true, ec);
+    if (ec)
+    {
+        ShowErrorFmt("MapSocket: failed to set socket non-blocking, usage will BLOCK: {}", ec.message());
+    }
+
+    // Prime the receive loop before the thread starts pumping
+    armReceive();
+
+    netThread_ = std::jthread(
+        [this](std::stop_token stopToken)
         {
-            // NOTE: ASIO returns the address in host byte order, but we store it in network byte order,
-            //     : so we convert it back.
-            const auto senderIP   = htonl(remoteEndpoint_.address().to_v4().to_uint());
-            const auto senderPort = remoteEndpoint_.port();
-            const auto ipp        = IPP(senderIP, senderPort);
-
-            const auto sizedBuffer = ByteSpan(buffer_.data(), bytesRecvd);
-
-            DebugPacketsFmt("Received {} bytes from {}", sizedBuffer.size(), ipp.toString());
-
-            if (ec)
-            {
-                ShowErrorFmt("Receive error from {}: {}", ipp.toString(), ec.message());
-            }
-            else if (sizedBuffer.empty())
-            {
-                ShowErrorFmt("Received empty buffer from {}", ipp.toString());
-            }
-            else // Everything is OK
-            {
-                onReceiveFn_(sizedBuffer, ipp);
-            }
-
-            if (!scheduler_.closeRequested() && socket_.is_open())
-            {
-                receive(); // Queue up more work
-            }
+            TracySetThreadName("Map Network Thread");
+            const auto stopOnRequest = std::stop_callback(
+                stopToken,
+                [this]()
+                {
+                    netContext_.stop();
+                });
+            netContext_.run();
         });
 }
 
-void MapSocket::send(const IPP& ipp, ByteSpan buffer)
+MapSocket::Impl::~Impl()
 {
     TracyZoneScoped;
 
-    DebugPacketsFmt("Sending {} bytes to {}", buffer.size(), ipp.toString());
+    netThread_.request_stop();
+    if (netThread_.joinable())
+    {
+        netThread_.join();
+    }
 
-    // Like with the ip from startReceive(), ASIO is expecting us to be handling it
-    // in host byte order, but we store it in network byte order. So, we need to convert it.
-    const auto ip       = ntohl(ipp.getIP());
-    const auto endpoint = asio::ip::udp::endpoint(asio::ip::address_v4(ip), ipp.getPort());
+    std::error_code ec;
+    socket_.close(ec);
+}
 
-    // Sends normally complete near-instantly. If the OS send path is backing up, completions
-    // arrive late (on POSIX, ASIO silently parks would-block sends until the socket is
-    // writable again) and the in-flight count climbs. Its per-tick high-water mark is the
-    // backpressure signal that send error codes alone can't show.
-    ++inFlightSends_;
-    mapStatistics_.set(MapStatistics::Key::MaxInFlightSendsPerTick,
-                       std::max(mapStatistics_.get(MapStatistics::Key::MaxInFlightSendsPerTick), inFlightSends_));
+//
+// Ingress: network thread -> main thread
+//
 
-    socket_.async_send_to(
-        asio::buffer(buffer),
-        endpoint,
-        [this](const std::error_code& ec, std::size_t bytesSent)
+void MapSocket::Impl::armReceive()
+{
+    socket_.async_receive_from(
+        asio::buffer(recvBuffer_), remoteEndpoint_, [this](const std::error_code& ec, std::size_t bytesRecvd)
         {
-            --inFlightSends_;
-
-            if (ec)
+            if (!ec && bytesRecvd > 0)
             {
-                // ENOBUFS/EWOULDBLOCK (WSAENOBUFS/WSAEWOULDBLOCK on Windows): the OS couldn't
-                // accept the datagram right now, i.e. the send path is backing up.
-                // Aggregated and logged once per tick in flushDiagnostics(), so a burst of
-                // failures can't flood the log while the server is already under pressure.
-                if (ec == asio::error::no_buffer_space ||
-                    ec == asio::error::would_block ||
-                    ec == asio::error::try_again)
+                if (ingress_.try_emplace(endpointToIPP(remoteEndpoint_), ByteSpan(recvBuffer_.data(), bytesRecvd)))
                 {
-                    mapStatistics_.increment(MapStatistics::Key::TotalSendsBlockedPerTick);
-                    ++sendsBlockedThisTick_;
-                    blockedReasons_.insert(ec);
+                    scheduleMainDrain();
                 }
                 else
                 {
-                    mapStatistics_.increment(MapStatistics::Key::TotalSendErrorsPerTick);
-                    ++sendsDroppedThisTick_;
-                    droppedReasons_.insert(ec);
+                    ingressDropped_.fetch_add(1, std::memory_order_relaxed);
                 }
             }
-            else
+            else if (ec && ec != asio::error::operation_aborted)
             {
-                mapStatistics_.increment(MapStatistics::Key::TotalBytesSentPerTick, static_cast<int64>(bytesSent));
+                recvErrors_.fetch_add(1, std::memory_order_relaxed);
+            }
+
+            // operation_aborted means the socket was closed during shutdown; stop re-arming.
+            if (socket_.is_open())
+            {
+                armReceive();
             }
         });
-
-    // This will only be called in the middle of a doSocketsFor() call, so we don't
-    // need to enqueue more work when we're done here.
 }
 
-void MapSocket::flushDiagnostics()
+void MapSocket::Impl::scheduleMainDrain()
+{
+    bool expected = false;
+    if (ingressDrainScheduled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    {
+        if (!scheduler_.closeRequested())
+        {
+            scheduler_.postToMainThread(
+                [this]()
+                {
+                    drainIngress();
+                });
+        }
+    }
+}
+
+void MapSocket::Impl::drainIngress()
 {
     TracyZoneScoped;
+
+    ingressDrainScheduled_.store(false, std::memory_order_release);
+
+    while (Datagram* d = ingress_.front())
+    {
+        // onReceiveFn_ copies out of the span synchronously, so pointing at the ring slot for
+        // the duration of the call is safe; pop() only frees it afterwards.
+        onReceiveFn_(ByteSpan(d->data.data(), d->length), d->ipp);
+        ingress_.pop();
+    }
+}
+
+//
+// Egress: main thread -> network thread
+//
+
+void MapSocket::Impl::send(const IPP& ipp, ByteSpan buffer)
+{
+    TracyZoneScoped;
+
+    // try_emplace constructs the datagram directly in the ring slot, copying the payload
+    // exactly once. Fails (no overwrite) when the main thread is outrunning the network
+    // thread's drain; drop (UDP) and count.
+    if (!egress_.try_emplace(ipp, buffer))
+    {
+        egressDropped_.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+
+    // Track high-water queue depth as the egress backpressure signal.
+    const auto depth = static_cast<int64>(egress_.size());
+    auto       prev  = maxEgressDepth_.load(std::memory_order_relaxed);
+    while (depth > prev && !maxEgressDepth_.compare_exchange_weak(prev, depth, std::memory_order_relaxed))
+    {
+    }
+
+    // Coalesced wake, same shape as the ingress side.
+    bool expected = false;
+    if (egressDrainScheduled_.compare_exchange_strong(expected, true, std::memory_order_acq_rel))
+    {
+        asio::post(
+            netContext_,
+            [this]()
+            {
+                drainEgress();
+            });
+    }
+}
+
+void MapSocket::Impl::drainEgress()
+{
+    TracyZoneScoped;
+
+    egressDrainScheduled_.store(false, std::memory_order_release);
+
+    while (Datagram* d = egress_.front())
+    {
+        if (const auto result = sendOne(*d); result)
+        {
+            egressBytesSent_.fetch_add(static_cast<int64>(*result), std::memory_order_relaxed);
+        }
+        else
+        {
+            recordSendError(result.error());
+        }
+        egress_.pop();
+    }
+}
+
+auto MapSocket::Impl::sendOne(const Datagram& d) -> ErrorOr<std::size_t, std::error_code>
+{
+    const auto endpoint = ippToEndpoint(d.ipp);
+
+    std::error_code ec;
+    const auto      bytesSent = socket_.send_to(asio::buffer(d.data.data(), d.length), endpoint, 0, ec);
+
+    if (ec)
+    {
+        return Error(ec);
+    }
+    return bytesSent;
+}
+
+void MapSocket::Impl::recordSendError(const std::error_code& ec)
+{
+    // ENOBUFS/EWOULDBLOCK (WSAENOBUFS/WSAEWOULDBLOCK on Windows): the OS couldn't accept the
+    // datagram right now, i.e. the send path is backing up. Everything else is a real error.
+    // Either way the datagram is dropped (UDP).
+    if (ec == asio::error::no_buffer_space ||
+        ec == asio::error::would_block ||
+        ec == asio::error::try_again)
+    {
+        egressBlocked_.fetch_add(1, std::memory_order_relaxed);
+        const std::lock_guard<std::mutex> lock(diagMutex_);
+        blockedReasons_.insert(ec);
+    }
+    else
+    {
+        egressErrors_.fetch_add(1, std::memory_order_relaxed);
+        const std::lock_guard<std::mutex> lock(diagMutex_);
+        droppedReasons_.insert(ec);
+    }
+}
+
+void MapSocket::Impl::flushDiagnostics()
+{
+    TracyZoneScoped;
+
+    const auto ingressDropped = ingressDropped_.exchange(0, std::memory_order_relaxed);
+    const auto recvErrors     = recvErrors_.exchange(0, std::memory_order_relaxed);
+    const auto egressDropped  = egressDropped_.exchange(0, std::memory_order_relaxed);
+    const auto egressBlocked  = egressBlocked_.exchange(0, std::memory_order_relaxed);
+    const auto egressErrors   = egressErrors_.exchange(0, std::memory_order_relaxed);
+    const auto egressBytes    = egressBytesSent_.exchange(0, std::memory_order_relaxed);
+    const auto maxDepth       = maxEgressDepth_.exchange(0, std::memory_order_relaxed);
+
+    std::set<std::error_code> blocked;
+    std::set<std::error_code> dropped;
+    {
+        const std::lock_guard<std::mutex> lock(diagMutex_);
+        blocked.swap(blockedReasons_);
+        dropped.swap(droppedReasons_);
+    }
+
+    if (egressBytes > 0)
+    {
+        mapStatistics_.increment(Key::TotalBytesSentPerTick, egressBytes);
+    }
+
+    if (egressBlocked > 0)
+    {
+        mapStatistics_.increment(Key::TotalSendsBlockedPerTick, egressBlocked);
+    }
+
+    if (egressErrors > 0)
+    {
+        mapStatistics_.increment(Key::TotalSendErrorsPerTick, egressErrors);
+    }
+
+    if (ingressDropped > 0)
+    {
+        mapStatistics_.increment(Key::IngressPacketsDroppedPerTick, ingressDropped);
+    }
+
+    if (egressDropped > 0)
+    {
+        mapStatistics_.increment(Key::EgressPacketsDroppedPerTick, egressDropped);
+    }
+
+    mapStatistics_.set(Key::MaxInFlightSendsPerTick,
+                       std::max(mapStatistics_.get(Key::MaxInFlightSendsPerTick), maxDepth));
 
     const auto reasonsToString = [](const std::set<std::error_code>& reasons)
     {
@@ -163,22 +450,49 @@ void MapSocket::flushDiagnostics()
         return out;
     };
 
-    if (sendsBlockedThisTick_ > 0)
+    if (egressBlocked > 0)
     {
         ShowWarningFmt("{} sends pushed back by the OS this tick (send path backing up, datagrams dropped). Reasons: {}",
-                       sendsBlockedThisTick_,
-                       reasonsToString(blockedReasons_));
+                       egressBlocked,
+                       reasonsToString(blocked));
     }
 
-    if (sendsDroppedThisTick_ > 0)
+    if (egressErrors > 0)
     {
         ShowErrorFmt("{} sends failed this tick (datagrams dropped). Reasons: {}",
-                     sendsDroppedThisTick_,
-                     reasonsToString(droppedReasons_));
+                     egressErrors,
+                     reasonsToString(dropped));
     }
 
-    sendsBlockedThisTick_ = 0;
-    sendsDroppedThisTick_ = 0;
-    blockedReasons_.clear();
-    droppedReasons_.clear();
+    if (egressDropped > 0)
+    {
+        ShowWarningFmt("{} outgoing datagrams dropped this tick (egress queue full, main thread outrunning the network thread)", egressDropped);
+    }
+
+    if (ingressDropped > 0)
+    {
+        ShowWarningFmt("{} incoming datagrams dropped this tick (ingress queue full, main thread not draining fast enough)", ingressDropped);
+    }
+
+    if (recvErrors > 0)
+    {
+        ShowErrorFmt("{} receive errors this tick", recvErrors);
+    }
+}
+
+MapSocket::MapSocket(Scheduler& scheduler, MapStatistics& mapStatistics, const uint16 port, ReceiveFn onReceiveFn)
+: impl_(std::make_unique<Impl>(scheduler, mapStatistics, port, std::move(onReceiveFn)))
+{
+}
+
+MapSocket::~MapSocket() = default;
+
+void MapSocket::send(const IPP& ipp, ByteSpan buffer)
+{
+    impl_->send(ipp, buffer);
+}
+
+void MapSocket::flushDiagnostics()
+{
+    impl_->flushDiagnostics();
 }

--- a/src/map/map_socket.cpp
+++ b/src/map/map_socket.cpp
@@ -481,7 +481,7 @@ void MapSocket::Impl::flushDiagnostics()
 }
 
 MapSocket::MapSocket(Scheduler& scheduler, MapStatistics& mapStatistics, const uint16 port, ReceiveFn onReceiveFn)
-: impl_(std::make_unique<Impl>(scheduler, mapStatistics, port, std::move(onReceiveFn)))
+: impl_(makeBox<Impl>(scheduler, mapStatistics, port, std::move(onReceiveFn)))
 {
 }
 

--- a/src/map/map_socket.h
+++ b/src/map/map_socket.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2025 LandSandBoat Dev Teams
@@ -21,46 +21,31 @@
 
 #pragma once
 
-#include <common/blowfish.h>
 #include <common/cbasetypes.h>
 #include <common/ipp.h>
-#include <common/scheduler.h>
 
-#include <map/map_constants.h>
-#include <map/map_statistics.h>
 #include <map/socket.h>
 
-#include <asio/ip/network_v4.hpp>
-#include <asio/ip/udp.hpp>
-#include <asio/ts/buffer.hpp>
-#include <asio/ts/internet.hpp>
+#include <memory>
 
-#include <set>
-#include <system_error>
+class Scheduler;
+class MapStatistics;
 
+// MapSocket owns a dedicated networking thread. That thread does nothing but drain the OS
+// receive buffer as fast as the kernel will hand us datagrams (pushing them into a lockless
+// ingress ring) and drain our egress ring back out to the wire.
 class MapSocket final : public Socket
 {
 public:
     MapSocket(Scheduler& scheduler, MapStatistics& mapStatistics, uint16 port, ReceiveFn onReceiveFn);
     ~MapSocket() override;
 
+    DISALLOW_COPY_AND_MOVE(MapSocket);
+
     void send(const IPP& ipp, ByteSpan buffer) override;
     void flushDiagnostics() override;
 
 private:
-    void receive();
-
-    Scheduler&                scheduler_;
-    MapStatistics&            mapStatistics_;
-    uint16                    port_;
-    int64                     inFlightSends_;
-    int64                     sendsBlockedThisTick_;
-    int64                     sendsDroppedThisTick_;
-    std::set<std::error_code> blockedReasons_;
-    std::set<std::error_code> droppedReasons_;
-    asio::ip::udp::socket     socket_;
-    NetworkBuffer             buffer_; // TODO: Pass in the global buffer, or only use this one
-    asio::ip::udp::endpoint   remoteEndpoint_;
-
-    ReceiveFn onReceiveFn_;
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
 };

--- a/src/map/map_statistics.cpp
+++ b/src/map/map_statistics.cpp
@@ -48,8 +48,12 @@ auto MapStatistics::toString(Key key)
             return "Total Sends Blocked Per Tick (OS backpressure)";
         case Key::TotalSendErrorsPerTick:
             return "Total Send Errors Per Tick";
+        case Key::IngressPacketsDroppedPerTick:
+            return "Ingress Packets Dropped Per Tick (recv queue full)";
+        case Key::EgressPacketsDroppedPerTick:
+            return "Egress Packets Dropped Per Tick (send queue full)";
         case Key::MaxInFlightSendsPerTick:
-            return "Max In-Flight Sends Per Tick";
+            return "Max In-Flight Sends Per Tick (egress queue depth)";
         case Key::TasksTickTime:
             return "Tasks Tick Time (ms)";
         case Key::NetworkTickTime:

--- a/src/map/map_statistics.h
+++ b/src/map/map_statistics.h
@@ -36,6 +36,8 @@ public:
         TotalBytesSentPerTick,
         TotalSendsBlockedPerTick,
         TotalSendErrorsPerTick,
+        IngressPacketsDroppedPerTick,
+        EgressPacketsDroppedPerTick,
         MaxInFlightSendsPerTick,
         TasksTickTime,
         NetworkTickTime,

--- a/src/map/socket.h
+++ b/src/map/socket.h
@@ -23,14 +23,13 @@
 
 #include <common/cbasetypes.h>
 #include <common/ipp.h>
-
-#include <functional>
+#include <common/types/fn.h>
 
 class Socket
 {
 public:
     // Called when bytes are received from a client, with the sender's address.
-    using ReceiveFn = std::function<void(ByteSpan, const IPP&)>;
+    using ReceiveFn = Fn<void(ByteSpan, const IPP&)>;
 
     virtual ~Socket() = default;
 

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -8,6 +8,8 @@ import fileinput
 import shutil
 import importlib
 import pathlib
+import socket
+import urllib.request
 
 import platform
 
@@ -839,18 +841,62 @@ def set_external_ip(ip_str):
     _ = db_query(query)
 
 
-def set_external_ip_dialog():
-    import urllib.request
+def find_local_network_ip():
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # No packets are actually sent; this just picks the interface the
+        # kernel would use to reach an external host.
+        s.connect(("8.8.8.8", 80))
+        return s.getsockname()[0]
+    finally:
+        s.close()
 
-    if input("Make server public-facing? [y/N] ").lower() == "y":
-        external_ip = urllib.request.urlopen("https://ident.me").read().decode("utf8")
-        print_green(f"Detected your public-facing IP as: {external_ip}")
-        if input("Is this correct? [y/N] ").lower() == "y":
-            set_external_ip(external_ip)
-        else:
-            external_ip = input("Please enter your public-facing IP: ")
-            if len(external_ip.strip()) > 0:
-                set_external_ip(external_ip)
+
+def find_public_ip():
+    return urllib.request.urlopen("https://ident.me").read().decode("utf8")
+
+
+def set_local_only_ip():
+    set_external_ip("127.0.0.1")
+
+
+def set_local_network_ip():
+    try:
+        detected_ip = find_local_network_ip()
+    except Exception as e:
+        print_red(f"Could not detect local network IP: {e}")
+        return
+    print_green(f"Detected your local network IP as: {detected_ip}")
+    set_external_ip(detected_ip)
+
+
+def set_public_ip():
+    try:
+        detected_ip = find_public_ip()
+    except Exception as e:
+        print_red(f"Could not detect public IP: {e}")
+        return
+    print_green(f"Detected your public-facing IP as: {detected_ip}")
+    set_external_ip(detected_ip)
+
+
+def set_manual_ip():
+    external_ip = input("Please enter the zone IP: ")
+    if len(external_ip.strip()) > 0:
+        set_external_ip(external_ip.strip())
+
+
+def set_external_ip_dialog():
+    present_menu(
+        "Set Zone IP Addresses",
+        {
+            "1": ["Local only (127.0.0.1)", set_local_only_ip],
+            "2": ["Local network (auto-detect LAN IP)", set_local_network_ip],
+            "3": ["Public IP (via ident.me)", set_public_ip],
+            "m": ["Manual entry", set_manual_ip],
+            "q": ["Quit to tasks menu", NOOP],
+        },
+    )
 
 
 def print_db_tables_by_size():


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

All the meat of this is in map_socket: Instead of the very nebulous and OS-defined network buffers getting blown out under heavy load and us just... having to deal with it, we'll drain the OS socket ingress buffer into our own comparitively HUGE buffer as fast as possible on a dedicated thread, and drain it internally at our regular cadence.

This gives us opportunities to properly report if things are starting to go south, and not require the operator to tune (to their peril!) their OS network buffer sizes, etc.

This DOES NOT YET include things like tighter buffer lifecycle management. We're memcpying payloads around. At this scale, not a big deal, calm down.