### PR TITLE
[lua] Gigas BST Fixes

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -753,10 +753,10 @@ xi.mob.callPets = function(mob, petIds, params)
         actionParams =
         {
             finishCategory = params.action.finishCategory or 11,
-            actionID = params.action.messageID or 307,
-            animationID = params.action.animationID or 439,
-            messageID = params.action.messageID or 0,
-            param = params.action.param or 0,
+            actionID       = params.action.messageID or 307,
+            animationID    = params.action.animationID or 439,
+            messageID      = params.action.messageID or 0,
+            param          = params.action.param or 0,
         }
     end
 
@@ -778,10 +778,11 @@ xi.mob.callPets = function(mob, petIds, params)
             end
         end
 
-        local spawnPos = mobArg:getSpawnPos()
-        local pos = mobArg:getPos()
-        params.maxSpawns = params.maxSpawns or #petIds
+        local spawnPos     = mobArg:getSpawnPos()
+        local pos          = mobArg:getPos()
+        params.maxSpawns   = params.maxSpawns or #petIds
         local spawnedCount = 0
+
         for _, petId in ipairs(petIds) do
             local petToSummon = GetMobByID(petId)
             if

--- a/scripts/mixins/families/gigas_bst.lua
+++ b/scripts/mixins/families/gigas_bst.lua
@@ -1,0 +1,59 @@
+-----------------------------------
+-- Mixin for regular Gigas Beastmaster mobs (not the NMs).
+-- They summon their bat pet with the Summoner cast, and while unengaged resummon it on a timer. A pet
+-- killed in combat is not resummoned until the mob is no longer engaged, because ROAM_TICK (which drives
+-- the summon) never fires while engaged. See scripts/mixins/families/gigas_bst_nm.lua for the NM variant.
+-----------------------------------
+require('scripts/globals/mixins')
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+-----------------------------------
+
+local callPetParams =
+{
+    inactiveTime   = 3000, -- Makes xi.mob.callPets play the retail Summoner cast (casm -> shsm) while summoning.
+    persistOnDeath = true, -- The bat outlives the gigas.
+    maxSpawns      = 1,
+}
+
+g_mixins.families.gigas_beastmaster = function(mob)
+    mob:addListener('SPAWN', 'GIGAS_BST_SPAWN', function(mobArg)
+        mobArg:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
+        mobArg:setLocalVar('[Pet]Timer', 0)
+    end)
+
+    mob:addListener('ROAM_TICK', 'GIGAS_BST_ROAM_TICK', function(mobArg)
+        -- Never interrupt an in-progress summon (callPets stuns the owner during the cast).
+        if xi.combat.behavior.isEntityBusy(mobArg) then
+            return
+        end
+
+        local petId = mobArg:getID() + 1 -- Gigas BST mobs link their bat at mob id + 1 (see setMobPet).
+        local pet   = GetMobByID(petId)
+        if not pet then
+            return
+        end
+
+        if pet:isSpawned() then
+            return
+        end
+
+        local currentTime = GetSystemTime()
+        local summonTime  = mobArg:getLocalVar('[Pet]Timer')
+        if summonTime == 0 then
+            mobArg:setLocalVar('[Pet]Timer', currentTime + math.randomInt(60, 70))
+            return
+        end
+
+        if currentTime < summonTime then
+            return
+        end
+
+        if xi.mob.callPets(mobArg, petId, callPetParams) then
+            mobArg:setLocalVar('[Pet]Timer', 0)
+        end
+    end)
+end
+
+return g_mixins.families.gigas_beastmaster

--- a/scripts/mixins/families/gigas_bst_nm.lua
+++ b/scripts/mixins/families/gigas_bst_nm.lua
@@ -1,74 +1,74 @@
 -----------------------------------
 -- Mixin for Gigas Beastmaster Notorious Monsters
--- (The kind that either use Familiar or Charm)
+-- They summon their bat pet with the Summoner cast and empower it with Familiar.
 -- Currently used by: Enkelados, Eurymedon, Ophion, Pallas - Should also be added to Gigas Beastmaster when Expeditionary Force is implemented.
 -----------------------------------
 require('scripts/globals/mixins')
 -----------------------------------
