### PR TITLE
[lua] [C++] Era experience points loss setting

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -87,6 +87,9 @@ xi.settings.map =
     -- Minimum level at which experience points can be lost
     EXP_LOSS_LEVEL = 31,
 
+    -- Enable/Disable pre-Abyssea experience point loss tiers. set true with EXP_LOSS_LEVEL = 4, for pre-Abyssea experience point loss behavior. https://wiki.ffo.jp/html/15196.html
+    USE_PRE_ABYSSEA_EXP_LOSS_TIERS = false,
+
     -- Minimum level at which regional influence is lost in conquest when a player dies
     -- Level 5 and below don't lose influence: http://wiki.ffo.jp/html/498.html
     MINIMUM_LEVEL_CONQUEST_INFUENCE_LOSS = 6,

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5550,6 +5550,11 @@ void DelExperiencePoints(CCharEntity* PChar, float retainPercent, uint16 forcedX
     uint8  mLevel  = (PChar->m_LevelRestriction != 0 && PChar->m_LevelRestriction < PChar->GetMLevel()) ? PChar->m_LevelRestriction : PChar->GetMLevel();
     uint16 exploss = mLevel <= 67 ? (GetExpNEXTLevel(mLevel) * 8) / 100 : 2400;
 
+    if (mLevel <= 24 && settings::get<bool>("map.USE_PRE_ABYSSEA_EXP_LOSS_TIERS"))
+    {
+        exploss = (GetExpNEXTLevel(mLevel) * 10) / 100;
+    }
+
     if (forcedXpLoss > 0)
     {
         // Override normal XP loss with specified value.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds a new tier of experience points loss for levels 24 or lower @ 10%. - Changed May 10th, 2011.
https://wiki.ffo.jp/html/15196.html

## Steps to test these changes

Enable the setting, be level 24 or lower, die, get 10% TNL taken as XP. 