### PR TITLE
[Chore] Audit all mission uses of `npcUtil.tradeHasExactly()`

### DIFF
--- a/scripts/missions/bastok/2_1_The_Crystal_Line.lua
+++ b/scripts/missions/bastok/2_1_The_Crystal_Line.lua
@@ -103,7 +103,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 1 and
-                        npcUtil.tradeHasExactly(trade, xi.item.FADED_CRYSTAL)
+                        npcUtil.tradeMatches(trade, { { xi.item.FADED_CRYSTAL, 1 } })
                     then
                         return mission:progressEvent(506)
                     end
@@ -147,7 +147,7 @@ mission.sections =
 
                 [506] = function(player, csid, option, npc)
                     if option == 0 then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         npcUtil.giveKeyItem(player, xi.ki.C_L_REPORT)
                     end
                 end,

--- a/scripts/missions/bastok/2_2_Wading_Beasts.lua
+++ b/scripts/missions/bastok/2_2_Wading_Beasts.lua
@@ -90,7 +90,7 @@ mission.sections =
             ['Alois'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.LIZARD_EGG) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.LIZARD_EGG, 1 } }) then
                         if not player:hasCompletedMission(mission.areaId, mission.missionId) then
                             return mission:progressEvent(372)
                         else
@@ -106,13 +106,13 @@ mission.sections =
             {
                 [372] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
 
                 [373] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
+++ b/scripts/missions/bastok/2_3_2_The_Emissary_Windurst.lua
@@ -26,7 +26,7 @@ mission.sections =
             ['Uu_Zhoumo'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.ASPIR_KNIFE) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.ASPIR_KNIFE, 1 } }) then
                         return mission:progressEvent(41)
                     end
                 end,
@@ -51,7 +51,7 @@ mission.sections =
                 end,
 
                 [41] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:delKeyItem(xi.ki.DULL_SWORD)
                     player:setMissionStatus(mission.areaId, 6)
                 end,

--- a/scripts/missions/bastok/3_2_To_the_Forsaken_Mines.lua
+++ b/scripts/missions/bastok/3_2_To_the_Forsaken_Mines.lua
@@ -28,7 +28,7 @@ local handleAcceptMission = function(player, csid, option, npc)
 end
 
 local handleMissionTrade = function(player, npc, trade)
-    if npcUtil.tradeHasExactly(trade, xi.item.GLOCOLITE) then
+    if npcUtil.tradeMatches(trade, { { xi.item.GLOCOLITE, 1 } }) then
         if player:hasCompletedMission(mission.areaId, mission.missionId) then
             return mission:progressEvent(1006)
         else
@@ -39,7 +39,7 @@ end
 
 local handleTradeEventFinish = function(player, csid, option, npc)
     if mission:complete(player) then
-        player:confirmTrade()
+        player:tradeComplete()
     end
 end
 
@@ -126,11 +126,11 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.SLICE_OF_HARE_MEAT) and
+                        npcUtil.tradeMatches(trade, { { xi.item.SLICE_OF_HARE_MEAT, 1 } }) and
                         not player:findItem(xi.item.GLOCOLITE) and
                         npcUtil.popFromQM(player, npc, gusgenID.mob.BLIND_MOBY, { hide = 180 })
                     then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         return mission:messageSpecial(gusgenID.text.YOU_PUT_ITEM_DOWN, xi.item.SLICE_OF_HARE_MEAT)
                     else
                         return mission:messageSpecial(gusgenID.text.NOTHING_SEEMS_HAPPENING)

--- a/scripts/missions/bastok/3_3_Jeuno.lua
+++ b/scripts/missions/bastok/3_3_Jeuno.lua
@@ -160,7 +160,7 @@ mission.sections =
                     -- the key into a key item, allowing the player to drop the inventory key for space.
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
+                        npcUtil.tradeMatches(trade, { { xi.item.DELKFUTT_KEY, 1 } })
                     then
                         return mission:progressCutscene(1)
                     end
@@ -184,7 +184,7 @@ mission.sections =
 
                     if not player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
                         npcUtil.giveKeyItem(player, xi.ki.DELKFUTT_KEY)
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/bastok/6_2_The_Pirates_Cove.lua
+++ b/scripts/missions/bastok/6_2_The_Pirates_Cove.lua
@@ -22,7 +22,7 @@ local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.THE_P
 
 mission.reward =
 {
-    gil = 40000,
+    gil  = 40000,
     rank = 7,
 }
 
