### PR TITLE
[core] Session hash collision, login hardening, rlimits

### DIFF
--- a/src/common/application.cpp
+++ b/src/common/application.cpp
@@ -160,16 +160,13 @@ void Application::tryIncreaseRLimits()
 #ifndef _WIN32
     rlimit limits{};
 
-    uint32 newRLimit = 10240;
-
-    // Get old limits
+    // Raise the soft limit to the hard limit.
     if (getrlimit(RLIMIT_NOFILE, &limits) == 0)
     {
-        // Increase open file limit, which includes sockets, to newRLimit. This only effects the current process and child processes
-        limits.rlim_cur = newRLimit;
+        limits.rlim_cur = limits.rlim_max;
         if (setrlimit(RLIMIT_NOFILE, &limits) == -1)
         {
-            std::cerr << fmt::format("Failed to increase rlim_cur to {}\n", newRLimit);
+            std::cerr << fmt::format("Failed to increase rlim_cur to {}\n", static_cast<uint64>(limits.rlim_max));
         }
     }
 #endif

--- a/src/login/auth_session.cpp
+++ b/src/login/auth_session.cpp
@@ -28,6 +28,8 @@
 
 #include <bcrypt/BCrypt.hpp>
 
+#include <atomic>
+
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
@@ -288,9 +290,15 @@ void auth_session::read_func()
             */
 
             // Success
+            static std::atomic<uint32> authSeq{ 0 };
+
+            uint32 hashData[] = {
+                earth_time::timestamp() ^ static_cast<uint32>(getpid()),
+                authSeq.fetch_add(1, std::memory_order_relaxed),
+            };
+
             unsigned char hash[16];
-            uint32        hashData = earth_time::timestamp() ^ getpid();
-            md5(reinterpret_cast<uint8*>(&hashData), hash, sizeof(hashData));
+            md5(reinterpret_cast<uint8*>(hashData), hash, sizeof(hashData));
 
             json loginSuccessReply;
             loginSuccessReply["result"]       = static_cast<uint8>(login_result::LOGIN_SUCCESS);

--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -26,6 +26,8 @@
 #include "common/md52.h"
 #include "common/utils.h"
 
+#include <asio/write.hpp>
+
 void data_session::deleteCharFromCharInfo(uint32_t ffxi_id)
 {
     for (auto& charInfo : characterInfoResponse.character_info)
@@ -519,6 +521,19 @@ void data_session::read_func()
                 }
             }
 
+            // Log and return error to client if we're somehow trying to send a char to a disabled zone
+            if (characterSelectionResponse.server_ip == 0)
+            {
+                ShowWarning(fmt::format("data_session: no map address for charid {} (zone {}); check zone_settings", charid, ZoneID));
+                if (auto viewSession = session.view_session.get())
+                {
+                    loginHelpers::generateErrorMessage(viewSession->buffer_.data(), loginErrors::errorCode::UNABLE_TO_CONNECT_TO_WORLD_SERVER);
+                    viewSession->do_write(0x24);
+                }
+
+                return;
+            }
+
             unsigned char Hash[16] = {};
             md5(reinterpret_cast<uint8*>(&characterSelectionResponse), Hash, sizeof(lpkt_next_login));
 
@@ -527,10 +542,21 @@ void data_session::read_func()
             if (auto viewSession = session.view_session.get())
             {
                 std::memcpy(viewSession->buffer_.data(), &characterSelectionResponse, sizeof(characterSelectionResponse));
-                viewSession->do_write(sizeof(characterSelectionResponse));
 
-                viewSession->socket_.lowest_layer().shutdown(asio::socket_base::shutdown_both); // Client waits for us to close the socket
-                viewSession->socket_.lowest_layer().close();
+                // Write synchronously here to ensure the write() completes before the subsequent shutdown
+                std::error_code writeEc;
+                asio::write(viewSession->socket_.next_layer(),
+                            asio::buffer(viewSession->buffer_.data(), sizeof(characterSelectionResponse)),
+                            writeEc);
+                if (writeEc)
+                {
+                    ShowError(fmt::format("data_session: failed to write charselect reply to {}: {}", ipAddress, writeEc.message()));
+                }
+
+                // Client waits for us to close the socket.
+                std::error_code closeEc;
+                viewSession->socket_.lowest_layer().shutdown(asio::socket_base::shutdown_both, closeEc);
+                viewSession->socket_.lowest_layer().close(closeEc);
                 session.view_session = nullptr;
 
                 session.incrementKeyValue = 0;     // Reset incremented key after inserting into db


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Couple of minor tweaks based on observed errors under _unrealistic_ conditions:
- Non-Windows: Raise the requested FD limit up to kernel process max, instead of a fixed 10240. The limit is arbitrary and comes from an older pre-ASIO time and the system can scale way beyond that.
- Add an atomic counter to the session hash to resolve same-IP collisions. Timestamp resolution is in seconds so multiple connections from the same IP would end up with the same hash.
- Ensure xi_connect doesnt throw if client _somehow_ disconnects mid transaction
- Do the final write+shutdown synchronously so that the view session doesn't eventually get cut-off mid-write

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
