### PR TITLE
[core] Tick all zones all the time / Grid scheduling

### DIFF
--- a/scripts/tests/systems/spawn_handler.lua
+++ b/scripts/tests/systems/spawn_handler.lua
@@ -266,6 +266,7 @@ describe('Spawn Handler', function()
             local despawned = false
             for _ = 1, 24 do
                 xi.test.world:tick(xi.tick.VANA_HOUR)
+                xi.test.world:skipTime(1)
                 xi.test.world:tickEntity(xolotl)
                 if not xolotl:isSpawned() then
                     despawned = true
@@ -425,6 +426,7 @@ describe('Spawn Handler', function()
             local despawned = false
             for _ = 1, 24 do
                 xi.test.world:tick(xi.tick.VANA_HOUR)
+                xi.test.world:skipTime(1)
                 for _, mob in ipairs(slot) do
                     xi.test.world:tickEntity(mob)
                 end

--- a/src/common/scheduler.h
+++ b/src/common/scheduler.h
@@ -41,6 +41,7 @@
 #include <asio/use_awaitable.hpp>
 
 #include <common/types/maybe.h>
+#include <common/xirand.h>
 
 #include <atomic>
 #include <chrono>
@@ -373,7 +374,8 @@ public:
     }
 
     // intervalOnMainThread
-    //   Queues a task on the main thread that repeats at the specified interval.
+    //   Queues a task on the main thread that repeats on a fixed period.
+    //   First run is jittered by 0..interval, not exactly one interval after this call.
     //   Returns a Token that can be used to cancel the task.
     //   The task will stop if the token goes out of scope, or if the scheduler is stopped.
     //   Since a coroutine cannot be restarted once it has been completed, we must either pass in
@@ -383,12 +385,18 @@ public:
     {
         auto signal = std::make_shared<asio::cancellation_signal>();
 
+        // Offset the start by a random phase so timers created together don't all fire on the same grid point.
+        const auto durationMs = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        const auto phase      = std::chrono::milliseconds(xirand::GetRandomNumber<int64_t>(0, durationMs));
+
         asio::co_spawn(
             mainContext_.get_executor(),
-            [this, duration, signal, fn = std::forward<T>(func)]() mutable -> Task<void>
+            [this, duration, phase, signal, fn = std::forward<T>(func)]() mutable -> Task<void>
             {
                 try
                 {
+                    // Seed the grid with the random phase so a batch of timers doesn't stay in lockstep.
+                    auto deadline = std::chrono::steady_clock::now() + phase;
                     while (!this->closeRequested())
                     {
                         if constexpr (detail::IsInvocableReturnsVoid<T>)
@@ -399,7 +407,16 @@ public:
                         {
                             co_await fn();
                         }
-                        co_await yieldFor(duration);
+
+                        deadline += duration;
+
+                        // Overran a whole period -> resync to now rather than bursting.
+                        if (const auto now = std::chrono::steady_clock::now(); deadline < now)
+                        {
+                            deadline = now;
+                        }
+
+                        co_await yieldUntil(deadline);
                     }
                 }
                 catch (const asio::system_error& e)
@@ -520,6 +537,17 @@ public:
         const auto executor = co_await asio::this_coro::executor;
         auto       timer    = asio::steady_timer(executor);
         timer.expires_after(duration);
+        co_await timer.async_wait(asio::bind_allocator(asio::recycling_allocator<void>(), asio::use_awaitable));
+    }
+
+    // yieldUntil
+    //   co_await on this to hand control back to the scheduler, without re-scheduling until
+    //   the time point has passed
+    [[nodiscard]] static auto yieldUntil(const std::chrono::steady_clock::time_point deadline) -> Task<void>
+    {
+        const auto executor = co_await asio::this_coro::executor;
+        auto       timer    = asio::steady_timer(executor);
+        timer.expires_at(deadline);
         co_await timer.async_wait(asio::bind_allocator(asio::recycling_allocator<void>(), asio::use_awaitable));
     }
 

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -736,7 +736,7 @@ void MapNetworking::flushStatistics()
 
     for (auto& [id, PZone] : g_PZoneList)
     {
-        if (PZone->IsZoneActive())
+        if (!PZone->GetZoneEntities()->CharListEmpty())
         {
             activeZoneCount += 1;
             playerCount += PZone->GetZoneEntities()->GetCharList().size();

--- a/src/map/spawn_handler.cpp
+++ b/src/map/spawn_handler.cpp
@@ -21,7 +21,6 @@
 
 #include "spawn_handler.h"
 
-#include "ai/ai_container.h"
 #include "common/timer.h"
 #include "common/vana_time.h"
 #include "data/enums/weather.h"
@@ -241,23 +240,13 @@ void SpawnHandler::Tick(const timer::time_point now)
 // Despawn mobs now outside their spawn window. Not tied to 30s task.
 void SpawnHandler::onGameHour(const uint32 hour) const
 {
-    const bool zoneActive = zone_->IsZoneActive();
-
     zone_->ForEachMob(
-        [zoneActive, hour](CMobEntity* PMob)
+        [hour](CMobEntity* PMob)
         {
             const auto window = spawnWindowOf(PMob);
             if (window.has_value() && PMob->isAlive() && !hourInWindow(hour, window->spawnHour, window->despawnHour))
             {
-                if (zoneActive)
-                {
-                    PMob->SetDespawnTime(1ms);
-                }
-                else
-                {
-                    // Sleeping zone -> process the despawn immediately since AI doesnt tick on its own
-                    PMob->PAI->Despawn();
-                }
+                PMob->SetDespawnTime(1ms);
             }
         });
 }

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -829,6 +829,12 @@ auto LoadZones(Scheduler& scheduler, MapConfig config, const std::vector<uint16>
             luautils::OnZoneInitialize(g_PZoneList[zoneId]->GetID());
         }
     }
+
+    // Start zone timers after all entities are loaded
+    for (auto zoneId : zonesIdsToLoad)
+    {
+        g_PZoneList[zoneId]->createZoneTimers();
+    }
 }
 
 auto LoadZoneList(Scheduler& scheduler, MapConfig config) -> Task<void>

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -99,20 +99,6 @@ CZone::CZone(Scheduler& scheduler, MapConfig config, ZONEID ZoneID, REGION_TYPE 
 
     LoadZoneLines();
     LoadZoneWeather();
-
-    if (config_.isTestServer)
-    {
-        return;
-    }
-
-    // This must run continually, regardless of if the zone is awake
-    spawnHandlerTimerToken_ = scheduler.intervalOnMainThread(
-        kSpawnHandlerInterval,
-        [this]() -> Task<void>
-        {
-            this->spawnHandler().Tick(timer::now());
-            co_return;
-        });
 }
 
 CZone::~CZone()
@@ -770,32 +756,9 @@ void CZone::UpdateWeather()
         });
 }
 
