### PR TITLE
[lua][sql] Add Orichalcum Survey assault

### DIFF
--- a/scripts/assaults/Leujaoam_Sanctum/orichalcum_survey.lua
+++ b/scripts/assaults/Leujaoam_Sanctum/orichalcum_survey.lua
@@ -1,0 +1,94 @@
+-----------------------------------
+-- Assault: Orichalcum Survey
+-- Instance 6901
+-- Objective: Find the Orichalcum ore
+-----------------------------------
+local ID = zones[xi.zone.LEUJAOAM_SANCTUM]
+-----------------------------------
+
+local content = InstanceAssault:new(
+{
+    zoneID           = xi.zone.LEUJAOAM_SANCTUM,
+    assaultID        = xi.assault.mission.ORICHALCUM_SURVEY,
+    instanceID       = xi.assault.instance.ORICHALCUM_SURVEY,
+    assaultArea      = xi.assault.assaultArea.LEUJAOAM_SANCTUM,
+    requiredOrders   = xi.ki.LEUJAOAM_ASSAULT_ORDERS,
+
+    runeOfReleasePos = { x = -432, y = -27, z = 169, rot = 49 },
+    ancientBoxPos    = { x = -432, y = -27, z = 167, rot = 129 },
+    releasePos       = { x = 7, z = 8 },
+
+    suggestedLevel   = 50,
+    basePoints       = 1200,
+    requiredProgress = 1,
+
+    wallNPCs       = { ID.npc._1xo },
+
+    entranceParams   =
+    {
+        instanceID   = xi.assault.instance.ORICHALCUM_SURVEY,
+        entryEvent   = { 140, 2, -4, 0, 50, 0, 1 },
+        confirmEvent = { 140, 4 },
+        memberEvent  = { 147, 0 },
+    },
+})
+
+content.mobs =
+{
+    { baseID = ID.mob.QIQIRN_MINER, offset = 7 },
+}
+
+content.npcs =
+{
+    { baseID = ID.npc.MINING_POINTS, offset = 9 },
+    { baseID = ID.npc.MULWAHAH, offset = 0 },
+}
+
+function content:onInstanceCreated(instance)
+    InstanceAssault.onInstanceCreated(self, instance)
+
+    local mulwahah = GetNPCByID(ID.npc.MULWAHAH, instance)
+    if mulwahah then
+        mulwahah:setStatus(xi.status.NORMAL)
+    end
+
+    for i = 0, 9 do
+        local pointID = ID.npc.MINING_POINTS + i
+        local point   = GetNPCByID(pointID, instance)
+
+        if point then
+            point:setStatus(xi.status.NORMAL)
+        end
+    end
+end
+
+content.loot =
+{
+    appraisalReward =
+    {
+        {
+            { itemId = xi.item.UNAPPRAISED_GLOVES,   weight = 3500 },
+            { itemId = xi.item.UNAPPRAISED_NECKLACE, weight = 3500 },
+            { itemId = xi.item.UNAPPRAISED_BOX,      weight = 3000 },
+        },
+    },
+
+    bonusLoot =
+    {
+        {
+            { itemId = xi.item.REMEDY,       weight = 10000 },
+        },
+
+        {
+            { itemId = xi.item.HI_POTION_P3, weight = 5000 },
+            { itemId = xi.item.REMEDY,       weight = 5000 },
+        },
+
+        {
+            { itemId = xi.item.HI_POTION_P3, weight = 1000 },
+            { itemId = xi.item.NONE,         weight = 9000 },
+        },
+    },
+}
+
+return content:register()

--- a/scripts/zones/Leujaoam_Sanctum/IDs.lua
+++ b/scripts/zones/Leujaoam_Sanctum/IDs.lua
@@ -19,6 +19,7 @@ zones[xi.zone.LEUJAOAM_SANCTUM] =
         LOGIN_CAMPAIGN_UNDERWAY       = 7007, -- The [/January/February/March/April/May/June/July/August/September/October/November/December] <number> Login Campaign is currently underway!
         LOGIN_NUMBER                  = 7008, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7028, -- Your party is unable to participate because certain members' levels are restricted.
+        OBTAIN_PICKAXE                = 7331, -- Obtained temporary item: a pickaxe!
         PLAYER_OBTAINS_ITEM           = 7332, -- <name> obtains <item>!
         ASSAULT_START_OFFSET          = 7467, -- Max MP Down removed for <name>.
         TIME_TO_COMPLETE              = 7528, -- You have <number> [minute/minutes] (Earth time) to complete this mission.