@@ -130,7 +130,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        npcUtil.tradeHasExactly(trade, xi.item.FRAG_ROCK)
+                        npcUtil.tradeMatches(trade, { { xi.item.FRAG_ROCK, 1 } })
                     then
                         return mission:progressEvent(99)
                     end
@@ -150,7 +150,7 @@ mission.sections =
                 end,
 
                 [99] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 3)
                 end,
             },
@@ -163,10 +163,10 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        npcUtil.tradeHasExactly(trade, xi.item.CHUNK_OF_ADAMAN_ORE) and
+                        npcUtil.tradeMatches(trade, { { xi.item.CHUNK_OF_ADAMAN_ORE, 1 } }) and
                         npcUtil.popFromQM(player, npc, { ifritsCauldronID.mob.PIRATES_COVE_NMS, ifritsCauldronID.mob.PIRATES_COVE_NMS + 1 }, { claim = false, hide = 900 })
                     then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         GetMobByID(ifritsCauldronID.mob.PIRATES_COVE_NMS):lookAt(player:getPos()) -- Salamander
                         GetMobByID(ifritsCauldronID.mob.PIRATES_COVE_NMS + 1):updateClaim(player) -- Magma
                         return mission:messageSpecial(ifritsCauldronID.text.BAD_FEELING_ABOUT_PLACE)

--- a/scripts/missions/cop/3_5_Darkness_Named.lua
+++ b/scripts/missions/cop/3_5_Darkness_Named.lua
@@ -41,9 +41,9 @@ mission.sections =
                         not player:hasKeyItem(xi.ki.PSOXJA_PASS) and
                         mission:getVar(player, 'Status') == 2 and
                         (
-                            npcUtil.tradeHasExactly(trade, xi.item.CARMINE_CHIP) or
-                            npcUtil.tradeHasExactly(trade, xi.item.CYAN_CHIP) or
-                            npcUtil.tradeHasExactly(trade, xi.item.GRAY_CHIP)
+                            npcUtil.tradeMatches(trade, { { xi.item.CARMINE_CHIP, 1 } }) or
+                            npcUtil.tradeMatches(trade, { { xi.item.CYAN_CHIP, 1 } }) or
+                            npcUtil.tradeMatches(trade, { { xi.item.GRAY_CHIP, 1 } })
                         )
                     then
                         -- ToDo Uncaptured CS 51 seems to imply you traded the wrong item
@@ -86,7 +86,7 @@ mission.sections =
             onEventFinish =
             {
                 [52] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
 
                     player:addGil(xi.settings.main.GIL_RATE * 500) -- Silent since the gil reward is baked into the CS.
                     npcUtil.giveKeyItem(player, xi.ki.PSOXJA_PASS)

--- a/scripts/missions/cop/5_3_Three_Paths.lua
+++ b/scripts/missions/cop/5_3_Three_Paths.lua
@@ -219,7 +219,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId, xi.mission.status.COP.LOUVERANCE) == 11 and
-                        npcUtil.tradeHasExactly(trade, xi.item.GOLD_KEY)
+                        npcUtil.tradeMatches(trade, { { xi.item.GOLD_KEY, 1 } })
                     then
                         return mission:progressEvent(3)
                     end
@@ -229,7 +229,7 @@ mission.sections =
             onEventFinish =
             {
                 [3] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     -- NOTE: This event transports you to the BCNM exit, and is handled by the client.
                     -- POS: -87.410 180 499.929 127 13
                     player:setMissionStatus(mission.areaId, 12, xi.mission.status.COP.LOUVERANCE)

--- a/scripts/missions/rov/1_04_Set_Free.lua
+++ b/scripts/missions/rov/1_04_Set_Free.lua
@@ -27,7 +27,7 @@ local handleTradeEventFinish = function(player, csid, option, npc)
 
     local pathId = player:getMissionStatus(mission.areaId)
 
-    player:confirmTrade()
+    player:tradeComplete()
     mission:complete(player)
     player:setMissionStatus(mission.areaId, pathId)
 end
@@ -45,7 +45,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, { { xi.item.CLUMP_OF_BEE_POLLEN, 3 } }) and
+                        npcUtil.tradeMatches(trade, { { xi.item.CLUMP_OF_BEE_POLLEN, 3 } }) and
                         player:getMissionStatus(mission.areaId) == 1
                     then
                         return mission:progressEvent(178, 0, 0, 0, 0, 0, 0, player:hasJob(0) and 1 or 0)