-bool CZone::CheckMobsPathedBack()
-{
-    bool allMobsHomeAndHealed = true;
-    if (m_zoneEntities && m_zoneEntities->GetMobList().size() > 0)
-    {
-        const auto& mobListMap = m_zoneEntities->GetMobList();
-        for (const auto& pair : mobListMap)
-        {
-            CMobEntity* mob = dynamic_cast<CMobEntity*>(pair.second);
-            // if the mob is (not dead/despawned AND it is not fully healed) OR it is pathing home
-            if (mob && ((!mob->isDead() && !mob->isFullyHealed()) || mob->m_IsPathingHome))
-            {
-                // at least one mob is away from home or not fully healed
-                allMobsHomeAndHealed = false;
-                break;
-            }
-        }
-    }
-
-    return allMobsHomeAndHealed;
-}
-
 /************************************************************************
  *                                                                       *
- *  Remove a character from the zone. If ZoneServer and character are    *
- *  online, and there is no more left in the zone, then stop zone        *
+ *  Remove a character from the zone.                                     *
  *                                                                       *
  ************************************************************************/
 
@@ -805,11 +768,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
     m_zoneEntities->DecreaseZoneCounter(PChar);
 
-    if (m_zoneEntities->CharListEmpty())
-    {
-        m_timeZoneEmpty = timer::now();
-    }
-    else
+    if (!m_zoneEntities->CharListEmpty())
     {
         m_zoneEntities->DespawnPC(PChar);
     }