@@ -28,11 +29,24 @@ zones[xi.zone.LEUJAOAM_SANCTUM] =
         TIME_REMAINING_MINUTES        = 7533, -- Time remaining: <number> [minute/minutes] (Earth time).
         TIME_REMAINING_SECONDS        = 7534, -- Time remaining: <number> [second/seconds] (Earth time).
         PARTY_FALLEN                  = 7536, -- All party members have fallen in battle. Mission failure in <number> [minute/minutes].
+        FIND_NOTHING                  = 7545, -- You find nothing.
+        OBTAIN_PEBBLE                 = 7546, -- You obtain a pebble.
+        OBTAIN_ORICHALCUM_ORE         = 7547, -- You obtain an Orichalcum ore.
+        PICKAXE_BREAKS                = 7548, -- Your pickaxe breaks.
+        NO_PICKAXE                    = 7549, -- Mining is possible here if you have a pickaxe.
+        MOVE_CLOSER                   = 7550, -- You must move closer to the target (mining point).
+        CANT_MINE_RIGHT_NOW           = 7551, -- You can't mine here right now (worm is up).
+        YOU_FOUND_SOME                = 7553, -- You found some? Let's take a look then...
+        AMAZING_LOOK_AT_IT            = 7554, -- Amazing! Look at it shine! This is definitely a chunk of orichalcum ore.
+        THE_RUMORS_WERE_TRUE          = 7555, -- The rumors were true! Excellent work!
+        ALREADY_HAVE_PICKAXE          = 7556, -- You only get as many pickaxes as you need. Now, get moving!
+        BRING_ORICHALCUM_ORE_BACK     = 7557, -- If you come across a chunk of orichalcum ore, bring it directly back to me.
     },
 
     mob =
     {
         LEUJAOAM_WORM = GetFirstID('Leujaoam_Worm'),
+        MINERAL_EATER = GetFirstID('Mineral_Eater'),
         QIQIRN_MINER  = GetFirstID('Qiqirn_Miner'),
     },
 
@@ -42,6 +56,7 @@ zones[xi.zone.LEUJAOAM_SANCTUM] =
         RUNE_OF_RELEASE = GetFirstID('Rune_of_Release'),
         MINING_POINTS   = GetFirstID('Mining_Point'),
         MULWAHAH        = GetFirstID('Mulwahah'),
+        _1xo            = GetFirstID('_1xo'),
     }
 }
 

--- a/scripts/zones/Leujaoam_Sanctum/mobs/Mineral_Eater.lua
+++ b/scripts/zones/Leujaoam_Sanctum/mobs/Mineral_Eater.lua
@@ -1,0 +1,50 @@
+-----------------------------------
+-- Area: Leujaoam Sanctum (Orichalcum Survey)
+--  Mob: Mineral Eater
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local function linkedPointID(mob)
+    local pointID = mob:getLocalVar('pointId')
+    if pointID ~= 0 then
+        return pointID
+    end
+
+    return nil
+end
+
+local function setPointWormState(mob, isActive)
+    local instance = mob:getInstance()
+    if not instance then
+        return
+    end
+
+    local pointID = linkedPointID(mob)
+    if not pointID then
+        return
+    end
+
+    local point = GetNPCByID(pointID, instance)
+    if point then
+        point:setLocalVar('wormActive', isActive and 1 or 0)
+        if not isActive then
+            point:setLocalVar('wormMobId', 0)
+        end
+    end
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setMaxHP(1700)
+    mob:setHP(1700)
+    xi.assault.adjustMobLevel(mob)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+    mob:setAnimationSub(0)
+    setPointWormState(mob, true)
+end
+
+entity.onMobDespawn = function(mob)
+    setPointWormState(mob, false)
+end
+
+return entity

