### PR TITLE
[Fix] Laughing Bison animation for the sign

### DIFF
--- a/scripts/zones/Mhaura/Zone.lua
+++ b/scripts/zones/Mhaura/Zone.lua
@@ -7,19 +7,22 @@ local ID = zones[xi.zone.MHAURA]
 local zoneObject = {}
 
 zoneObject.onGameHour = function(zone)
+    -- Script for Laughing Bison sign flip animations.
     local laughingBison = GetNPCByID(ID.npc.LAUGHING_BISON)
     if laughingBison then
-        -- Script for Laughing Bison sign flip animations
-        local timer = 1152 - (GetSystemTime() - 1009810802) % 1152
+        local departureTime = VanadielHour() % 8
 
-        -- Next ferry is Al Zhabi for higher values.
-        if timer >= 576 then
+        -- Next ferry is Al Zhabi.
+        if departureTime == 0 then
             laughingBison:setAnimationSub(1)
-        else
+
+        -- Next ferry is Selbina.
+        elseif departureTime == 4 then
             laughingBison:setAnimationSub(0)
         end
     end
 
+    -- Pirate logic.
     local destinationId = math.randomInt(1, 100) <= 10 and xi.zone.SHIP_BOUND_FOR_SELBINA_PIRATES or xi.zone.SHIP_BOUND_FOR_SELBINA
     zone:setLocalVar('[Pirate]Zone', destinationId)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This change should make Laughing Bison's sign flip at the proper time and with the proper destination.

## Steps to test these changes

Go to Mhaura. Wait in front of Laughing Bison and watch the sign flip when the boat departs.