### PR TITLE
[C++,lua]  Play zone music after Chocobo music ends

### DIFF
--- a/scripts/effects/mounted.lua
+++ b/scripts/effects/mounted.lua
@@ -9,20 +9,26 @@ effectObject.onEffectGain = function(target, effect)
     local mountId = effect:getPower()
     -- Retail sends a music change packet (packet ID 0x5F) in both cases.
 
+    local music     = 0
     local animation = xi.animation.NONE
 
     if
         mountId == xi.mount.CHOCOBO or
         mountId == xi.mount.NOBLE_CHOCOBO
     then
-        target:changeMusic(xi.musicSlot.MOUNT, 212)
+        music     = 212
         animation = xi.animation.CHOCOBO
     else
-        target:changeMusic(xi.musicSlot.MOUNT, 84)
+        music     = 84
         animation = xi.animation.MOUNT
     end
 
     if not target:isInEvent() then
+        local musicEnd = target:getCharVar('[CHOCOBO]MusicEnd')
+        if musicEnd == 0 or GetSystemTime() < musicEnd then
+            target:changeMusic(xi.musicSlot.MOUNT, music)
+        end
+
         target:setAnimation(animation)
     end
 
@@ -35,10 +41,20 @@ effectObject.onEffectGain = function(target, effect)
     attohwaChasmGlobal.removeMimeoKIs(target)
 end
 
+-- Tick timer is reset on zone
 effectObject.onEffectTick = function(target, effect)
+    local musicEnd = target:getCharVar('[CHOCOBO]MusicEnd')
+
+    if GetSystemTime() >= musicEnd then
+        target:changeMusic(xi.musicSlot.MOUNT, 0)
+        target:setCharVar('[CHOCOBO]MusicEnd', -1) -- Song played and finished.
+        effect:setTick(0)
+    end
 end
 
 effectObject.onEffectLose = function(target, effect)
+    target:setCharVar('[CHOCOBO]MusicEnd', 0)
+
     if not target:isInEvent() then -- Paranoia safety check
         target:setAnimation(xi.animation.NONE)
     end

--- a/scripts/globals/chocobo.lua
+++ b/scripts/globals/chocobo.lua
@@ -240,7 +240,8 @@ xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
             end
         end
 
-        player:addStatusEffect(xi.effect.MOUNTED, { duration = duration, origin = player, silent = true })
+        player:setCharVar('[CHOCOBO]MusicEnd', GetSystemTime() + 390)
+        player:addStatusEffect(xi.effect.MOUNTED, { duration = duration, origin = player, silent = true, tick = 15 })
 
         -- Renting a chocobo force despawns every type of pets
         -- Note: This does not honor cooldown reductions offered otherwise when dismissing pets with full life.
@@ -249,6 +250,9 @@ xi.chocobo.renterOnEventFinish = function(player, csid, option, eventSucceed)
 
         if info.pos then
             player:setPos(unpack(info.pos))
+        else
+            -- Set chocobo music if not renting from a city
+            player:changeMusic(xi.musicSlot.MOUNT, 212)
         end
     elseif chocoGame ~= 0 and csid == eventSucceed then
         player:despawnPet()

--- a/src/map/packets/s2c/0x00a_login.cpp
+++ b/src/map/packets/s2c/0x00a_login.cpp
@@ -179,7 +179,18 @@ GP_SERV_COMMAND_LOGIN::GP_SERV_COMMAND_LOGIN(CCharEntity* PChar, const EventInfo
     packet.MusicNum[1] = PChar->PInstance ? PChar->PInstance->GetBackgroundMusicNight() : PChar->loc.zone->GetBackgroundMusicNight();
     packet.MusicNum[2] = PChar->PInstance ? PChar->PInstance->GetSoloBattleMusic() : PChar->loc.zone->GetSoloBattleMusic();
     packet.MusicNum[3] = PChar->PInstance ? PChar->PInstance->GetPartyBattleMusic() : PChar->loc.zone->GetPartyBattleMusic();
-    packet.MusicNum[4] = PChar->animation == xi::Animation::Mount ? 0x54 : 0xD4;
+    if (PChar->animation == xi::Animation::Chocobo && PChar->getCharVar("[CHOCOBO]MusicEnd") != -1) // Music has not played to completion yet.
+    {
+        packet.MusicNum[4] = 0xD4;
+    }
+    else if (PChar->animation == xi::Animation::Mount)
+    {
+        packet.MusicNum[4] = 0x54;
+    }
+    else
+    {
+        packet.MusicNum[4] = 0;
+    }
 
     const auto csid = currentEvent->eventId;
     if (csid != -1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There are two problems with Chocobo music.
1. When renting from a city, Chocobo music begins before you zone. On retail the music update is sent on zone.
2. When the Chocobo music ends (390 seconds) no music plays and it's silent. On retail it swaps back to zone music.

[C++] The music packet in slot 4 is always 0 unless you are mounted: the number depends if Chocobo mount or personal mount. Observed in captures.
[lua] A new 15 second tick is added that checks when the song has finished and puts it to the played and finished state. The tick timer resets on zone which is why it's 15 seconds.

Capture where I rented a Chocobo from the city, zoned a few times, and let the time ware out; mounted a raptor in the field and zoned and tried to let the time wear out (it didn't); and rented from a crag.
https://drive.google.com/file/d/1-V8DsCVWdCMvRxHsX5U1ZOuT9hk83mEB/view?usp=drive_link

## Steps to test these changes

Get on a chocobo and let the song wear off after 390 seconds zone music should start.