--- a/scripts/zones/Leujaoam_Sanctum/mobs/Qiqirn_Miner.lua
+++ b/scripts/zones/Leujaoam_Sanctum/mobs/Qiqirn_Miner.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+-- Area: Leujaoam Sanctum (Orichalcum Survey)
+--  Mob: Qiqirn Miner
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local function applyDormantState(mob)
+    mob:hideHP(true)
+    mob:setMobMod(xi.mobMod.NO_AGGRO, 1)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 0)
+    mob:setStatus(xi.status.NORMAL)
+    -- TODO Find a way that the Qiqirn are not being hit by AoE as secondary target. So far I only found setUntargetable but it's not what we want.
+end
+
+local function applyAggressiveState(mob)
+    mob:setStatus(xi.status.UPDATE)
+    mob:setMaxHP(17000)
+    mob:setHP(17000)
+    mob:hideHP(false)
+    mob:setAutoAttackEnabled(true)
+    mob:setMobMod(xi.mobMod.NO_AGGRO, 0)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
+end
+
+local function awakenMob(mob, sourcePlayer)
+    if not mob:getInstance() then
+        return
+    end
+
+    applyAggressiveState(mob)
+end
+
+entity.onMobSpawn = function(mob)
+    xi.assault.adjustMobLevel(mob)
+
+    applyDormantState(mob)
+
+    mob:removeListener('ORICHALCUM_WAKE')
+    mob:addListener('ORICHALCUM_WAKE', 'ORICHALCUM_WAKE', function(mobArg, sourcePlayer)
+        awakenMob(mobArg, sourcePlayer)
+    end)
+end
+
+entity.onMobDespawn = function(mob)
+    mob:removeListener('ORICHALCUM_WAKE')
+end
+
+return entity

