### PR TITLE
[Proposal] Introduce `npcUtil.tradeMatches()` and apply usage to some missions

### DIFF
--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -936,6 +936,60 @@ function npcUtil.tradeHasExactly(trade, items)
     return npcUtil.tradeHas(trade, items, true)
 end
 
+-- Function to check if a trade contains exactly what's defined. Does not lock items. Use player:tradeComplete()
+function npcUtil.tradeMatches(trade, itemTable)
+    -- Create table of traded items.
+    --[[ Structure:
+    local tradedItemsTable =
+    {
+        [itemId1] = amount1,
+        [itemId2] = amount2,
+    }
+    ]]--
+
+    local tradedItemsTable = {}
+    local tradedItemId
+    local tradedQuantity
+    for slot = 0, trade:getSlotCount() - 1 do
+        tradedItemId                   = trade:getItemId(slot)
+        tradedQuantity                 = trade:getItemQty(tradedItemId)
+        tradedItemsTable[tradedItemId] = tradedQuantity
+    end
+
+    -- Create table of needed items, matching structure above.
+    local neededItemsTable = {}
+    local neededItemId
+    local neededQuantity
+    for _, entry in pairs(itemTable) do
+        neededItemId   = entry[1]
+        neededQuantity = entry[2]
+
+        -- Insert new entry or update previous entry quantity.
+        if neededItemId then
+            neededItemsTable[neededItemId] = neededItemsTable[neededItemId] == nil and neededQuantity or neededItemsTable[neededItemId] + neededQuantity
+        end
+    end
+
+    -- Check if all needed items have been traded. Remove from list if so.
+    for itemNeeded, quantityNeeded in pairs(neededItemsTable) do
+        local tradedQty = tradedItemsTable[itemNeeded] == nil and 0 or tradedItemsTable[itemNeeded]
+        if quantityNeeded > tradedQty then
+            return false
+        else
+            tradedItemsTable[itemNeeded] = tradedQty - quantityNeeded
+        end
+    end
+
+    -- Check if any excess items were traded.
+    for _, v in pairs(tradedItemsTable) do
+        if v > 0 then
+            return false
+        end
+    end
+
+    return true
+end
+
 -- Checks to see if a trade only contains one item, but the total count can be variable
 function npcUtil.tradeHasOnly(trade, itemID)
     return npcUtil.tradeHasExactly(trade, { { itemID, trade:getItemCount() } })