@@ -69,7 +69,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, { { xi.item.MANDRAGORA_DEWDROP, 3 } }) and
+                        npcUtil.tradeMatches(trade, { { xi.item.MANDRAGORA_DEWDROP, 3 } }) and
                         player:getMissionStatus(mission.areaId) == 2
                     then
                         return mission:progressEvent(370, 0, 0, 0, 0, 0, 0, player:hasJob(0) and 1 or 0)

--- a/scripts/missions/rov/2_22_Keep_On_Giving.lua
+++ b/scripts/missions/rov/2_22_Keep_On_Giving.lua
@@ -35,7 +35,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     local requiredTrade = itemOptions[mission:getVar(player, 'Option')]
 
-                    if npcUtil.tradeHasExactly(trade, { requiredTrade }) then
+                    if npcUtil.tradeMatches(trade, { requiredTrade }) then
                         -- NOTE: First parameter is dependent on RotZ completion status regarding Kam'lanaut living.  With minimal requirements,
                         -- this was '1', while with RotZ completed this was '3'
 
@@ -54,7 +54,7 @@ mission.sections =
             {
                 [17] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/sandoria/1_1_Smash_the_Orcish_Scouts.lua
+++ b/scripts/missions/sandoria/1_1_Smash_the_Orcish_Scouts.lua
@@ -22,7 +22,7 @@ mission.reward =
 }
 
 local function handleTradeEvent(player, trade, firstId, repeatId)
-    if npcUtil.tradeHasExactly(trade, xi.item.ORCISH_AXE) then
+    if npcUtil.tradeMatches(trade, { { xi.item.ORCISH_AXE, 1 } }) then
         if not player:hasCompletedMission(mission.areaId, mission.missionId) then
             return mission:progressEvent(firstId)
         else
@@ -40,7 +40,7 @@ end
 
 local handleTradeEventFinish = function(player, csid, option, npc)
     if mission:complete(player) then
-        player:confirmTrade()
+        player:tradeComplete()
     end
 end
 

--- a/scripts/missions/sandoria/1_2_Bat_Hunt.lua
+++ b/scripts/missions/sandoria/1_2_Bat_Hunt.lua
@@ -31,12 +31,12 @@ local function handleTradeEvent(player, trade, firstId, repeatId)
 
     if
         not isRepeated and
-        npcUtil.tradeHasExactly(trade, xi.item.ORCISH_MAIL_SCALES)
+        npcUtil.tradeMatches(trade, { { xi.item.ORCISH_MAIL_SCALES, 1 } })
     then
         return mission:progressEvent(firstId)
     elseif
         isRepeated and
-        npcUtil.tradeHasExactly(trade, xi.item.BAT_FANG)
+        npcUtil.tradeMatches(trade, { { xi.item.BAT_FANG, 1 } })
     then
         return mission:progressEvent(repeatId)
     end
@@ -44,7 +44,7 @@ end
 
 local handleTradeEventFinish = function(player, csid, option, npc)
     if mission:complete(player) then
-        player:confirmTrade()
+        player:tradeComplete()
     end
 end
 

--- a/scripts/missions/sandoria/2_1_The_Rescue_Drill.lua
+++ b/scripts/missions/sandoria/2_1_The_Rescue_Drill.lua
@@ -375,7 +375,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 9 and
-                        npcUtil.tradeHasExactly(trade, xi.item.BRONZE_SWORD)
+                        npcUtil.tradeMatches(trade, { { xi.item.BRONZE_SWORD, 1 } })
                     then
                         return mission:progressEvent(2)
                     end
@@ -406,7 +406,7 @@ mission.sections =
 
                 [2] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 10)
-                    player:confirmTrade()
+                    player:tradeComplete()
                 end,
             },
         },

--- a/scripts/missions/sandoria/2_3_1_Journey_to_Bastok.lua
+++ b/scripts/missions/sandoria/2_3_1_Journey_to_Bastok.lua
@@ -56,7 +56,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 5 and
-                        npcUtil.tradeHasExactly(trade, xi.item.ONZ_OF_MYTHRIL_SAND)
+                        npcUtil.tradeMatches(trade, { { xi.item.ONZ_OF_MYTHRIL_SAND, 1 } })
                     then
                         return mission:progressEvent(205)
                     end