--- a/scripts/zones/Leujaoam_Sanctum/npcs/Mining_Point.lua
+++ b/scripts/zones/Leujaoam_Sanctum/npcs/Mining_Point.lua
@@ -1,0 +1,283 @@
+-----------------------------------
+-- Area: Leujaoam Sanctum
+-- Mining Point
+-----------------------------------
+local ID = zones[xi.zone.LEUJAOAM_SANCTUM]
+-----------------------------------
+local miningPointSpawnOptions =
+{
+    [17060016] =
+    {
+        { x = -549.027, y = -51.000, z = 199.134, rot = 0 },
+        { x = -513.640, y = -52.000, z = 204.103, rot = 0 },
+        { x = -528.246, y = -51.504, z = 203.002, rot = 0 },
+        { x = -525.456, y = -51.000, z = 216.318, rot = 0 },
+        { x = -520.596, y = -51.525, z = 243.901, rot = 0 },
+    },
+
+    [17060017] =
+    {
+        { x = -495.485, y = -32.000, z = 337.122, rot = 0 },
+        { x = -500.969, y = -35.000, z = 322.946, rot = 0 },
+        { x = -540.252, y = -51.534, z = 272.440, rot = 0 },
+        { x = -540.609, y = -51.350, z = 286.021, rot = 0 },
+        { x = -538.240, y = -48.901, z = 293.693, rot = 0 },
+    },
+
+    [17060018] =
+    {
+        { x = -398.561, y = -23.000, z = 248.782, rot = 0 },
+        { x = -408.464, y = -23.000, z = 230.004, rot = 0 },
+        { x = -442.548, y = -23.568, z = 226.753, rot = 0 },
+        { x = -447.546, y = -23.446, z = 227.051, rot = 0 },
+        { x = -419.918, y = -24.169, z = 249.661, rot = 0 },
+    },
+
+    [17060019] =
+    {
+        { x = -367.485, y = 4.000,   z = 151.937, rot = 0 },
+        { x = -351.443, y = 3.000,   z = 147.359, rot = 0 },
+        { x = -331.361, y = 4.289,   z = 178.428, rot = 0 },
+        { x = -312.000, y = 5.130,   z = 155.979, rot = 0 },
+        { x = -310.905, y = 4.5,     z = 160.516, rot = 0 },
+    },
+
+    [17060020] =
+    {
+        { x = -322.529, y = 0.000,   z = 195.094, rot = 0 },
+        { x = -326.596, y = -0.034,  z = 249.966, rot = 0 },
+        { x = -319.922, y = 0.000,   z = 239.955, rot = 0 },
+        { x = -311.480, y = 0.697,   z = 247.904, rot = 0 },
+        { x = -310.441, y = 0.433,   z = 224.163, rot = 0 },
+    },
+
+    [17060021] =
+    {
+        { x = -490.164, y = -28.000, z = 100.872, rot = 0 },
+        { x = -420.692, y = -11.000, z = 83.443,  rot = 0 },
+        { x = -396.473, y = -3.385,  z = 99.225,  rot = 0 },
+        { x = -461.404, y = -27.615, z = 93.306,  rot = 0 },
+        { x = -416.124, y = -8.031,  z = 96.842,  rot = 0 },
+    },
+
+    [17060022] =
+    {
+        { x = -381.492, y = -28.000, z = 183.591, rot = 0 },
+        { x = -390.760, y = -28.030, z = 180.265, rot = 0 },
+        { x = -376.461, y = -27.573, z = 217.242, rot = 0 },
+        { x = -379.159, y = -28.457, z = 177.491, rot = 0 },
+        { x = -379.200, y = -28.000, z = 200.480, rot = 0 },
+        { x = -403.751, y = -27.500, z = 179.859, rot = 0 },
+    },
+
+    [17060023] =
+    {
+        { x = -419.408, y = -31.000, z = 334.733, rot = 0 },
+        { x = -420.536, y = -32.000, z = 310.364, rot = 0 },
+        { x = -425.876, y = -32.087, z = 331.704, rot = 0 },
+        { x = -414.012, y = -32.064, z = 308.767, rot = 0 },
+        { x = -414.728, y = -31.796, z = 304.956, rot = 0 },
+    },
+
+    [17060024] =
+    {
+        { x = -446.034, y = -52.121, z = 248.996, rot = 0 },
+        { x = -435.199, y = -55.000, z = 159.421, rot = 0 },
+        { x = -436.735, y = -51.728, z = 250.734, rot = 0 },
+        { x = -459.998, y = -27.506, z = 87.984,  rot = 0 },
+        { x = -437.327, y = -55.535, z = 154.233, rot = 0 },
+    },
+
+    [17060025] =
+    {
+        { x = -325.807, y = -28.000, z = 229.322, rot = 0 },
+        { x = -317.824, y = -28.000, z = 170.400, rot = 0 },
+        { x = -322.858, y = -28.289, z = 231.136, rot = 0 },
+        { x = -317.708, y = -27.929, z = 241.236, rot = 0 },
+        { x = -316.305, y = -27.520, z = 162.845, rot = 0 },
+    },
+}
+
+---@type TNpcEntity
+local entity = {}
+
+local function initializeMiningPoint(npc)
+    npc:setLocalVar('hitsRemaining', 7)
+    npc:setLocalVar('wormActive', 0)
+    npc:setLocalVar('wormMobId', 0)
+    npc:setLocalVar('miningLockUntil', 0)
+    npc:setLocalVar('initialized', 1)
+end
+
+local function respawnMiningPoint(npc)
+    local options = miningPointSpawnOptions[npc:getID()]
+    if options then
+        local spawn = utils.randomEntry(options)
+        if spawn then
+            npc:setPos(spawn.x, spawn.y, spawn.z, spawn.rot)
+        end
+    end
+
+    npc:setStatus(xi.status.NORMAL)
+    initializeMiningPoint(npc)
+end
+
+local function despawnMiningPoint(npc)
+    npc:setStatus(xi.status.DISAPPEAR)
+    npc:timer(180000, function(npcArg)
+        respawnMiningPoint(npcArg)
+    end)
+end
+
+local function activateQiqirnMiners(instance, player)
+    for i = 0, 7 do
+        local mobID = ID.mob.QIQIRN_MINER + i
+        local miner = GetMobByID(mobID, instance)
+
+        if miner then
+            miner:triggerListener('ORICHALCUM_WAKE', miner, player)
+        end
+    end
+end
+
+local function spawnLinkedWorm(player, npc, instance)
+    for i = 0, 9 do
+        local mobID = ID.mob.MINERAL_EATER + i
+        local worm  = GetMobByID(mobID, instance)
+
+        if worm and not worm:isSpawned() then
+            local angle   = math.randomFloat(0, 2 * math.pi)
+            local spawnX  = npc:getXPos() + math.cos(angle) * 0.15
+            local spawnZ  = npc:getZPos() + math.sin(angle) * 0.15
+            worm:setLocalVar('pointId', npc:getID())
+            worm:setSpawn(spawnX, npc:getYPos(), spawnZ, npc:getRotPos())
+            local spawnedWorm = SpawnMob(mobID, instance)
+            if spawnedWorm then
+                spawnedWorm:setLocalVar('pointId', npc:getID())
+                spawnedWorm:updateEnmity(player)
+            else
+                worm:setLocalVar('pointId', npc:getID())
+                worm:updateEnmity(player)
+            end
+
+            npc:setLocalVar('wormActive', 1)
+            npc:setLocalVar('wormMobId', mobID)
+            return true
+        end
+    end
+
+    return false
+end
+
+entity.onSpawn = function(npc)
+    respawnMiningPoint(npc)
+end
+
+entity.onTrigger = function(player, npc)
+    local instance = npc:getInstance()
+
+    if not instance then
+        return
+    end
+
+    if npc:getLocalVar('initialized') == 0 then
+        initializeMiningPoint(npc)
+    end
+
+    if player:checkDistance(npc) > 3 then
+        player:messageText(player, ID.text.MOVE_CLOSER, false)
+        return
+    end
+
+    if not player:hasItem(xi.item.PICKAXE, xi.inv.TEMPITEMS) then
+        player:messageSpecial(ID.text.NO_PICKAXE, xi.item.PICKAXE)
+        return
+    end
+
+    if npc:getLocalVar('wormActive') == 1 then
+        local wormID = npc:getLocalVar('wormMobId')
+        if wormID ~= 0 then
+            local worm = GetMobByID(wormID, instance)
+            if not worm or not worm:isSpawned() then
+                npc:setLocalVar('wormActive', 0)
+                npc:setLocalVar('wormMobId', 0)
+            end
+        end
+
+        if npc:getLocalVar('wormActive') == 1 then
+            player:messageText(player, ID.text.CANT_MINE_RIGHT_NOW, false)
+            return
+        end
+    end
+
+    if npc:getLocalVar('miningLockUntil') > GetSystemTime() then
+        return
+    end
+
+    local hitsRemaining = npc:getLocalVar('hitsRemaining')
+    if hitsRemaining <= 0 then
+        player:messageText(player, ID.text.FIND_NOTHING, false)
+        return
+    end
+
+    -- 10% chance to spawn a worm
+    if math.random(1, 100) <= 10 then
+        if spawnLinkedWorm(player, npc, instance) then
+            player:messageText(player, ID.text.CANT_MINE_RIGHT_NOW, false)
+            return
+        end
+    end
+
+    -- Setting a 4 sec lock between mining attempts to prevent spamming
+    npc:setLocalVar('miningLockUntil', GetSystemTime() + 4)
+    player:lookAt(npc:getXPos(), npc:getYPos(), npc:getZPos())
+    player:positionSpecial(
+        {
+            x = player:getXPos(),
+            y = player:getYPos(),
+            z = player:getZPos(),
+            rot = player:getRotPos(),
+        },
+        0x0A
+    )
+    player:timer(100, function(playerArg)
+        local point = GetNPCByID(npc:getID(), instance)
+        if playerArg and point then
+            playerArg:sendEmote(point, xi.emote.EXCAVATION, xi.emoteMode.MOTION, false)
+        end
+    end)
+
+    local hitsAfter = hitsRemaining - 1
+    npc:setLocalVar('hitsRemaining', hitsAfter)
+
+    local outcomeRoll = math.random(1, 200)
+    if outcomeRoll <= 180 then
+        player:messageText(player, ID.text.FIND_NOTHING, false)
+    elseif outcomeRoll <= 199 then
+        if player:addItem(xi.item.PEBBLE) then
+            player:messageSpecial(ID.text.OBTAIN_PEBBLE, xi.item.PEBBLE)
+        else
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.PEBBLE)
+        end
+    else  -- 0.5% chance to find a chunk of orichalcum ore
+        if player:addTempItem(xi.item.CHUNK_OF_ORICHALCUM_ORE) then
+            player:messageSpecial(ID.text.OBTAIN_ORICHALCUM_ORE, xi.item.CHUNK_OF_ORICHALCUM_ORE)
+            activateQiqirnMiners(instance, player)
+        else
+            player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.CHUNK_OF_ORICHALCUM_ORE)
+        end
+    end
+
+    -- 8% chance to break the pickaxe
+    if math.random(1, 100) <= 8 then
+        if player:delItem(xi.item.PICKAXE, 1, xi.inv.TEMPITEMS) then
+            player:messageSpecial(ID.text.PICKAXE_BREAKS, xi.item.PICKAXE)
+        end
+    end
+
+    if hitsAfter <= 0 then
+        despawnMiningPoint(npc)
+    end
+end
+
+return entity