@@ -819,7 +778,7 @@ void CZone::DecreaseZoneCounter(CCharEntity* PChar)
 
 /************************************************************************
  *                                                                       *
- *  Add a character to the zone. If zone isn't running, then load zone.  *
+ *  Add a character to the zone.                                         *
  *  Be sure to check the number of characters in the zone.               *
  *  The maximum number of characters in one zone is 768                  *
  *                                                                       *
@@ -844,11 +803,6 @@ void CZone::IncreaseZoneCounter(CCharEntity* PChar)
     }
 
     m_zoneEntities->InsertPC(PChar);
-
-    if (!zoneTimerToken_.has_value() && !m_zoneEntities->CharListEmpty())
-    {
-        createZoneTimers();
-    }
 
     PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::OnZonePathos, EffectNotice::Silent);
 
@@ -964,12 +918,6 @@ auto CZone::ZoneServer(timer::time_point tick) -> Task<void>
         m_BattlefieldHandler->HandleBattlefields(tick);
     }
 
-    if (zoneTimerToken_.has_value() && m_zoneEntities->CharListEmpty() && m_timeZoneEmpty + 5s < timer::now() && CheckMobsPathedBack())
-    {
-        zoneTimerToken_.reset();
-        zoneTimerTriggerAreasToken_.reset();
-    }
-
     co_return;
 }
 
@@ -1061,11 +1009,19 @@ void CZone::createZoneTimers()
 {
     TracyZoneScoped;
 
-    // We'll manually tick on while testing, don't install the timers
+    // We'll manually tick while testing, don't install the timers.
     if (config_.isTestServer)
     {
         return;
     }
+
+    spawnHandlerTimerToken_ = scheduler_.intervalOnMainThread(
+        kSpawnHandlerInterval,
+        [this]() -> Task<void>
+        {
+            this->spawnHandler().Tick(timer::now());
+            co_return;
+        });
 
     zoneTimerToken_ = scheduler_.intervalOnMainThread(
         kLogicUpdateInterval,
@@ -1300,11 +1256,6 @@ void CZone::CharZoneOut(CCharEntity* PChar)
     }
 
     charutils::WriteHistory(PChar);
-}
-
-bool CZone::IsZoneActive() const
-{
-    return zoneTimerToken_.has_value();
 }
 
 CZoneEntities* CZone::GetZoneEntities()

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -576,7 +576,6 @@ public:
     bool CanUseMisc(xi::ZoneMisc misc) const;
     void SetWeather(xi::Weather weather);
     void UpdateWeather();
-    bool CheckMobsPathedBack();
 
     virtual void SpawnPCs(CCharEntity* PChar);
     virtual void SpawnMOBs(CCharEntity* PChar);
@@ -614,8 +613,9 @@ public:
 
     virtual void UpdateEntityPacket(CBaseEntity* PEntity, ENTITYUPDATE type, uint8 updatemask, bool alwaysInclude = false);
 
-    bool           IsZoneActive() const;
     CZoneEntities* GetZoneEntities();
+
+    void createZoneTimers();
 
     virtual auto ZoneServer(timer::time_point tick) -> Task<void>;
     virtual auto CheckTriggerAreas() -> Task<void>;
@@ -647,7 +647,6 @@ public:
     void LoadXiMesh();
 
 protected:
-    void createZoneTimers();
     void CharZoneIn(CCharEntity* PChar);
     void CharZoneOut(CCharEntity* PChar);
 
@@ -691,8 +690,6 @@ private:
     zoneLineList_t m_zoneLineList;
 
     CTreasurePool* m_TreasurePool;
-
-    timer::time_point m_timeZoneEmpty; // The time point when the last player left the zone
 
     HashMap<std::string, QueryByNameResult_t> m_queryByNameResults;
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -209,11 +209,6 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
 
     if (PChar->PInstance)
     {
-        if (!zoneTimerToken_.has_value())
-        {
-            createZoneTimers();
-        }
-
         PChar->targid = PChar->PInstance->GetNewCharTargID();
 
         if (PChar->targid >= 0x700)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
### Zones no longer "sleep"
#### Rationale: 
Lots of gotchas with having zones where entities are not ticking leading to subtle bugs relating to spawns/respawns or pathing when players leave the zone (Qulun Dome and Dragon's Aery are notorious examples of unintended MPKs).

This will make the code in general easier to reason about and not have to simulate certain scenario in a roundabout way (see Dark Ixion for an example). Besieged/Reives/Goblin Diggers (just to name a few) should now be much easier to implement.

#### Will it break my machine?
An _extensive_ set of benchmarks on severely underpowered configurations has shown this to be viable at _very high_ player counts on a _single_ process. As is quite often the case, Windows does lag a tiny bit behind Linux but you shouldn't see a meaningful difference in practice.

Worth noting that **Debug** builds may no longer be able to reliably honor ticks. Stick to **RelWithDebInfo** build types unless absolutely necessary. 

The primary reason is the addition of an extensive set of assertions and checks on iterators on such builds, combined with inlining being disabled and having to iterate a little above 100,000 entities every complete loop. 

It is possible to render the **Debug** builds viable by disabling certain flags but given that they offer real bug-catching value, we do not recommend going down this route.

### Grid scheduling
The old scheduler waited its interval after each tick finished, so the more zones stayed awake, the more each tick's work piled into the next one and the whole world quietly drifted below its target rate.

Ticks now fire on a fixed grid: the next one is scheduled from when the last tick should have run, not from when it actually finished, so cadence should hold no matter how heavy a round gets.

A slight amount of jitter is added at task creation to attempt to spread the tasks instead of having them all tightly following each other.

None of this would have been possible without @zach2good tireless optimizations!

## Steps to test these changes
Play, find bugs, report them?

<!-- Clear and detailed steps to test your changes here -->