--- a/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
+++ b/scripts/missions/amk/02_Drenched_It_Began_with_a_Raindrop.lua
@@ -32,9 +32,7 @@ local moogleTriggerEvent =
     ['Moogle'] =
     {
         onTrade = function(player, npc, trade)
-            if
-                npcUtil.tradeHasExactly(trade, { xi.item.ORCISH_PLATE_ARMOR, xi.item.QUADAV_BACKSCALE, xi.item.YAGUDO_CAULK })
-            then
+            if npcUtil.tradeMatches(trade, { { xi.item.ORCISH_PLATE_ARMOR, 1 }, { xi.item.QUADAV_BACKSCALE, 1 }, { xi.item.YAGUDO_CAULK, 1 } }) then
                 return mission:progressEvent(30024)
             end
         end,
@@ -44,7 +42,7 @@ local moogleTriggerEvent =
     {
         [30024] = function(player, csid, option, npc)
             if mission:complete(player) then
-                player:confirmTrade()
+                player:tradeComplete()
             end
         end,
     },

--- a/scripts/missions/asa/03_That_Which_Curdles_Blood.lua
+++ b/scripts/missions/asa/03_That_Which_Curdles_Blood.lua
@@ -13,7 +13,7 @@ local mission = Mission:new(xi.mission.log_id.ASA, xi.mission.id.asa.THAT_WHICH_
 
 mission.reward =
 {
-    keyItem          =
+    keyItem =
     {
         xi.ki.DOMINAS_SCARLET_SEAL,
         xi.ki.DOMINAS_CERULEAN_SEAL,
@@ -24,19 +24,6 @@ mission.reward =
     },
     nextMission = { xi.mission.log_id.ASA, xi.mission.id.asa.SUGAR_COATED_DIRECTIVE },
 }
-
-local function handleTradeEvent(player, trade, firstId)
-    local asaKit = mission:getVar(player, 'Option')
-    if npcUtil.tradeHasExactly(trade, asaKit) then
-        return mission:progressEvent(firstId)
-    end
-end
-
-local handleTradeEventFinish = function(player, csid, option, npc)
-    if mission:complete(player) then
-        player:confirmTrade()
-    end
-end
 
 mission.sections =
 {
@@ -98,12 +85,20 @@ mission.sections =
             ['Trodden_Snow'] =
             {
                 onTrade = function(player, npc, trade)
-                    return handleTradeEvent(player, trade, 44)
+                    local asaKit = mission:getVar(player, 'Option')
+                    if npcUtil.tradeMatches(trade, { asaKit, 1 }) then
+                        return mission:progressEvent(44)
+                    end
                 end,
             },
+
             onEventFinish =
             {
-                [44] = handleTradeEventFinish,
+                [44] = function(player, csid, option, npc)
+                    if mission:complete(player) then
+                        player:tradeComplete()
+                    end
+                end,
             },
         },
     },

--- a/scripts/missions/asa/05_Enemy_Of_The_Empire_I.lua
+++ b/scripts/missions/asa/05_Enemy_Of_The_Empire_I.lua
@@ -43,42 +43,6 @@ local mobList =
     { 'Shore Sahagin',    'ShoreSahagin'    },
 }
 