--- a/scripts/zones/Leujaoam_Sanctum/npcs/Mulwahah.lua
+++ b/scripts/zones/Leujaoam_Sanctum/npcs/Mulwahah.lua
@@ -1,0 +1,56 @@
+-----------------------------------
+-- Area: Leujaoam Sanctum
+-- Mulwahah
+-----------------------------------
+local ID = zones[xi.zone.LEUJAOAM_SANCTUM]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    local instance = npc:getInstance()
+
+    if not instance then
+        return
+    end
+
+    -- Hand-in the orichalcum ore with the same pacing as retail.
+    if player:hasItem(xi.item.CHUNK_OF_ORICHALCUM_ORE, xi.inv.TEMPITEMS) then
+        if player:delItem(xi.item.CHUNK_OF_ORICHALCUM_ORE, 1, xi.inv.TEMPITEMS) then
+            player:messageSpecial(ID.text.YOU_FOUND_SOME, 0)
+
+            player:timer(3000, function()
+                if player:getInstance() then
+                    player:messageSpecial(ID.text.AMAZING_LOOK_AT_IT, xi.item.CHUNK_OF_ORICHALCUM_ORE)
+
+                    player:timer(2000, function()
+                        if player:getInstance() then
+                            player:messageSpecial(ID.text.THE_RUMORS_WERE_TRUE, 0)
+
+                            player:timer(5000, function()
+                                if instance:getProgress() < 1 then
+                                    instance:setProgress(1)
+                                end
+                            end)
+                        end
+                    end)
+                end
+            end)
+
+            return
+        end
+    end
+
+    player:messageSpecial(ID.text.BRING_ORICHALCUM_ORE_BACK, xi.item.CHUNK_OF_ORICHALCUM_ORE)
+
+    if player:hasItem(xi.item.PICKAXE, xi.inv.TEMPITEMS) then
+        player:messageSpecial(ID.text.ALREADY_HAVE_PICKAXE, xi.item.PICKAXE)
+        return
+    else
+        if player:addTempItem(xi.item.PICKAXE) then
+            player:messageSpecial(ID.text.OBTAIN_PICKAXE, xi.item.PICKAXE)
+        end
+    end
+end
+
+return entity

