### PR TITLE
Core: Crash directly in Watchdog instead of throwing

### DIFF
--- a/src/common/console_service.cpp
+++ b/src/common/console_service.cpp
@@ -207,6 +207,13 @@ void ConsoleService::registerDefaultCommands()
         });
 
     registerCommand(
+        "hang", "Inject an infinite loop to force a hang (main thread)", [](std::vector<std::string>& inputs)
+        {
+            fmt::print("> Hanging...\n");
+            hang();
+        });
+
+    registerCommand(
         "exit", "Request application exit", [&](std::vector<std::string>& inputs)
         {
             application_.requestExit();
@@ -277,7 +284,12 @@ auto ConsoleService::consoleLoop() -> Task<void>
 
                         try
                         {
-                            it->second.func(args);
+                            auto& command = it->second;
+
+                            // Try and populate trace buffer in case something goes wrong
+                            ShowTraceFmt("Handling console command: {}", command.name);
+
+                            command.func(args);
                         }
                         catch (const std::exception& e)
                         {

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -893,13 +893,18 @@ bool definitelyLessThan(float a, float b)
 
 void crash()
 {
-#ifndef _DEBUG
-    ShowInfo("crash command is likely optimized out in release mode.");
-#endif
-
-    int* volatile ptr = nullptr;
+    unsigned long long* volatile ptr = nullptr;
     // cppcheck-suppress nullPointer
-    *ptr = 0xDEAD;
+    *ptr = 0xDEADBEEF;
+}
+
+void hang()
+{
+    // NOLINTNEXTLINE(bugprone-infinite-loop): the hang is deliberate.
+    for (volatile bool spin = true; spin;)
+    {
+        // Spin! Wheeeee!
+    }
 }
 
 std::unique_ptr<FILE> utils::openFile(const std::string& path, const std::string& mode)

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -176,6 +176,7 @@ bool definitelyGreaterThan(float a, float b);
 bool definitelyLessThan(float a, float b);
 
 void crash();
+void hang();
 
 template <typename T>
 std::set<std::filesystem::path> sorted_directory_iterator(std::string path_name)

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -323,17 +323,9 @@ auto MapEngine::watchdogWatcher() -> Task<void>
             }
             else if (!settings::get<bool>("main.DISABLE_INACTIVITY_WATCHDOG"))
             {
-                std::string outputStr = "!!! INACTIVITY WATCHDOG HAS TRIGGERED !!!\n\n";
-
+                std::string outputStr;
+                outputStr += "!!! INACTIVITY WATCHDOG HAS TRIGGERED !!!\n\n";
                 outputStr += fmt::format("Process main tick has taken {}ms or more.\n", period);
-                outputStr += fmt::format("Backtrace Messages:\n\n");
-
-                const auto backtrace = logging::GetBacktrace();
-                for (const auto& line : backtrace)
-                {
-                    outputStr += fmt::format("    {}\n", line);
-                }
-
                 outputStr += "\nKilling Process!!!\n";
 
                 ShowCritical(outputStr);
@@ -341,7 +333,8 @@ auto MapEngine::watchdogWatcher() -> Task<void>
                 // Allow some time for logging to flush
                 std::this_thread::sleep_for(200ms);
 
-                throw std::runtime_error("Watchdog thread time exceeded. Killing process.");
+                // Terminate directly rather than throwing.
+                crash();
             }
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

By my own design, we swallow exceptions in jobs that are yeeted into worker threads. This will force a crash, invoking crash handlers, dumping backtrace buffers, etc.

I'll re-address crash handling soon.