-
-local variables =
-{
-    HPP_TRIGGER           = 'hppTrigger',      -- HP % threshold at which Familiar/Charm may activate
-    COOLDOWN              = 'cooldown',        -- Duration in seconds between uses (default 7200)
-    ENGAGE_DELAY          = 'engageDelay',     -- Delay after engage before ability can activate (default 2s)
-    ENGAGE_READY_TIME     = 'engageReadyTime', -- Timestamp when engage delay expires
-    NEXT_READY_TIME       = 'nextReadyTime',   -- Timestamp when cooldown expires
-}
-
-local configuration =
-{
-    minimumHppTrigger   = 40,   -- Minimum use threshold
-    maximumHppTrigger   = 60,   -- Maximum use threshold
-    cooldownSeconds     = 7200, -- 2 hour delay between uses
-    engageDelaySeconds  = 2,    -- Delay after engage
-}
-
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
+-----------------------------------
+
+local callPetParams =
+{
+    inactiveTime   = 3000, -- Makes xi.mob.callPets play the retail Summoner cast (casm -> shsm) while summoning.
+    persistOnDeath = true, -- The bat outlives the gigas.
+    maxSpawns      = 1,
+}
 
 g_mixins.families.gigas_beastmaster_nm = function(mob)
-    mob:addListener('PRESPAWN', 'GIGAS_BEASTMASTER_PRESPAWN', function(mobArg)
-        mobArg:setLocalVar(variables.HPP_TRIGGER,       math.randomInt(configuration.minimumHppTrigger, configuration.maximumHppTrigger))
-        mobArg:setLocalVar(variables.COOLDOWN,          configuration.cooldownSeconds)
-        mobArg:setLocalVar(variables.ENGAGE_DELAY,      configuration.engageDelaySeconds)
-        mobArg:setLocalVar(variables.ENGAGE_READY_TIME, 0)
-        mobArg:setLocalVar(variables.NEXT_READY_TIME,   0)
+    mob:addListener('SPAWN', 'GIGAS_BEASTMASTER_SPAWN', function(mobArg)
+        mobArg:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
+
+        mobArg:setLocalVar('[Pet]Timer', 0)
+        mobArg:setLocalVar('[2-Hour]HPP', math.randomInt(40, 60))
+        mobArg:setLocalVar('[2-Hour]Used', 0)
     end)
 
-    mob:addListener('ENGAGE', 'GIGAS_BEASTMASTER_ENGAGE', function(mobArg)
-        local delay = mobArg:getLocalVar(variables.ENGAGE_DELAY)
-
-        mobArg:setLocalVar(variables.ENGAGE_READY_TIME, GetSystemTime() + delay)
-        mobArg:setLocalVar(variables.NEXT_READY_TIME,   0)
-    end)
-
-    mob:addListener('COMBAT_TICK', 'GIGAS_BEASTMASTER_COMBAT_TICK', function(mobArg)
-        local currentTime = GetSystemTime()
-
-        if currentTime < mobArg:getLocalVar(variables.ENGAGE_READY_TIME) then
+    mob:addListener('COMBAT_TICK', 'GIGAS_BST_NM_COMBAT_TICK', function(mobArg)
+        -- Never interrupt an in-progress summon (callPets stuns the owner during the cast).
+        if xi.combat.behavior.isEntityBusy(mobArg) then
             return
         end
 
-        if currentTime < mobArg:getLocalVar(variables.NEXT_READY_TIME) then
+        -- Fetch pet.
+        local petId = mobArg:getID() + 1 -- Every gigas BST NM links its pet at mob id + 1 (see setMobPet).
+        local pet   = GetMobByID(petId)
+        if not pet then
             return
         end
 
-        if mobArg:getHPP() > mobArg:getLocalVar(variables.HPP_TRIGGER) then
+        -- Get control variables.
+        local currentTime    = GetSystemTime()
+        local canUseFamiliar = mobArg:getLocalVar('[2-Hour]Used') == 0 and mobArg:getHPP() <= mobArg:getLocalVar('[2-Hour]HPP')
+
+        -- Pet logic.
+        if not pet:isAlive() then
+            local petTime = mobArg:getLocalVar('[Pet]Timer')
+            if petTime == 0 then
+                mobArg:setLocalVar('[Pet]Timer', currentTime + 60)
+                return
+            end
+
+            -- Summon whenever timer allows or bypass timer if it can 2-Hour.
+            if currentTime < petTime and not canUseFamiliar then
+                return
+            end
+
+            if not xi.mob.callPets(mobArg, petId, callPetParams) then
+                return
+            end
+
+            mobArg:setLocalVar('[Pet]Timer', 0)
+        end
+
+        -- Use 2-Hour
+        if not canUseFamiliar then
             return
         end
 
-        -- Determine whether to use Familiar or Charm based on pet status (if alive, use Familiar, if dead, Charm)
-        local abilityToUse = xi.mobSkill.CHARM
-
-        local pet = mobArg:getPet()
-        if pet and pet:isAlive() then
-            abilityToUse = xi.mobSkill.FAMILIAR_1
-        end
-
-        mobArg:useMobAbility(abilityToUse)
-
-        -- Apply cooldown to the 2-hour timer
-        mobArg:setLocalVar(variables.NEXT_READY_TIME, currentTime + mobArg:getLocalVar(variables.COOLDOWN))
+        mobArg:useMobAbility(xi.mobSkill.FAMILIAR_1)
+        mobArg:setLocalVar('[2-Hour]Used', 1)
     end)
 end
 

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Sentry.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Giant_Sentry.lua
@@ -3,6 +3,8 @@
 --  Mob: Giant Sentry
 -- Note: PH for Hippolytos and Eurymedon
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 local ID = zones[xi.zone.LOWER_DELKFUTTS_TOWER]
 -----------------------------------
 ---@type TMobEntity

--- a/scripts/zones/Lower_Delkfutts_Tower/mobs/Gigas_Butcher.lua
+++ b/scripts/zones/Lower_Delkfutts_Tower/mobs/Gigas_Butcher.lua
@@ -2,6 +2,8 @@
 -- Area: Lower Delkfutt's Tower
 --  Mob: Gigas Butcher
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Sentry.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Giant_Sentry.lua
@@ -3,6 +3,8 @@
 --  Mob: Giant Sentry
 -- Note: PH for Rhoitos and Eurytos
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 local ID = zones[xi.zone.MIDDLE_DELKFUTTS_TOWER]
 -----------------------------------
 ---@type TMobEntity

--- a/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Kettlemaster.lua
+++ b/scripts/zones/Middle_Delkfutts_Tower/mobs/Gigas_Kettlemaster.lua
@@ -3,6 +3,8 @@
 --  Mob: Gigas Kettlemaster
 -- Note: PH for Ophion
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 local ID = zones[xi.zone.MIDDLE_DELKFUTTS_TOWER]
 -----------------------------------
 ---@type TMobEntity

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Gigas_Bonecutter.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Gigas_Bonecutter.lua
@@ -3,6 +3,8 @@
 --  Mob: Gigas Bonecutter
 -- Note: PH for Enkelados
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 local ID = zones[xi.zone.UPPER_DELKFUTTS_TOWER]
 -----------------------------------
 ---@type TMobEntity

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Jotunn_Wildkeeper.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Jotunn_Wildkeeper.lua
@@ -2,6 +2,8 @@
 -- Area: Upper Delkfutt's Tower
 --  Mob: Jotunn Wildkeeper
 -----------------------------------
+mixins = { require('scripts/mixins/families/gigas_bst') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Pallas.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Pallas.lua
@@ -17,4 +17,8 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
 end
 
+entity.onMobDeath = function(mob, player, optParams)
+    xi.hunts.checkHunt(mob, player, 489)
+end
+
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request implements various fixes for BST Gigas (both NMs and normal mobs) based on retail captures. It does the following things:

**gigas_bst_nm.lua — Gigas BST Notorious Monsters**

- Fixes the incorrect summoning animation.
- NMs now re summon pets on a 60 second timer, including during combat.
- Removes charm from these NMs. This was specifically called out as being removed in a [prior official post dated April 19, 2007](https://www.playonline.com/ff11us/polnews/news10164.shtml).
- When the NM goes to use familiar, it will summon the pet and then immediately use familiar on it - just like retail. Familiar requires a living pet.
- Ensures the pet persists even when its owner is killed, per retail.
- General cleanup.

**gigas_bst.lua — Regular Gigas BST mobs (new file)**

- Creates a new mixin for non-NM BST Gigas including Gigas Bonecutter, Gigas Butcher, Gigas Kettlemaster, Giant Sentry, and Jotunn Wildkeeper. Adds mixin call in the lua files for all of them.
- Fixes the incorrect summoning animation.
- BST pets are now summoned on a 60-70 second timer, which is an average based on retail captures across the different mobs called out here.
- Ensure the BST never resummons the pet while engaged in combat, per retail. A pet killed mid fight stays dead unless the mob drops aggro or is killed.
- Ensures the pet persists even when its owner is killed, per retial.

## Steps to test these changes

Fight Pallas, Enkelados, Ophion, Eurymedon, Gigas Bonecutter, Jotunn Wildkeeper, Gigas Kettlemaster, Giant Sentry, Gigas Butcher and witness the updated/new behavior.

## Sources Used

Gigas BST - https://youtu.be/7R6cqBpMWBY
Pallas - https://www.youtube.com/watch?v=MzgWw8yhNgk
Pallas - https://www.dropbox.com/s/h3yy0zfbdrbou14/Pallas%20Retail%20Testing%20Part%202.zip?dl=0
https://youtu.be/y50SN8hNjDs