### PR TITLE
[lua][module] Corrects module load error if no expansions disabled

### DIFF
--- a/modules/era/lua/zones/Aht_Urhgan_Whitegate/npcs/aht_urhgan_whitegate_vendors.lua
+++ b/modules/era/lua/zones/Aht_Urhgan_Whitegate/npcs/aht_urhgan_whitegate_vendors.lua
@@ -73,4 +73,8 @@ if not xi.module.isContentEnabled('SOA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Al_Zahbi/npcs/al_zahbi_vendors.lua
+++ b/modules/era/lua/zones/Al_Zahbi/npcs/al_zahbi_vendors.lua
@@ -58,4 +58,8 @@ if not xi.module.isContentEnabled('WOTG') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Bastok_Markets/npcs/bastok_markets_vendors.lua
+++ b/modules/era/lua/zones/Bastok_Markets/npcs/bastok_markets_vendors.lua
@@ -179,4 +179,8 @@ if not xi.module.isContentEnabled('WOTG') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Bastok_Mines/npcs/bastok_mines_vendors.lua
+++ b/modules/era/lua/zones/Bastok_Mines/npcs/bastok_mines_vendors.lua
@@ -70,4 +70,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Kazham/npcs/kazham_vendors.lua
+++ b/modules/era/lua/zones/Kazham/npcs/kazham_vendors.lua
@@ -55,4 +55,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Lower_Jeuno/npcs/lower_jeuno_vendors.lua
+++ b/modules/era/lua/zones/Lower_Jeuno/npcs/lower_jeuno_vendors.lua
@@ -160,4 +160,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Mhaura/npcs/Pikini-Mikini.lua
+++ b/modules/era/lua/zones/Mhaura/npcs/Pikini-Mikini.lua
@@ -29,4 +29,8 @@ if not xi.module.isContentEnabled('SOA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Nashmau/npcs/nashmau_vendors.lua
+++ b/modules/era/lua/zones/Nashmau/npcs/nashmau_vendors.lua
@@ -94,4 +94,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Northern_San_dOria/npcs/northern_san_doria_vendors.lua
+++ b/modules/era/lua/zones/Northern_San_dOria/npcs/northern_san_doria_vendors.lua
@@ -75,4 +75,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Port_Windurst/npcs/port_windurst_vendors.lua
+++ b/modules/era/lua/zones/Port_Windurst/npcs/port_windurst_vendors.lua
@@ -106,4 +106,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Rabao/npcs/rabao_vendors.lua
+++ b/modules/era/lua/zones/Rabao/npcs/rabao_vendors.lua
@@ -55,4 +55,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Selbina/npcs/Dohdjuma.lua
+++ b/modules/era/lua/zones/Selbina/npcs/Dohdjuma.lua
@@ -27,4 +27,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Southern_San_dOria/npcs/southern_san_doria_vendors.lua
+++ b/modules/era/lua/zones/Southern_San_dOria/npcs/southern_san_doria_vendors.lua
@@ -103,4 +103,8 @@ if not xi.module.isContentEnabled('WOTG') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Tavnazian_Safehold/npcs/tavnazian_safehold_vendors.lua
+++ b/modules/era/lua/zones/Tavnazian_Safehold/npcs/tavnazian_safehold_vendors.lua
@@ -62,4 +62,8 @@ if not xi.module.isContentEnabled('SOA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Upper_Jeuno/npcs/upper_jeuno_vendors.lua
+++ b/modules/era/lua/zones/Upper_Jeuno/npcs/upper_jeuno_vendors.lua
@@ -72,4 +72,8 @@ if not xi.module.isContentEnabled('ROV') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m

--- a/modules/era/lua/zones/Windurst_Woods/npcs/windurst_woods_vendors.lua
+++ b/modules/era/lua/zones/Windurst_Woods/npcs/windurst_woods_vendors.lua
@@ -41,4 +41,8 @@ if not xi.module.isContentEnabled('ABYSSEA') then
     end)
 end
 
+if #m.overrides == 0 then
+    return { name = moduleName }
+end
+
 return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Corrects errors appearing from loading modules if no expansions are disabled.

## Steps to test these changes

- Load `era/` in `init.txt`
- Do not restrict content in main.lua
- Load map server and see no errors