@@ -67,7 +67,7 @@ mission.sections =
             {
                 [205] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         player:setMissionStatus(mission.areaId, 6)
                         player:addMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_ABROAD)
                     end

--- a/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
+++ b/scripts/missions/sandoria/2_3_2_Journey_to_Windurst.lua
@@ -134,7 +134,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, { { xi.item.PARANA_SHIELD, 2 } }) and
+                        npcUtil.tradeMatches(trade, { { xi.item.PARANA_SHIELD, 2 } }) and
                         player:getMissionStatus(mission.areaId) == 6
                     then
                         return mission:progressEvent(457) -- Has delivered shield
@@ -156,7 +156,7 @@ mission.sections =
             {
                 [457] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         player:addMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.JOURNEY_ABROAD)
                         player:setMissionStatus(mission.areaId, 7)
                     end

--- a/scripts/missions/sandoria/3_2_The_Crystal_Spring.lua
+++ b/scripts/missions/sandoria/3_2_The_Crystal_Spring.lua
@@ -93,6 +93,12 @@ mission.sections =
         {
             ['Ambrotien'] =
             {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(2030)
+                    end
+                end,
+
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
@@ -102,16 +108,16 @@ mission.sections =
                         return mission:progressEvent(2031)
                     end
                 end,
-
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(2030)
-                    end
-                end,
             },
 
             ['Endracion'] =
             {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(1030)
+                    end
+                end,
+
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
@@ -121,23 +127,17 @@ mission.sections =
                         return mission:progressEvent(1031)
                     end
                 end,
-
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(1030)
-                    end
-                end,
             },
 
             onEventFinish =
             {
                 [1030] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 2)
                 end,
 
                 [2030] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 2)
                 end,
             },
@@ -147,6 +147,12 @@ mission.sections =
         {
             ['Grilau'] =
             {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(1030)
+                    end
+                end,
+
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
@@ -156,18 +162,12 @@ mission.sections =
                         return mission:progressEvent(1031)
                     end
                 end,
-
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(1030)
-                    end
-                end,
             },
 
             onEventFinish =
             {
                 [1030] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 2)
                 end,
             },
