### PR TITLE
[core] Suppress Guild Close message / Music IDs uint16

### DIFF
--- a/scripts/globals/guild_shops.lua
+++ b/scripts/globals/guild_shops.lua
@@ -352,7 +352,7 @@ end
 xi.guildShops.onShopClose = function(player, npc)
     local shop = shopFor(npc)
     if shop ~= nil then
-        player:sendGuildClose(shop.hours[1], shop.hours[2])
+        player:sendGuildClose(shop.hours[1], shop.hours[2], true)
     end
 
     player:clearGuildShop()

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -644,8 +644,9 @@ end
 
 ---@param open integer
 ---@param close integer
+---@param passive boolean?
 ---@return nil
-function CBaseEntity:sendGuildClose(open, close)
+function CBaseEntity:sendGuildClose(open, close, passive)
 end
 
 ---@return nil

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2850,7 +2850,7 @@ void CLuaBaseEntity::clearGuildShop() const
  *  Example : player:sendGuildClose(8, 23)
  ************************************************************************/
 
-void CLuaBaseEntity::sendGuildClose(uint8 open, uint8 close) const
+void CLuaBaseEntity::sendGuildClose(uint8 open, uint8 close, sol::optional<bool> passive) const
 {
     auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
     if (!PChar)
@@ -2859,7 +2859,7 @@ void CLuaBaseEntity::sendGuildClose(uint8 open, uint8 close) const
         return;
     }
 
-    PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(GP_SERV_COMMAND_GUILD_OPEN_STAT::Close, open, close, 0);
+    PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(GP_SERV_COMMAND_GUILD_OPEN_STAT::Close, open, close, 0, PassiveGuildClose(passive.value_or(false)));
 }
 
 /************************************************************************

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -184,7 +184,7 @@ public:
     auto sendGuild(uint16 guildId, uint8 open, uint8 close, uint8 holiday) const -> bool;                          // Sends guild shop menu
     auto openGuildShop(CLuaBaseEntity* PNpc, uint8 open, uint8 close, sol::optional<uint8> holiday) const -> bool; // Opens a lua guild shop and remembers the NPC the PC opened it with
     void clearGuildShop() const;                                                                                   // Clears the PC's open guild shop handle
-    void sendGuildClose(uint8 open, uint8 close) const;                                                            // Sends the guild-open packet with a Close status
+    void sendGuildClose(uint8 open, uint8 close, sol::optional<bool> passive) const;                               // Sends the guild-open packet with a Close status
     void openSendBox() const;                                                                                      // Opens send box (to deliver items)
     void leaveGame();
     void sendEmote(const CLuaBaseEntity* target, uint8 emID, uint8 emMode, bool othersOnly) const;

--- a/src/map/packets/s2c/0x086_guild_open.cpp
+++ b/src/map/packets/s2c/0x086_guild_open.cpp
@@ -23,7 +23,7 @@
 
 #include "common/utils.h"
 
-GP_SERV_COMMAND_GUILD_OPEN::GP_SERV_COMMAND_GUILD_OPEN(const GP_SERV_COMMAND_GUILD_OPEN_STAT status, const uint8 open, const uint8 close, const uint8 holiday)
+GP_SERV_COMMAND_GUILD_OPEN::GP_SERV_COMMAND_GUILD_OPEN(const GP_SERV_COMMAND_GUILD_OPEN_STAT status, const uint8 open, const uint8 close, const uint8 holiday, const PassiveGuildClose passive)
 {
     auto& packet = this->data();
 
@@ -36,6 +36,12 @@ GP_SERV_COMMAND_GUILD_OPEN::GP_SERV_COMMAND_GUILD_OPEN(const GP_SERV_COMMAND_GUI
         {
             // Pack guild hours into Time field (bits representing open to close hours)
             packBitsBE(reinterpret_cast<uint8*>(&packet.Time), 0xFFFFFF, open, close - open);
+
+            // Bit 31 suppresses the client-side close message if shop isn't currently open.
+            if (passive)
+            {
+                packet.Time |= 0x80000000;
+            }
         }
         break;
         case GP_SERV_COMMAND_GUILD_OPEN_STAT::Holiday:

--- a/src/map/packets/s2c/0x086_guild_open.h
+++ b/src/map/packets/s2c/0x086_guild_open.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common/cbasetypes.h"
+#include "common/types/flag.h"
 
 #include "base.h"
 
@@ -31,6 +32,8 @@ enum class GP_SERV_COMMAND_GUILD_OPEN_STAT : uint8
     Close   = 1,
     Holiday = 2
 };
+
+using PassiveGuildClose = xi::Flag<struct PassiveGuildCloseTag>;
 
 // https://github.com/atom0s/XiPackets/tree/main/world/server/0x0086
 // This packet is sent by the server to respond to the client requesting to open a guild shop menu.
@@ -44,5 +47,5 @@ public:
         uint32_t                        Time;
     };
 
-    GP_SERV_COMMAND_GUILD_OPEN(GP_SERV_COMMAND_GUILD_OPEN_STAT status, uint8 open, uint8 close, uint8 holiday);
+    GP_SERV_COMMAND_GUILD_OPEN(GP_SERV_COMMAND_GUILD_OPEN_STAT status, uint8 open, uint8 close, uint8 holiday, PassiveGuildClose passive = PassiveGuildClose::No);
 };

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -455,10 +455,10 @@ void CZone::LoadZoneSettings()
         m_zoneIP   = str2ip(rset->get<std::string>("zoneip"));
         m_zonePort = rset->get<uint16>("zoneport");
 
-        m_zoneMusic.m_songDay   = rset->get<uint8>("music_day");
-        m_zoneMusic.m_songNight = rset->get<uint8>("music_night");
-        m_zoneMusic.m_bSongS    = rset->get<uint8>("battlesolo");
-        m_zoneMusic.m_bSongM    = rset->get<uint8>("battlemulti");
+        m_zoneMusic.m_songDay   = rset->get<uint16>("music_day");
+        m_zoneMusic.m_songNight = rset->get<uint16>("music_night");
+        m_zoneMusic.m_bSongS    = rset->get<uint16>("battlesolo");
+        m_zoneMusic.m_bSongM    = rset->get<uint16>("battlemulti");
         m_tax                   = static_cast<uint16>(rset->get<float>("tax") * 100); // tax for bazaar
         m_miscMask              = rset->get<xi::ZoneMisc>("misc");
         m_zoneType              = rset->get<xi::ZoneType>("zonetype");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Guild closure messages are printing anywhere in the zone presently if you've talked to a Guild Shop NPC.
Confirmed retail sends this packet anywhere in the zone but discovered they set a magic bit for this exact scenario. 
With it set, the message only prints if your shop window is open.

And another commit changing the type of music IDs retrieved from DB from uint8 to uint16 after noticing zones and instances were not using the same type and that the client handles all of this as uint16

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
