### PR TITLE
[sql] Fix Gold Musketeer's Ring and Diabolos's Torque latents

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -558,7 +558,7 @@ INSERT INTO `item_latents` VALUES (13557,13,3,53,0);     -- MND +3 in areas insi
 
 -- Gold Musketeer's Ring
 INSERT INTO `item_latents` VALUES (13558,1,4,53,0);      -- DEF +4 in areas inside own nation's control
-INSERT INTO `item_latents` VALUES (13558,10,2,53,0);     -- VIT +3 in areas inside own nation's control
+INSERT INTO `item_latents` VALUES (13558,10,3,53,0);     -- VIT +3 in areas inside own nation's control
 INSERT INTO `item_latents` VALUES (13558,11,2,53,0);     -- AGI +2 in areas inside own nation's control
 
 -- Patriarch Protector's Ring
@@ -1249,7 +1249,7 @@ INSERT INTO `item_latents` VALUES (14783,10,4,26,1);     -- VIT+4 during Nightti
 INSERT INTO `item_latents` VALUES (14806,4,40,53,1);     -- convmptohp 40 in areas outside own nation's control
 
 -- Diabolos's Earring
-INSERT INTO `item_latents` VALUES (14814,25,-3,52,8);    -- cumulative acc-3 in Dark weather
+INSERT INTO `item_latents` VALUES (14814,25,-3,52,8);    -- ACC-3 in Dark weather (cancels base +3)
 INSERT INTO `item_latents` VALUES (14814,30,2,52,8);     -- magic acc+2 in Dark weather
 
 -- Rasetsu Tekko
@@ -1556,8 +1556,8 @@ INSERT INTO `item_latents` VALUES (15504,25,3,53,0);     -- ACC +3 in areas insi
 INSERT INTO `item_latents` VALUES (15506,369,1,1,85);    -- Refresh when HP >=85%
 
 -- Diabolos's Torque
-INSERT INTO `item_latents` VALUES (15516,24,7,52,8);     -- ranged acc+8 in Dark weather
-INSERT INTO `item_latents` VALUES (15516,26,-16,52,8);   -- cumulative ranged acc-8 in Dark weather
+INSERT INTO `item_latents` VALUES (15516,24,8,52,8);     -- RATT+8 in Dark weather
+INSERT INTO `item_latents` VALUES (15516,26,-8,52,8);    -- RACC-8 in Dark weather (cancels base +8)
 
 -- Storm Muffler
 INSERT INTO `item_latents` VALUES (15519,370,1,58,0);    -- Regen +1


### PR DESCRIPTION
Correct nation-control VIT from +2 to +3, and Dark-weather ACC latent from -3 to -6 so net ACC is -3 as retail describes.

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes two incorrect item latents:

1. **Gold Musketeer's Ring (13558)** — nation-control VIT was `+2`; retail and the SQL comment both expect `+3` (`DEF+4 VIT+3 AGI+2`).
2. **Diabolos's Earring (14814)** — Dark-weather ACC latent was `-3`. Base ACC is `+3`, so that only cancels to net `0`. Retail text is `Dark weather: Accuracy-3`, which should be net `-3`. Latent changed to `-6` (same cumulative pattern as Diabolos's Torque: base RACC `+8` + latent `-16` → net `-8`).

## Steps to test these changes

**Gold Musketeer's Ring**
1. Bastok citizen with Signet in a Bastok-owned outdoor conquest region.
2. Note VIT unequipped, then equip the ring.
3. VIT should increase by **3** (not 2). AGI+2 and DEF+4 should still apply.

**Diabolos's Earring**
1. Note Accuracy unequipped.
2. Equip the earring — Accuracy should be **+3**.
3. `!setweather gloom` (or Darkness).
4. Accuracy should be **-3** vs unequipped (not 0).
5. Magic Accuracy +2 in Dark weather should still apply.