### PR TITLE
[core] Improve EntityID_t; Resolve UAF with captured pointers in lua bindings

### DIFF
--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -240,7 +240,7 @@ bool CAIContainer::Internal_ChangeTarget(uint16 targetid)
     {
         if (IsEngaged() || targetid == 0)
         {
-            entity->SetBattleTargetID(targetid);
+            entity->setBattleTarget(EntityID_t(entity->GetEntity(targetid)));
             return true;
         }
         else
@@ -256,7 +256,7 @@ bool CAIContainer::Internal_Disengage()
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        entity->SetBattleTargetID(0);
+        entity->setBattleTarget(std::nullopt);
         return true;
     }
     return false;

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -129,13 +129,13 @@ auto CMobController::TryDeaggro() -> bool
         PTarget = PMob->PEnmityContainer->GetHighestEnmity();
         if (PTarget)
         {
-            PMob->SetBattleTargetID(PTarget->targid);
+            PMob->setBattleTarget(PTarget->entityId());
             // Reset deaggro time so that the mob is given time to actually try to path towards the new highest enmity target
             TapDeaggroTime();
         }
         else
         {
-            PMob->SetBattleTargetID(0);
+            PMob->setBattleTarget(std::nullopt);
         }
 
         return TryDeaggro();

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -33,13 +33,13 @@ CAttackState::CAttackState(CBattleEntity* PEntity, uint16 targid)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
 {
-    PEntity->SetBattleTargetID(targid);
+    PEntity->setBattleTarget(EntityID_t(PEntity->GetEntity(targid)));
     PEntity->SetBattleStartTime(timer::now());
     CAttackState::UpdateTarget();
 
     if (!GetTarget() || m_errorMsg)
     {
-        PEntity->SetBattleTargetID(0);
+        PEntity->setBattleTarget(std::nullopt);
         if (this->HasErrorMsg())
         {
             throw CStateInitException(m_errorMsg->copy());

--- a/src/map/entities/CMakeLists.txt
+++ b/src/map/entities/CMakeLists.txt
@@ -7,6 +7,8 @@ set(ENTITY_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/battle_entity.h
     ${CMAKE_CURRENT_SOURCE_DIR}/char_entity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/char_entity.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity_id.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/entity_id.h
     ${CMAKE_CURRENT_SOURCE_DIR}/fellow_entity.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/fellow_entity.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_entity.cpp

--- a/src/map/entities/base_entity.cpp
+++ b/src/map/entities/base_entity.cpp
@@ -23,11 +23,15 @@
 
 #include "common/tracy.h"
 
+#include <atomic>
+
 #include "ai/ai_container.h"
 
 #include "battlefield.h"
 #include "instance.h"
+#include "utils/zoneutils.h"
 #include "zone.h"
+#include "zone_instance.h"
 
 CBaseEntity::CBaseEntity()
 : id(0)
@@ -51,6 +55,10 @@ CBaseEntity::CBaseEntity()
 , m_nextUpdateTimer(timer::now())
 {
     TracyZoneScoped;
+
+    static std::atomic<uint64> nextSerial{ 1 };
+
+    serial_ = nextSerial.fetch_add(1, std::memory_order_relaxed);
 
     speed          = baseSpeed;
     animationSpeed = static_cast<uint8>(std::clamp<float>((baseSpeed / settings::get<float>("map.ANIMATION_SPEED_DIVISOR")), std::numeric_limits<uint8>::min(), std::numeric_limits<uint8>::max()));
@@ -213,6 +221,16 @@ CBaseEntity* CBaseEntity::GetEntity(uint16 targid, uint8 filter) const
     {
         return loc.zone->GetEntity(targid, filter);
     }
+}
+
+auto CBaseEntity::serial() const -> uint64
+{
+    return serial_;
+}
+
+auto CBaseEntity::entityId() const -> EntityID_t
+{
+    return EntityID_t{ this };
 }
 
 void CBaseEntity::SendZoneUpdate()

--- a/src/map/entities/base_entity.h
+++ b/src/map/entities/base_entity.h
@@ -259,6 +259,8 @@ public:
 
     bool IsDynamicEntity() const;
 
+    auto           serial() const -> uint64;
+    auto           entityId() const -> EntityID_t;
     uint32         id;             // global identifier unique on the server
     uint16         targid;         // local identifier unique to the zone
     ENTITYTYPE     objtype;        // Type of entity
@@ -298,6 +300,9 @@ protected:
     uint8                         speed; // speed of movement
 
     LineOfSightCache losCache_;
+
+private:
+    uint64 serial_{ 0 };
 };
 
 #endif // _BASEENTITY_H

--- a/src/map/entities/base_entity.h
+++ b/src/map/entities/base_entity.h
@@ -25,6 +25,7 @@
 #include "common/cbasetypes.h"
 #include "common/mmo.h"
 #include "common/timer.h"
+#include "entities/entity_id.h"
 #include "los_cache.h"
 #include "packets/basic.h"
 
@@ -161,26 +162,7 @@ enum UPDATETYPE : uint8
     UPDATE_DESPAWN  = 0x20,
 };
 
-// TODO: It is possible to make this structure part of the class, instead of the current ID and Targid, but without the clean() method.
-struct EntityID_t
-{
-    // TODO: Add a constructor that takes an id and targid.
-    // TODO: Clean with a destructor.
-    void clean()
-    {
-        id     = 0;
-        targid = 0;
-    }
-
-    // TODO: Globally rename targid to index, zoneIndex, etc.
-
-    uint32 id;     // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
-    uint16 targid; // The "index" of the entity in the current zone. Used for local targeting and referencing.
-
-    // TODO: Store the zoneId of this entity's zone. We can then use the targid (index) and the zoneId to build the global id.
-    // TODO: Store an incremental u64 as a UUID for the entity for disambiguation in the case of dynamic entities that might have the same targid.
-};
-
+class CBaseEntity;
 class CAIContainer;
 class CBattlefield;
 class CInstance;

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -2368,7 +2368,7 @@ void CBattleEntity::Die()
     {
         PAI->EventHandler.triggerListener("DEATH", this);
     }
-    SetBattleTargetID(0);
+    setBattleTarget(std::nullopt);
 }
 
 void CBattleEntity::processActionEffectFlags(const action_t& action) const
@@ -3615,7 +3615,7 @@ void CBattleEntity::OnDisengage(CAttackState& s)
 {
     TracyZoneScoped;
 
-    m_battleTarget = 0;
+    setBattleTarget(std::nullopt);
     if (animation == ANIMATION_ATTACK)
     {
         animation = ANIMATION_NONE;
@@ -3628,9 +3628,14 @@ void CBattleEntity::OnChangeTarget(CBattleEntity* PTarget)
 {
 }
 
-CBattleEntity* CBattleEntity::GetBattleTarget()
+void CBattleEntity::setBattleTarget(const Maybe<EntityID_t>& target)
 {
-    return static_cast<CBattleEntity*>(GetEntity(GetBattleTargetID()));
+    battleTarget_ = target.value_or(EntityID_t{});
+}
+
+auto CBattleEntity::GetBattleTarget() const -> CBattleEntity*
+{
+    return battleTarget_.resolve<CBattleEntity>();
 }
 
 bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
@@ -4065,7 +4070,7 @@ void CBattleEntity::PostTick()
 
 uint16 CBattleEntity::GetBattleTargetID() const
 {
-    return m_battleTarget;
+    return battleTarget_.targid;
 }
 
 bool CBattleEntity::hasEnmityEXPENSIVE() const

--- a/src/map/entities/battle_entity.h
+++ b/src/map/entities/battle_entity.h
@@ -23,6 +23,7 @@
 #define _BATTLEENTITY_H
 
 #include "common/types/hash_map.h"
+#include "common/types/maybe.h"
 
 #include <set>
 #include <type_traits>
@@ -351,12 +352,8 @@ public:
     virtual void Die();
     uint16       GetBattleTargetID() const;
 
-    void SetBattleTargetID(uint16 id)
-    {
-        m_battleTarget = id;
-    }
-
-    CBattleEntity* GetBattleTarget();
+    void setBattleTarget(const Maybe<EntityID_t>& target);
+    auto GetBattleTarget() const -> CBattleEntity*;
 
     bool hasEnmityEXPENSIVE() const; // Returns true if own notoriety container is not empty or mob in zone has entity listed as battle target
 
@@ -439,7 +436,7 @@ private:
     JOBTYPE           m_sjob;
     uint8             m_mlvl; // CURRENT level of the main job
     uint8             m_slvl; // CURRENT level of the sub job
-    uint16            m_battleTarget{ 0 };
+    EntityID_t        battleTarget_{};
     timer::time_point m_battleStartTime;
     uint16            m_battleID = 0; // Current battle the entity is participating in. Battle ID must match in order for entities to interact with each other.
 

--- a/src/map/entities/entity_id.cpp
+++ b/src/map/entities/entity_id.cpp
@@ -1,0 +1,110 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "entity_id.h"
+
+#include "base_entity.h"
+#include "instance.h"
+#include "utils/zoneutils.h"
+#include "zone.h"
+
+EntityID_t::EntityID_t(const CBaseEntity* PEntity)
+{
+    if (PEntity == nullptr)
+    {
+        return;
+    }
+
+    id            = PEntity->id;
+    targid        = PEntity->targid;
+    zoneId        = PEntity->loc.zone ? static_cast<uint16>(PEntity->loc.zone->GetID()) : uint16{ 0 };
+    instanceRunId = PEntity->PInstance ? PEntity->PInstance->runId() : uint32{ 0 };
+    serial        = PEntity->serial();
+    objtype       = PEntity->objtype;
+}
+
+void EntityID_t::clean()
+{
+    *this = EntityID_t{};
+}
+
+auto EntityID_t::isSet() const -> bool
+{
+    return targid != 0;
+}
+
+auto EntityID_t::isDynamic() const -> bool
+{
+    return targid >= 0x700;
+}
+
+auto EntityID_t::operator==(const EntityID_t& other) const -> bool
+{
+    return isDynamic() ? serial == other.serial : id == other.id;
+}
+
+auto EntityID_t::operator==(const CBaseEntity* PEntity) const -> bool
+{
+    if (PEntity == nullptr)
+    {
+        return !isSet();
+    }
+
+    return PEntity->IsDynamicEntity() ? serial == PEntity->serial() : id == PEntity->id;
+}
+
+auto EntityID_t::resolveEntity() const -> CBaseEntity*
+{
+    if (targid == 0 || serial == 0)
+    {
+        return nullptr;
+    }
+
+    CZone* PZone = zoneutils::GetZone(zoneId);
+    if (PZone == nullptr)
+    {
+        return nullptr;
+    }
+
+    CBaseEntity* PEntity = nullptr;
+    if (instanceRunId != 0)
+    {
+        auto* PInstance = zoneutils::GetInstanceByRunId(zoneId, instanceRunId);
+        if (PInstance == nullptr)
+        {
+            return nullptr;
+        }
+
+        PEntity = PInstance->GetEntity(targid, objtype);
+    }
+    else
+    {
+        PEntity = PZone->GetEntity(targid, objtype);
+    }
+
+    // Verify that we retrieved the exact same entity (dynamic entities).
+    if (PEntity == nullptr || *this != PEntity)
+    {
+        return nullptr;
+    }
+
+    return PEntity;
+}

--- a/src/map/entities/entity_id.h
+++ b/src/map/entities/entity_id.h
@@ -1,0 +1,75 @@
+﻿/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+#include <type_traits>
+
+class CBaseEntity;
+
+// A resolvable reference to an entity.
+// Holds enough context to find the entity again at a later time in a safe fashion.
+struct EntityID_t
+{
+    EntityID_t() = default;
+    explicit EntityID_t(const CBaseEntity* PEntity);
+
+    void clean();
+    auto isSet() const -> bool;
+    auto isDynamic() const -> bool;
+
+    // Compare two entity IDs for equality. Dynamic entities use the auto-incrementing serial.
+    auto operator==(const EntityID_t& other) const -> bool;
+    auto operator==(const CBaseEntity* PEntity) const -> bool;
+
+    // TODO: Globally rename targid to index, zoneIndex, etc.
+    uint32 id{ 0 };            // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
+    uint16 targid{ 0 };        // The "index" of the entity in the current zone. Used for local targeting and referencing.
+    uint16 zoneId{ 0 };        // Zone the entity was in when this reference was taken.
+    uint32 instanceRunId{ 0 }; // Live instance the entity was in, 0 if it was not instanced.
+    uint64 serial{ 0 };        // Never-reused per-process counter, telling a rebuilt entity from the
+                               // one that held the slot before it. Only dynamic entities need it.
+    uint8 objtype{ 0 };        // What kind of entity this is.
+
+    // Look the entity up again, or nullptr if it is gone
+    //
+    //     if (auto* PTarget = target.resolve<CCharEntity>())
+    //     {
+    //         PTarget->doThing();
+    //     }
+    template <typename T = CBaseEntity>
+    [[nodiscard]] auto resolve() const -> T*
+    {
+        if constexpr (std::is_same_v<T, CBaseEntity>)
+        {
+            return resolveEntity();
+        }
+        else
+        {
+            return dynamic_cast<T*>(resolveEntity());
+        }
+    }
+
+private:
+    auto resolveEntity() const -> CBaseEntity*;
+};

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -19,6 +19,7 @@
 ===========================================================================
 */
 
+#include <atomic>
 #include <filesystem>
 #include <thread>
 
@@ -39,6 +40,10 @@ CInstance::CInstance(Scheduler& scheduler, MapConfig config, CZone* zone, uint32
 {
     TracyZoneScoped;
 
+    static std::atomic<uint32> nextRunId{ 1 };
+
+    runId_ = nextRunId.fetch_add(1, std::memory_order_relaxed);
+
     m_wipeTimer     = m_startTime;
     m_lastTimeCheck = m_startTime;
 
@@ -53,6 +58,11 @@ CInstance::~CInstance()
 uint16 CInstance::GetID() const
 {
     return m_instanceid;
+}
+
+auto CInstance::runId() const -> uint32
+{
+    return runId_;
 }
 
 uint32 CInstance::GetProgress() const

--- a/src/map/instance.h
+++ b/src/map/instance.h
@@ -51,7 +51,9 @@ public:
 
     void RegisterChar(CCharEntity*);
 
-    uint16             GetID() const;
+    uint16 GetID() const;
+    auto   runId() const -> uint32;
+
     uint8              GetLevelCap() const;
     const std::string& GetName();
     position_t         GetEntryLoc();                          // Get entry location
@@ -92,6 +94,7 @@ public:
 private:
     void LoadInstance();
 
+    uint32              runId_{ 0 };
     uint32              m_instanceid{ 0 };
     uint16              m_entrance{ 0 };
     std::string         m_instanceName;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -18998,18 +18998,18 @@ void CLuaBaseEntity::castSpell(const sol::object& spell, const sol::object& enti
 
 void CLuaBaseEntity::useJobAbility(uint16 skillID, const sol::object& pet)
 {
-    CBattleEntity* PTarget{ nullptr };
+    EntityID_t targetId{};
 
     if ((pet != sol::lua_nil) && pet.is<CLuaBaseEntity*>())
     {
         CLuaBaseEntity* PLuaBaseEntity = pet.as<CLuaBaseEntity*>();
-        PTarget                        = static_cast<CBattleEntity*>(PLuaBaseEntity->m_PBaseEntity);
+        targetId                       = EntityID_t(PLuaBaseEntity->m_PBaseEntity);
     }
 
     // clang-format off
-    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [PTarget, skillID](auto PEntity)
+    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [targetId, skillID](auto PEntity)
     {
-        if (PTarget)
+        if (auto* PTarget = targetId.resolve<CBattleEntity>())
         {
             PEntity->PAI->Ability(PTarget->targid, skillID);
         }
@@ -19053,9 +19053,9 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
         return;
     }
 
-    auto           skillid{ va.get<uint16>(0) };
-    CBattleEntity* PTarget{ nullptr };
-    auto*          PMobSkill{ battleutils::GetMobSkill(skillid) };
+    auto       skillid{ va.get<uint16>(0) };
+    EntityID_t targetId{};
+    auto*      PMobSkill{ battleutils::GetMobSkill(skillid) };
 
     if (!PMobSkill)
     {
@@ -19065,7 +19065,7 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
     if (va.size() >= 2)
     {
         CLuaBaseEntity* PLuaBaseEntity = va.get<CLuaBaseEntity*>(1);
-        PTarget                        = PLuaBaseEntity ? (CBattleEntity*)PLuaBaseEntity->m_PBaseEntity : nullptr;
+        targetId                       = PLuaBaseEntity ? EntityID_t(PLuaBaseEntity->m_PBaseEntity) : EntityID_t{};
     }
 
     Maybe<timer::duration> castTimeOverride = std::nullopt;
@@ -19087,9 +19087,10 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
     }
 
     // clang-format off
-    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [PTarget, skillid, PMobSkill, castTimeOverride, ignoreDistance](auto PEntity)
+    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [targetId, skillid, PMobSkill, castTimeOverride, ignoreDistance](auto PEntity)
     {
-        auto mobObj = dynamic_cast<CMobEntity*>(PEntity);
+        auto  mobObj  = dynamic_cast<CMobEntity*>(PEntity);
+        auto* PTarget = targetId.resolve<CBattleEntity>();
 
         // has both a valid target (specified by user and mob)
         if (PTarget && mobObj)
@@ -19140,7 +19141,7 @@ void CLuaBaseEntity::useMobAbility(sol::variadic_args va)
 
 void CLuaBaseEntity::usePetAbility(uint16 skillId, const sol::object& target) const
 {
-    CBattleEntity* PTarget{ nullptr };
+    EntityID_t targetId{};
 
     // Don't queue an ability if we're not in auto attack state or no state
     if (!m_PBaseEntity->PAI->IsCurrentState<CAttackState>() && !m_PBaseEntity->PAI->IsStateStackEmpty())
@@ -19162,13 +19163,13 @@ void CLuaBaseEntity::usePetAbility(uint16 skillId, const sol::object& target) co
     if ((target != sol::lua_nil) && target.is<CLuaBaseEntity*>())
     {
         const auto* PLuaBaseEntity = target.as<CLuaBaseEntity*>();
-        PTarget                    = static_cast<CBattleEntity*>(PLuaBaseEntity->m_PBaseEntity);
+        targetId                   = EntityID_t(PLuaBaseEntity->m_PBaseEntity);
     }
 
     // clang-format off
-    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [PTarget, skillId](auto PEntity)
+    m_PBaseEntity->PAI->QueueAction(queueAction_t(0ms, true, [targetId, skillId](auto PEntity)
     {
-        if (PTarget)
+        if (auto* PTarget = targetId.resolve<CBattleEntity>())
         {
             PEntity->PAI->PetSkill(PTarget->targid, skillId);
         }

--- a/src/map/packets/c2s/0x0f5_tracking_start.cpp
+++ b/src/map/packets/c2s/0x0f5_tracking_start.cpp
@@ -46,9 +46,6 @@ void GP_CLI_COMMAND_TRACKING_START::process(MapSession* PSession, CCharEntity* P
     // Only allow players to track targets that are actually scannable, and within their wide scan range
     if (target->isWideScannable() && dist <= charutils::getWideScanRange(PChar))
     {
-        PChar->WideScanTarget = EntityID_t{
-            .id     = target->id,
-            .targid = target->targid
-        };
+        PChar->WideScanTarget = target->entityId();
     }
 }

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -42,7 +42,7 @@ void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PCha
         PChar->BazaarID.id     = PTarget->id;
         PChar->BazaarID.targid = PTarget->targid;
 
-        EntityID_t EntityID = { PChar->id, PChar->targid };
+        auto EntityID = PChar->entityId();
 
         if (!PChar->m_isGMHidden || (PChar->m_isGMHidden && PTarget->m_GMlevel >= PChar->m_GMlevel))
         {

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1412,7 +1412,7 @@ void DetachPet(CBattleEntity* PMaster)
             {
                 PMob->PEnmityContainer->UpdateEnmity(PChar, 0, 0);
                 // need to set battle target to prevent mob enmity clear if in attack state when uncharming
-                PMob->SetBattleTargetID(PChar->targid);
+                PMob->setBattleTarget(PChar->entityId());
             }
             else
             {
@@ -1428,7 +1428,7 @@ void DetachPet(CBattleEntity* PMaster)
             if ((state && state->GetAbility()->getID() == ABILITY_LEAVE) || PChar->isDead())
             {
                 PMob->PEnmityContainer->Clear();
-                PMob->SetBattleTargetID(0);
+                PMob->setBattleTarget(std::nullopt);
                 PMob->m_OwnerID.clean();
                 PMob->updatemask |= UPDATE_STATUS;
             }

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -114,6 +114,12 @@ auto GetZone(uint16 zoneId) -> CZone*
     return nullptr;
 }
 
+auto GetInstanceByRunId(const uint16 zoneId, const uint32 runId) -> CInstance*
+{
+    auto* PZoneInstance = dynamic_cast<CZoneInstance*>(GetZone(zoneId));
+    return PZoneInstance ? PZoneInstance->getInstanceByRunId(runId) : nullptr;
+}
+
 auto GetEntity(const uint32 id, const uint8 filter) -> CBaseEntity*
 {
     const uint16 DynamicEntityStart = 0x700;

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -31,6 +31,7 @@
 
 class CBaseEntity;
 class CCharEntity;
+class CInstance;
 class CNpcEntity;
 
 namespace zoneutils
@@ -72,6 +73,7 @@ auto GetCurrentContinent(uint16 zoneId) -> CONTINENT_TYPE;
 auto GetWeatherElement(xi::Weather weather) -> int;
 
 auto GetZone(uint16 zoneId) -> CZone*;
+auto GetInstanceByRunId(uint16 zoneId, uint32 runId) -> CInstance*; // the live instance of a run, or nullptr if that run has ended
 auto GetEntity(uint32 id, uint8 filter = -1) -> CBaseEntity*;
 auto GetCharByName(const std::string& name) -> CCharEntity*;
 auto GetCharFromWorld(uint32 charId, uint16 targId) -> CCharEntity*;  // returns pointer to character by id and target id

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -571,7 +571,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
         }
         if (PCurrentMob->GetBattleTargetID() == PChar->targid)
         {
-            PCurrentMob->SetBattleTargetID(0);
+            PCurrentMob->setBattleTarget(std::nullopt);
         }
     }
 

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -90,6 +90,14 @@ CBaseEntity* CZoneInstance::GetEntity(uint16 targid, uint8 filter)
     return PEntity;
 }
 
+auto CZoneInstance::getInstanceByRunId(uint32 runId) const -> CInstance*
+{
+    TracyZoneScoped;
+
+    const auto it = instancesByRun_.find(runId);
+    return it != instancesByRun_.end() ? it->second : nullptr;
+}
+
 void CZoneInstance::InsertMOB(CBaseEntity* PMob)
 {
     TracyZoneScoped;
@@ -413,6 +421,8 @@ auto CZoneInstance::ZoneServer(timer::time_point tick) -> Task<void>
     {
         ShowDebug("[CZoneInstance] ZoneServer cleaned up Instance %s", PInstance->GetName());
 
+        instancesByRun_.erase(PInstance->runId());
+
         m_InstanceList.erase(
             std::find_if(
                 m_InstanceList.begin(),
@@ -592,5 +602,9 @@ CInstance* CZoneInstance::CreateInstance(uint32 instanceid)
     TracyZoneScoped;
 
     m_InstanceList.emplace_back(std::make_unique<CInstance>(scheduler_, config_, this, instanceid));
-    return m_InstanceList.back().get();
+
+    auto* PInstance = m_InstanceList.back().get();
+    instancesByRun_.emplace(PInstance->runId(), PInstance);
+
+    return PInstance;
 }

--- a/src/map/zone_instance.h
+++ b/src/map/zone_instance.h
@@ -24,6 +24,8 @@
 #include "instance.h"
 #include "zone.h"
 
+#include <common/types/flat_hash_map.h>
+
 class CZoneInstance : public CZone
 {
 public:
@@ -37,6 +39,8 @@ public:
     virtual CCharEntity* GetCharByName(const std::string& name) override; // finds the player if exists in zone
     virtual CCharEntity* GetCharByID(uint32 id) override;
     virtual CBaseEntity* GetEntity(uint16 targid, uint8 filter = -1) override; // get a pointer to any entity in the zone
+
+    auto getInstanceByRunId(uint32 runId) const -> CInstance*;
 
     virtual void SpawnPCs(CCharEntity* PChar) override;
     virtual void SpawnMOBs(CCharEntity* PChar) override;
@@ -83,5 +87,6 @@ public:
 private:
     typedef std::vector<std::unique_ptr<CInstance>> instanceList_t;
 
-    instanceList_t m_InstanceList;
+    instanceList_t                  m_InstanceList;
+    FlatHashMap<uint32, CInstance*> instancesByRun_;
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Resolves a few real UAF in several lua bindings where pointers are captured for later execution.
- Starting the rework and spread of EntityID_t, limited to just swapping BattleEntity::battleTarget for now.
- Adds auto-incrementing IDs to entities and instances for accurate entity retrieval - does not address any particular bug but it's too sketchy not to when dealing with entities recycling their targids (pets, trusts...)

Intent is to replace all places in the codebase where targid and/or entity pointers are taken as parameter with this as the leading pattern because 1) it doesnt make sense to handle this differently in several places 2) captured entity pointers are the cause of too many crashes hard to diagnose

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
