### PR TITLE
Core: Add speedup options for Windows

### DIFF
--- a/cmake/StandardProjectSettings.cmake
+++ b/cmake/StandardProjectSettings.cmake
@@ -78,7 +78,7 @@ if(MSVC)
         )
     endif()
 
-    link_libraries(WS2_32 dbghelp Shlwapi)
+    link_libraries(WS2_32 dbghelp Shlwapi winmm)
 endif()
 
 if(UNIX)

--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -31,6 +31,9 @@
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+
+#include <timeapi.h>
+#pragma comment(lib, "winmm.lib")
 #else // UNIX
 #include <sys/resource.h>
 #include <sys/time.h>
@@ -43,7 +46,10 @@ namespace
 {
 
 #ifdef _WIN32
+constexpr unsigned int kTimerResolutionMs = 1;
+
 unsigned long prevQuickEditMode;
+bool          timerResolutionRaised = false;
 #endif // _WIN32
 
 } // namespace
@@ -61,6 +67,8 @@ Application::Application(const ApplicationConfig& appConfig, int argc, char** ar
     tryDisableQuickEditMode();
     usercheck();
     tryIncreaseRLimits();
+    tryRaiseTimerResolution();
+    tryPreventBackgroundThrottling();
 
     debug::init();
 
@@ -85,6 +93,7 @@ Application::Application(const ApplicationConfig& appConfig, int argc, char** ar
 
 Application::~Application()
 {
+    tryRestoreTimerResolution();
     tryRestoreQuickEditMode();
     logging::ShutDown();
 }
@@ -173,6 +182,54 @@ void Application::tryIncreaseRLimits()
         }
     }
 #endif
+}
+
+void Application::tryRaiseTimerResolution()
+{
+#ifdef _WIN32
+    // Windows' default system timer resolution is ~15.6ms, which coarsely quantises every
+    // sleep and timed wait we make. Ask the OS for the finest resolution (1ms) so our
+    // scheduler ticks and network timing behave predictably.
+    // See: https://devblogs.microsoft.com/go/high-resolution-timers-windows/
+    if (timeBeginPeriod(kTimerResolutionMs) != TIMERR_NOERROR)
+    {
+        std::cerr << fmt::format("Failed to raise the system timer resolution to {}ms; timing may be coarse\n", kTimerResolutionMs);
+        return;
+    }
+
+    timerResolutionRaised = true;
+#endif // _WIN32
+}
+
+void Application::tryRestoreTimerResolution()
+{
+#ifdef _WIN32
+    // Balance timeBeginPeriod with a matching timeEndPeriod on the way out, but only if we
+    // actually raised the resolution.
+    if (timerResolutionRaised)
+    {
+        timeEndPeriod(kTimerResolutionMs);
+        timerResolutionRaised = false;
+    }
+#endif // _WIN32
+}
+
+void Application::tryPreventBackgroundThrottling() const
+{
+#ifdef _WIN32
+    // Since Windows 10, processes that aren't in the foreground can be throttled (EcoQoS),
+    // deprioritising their execution speed even when we've asked for high-resolution timers.
+    // Opt out so the server keeps running at full speed while backgrounded.
+    PROCESS_POWER_THROTTLING_STATE powerThrottling{};
+    powerThrottling.Version     = PROCESS_POWER_THROTTLING_CURRENT_VERSION;
+    powerThrottling.ControlMask = PROCESS_POWER_THROTTLING_EXECUTION_SPEED;
+    powerThrottling.StateMask   = 0; // 0 == throttling disabled for the masked controls
+
+    if (!SetProcessInformation(GetCurrentProcess(), ProcessPowerThrottling, &powerThrottling, sizeof(powerThrottling)))
+    {
+        std::cerr << fmt::format("Failed to opt out of background execution-speed throttling (error {})\n", GetLastError());
+    }
+#endif // _WIN32
 }
 
 void Application::tryDisableQuickEditMode() const

