### PR TITLE
[lua] Adjust Default Mog Locker State

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Fubruhn.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Fubruhn.lua
@@ -83,7 +83,8 @@ entity.onTrigger = function(player, npc)
         if mogLockerExpiryTimestamp == nil then
             -- a nil timestamp means they haven't unlocked it yet. We're going to unlock it by merely talking to this NPC.
             mogLockerExpiryTimestamp = xi.moghouse.unlockMogLocker(player)
-            accessType = xi.moghouse.setMogLockerAccessType(player, xi.moghouse.lockerAccessType.ALLAREAS)
+
+            accessType = xi.moghouse.setMogLockerAccessType(player, xi.moghouse.lockerAccessType.ALZAHBI)
         end
 
         player:startEvent(600, mogLockerExpiryTimestamp, accessType, xi.moghouse.MOGLOCKER_ALZAHBI_VALID_DAYS, player:getContainerSize(xi.inv.MOGLOCKER),


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Changes the default access of the Mog Locker to Al Zahbi only. Players can talk to Fubruhn after completing Immortal Sentries to change it to all areas.

https://www.bg-wiki.com/ffxi/Mog_Locker

## Steps to test these changes

Complete Immortal Sentries, unlock Mog Locker - see Al Zabhi access only until changed.
