### PR TITLE
[lua] Add forced gathering wait server setting

### DIFF
--- a/scripts/globals/hobbies/helm/logic.lua
+++ b/scripts/globals/hobbies/helm/logic.lua
@@ -161,6 +161,17 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
     player:delStatusEffect(xi.effect.INVISIBLE)
 
     if trade:hasItemQty(info.tool, 1) and trade:getItemCount() == 1 then
+        -- Forced wait between gathering attempts
+        if xi.settings.main.ENABLE_HELM_WAIT then
+            local now = GetSystemTime()
+
+            if now < player:getLocalVar('[HELM]LastAttempt') + 3 then
+                return
+            end
+
+            player:setLocalVar('[HELM]LastAttempt', now)
+        end
+
         -- start event
         local itemID = pickItem(player, info)
         local broke  = doesToolBreak(player, info) and 1 or 0

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -184,14 +184,15 @@ xi.settings.main =
         '\129\153\129\154 The Alter Ego Expo Campaign is active! \129\154\129\153\n' ..
         'Trusts gain the benefits of Increased HP, MP, and Status Resistances!',
 
-    HARVESTING_BREAK_CHANCE = 33, -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
-    EXCAVATION_BREAK_CHANCE = 33, -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
-    LOGGING_BREAK_CHANCE    = 33, -- % chance for the hatchet to break during logging.  Set between 0 and 100.
-    MINING_BREAK_CHANCE     = 33, -- % chance for the pickaxe to break during mining.  Set between 0 and 100.
-    HARVESTING_RATE         = 50, -- % chance to recieve an item from haresting.  Set between 0 and 100.
-    EXCAVATION_RATE         = 50, -- % chance to recieve an item from excavation.  Set between 0 and 100.
-    LOGGING_RATE            = 50, -- % chance to recieve an item from logging.  Set between 0 and 100.
-    MINING_RATE             = 50, -- % chance to recieve an item from mining.  Set between 0 and 100.
+    HARVESTING_BREAK_CHANCE = 33,    -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
+    EXCAVATION_BREAK_CHANCE = 33,    -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
+    LOGGING_BREAK_CHANCE    = 33,    -- % chance for the hatchet to break during logging.  Set between 0 and 100.
+    MINING_BREAK_CHANCE     = 33,    -- % chance for the pickaxe to break during mining.  Set between 0 and 100.
+    HARVESTING_RATE         = 50,    -- % chance to recieve an item from haresting.  Set between 0 and 100.
+    EXCAVATION_RATE         = 50,    -- % chance to recieve an item from excavation.  Set between 0 and 100.
+    LOGGING_RATE            = 50,    -- % chance to recieve an item from logging.  Set between 0 and 100.
+    MINING_RATE             = 50,    -- % chance to recieve an item from mining.  Set between 0 and 100.
+    ENABLE_HELM_WAIT        = false, -- Enforces a 3 second wait between HELM gathering attempts.
 
     HEALING_TP_CHANGE       = -100, -- Change in TP for each healing tick. Default is -100
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a server setting to add a forced delay between HELM attempts to prevent /fps 0 or animation altering addons from allowing players to gather faster.

## Steps to test these changes

- Set ENABLE_HELM_WAIT to true
- Use /fps 0 with Ashita
- See that you are rejected from gathering faster than the baseline animation time