### PR TITLE
[C++] Disallow Gardening Harvests into Locked Mog Safe 2

### DIFF
--- a/src/map/packets/c2s/0x0fe_myroom_plant_crop.cpp
+++ b/src/map/packets/c2s/0x0fe_myroom_plant_crop.cpp
@@ -21,6 +21,7 @@
 
 #include "0x0fe_myroom_plant_crop.h"
 
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "enums/msg_std.h"
 #include "items/item_flowerpot.h"
@@ -92,7 +93,9 @@ void GP_CLI_COMMAND_MYROOM_PLANT_CROP::process(MapSession* PSession, CCharEntity
             std::tie(resultID, totalQuantity) = gardenutils::CalculateResults(PChar, PPotItem);
             const uint8 stackSize             = xi::items::lookup(resultID)->getStackSize();
             const uint8 requiredSlots         = (uint8)ceil(float(totalQuantity) / stackSize);
-            const uint8 totalFreeSlots        = PChar->getStorage(LOC_MOGSAFE)->GetFreeSlotsCount() + PChar->getStorage(LOC_MOGSAFE2)->GetFreeSlotsCount();
+            const bool  safe2Unlocked         = (PChar->profile.mhflag & 0x20) && settings::get<bool>("main.ENABLE_MOG_HOUSE_2F");
+            const uint8 totalFreeSlots        = PChar->getStorage(LOC_MOGSAFE)->GetFreeSlotsCount() + (safe2Unlocked ? PChar->getStorage(LOC_MOGSAFE2)->GetFreeSlotsCount() : 0);
+
             if (requiredSlots > totalFreeSlots || totalQuantity == 0)
             {
                 PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::MoghouseCantPickUp); // Kupo. I can't pick anything right now, kupo.
@@ -102,7 +105,7 @@ void GP_CLI_COMMAND_MYROOM_PLANT_CROP::process(MapSession* PSession, CCharEntity
             for (uint8 slot = 0; slot < requiredSlots; ++slot)
             {
                 uint8 quantity = std::min(remainingQuantity, stackSize);
-                if (charutils::AddItem(PChar, LOC_MOGSAFE, resultID, quantity) == ERROR_SLOTID)
+                if (charutils::AddItem(PChar, LOC_MOGSAFE, resultID, quantity) == ERROR_SLOTID && safe2Unlocked)
                 {
                     charutils::AddItem(PChar, LOC_MOGSAFE2, resultID, quantity);
                 }


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Makes it so you cannot collect Gardening results into a empty (but not yet unlocked) Mog Safe 2. 

Partially related to the setting I added recently, but the bug could have surfaced before if you had tried to harvest without unlocking it yet from doing the Mog House exits.

Edit: Made sure and verified this was a bug with Critical, who checked the players inventory in the database.

## Steps to test these changes

Garden, try to Harvest with full Mog Safe 1 and locked Mog Safe 2