-local function handleTradeEvent(player, trade)
-    local mobOne = mission:getVar(player, 'MobOne')
-
-    -- Trading Soul Plates
-    if mobOne ~= 0 and npcUtil.tradeHasExactly(trade, xi.item.SOUL_PLATE) then
-        local mobTwo = mission:getVar(player, 'MobTwo')
-        local mobThree = mission:getVar(player, 'MobThree')
-        local platesTraded = mission:getVar(player, 'Plates')
-        local item = trade:getItem(0)
-        local plateData = item:getExData()
-
-        -- Check if traded Soulplate is one of the requested mobs
-        for value, data in pairs(mobList) do
-            if data[2] == plateData.signature then
-                mission:setVar(player, 'Found', value)
-                mission:setVar(player, 'Plates', platesTraded + 1)
-
-                -- Assign 99 to traded mob's var to mark it as completed
-                if value == mobOne then
-                    mission:setVar(player, 'MobOne', 99)
-                elseif value == mobTwo then
-                    mission:setVar(player, 'MobTwo', 99)
-                elseif value == mobThree then
-                    mission:setVar(player, 'MobThree', 99)
-                end
-
-                player:confirmTrade()
-                return mission:progressEvent(241)
-            end
-        end
-
-        -- Wrong soulplate traded
-        return mission:progressEvent(242)
-    end
-end
-
 mission.sections =
 {
     {
@@ -90,35 +54,79 @@ mission.sections =
         {
             ['Andrause'] =
             {
-                onTrigger = function(player, npc)
-                    local mobCheck = mission:getVar(player, 'MobOne')
+                onTrade = function(player, npc, trade)
+                    local mobOne = mission:getVar(player, 'MobOne')
+                    if mobOne == 0 then
+                        return
+                    end
+
+                    -- Trading Soul Plates
+                    if not npcUtil.tradeMatches(trade, { xi.item.SOUL_PLATE, 1 }) then
+                        return
+                    end
+
+                    local item = trade:getItem(0)
+                    if not item then
+                        return
+                    end
+
+                    local plateData = item:getExData()
+                    if not plateData then
+                        return
+                    end
+
+                    local mobTwo       = mission:getVar(player, 'MobTwo')
+                    local mobThree     = mission:getVar(player, 'MobThree')
                     local platesTraded = mission:getVar(player, 'Plates')
 
-                    if not player:hasKeyItem(xi.ki.BLACK_BOOK) then
-                        -- Select mobs for player to get pictures of
-                        if mobCheck == 0 then
-                            local mobOne, MobTwo, mobThree = unpack(utils.uniqueRandomTable(1, 23, 3))
+                    -- Check if traded Soulplate is one of the requested mobs
+                    for value, data in pairs(mobList) do
+                        if data[2] == plateData.signature then
+                            mission:setVar(player, 'Found', value)
+                            mission:setVar(player, 'Plates', platesTraded + 1)
 
-                            mission:setVar(player, 'MobOne', mobOne)
-                            mission:setVar(player, 'MobTwo', MobTwo)
-                            mission:setVar(player, 'MobThree', mobThree)
+                            -- Assign 99 to traded mob's var to mark it as completed
+                            if value == mobOne then
+                                mission:setVar(player, 'MobOne', 99)
+                            elseif value == mobTwo then
+                                mission:setVar(player, 'MobTwo', 99)
+                            elseif value == mobThree then
+                                mission:setVar(player, 'MobThree', 99)
+                            end
 
-                            return mission:progressEvent(237)
-                        -- Tell player what mobs are still needed
-                        elseif mobCheck ~= 0 and platesTraded == 0 then
-                            return mission:progressEvent(238, 3)
-                        elseif mobCheck ~= 0 and platesTraded == 1 then
-                            return mission:progressEvent(238, 2)
-                        elseif mobCheck ~= 0 and platesTraded == 2 then
-                            return mission:progressEvent(238, 1)
+                            return mission:progressEvent(241)
                         end
-                    elseif player:hasKeyItem(xi.ki.BLACK_BOOK) then
-                        return mission:progressEvent(240)
                     end
+
+                    -- Wrong soulplate traded
+                    return mission:progressEvent(242)
                 end,
 
-                onTrade = function(player, npc, trade)
-                    return handleTradeEvent(player, trade)
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.BLACK_BOOK) then
+                        return mission:event(240)
+                    end
+
+                    -- Select mobs for player to get pictures of
+                    if mission:getVar(player, 'MobOne') == 0 then
+                        local mobOne, MobTwo, mobThree = unpack(utils.uniqueRandomTable(1, 23, 3))
+
+                        mission:setVar(player, 'MobOne', mobOne)
+                        mission:setVar(player, 'MobTwo', MobTwo)
+                        mission:setVar(player, 'MobThree', mobThree)
+
+                        return mission:progressEvent(237)
+                    end
+
+                    -- Tell player what mobs are still needed
+                    local platesTraded = mission:getVar(player, 'Plates')
+                    if platesTraded == 0 then
+                        return mission:progressEvent(238, 3)
+                    elseif platesTraded == 1 then
+                        return mission:progressEvent(238, 2)
+                    elseif platesTraded == 2 then
+                        return mission:progressEvent(238, 1)
+                    end
                 end,
             },
 
@@ -129,8 +137,8 @@ mission.sections =
                 -- option 2 = yes, ill do it
                 -- option 5 = buy the camera, doesnt appear to be a 'not enough gil dialogue'
                 [237] = function(player, csid, option, npc)
-                    local mobOne = mission:getVar(player, 'MobOne')
-                    local mobTwo = mission:getVar(player, 'MobTwo')
+                    local mobOne   = mission:getVar(player, 'MobOne')
+                    local mobTwo   = mission:getVar(player, 'MobTwo')
                     local mobThree = mission:getVar(player, 'MobThree')
 
                     if option == 4 then
@@ -148,10 +156,10 @@ mission.sections =
 
                 -- Tell the player what mobs are still needed
                 [238] = function(player, csid, option, npc)
-                    local mobOne = mission:getVar(player, 'MobOne')
-                    local mobTwo = mission:getVar(player, 'MobTwo')
-                    local mobThree = mission:getVar(player, 'MobThree')
-                    local pickupReady = mission:getVar(player, 'Soulplate') < GetSystemTime()
+                    local mobOne       = mission:getVar(player, 'MobOne')
+                    local mobTwo       = mission:getVar(player, 'MobTwo')
+                    local mobThree     = mission:getVar(player, 'MobThree')
+                    local pickupReady  = mission:getVar(player, 'Soulplate') < GetSystemTime()
                     local platesTraded = mission:getVar(player, 'Plates')
 
                     if option == 6 then
@@ -188,12 +196,12 @@ mission.sections =
 
                 -- Player traded a soulplate correctly, tell them what mobs are still needed
                 [241] = function(player, csid, option, npc)
-                    local mobOne = mission:getVar(player, 'MobOne')
-                    local mobTwo = mission:getVar(player, 'MobTwo')
-                    local mobThree = mission:getVar(player, 'MobThree')
+                    local mobOne       = mission:getVar(player, 'MobOne')
+                    local mobTwo       = mission:getVar(player, 'MobTwo')
+                    local mobThree     = mission:getVar(player, 'MobThree')
                     local platesTraded = mission:getVar(player, 'Plates')
+                    local foundMob     = mission:getVar(player, 'Found')
 
-                    local foundMob = mission:getVar(player, 'Found')
                     if platesTraded == 1 then
                         -- 99 = Player traded correct plate for requested mob
                         if mobOne == 99 then
@@ -262,8 +270,9 @@ mission.sections =
 
                 -- Player finished all three plates, give them the KI and complete mission
                 [241] = function(player, csid, option, npc)
-                    local platesTraded = mission:getVar(player, 'Plates')
-                    if platesTraded == 3 then
+                    player:tradeComplete()
+
+                    if mission:getVar(player, 'Plates') == 3 then
                         mission:complete(player)
                     end
                 end,

--- a/scripts/missions/bastok/1_3_Fetichism.lua
+++ b/scripts/missions/bastok/1_3_Fetichism.lua
@@ -34,9 +34,7 @@ local handleAcceptMission = function(player, csid, option, npc)
 end
 
 local handleFetichTrade = function(player, npc, trade)
-    if
-        npcUtil.tradeHasExactly(trade, { xi.item.QUADAV_FETICH_HEAD, xi.item.QUADAV_FETICH_TORSO, xi.item.QUADAV_FETICH_ARMS, xi.item.QUADAV_FETICH_LEGS })
-    then
+    if npcUtil.tradeMatches(trade, { { xi.item.QUADAV_FETICH_HEAD, 1 }, { xi.item.QUADAV_FETICH_TORSO, 1 }, { xi.item.QUADAV_FETICH_ARMS, 1 }, { xi.item.QUADAV_FETICH_LEGS, 1 } }) then
         if not player:hasCompletedMission(mission.areaId, mission.missionId) then
             return mission:progressEvent(1008)
         else
@@ -47,7 +45,7 @@ end
 
 local handleCompleteEvent = function(player, csid, option, npc)
     if mission:complete(player) then
-        player:confirmTrade()
+        player:tradeComplete()
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Creates a new npcUtil meant to substitute `npcUtil.tradeHasExactly()`
The reasoning behind this:
- `tradeHasExactly()` locks items as reserved to then consume ONLY those items, but ONLY if `confirmTrade()` is called. This means that if it isnt called, items remain locked.
  - The issue is that this is unneeded. We already want the trade to contain only those items. No more and no less.
- Auditing every single case of `tradeHasExactly()` is impossible in a single pass. theres over 450+ uses. Substituting them with this one will not only fix the uses, but also mark the fixed cases as fixed.
- Mechanically, the function is similar, but:
  - Requires a concrete definition, instead of being a multi-tool that supports a million combinations of defintions. Thats insane.
  - Does not lock items. We already want an exact list of items and quantities.

## Steps to test these changes

The function works properly, but just slap it on an npc onTrade function and try different combinations.
