### PR TITLE
[C++] [lua] Remove Skillchain Resistance Rank Reduction + Add Pre SoA Magic Burst Module

### DIFF
--- a/modules/era/lua/combat/magic_burst.lua
+++ b/modules/era/lua/combat/magic_burst.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- Pre-SoA Magic Burst Module
+-- Restores the pre-2015 magic burst multiplier: 1.25 + 0.05 per skillchain step.
+-- https://forum.square-enix.com/ffxi/threads/46531
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_magic_burst'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.spells.damage.calculateIfMagicBurst', function(caster, target, spellElement, magicBurstTier)
+    if spellElement <= xi.element.NONE then
+        return 1
+    end
+
+    return 1.25 + 0.05 * utils.clamp(magicBurstTier, 1, 5)
+end)
+
+return m

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3420,14 +3420,6 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
         return ActionProcSkillChain::None;
     }
 
-    Mod resistanceRankMods[] = { Mod::FIRE_RES_RANK, Mod::ICE_RES_RANK, Mod::WIND_RES_RANK, Mod::EARTH_RES_RANK, Mod::THUNDER_RES_RANK, Mod::ICE_RES_RANK, Mod::LIGHT_RES_RANK, Mod::DARK_RES_RANK };
-
-    // Reset the effects resistance rank mods
-    for (const auto& resistanceRank : resistanceRankMods)
-    {
-        PSCEffect->setMod(resistanceRank, 0);
-    }
-
     if (skillchain != SC_NONE)
     {
         PSCEffect->SetStartTime(timer::now());
@@ -3435,14 +3427,6 @@ auto GetSkillChainEffect(const CBattleEntity* PDefender, uint8 primary, uint8 se
         PSCEffect->SetTier(GetSkillchainTier(skillchain));
         PSCEffect->SetPower(skillchain);
         PSCEffect->SetSubPower(std::min(PSCEffect->GetSubPower() + 1, 5)); // Linked, limited to 5
-
-        // Set new resistance rank modifiers
-        // https://www.bg-wiki.com/ffxi/Resist#Modifying_Resistance_Rank
-        for (auto& element : GetSkillchainMagicElement(skillchain))
-        {
-            const Mod resistanceRankMod = GetResistanceRankModFromElement(element);
-            PSCEffect->setMod(resistanceRankMod, -1);
-        }
 
         return GetSkillchainSubeffect(skillchain);
     }
@@ -3481,22 +3465,6 @@ std::vector<ELEMENT> GetSkillchainMagicElement(SKILLCHAIN_ELEMENT skillchain)
     };
 
     return resonanceToElement.at(skillchain);
-}
-
-Mod GetResistanceRankModFromElement(ELEMENT& element)
-{
-    static const HashMap<ELEMENT, Mod> elementToMod = {
-        { ELEMENT_FIRE, Mod::FIRE_RES_RANK },
-        { ELEMENT_WATER, Mod::WATER_RES_RANK },
-        { ELEMENT_WIND, Mod::WIND_RES_RANK },
-        { ELEMENT_EARTH, Mod::EARTH_RES_RANK },
-        { ELEMENT_THUNDER, Mod::THUNDER_RES_RANK },
-        { ELEMENT_ICE, Mod::ICE_RES_RANK },
-        { ELEMENT_LIGHT, Mod::LIGHT_RES_RANK },
-        { ELEMENT_DARK, Mod::DARK_RES_RANK },
-    };
-
-    return elementToMod.at(element);
 }
 
 auto TakeSkillchainDamage(CBattleEntity* PAttacker, CBattleEntity* PDefender, int32 lastSkillDamage, CBattleEntity* taChar) -> int32

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -137,7 +137,6 @@ uint8                GetSkillchainTier(SKILLCHAIN_ELEMENT skillchain);
 auto                 GetSkillchainSubeffect(SKILLCHAIN_ELEMENT skillchain) -> ActionProcSkillChain;
 int16                GetSkillchainMinimumResistance(SKILLCHAIN_ELEMENT element, CBattleEntity* PDefender, ELEMENT& appliedEle);
 std::vector<ELEMENT> GetSkillchainMagicElement(SKILLCHAIN_ELEMENT skillchain);
-Mod                  GetResistanceRankModFromElement(ELEMENT& element);
 
 bool IsParalyzed(CBattleEntity* PAttacker);
 bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Removes a bonus skillchains were applying that lowers the monsters resistance rank by 1 tier. According to @WinterSolstice8 this is not how this actually works - so I am removing it for now so that it can be handled elsewhere when we figure out how it works.

## Steps to test these changes

rebuild

Make skillchains

enable the module, see magic bursts do a lot less damage.
