### PR TITLE
[sql] [module] NIN DRG SAM quest era module

### DIFF
--- a/modules/abyssea/sql/advanced_job_quest_mob_stats.sql
+++ b/modules/abyssea/sql/advanced_job_quest_mob_stats.sql
@@ -1,0 +1,19 @@
+-----------------------------------
+-- NIN/DRG/SAM Quest Mobs Original Difficulty Module
+-- Reverts the nerfs to the NIN/DRG/SAM quest mobs in the May 10, 2011 version update
+-- Source: https://forum.square-enix.com/ffxi/threads/7257
+-----------------------------------
+
+-- Level: set all six spawns to level 32 (min == max => fixed level)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17486187; -- Korroloka Leech (Korroloka Tunnel)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17486188; -- Korroloka Leech (Korroloka Tunnel)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17486189; -- Korroloka Leech (Korroloka Tunnel)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17350928; -- Cyranuce M Cutauleon (Ghelsba Outpost)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17219999; -- Forger (Konschtat Highlands)
+UPDATE mob_spawn_points SET minLevel = 32, maxLevel = 32 WHERE mobid = 17272838; -- Guardian Treant (The Sanctuary of Zi'Tah)
+
+-- HP: per-group override, keyed by (groupid, zoneid)
+UPDATE mob_groups SET HP =  900 WHERE groupid = 28 AND zoneid = 173; -- Korroloka Leech x3 (Korroloka Tunnel)
+UPDATE mob_groups SET HP = 2700 WHERE groupid = 26 AND zoneid = 140; -- Cyranuce M Cutauleon (Ghelsba Outpost)
+UPDATE mob_groups SET HP = 2000 WHERE groupid = 33 AND zoneid = 108; -- Forger (Konschtat Highlands)
+UPDATE mob_groups SET HP = 2000 WHERE groupid =  5 AND zoneid = 121; -- Guardian Treant (The Sanctuary of Zi'Tah)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request reverts the nerfs made to the NIN, DRG and SAM unlock quest mobs. This was discussed in [official patch notes](https://forum.square-enix.com/ffxi/threads/7257). With this module on, the mobs will be in their original pre-nerf state. I kept the name broad.

## Steps to test these changes

Enable the module by adding abyssea/sql/advanced_job_quest_mob_stats.sql to the init.txt. Do the NIN, DRG and SAM quests and fight the mobs. See they are stronger.