@@ -184,30 +184,30 @@ mission.sections =
         {
             ['Ambrotien'] =
             {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        return mission:messageText(southernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(2013)
                     end
                 end,
 
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(2013)
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:messageText(southernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
                     end
                 end,
             },
 
             ['Endracion'] =
             {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        return mission:messageText(southernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(1013)
                     end
                 end,
 
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(1013)
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:messageText(southernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
                     end
                 end,
             },
@@ -216,13 +216,13 @@ mission.sections =
             {
                 [1013] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
 
                 [2013] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -232,15 +232,15 @@ mission.sections =
         {
             ['Grilau'] =
             {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        return mission:messageText(northernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CRYSTAL_BASS, 1 } }) then
+                        return mission:progressEvent(1013)
                     end
                 end,
 
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CRYSTAL_BASS) then
-                        return mission:progressEvent(1013)
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:messageText(northernSandoriaID.text.ORIGINAL_MISSION_OFFSET + 68):setPriority(1000)
                     end
                 end,
             },
@@ -249,7 +249,7 @@ mission.sections =
             {
                 [1013] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
+++ b/scripts/missions/sandoria/3_3_Appointment_to_Jeuno.lua
@@ -196,7 +196,7 @@ mission.sections =
                     -- the key into a key item, allowing the player to drop the inventory key for space.
                     if
                         player:getMissionStatus(mission.areaId) == 4 and
-                        npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
+                        npcUtil.tradeMatches(trade, { { xi.item.DELKFUTT_KEY, 1 } })
                     then
                         return mission:progressCutscene(0)
                     end
@@ -220,7 +220,7 @@ mission.sections =
 
                     if not player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
                         npcUtil.giveKeyItem(player, xi.ki.DELKFUTT_KEY)
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/soa/4_1_2_Courier_Catastrophe.lua
+++ b/scripts/missions/soa/4_1_2_Courier_Catastrophe.lua
@@ -43,7 +43,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     local requiredItems = mission:getVar(player, 'Option')
 
-                    if npcUtil.tradeHasExactly(trade, { missionItems[requiredItems] }) then
+                    if npcUtil.tradeMatches(trade, { missionItems[requiredItems] }) then
                         return mission:progressEvent(167, 8, 0, 5, 0)
                     end
                 end,
@@ -59,7 +59,7 @@ mission.sections =
             {
                 [167] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/soa/4_5_1_Anagnorisis.lua
+++ b/scripts/missions/soa/4_5_1_Anagnorisis.lua
@@ -50,7 +50,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     local rewardItem = findRewardItem(player)
 
-                    if npcUtil.tradeHasExactly(trade, rewardItem) then
+                    if npcUtil.tradeMatches(trade, { { rewardItem, 1 } }) then
                         return mission:progressEvent(1544, rewardItem, 23, 2964, 975, 4063, 1999, 1999, 4)
                     end
                 end,
@@ -68,7 +68,7 @@ mission.sections =
             {
                 [1544] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
 

--- a/scripts/missions/toau/04_Knight_of_Gold.lua
+++ b/scripts/missions/toau/04_Knight_of_Gold.lua
@@ -28,8 +28,8 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 1 and
-                        (npcUtil.tradeHasExactly(trade, { { 'gil', 1000 } }) or
-                        npcUtil.tradeHasExactly(trade, xi.item.IMPERIAL_BRONZE_PIECE))
+                        (npcUtil.tradeMatches(trade, { { xi.item.GIL, 1000 } }) or
+                        npcUtil.tradeMatches(trade, { { xi.item.IMPERIAL_BRONZE_PIECE, 1 } }))
                     then
                         return mission:progressEvent(3022, { text_table = 0 })
                     end
@@ -84,7 +84,7 @@ mission.sections =
             onEventFinish =
             {
                 [3022] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 2)
                 end,
 

--- a/scripts/missions/toau/11_Imperial_Schemes.lua
+++ b/scripts/missions/toau/11_Imperial_Schemes.lua
@@ -60,10 +60,7 @@ mission.sections =
             onEventFinish =
             {
                 [3070] = function(player, csid, option, npc)
-                    if mission:complete(player) then
-                        player:setCharVar('Mission[4][11]Timer', VanadielUniqueDay() + 1)
-                        player:setLocalVar('Mission[4][11]mustZone', 1)
-                    end
+                    mission:complete(player)
                 end,
             },
         },

--- a/scripts/missions/toau/12_Royal_Puppeteer.lua
+++ b/scripts/missions/toau/12_Royal_Puppeteer.lua
@@ -41,7 +41,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 1 and
-                        npcUtil.tradeHasExactly(trade, xi.item.VIAL_OF_JODYS_ACID)
+                        npcUtil.tradeMatches(trade, { { xi.item.VIAL_OF_JODYS_ACID, 1 } })
                     then
                         return mission:progressEvent(279)
                     end
@@ -66,7 +66,7 @@ mission.sections =
 
                 [279] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/toau/12_Royal_Puppeteer.lua
+++ b/scripts/missions/toau/12_Royal_Puppeteer.lua
@@ -19,9 +19,7 @@ mission.sections =
 {
     {
         check = function(player, currentMission, missionStatus, vars)
-            return currentMission == mission.missionId and
-                not mission:getMustZone(player) and
-                VanadielUniqueDay() >= mission:getVar(player, 'Timer')
+            return currentMission == mission.missionId
         end,
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =

--- a/scripts/missions/windurst/2_3_2_The_Three_Kingdoms_Bastok.lua
+++ b/scripts/missions/windurst/2_3_2_The_Three_Kingdoms_Bastok.lua
@@ -56,7 +56,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 5 and
-                        npcUtil.tradeHasExactly(trade, xi.item.ONZ_OF_MYTHRIL_SAND)
+                        npcUtil.tradeMatches(trade, { { xi.item.ONZ_OF_MYTHRIL_SAND, 1 } })
                     then
                         return mission:progressEvent(255)
                     end
@@ -67,7 +67,7 @@ mission.sections =
             {
                 [255] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         player:setMissionStatus(mission.areaId, 7)
                         player:addMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS)
                     end

--- a/scripts/missions/windurst/3_2_Written_in_the_Stars.lua
+++ b/scripts/missions/windurst/3_2_Written_in_the_Stars.lua
@@ -143,7 +143,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 3 and
-                        npcUtil.tradeHasExactly(trade, { { xi.item.RUSTY_DAGGER, 3 } })
+                        npcUtil.tradeMatches(trade, { { xi.item.RUSTY_DAGGER, 3 } })
                     then
                         return mission:progressEvent(151)
                     end
@@ -164,7 +164,7 @@ mission.sections =
             {
                 [151] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
 

--- a/scripts/missions/windurst/3_3_A_New_Journey.lua
+++ b/scripts/missions/windurst/3_3_A_New_Journey.lua
@@ -84,7 +84,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:getMissionStatus(mission.areaId) == 2 and
-                        npcUtil.tradeHasExactly(trade, xi.item.DELKFUTT_KEY)
+                        npcUtil.tradeMatches(trade, { { xi.item.DELKFUTT_KEY, 1 } })
                     then
                         return mission:progressCutscene(2)
                     end
@@ -107,7 +107,7 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 3)
 
                     if not player:hasKeyItem(xi.ki.DELKFUTT_KEY) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         npcUtil.giveKeyItem(player, xi.ki.DELKFUTT_KEY)
                     end
                 end,

--- a/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
+++ b/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
@@ -181,7 +181,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.CURSED_KEY) and
+                        npcUtil.tradeMatches(trade, { { xi.item.CURSED_KEY, 1 } }) and
                         player:getZPos() < 332 and
                         player:getMissionStatus(mission.areaId) >= 3
                     then
@@ -193,7 +193,7 @@ mission.sections =
             onEventFinish =
             {
                 [23] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setPos(340, 0, 333)
                     player:delKeyItem(xi.ki.BLANK_BOOK_OF_THE_GODS)
                     player:setMissionStatus(mission.areaId, 5)

--- a/scripts/missions/windurst/8_1_Vain.lua
+++ b/scripts/missions/windurst/8_1_Vain.lua
@@ -168,7 +168,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.CURSE_WAND) and
+                        npcUtil.tradeMatches(trade, { { xi.item.CURSE_WAND, 1 } }) and
                         player:getMissionStatus(mission.areaId) == 3 and
                         player:hasKeyItem(xi.ki.MAGIC_DRAINED_STAR_SEEKER)
                     then
@@ -203,7 +203,7 @@ mission.sections =
                 end,
 
                 [120] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 4)
                 end,
             },

--- a/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
+++ b/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
@@ -131,7 +131,7 @@ mission.sections =
 
                     if
                         (missionStatus == 4 or missionStatus == 5) and
-                        npcUtil.tradeHasExactly(trade, xi.item.CLUMP_OF_GOOBBUE_HUMUS)
+                        npcUtil.tradeMatches(trade, { { xi.item.CLUMP_OF_GOOBBUE_HUMUS, 1 } }) -- NOTE: No associated trade completion?
                     then
                         return mission:progressEvent(13)
                     end

--- a/scripts/missions/wotg/09_Dancers_in_Distress.lua
+++ b/scripts/missions/wotg/09_Dancers_in_Distress.lua
@@ -119,7 +119,7 @@ mission.sections =
 
                     if
                         not mission:getMustZone(player) and
-                        npcUtil.tradeHasExactly(trade, quizItems[chosenItemIndex])
+                        npcUtil.tradeMatches(trade, { { quizItems[chosenItemIndex], 1 } })
                     then
                         return mission:progressEvent(3, 0, 0, 0, 0, 0, 0, 0, chosenItemIndex)
                     end
@@ -136,7 +136,7 @@ mission.sections =
             {
                 [3] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/wotg/10_Daughter_of_a_Knight.lua
+++ b/scripts/missions/wotg/10_Daughter_of_a_Knight.lua
@@ -59,7 +59,7 @@ mission.sections =
             ['Amaura'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CERNUNNOS_BULB) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.CERNUNNOS_BULB, 1 } }) then
                         -- TODO: What are these args from caps?
                         -- Observed : 647298804, 0, 1743, 1, 759, 600, 0, 4
                         return mission:progressEvent(937, 0, 2)
@@ -100,8 +100,8 @@ mission.sections =
             ['Humus-rich_Earth'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CERNUNNOS_BULB) then
-                        player:confirmTrade()
+                    if npcUtil.tradeMatches(trade, { { xi.item.CERNUNNOS_BULB, 1 } }) then
+                        player:tradeComplete()
                         player:setMissionStatus(mission.areaId, 3)
 
                         return mission:messageSpecial(pastJugnerID.text.YOU_PLANT_ITEM, xi.item.CERNUNNOS_BULB)

--- a/scripts/missions/wotg/21_Proof_of_Valor.lua
+++ b/scripts/missions/wotg/21_Proof_of_Valor.lua
@@ -127,7 +127,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     for itemId, signatureValue in pairs(orcItems) do
-                        if npcUtil.tradeHasExactly(trade, itemId) then
+                        if npcUtil.tradeMatches(trade, { { itemId, 1 } }) then
                             mission:setLocalVar(player, 'numSignatures', signatureValue)
 
                             return mission:progressEvent(136, itemId)
@@ -168,7 +168,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.ANGLERS_CASSOULET) and
+                        npcUtil.tradeMatches(trade, { { xi.item.ANGLERS_CASSOULET, 1 } }) and
                         mission:isVarBitsSet(player, 'Remind', 0)
                     then
                         return mission:progressEvent(135)
@@ -286,7 +286,7 @@ mission.sections =
             ['Rongelouts_N_Distaud'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.GNOLE_CLAW) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.GNOLE_CLAW, 1 } }) then
                         return mission:progressEvent(144)
                     end
                 end,