--- a/sql/instance_entities.sql
+++ b/sql/instance_entities.sql
@@ -498,6 +498,7 @@ INSERT INTO `instance_entities` VALUES (6901,17060023);
 INSERT INTO `instance_entities` VALUES (6901,17060024);
 INSERT INTO `instance_entities` VALUES (6901,17060025);
 INSERT INTO `instance_entities` VALUES (6901,17060026);
+INSERT INTO `instance_entities` VALUES (6901,17060144);
 INSERT INTO `instance_entities` VALUES (6901,17060130);
 INSERT INTO `instance_entities` VALUES (6901,17060140);
 

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -925,14 +925,14 @@ INSERT INTO `mob_spawn_points` VALUES (17059855,0,'Leujaoam_Worm','Leujaoam Worm
 
 -- Orichalcum survey assaut entrance @ -432 -27.627 169
 -- all worms spawn @ mining points in npc_list
-INSERT INTO `mob_spawn_points` VALUES (17059856,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-519.519,-52.068,196.745,113,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059857,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-538.091,-48.863,294.327,108,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059858,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-414.927,-24.107,247.502,252,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059859,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-318.907,3.821,159.317,193,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059860,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-312.961,-0.335,217.331,23,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059861,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-428.855,-17.967,59.715,241,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059862,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-378.242,-28.197,178.675,209,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17059863,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-417.615,-32.208,323.733,184,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059856,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-536.691,-51,204.461,113,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059857,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-503.933,-39,307.678,108,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059858,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-405.292,-23,230.958,252,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059859,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-366.991,3,162.922,193,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059860,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-318.242,1,225.166,23,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059861,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-422.101,-14,70.077,241,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059862,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-373.936,-28,180.027,209,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17059863,0,'Qiqirn_Miner','Qiqirn Miner',2,0,0,-425.597,-32,322.252,184,NULL,NULL);
 -- each mineral eater can spawn from any mining point
 INSERT INTO `mob_spawn_points` VALUES (17059864,0,'Mineral_Eater','Mineral Eater',3,77,78,-424.166,-32.041,335.851,54,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17059865,0,'Mineral_Eater','Mineral Eater',3,77,78,-551.561,-51.654,207.978,94,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->
This PR adds the Assault Orichalcum Survey in the new framework. 
Adds the mining points in random position, Qirqirn NPC like, Mulwahah

All the mechanics like retail about mining the points:
- Spawns Mineral Eater worms randomly 
- Pickaxe break
- Pebble
- Orichalcum ore 

When the orichalcum ore is found, Qiqirn become mob and aggro on sight.

TODO: Make sure the Qiqirn (when they are npc like) cannot be hit by AoE spells casted on worms when they are in range.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
Get the Key item to join the assault (must have PFC badge), enter the assault.
Good luck finding the ore!