--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -33,7 +33,6 @@
 #include <windows.h>
 
 #include <timeapi.h>
-#pragma comment(lib, "winmm.lib")
 #else // UNIX
 #include <sys/resource.h>
 #include <sys/time.h>

--- a/src/common/application.h
+++ b/src/common/application.h
@@ -69,6 +69,9 @@ public:
     void handleSignal(const std::error_code& error, int signal);
     void usercheck() const;
     void tryIncreaseRLimits();
+    void tryRaiseTimerResolution();
+    void tryRestoreTimerResolution();
+    void tryPreventBackgroundThrottling() const;
     void tryDisableQuickEditMode() const;
     void tryRestoreQuickEditMode() const;
     void prepareLogging();

--- a/tools/dbtool.py
+++ b/tools/dbtool.py
@@ -1372,6 +1372,53 @@ def validate_yaml_data():
         print_red("YAML validation failed.")
 
 
+def add_windows_defender_exclusions():
+    if platform.system() != "Windows":
+        print_red("Windows Defender exclusions are only applicable on Windows.")
+        return
+
+    # Excluding the whole server directory stops Defender from scanning the thousands of
+    # Lua/data files that are opened during start-up, and excluding the map process stops it
+    # scanning on every file access the process makes. On Windows this is the single biggest
+    # contributor to slow start-up (each CreateFile otherwise triggers a synchronous AV scan).
+    exclusion_path = server_dir_path
+    exclusion_process = f"xi_map{exe}"
+
+    print_red(
+        "This will add Windows Defender exclusions so it stops scanning the server's\n"
+        "files and the map process. This can dramatically reduce server start-up time.\n"
+    )
+    print("The following will be run (requires an Administrator terminal):\n")
+    print(f'  Add-MpPreference -ExclusionPath "{exclusion_path}"')
+    print(f'  Add-MpPreference -ExclusionProcess "{exclusion_process}"\n')
+
+    if input('Type "yes" to continue.\n> ').strip().lower() != "yes":
+        print_red("Aborted.")
+        return
+
+    command = (
+        f'Add-MpPreference -ExclusionPath "{exclusion_path}"; '
+        f'Add-MpPreference -ExclusionProcess "{exclusion_process}"'
+    )
+
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-Command", command],
+        capture_output=True,
+        text=True,
+    )
+
+    if result.returncode == 0:
+        print_green("Windows Defender exclusions added successfully.")
+    else:
+        print_red("Failed to add Windows Defender exclusions.")
+        print_red(
+            "This usually means dbtool is not running as Administrator.\n"
+            "You can launch Powershell as Administrator and paste in the following commands:\n"
+            f'    Add-MpPreference -ExclusionPath "{exclusion_path}"\n'
+            f'    Add-MpPreference -ExclusionProcess "{exclusion_process}"'
+        )
+
+
 def tasks_menu():
     present_menu(
         "Maintenance Tasks",
@@ -1399,6 +1446,7 @@ def tasks_menu():
             ],
             "d": ["Dump Table", dump_table],
             "a": ["Dump All Tables", dump_all_tables],
+            "w": ["Add Windows Defender exclusions (speeds up start-up)", add_windows_defender_exclusions],
             "q": ["Quit to main menu", NOOP],
         },
     )


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Two things:
- Fixes the issue described in this comment, making scheduling on Windows _garbage_:
```
    // Windows' default system timer resolution is ~15.6ms, which coarsely quantises every
    // sleep and timed wait we make. Ask the OS for the finest resolution (1ms) so our
    // scheduler ticks and network timing behave predictably.
    // See: https://devblogs.microsoft.com/go/high-resolution-timers-windows/
```
- Adds a dbtool task to make startup 10x faster on Windows. I shit you not. From 140s to 12s on my Windows laptop. This is probably parity with Linux now. (dbtool -> tasks (t) -> Windows thing (w)

## Steps to test these changes

Do Windows things as normal, not want to die.