@@ -312,8 +312,8 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasOnly(trade, xi.item.BUNCH_OF_GYSAHL_GREENS) and
-                        mission:isVarBitsSet(player, 'Remind', 3)
+                        mission:isVarBitsSet(player, 'Remind', 3) and
+                        npcUtil.tradeHasOnly(trade, xi.item.BUNCH_OF_GYSAHL_GREENS)
                     then
                         -- TODO: This formula is estimated; however, a trade of a single gysahl green
                         -- awards 5 signatures.  While not aligning with Wiki, adding a bonus to that
@@ -457,26 +457,26 @@ mission.sections =
                 end,
 
                 [133] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
 
                     local numSignatures = mission:getLocalVar(player, 'numSignatures')
                     completePetition(player, 17, numSignatures)
                 end,
 
                 [134] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
 
                     local numSignatures = mission:getLocalVar(player, 'numSignatures')
                     completePetition(player, 16, numSignatures)
                 end,
 
                 [135] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     completePetition(player, 14, 12)
                 end,
 
                 [136] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
 
                     local numSignatures = mission:getLocalVar(player, 'numSignatures')
                     completePetition(player, 15, numSignatures)
@@ -493,7 +493,7 @@ mission.sections =
                 end,
 
                 [144] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
 
                     if option == 1 then
                         completePetition(player, 18, 35)

