### PR TITLE
[LUA] Fix Better Part of Valor waterfall trigger

### DIFF
--- a/scripts/quests/crystalWar/WOTG_BAS_1_Better_Part_of_Valor.lua
+++ b/scripts/quests/crystalWar/WOTG_BAS_1_Better_Part_of_Valor.lua
@@ -82,7 +82,7 @@ quest.sections =
 
         [xi.zone.NORTH_GUSTABERG_S] =
         {
-            ['qm1'] =
+            ['qm3'] =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the waterfall `???` interaction for the Bastok [S] quest **Better Part of Valor**.

The quest was binding event 3 to `qm1`, but the `???` at the documented waterfall coordinates in North Gustaberg [S] is `qm3`.

This changes the quest interaction binding from:

```lua
['qm1']
```

to:

```lua
['qm3']
```

No SQL changes are required because the correct `qm3` entity already exists at the waterfall location.

## Steps to test these changes

1. Add the quest and set the character to the waterfall stage:

   ```
   !addquest 7 12
   !setquestvar <PlayerName> 7 12 Prog 1
   !pos -232 41 425 88
   ```

2. Interact with the waterfall `???`.

3. Confirm event 3 begins.

4. Complete the cutscene.

5. Check the quest variable:

   ```
   !getquestvar <PlayerName> 7 12 Prog
   ```

6. Confirm `Prog` advances to `2`.