### PR TITLE
[lua] DRG Unlock Quest Audits

### DIFF
--- a/scripts/battlefields/Ghelsba_Outpost/holy_crest.lua
+++ b/scripts/battlefields/Ghelsba_Outpost/holy_crest.lua
@@ -10,7 +10,7 @@ local content = BattlefieldQuest:new({
     zoneId        = xi.zone.GHELSBA_OUTPOST,
     battlefieldId = xi.battlefield.id.HOLY_CREST,
     maxPlayers    = 6,
-    timeLimit     = utils.minutes(30),
+    timeLimit     = utils.minutes(15),
     index         = 1,
     area          = 1,
     entryNpc      = 'Hut_Door',
@@ -27,15 +27,16 @@ function content:onEventFinishWin(player, csid, option, npc)
         option ~= 0 and
         player:hasKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
     then
-        npcUtil.completeQuest(player, xi.questLog.SANDORIA, xi.quest.id.sandoria.THE_HOLY_CREST, {
-            title = xi.title.HEIR_TO_THE_HOLY_CREST,
-            var   = 'TheHolyCrest_Event',
-        })
-
         player:delKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
         player:unlockJob(xi.job.DRG)
-        player:messageSpecial(ghelsbaID.text.YOU_CAN_NOW_BECOME_A_DRAGOON)
         player:setPetName(xi.petType.WYVERN, option + 1)
+        player:messageSpecial(ghelsbaID.text.YOU_CAN_NOW_BECOME_A_DRAGOON)
+
+        npcUtil.completeQuest(player, xi.questLog.SANDORIA, xi.quest.id.sandoria.THE_HOLY_CREST, {
+            title   = xi.title.HEIR_TO_THE_HOLY_CREST,
+            keyItem = xi.ki.JOB_GESTURE_DRAGOON,
+            var     = 'TheHolyCrest_Event',
+        })
     end
 end
 

--- a/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
+++ b/scripts/zones/Ghelsba_Outpost/mobs/Cyranuce_M_Cutauleon.lua
@@ -7,6 +7,7 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.SILENCE)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits the DRG unlock quest "The Holy Crest" against [retail captures](https://www.youtube.com/watch?v=NPHMt_GiFS8) and does the following things:

- Makes the BCNM mob Cyranuce M Cutauleon always aggressive, because he aggros even at 99.
- Adds the Dragoon job emote upon completion.
- Sets the battlefield timer to 15 minutes, per retail.
- Fixes a cosmetic message ordering issue with how rewards are handled at completion.

## Steps to test these changes

Finish the quest and see it all works as intended.