--- a/scripts/missions/wotg/29_A_Hawk_in_Repose.lua
+++ b/scripts/missions/wotg/29_A_Hawk_in_Repose.lua
@@ -26,7 +26,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.LILAC) and
+                        npcUtil.tradeMatches(trade, { { xi.item.LILAC, 1 } }) and
                         mission:getVar(player, 'Status') == 1
                     then
                         return mission:progressEvent(503, 0, 23, 1753, 0, 0, 0, 1, 3871)
@@ -47,7 +47,7 @@ mission.sections =
                 end,
 
                 [503] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     mission:complete(player)
                 end,
             },

--- a/scripts/missions/wotg/45_Time_Slips_Away.lua
+++ b/scripts/missions/wotg/45_Time_Slips_Away.lua
@@ -26,7 +26,7 @@ mission.sections =
             ['Veridical_Conflux'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.PUNCH_BUG) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.PUNCH_BUG, 1 } }) then
                         return mission:progressEvent(35, 64, 23, 1756, 0, 0, 0, 0, 0)
                     end
                 end,
@@ -38,7 +38,7 @@ mission.sections =
             {
                 [35] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },

--- a/scripts/missions/wotg/46_When_Wills_Collide.lua
+++ b/scripts/missions/wotg/46_When_Wills_Collide.lua
@@ -27,7 +27,7 @@ mission.sections =
                 onTrade = function(player, npc, trade)
                     if
                         not player:hasKeyItem(xi.ki.BOTTLED_PUNCH_BUG) and
-                        npcUtil.tradeHasExactly(trade, xi.item.PUNCH_BUG)
+                        npcUtil.tradeMatches(trade, { { xi.item.PUNCH_BUG, 1 } }) -- NOTE: No associated trade completion?
                     then
                         return mission:progressEvent(42, 76, 0, 1267351, 120, 0, 8323092, 0, 0)
                     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

What title sais. No more uses of that function in missions. Also comments when no trade completion is present (except when theres a comment addressing it already)

Also fixes wrong requirements for ToAU12 mission. maybe leftovers from a previous implementation. Double-checked using my own captures. It doesnt help that wikis are writen very stupidly in this concrete 11 to 12 step.

## Steps to test these changes

Run missions. No blocked items should result anymore.
