### PR TITLE
[core] Cancel item use on job change

### DIFF
--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -248,6 +248,13 @@ auto CItemState::Update(const timer::time_point tick) -> bool
 
 void CItemState::Cleanup(timer::time_point tick)
 {
+    if (!IsCompleted() && !m_interrupted && m_PItem)
+    {
+        ActionInterrupts::ItemInterrupt(m_PEntity);
+        m_PEntity->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, m_PItem->getID(), 0, MsgBasic::ItemFailsToActivate);
+        m_interrupted = true;
+    }
+
     m_PEntity->UContainer->Clean();
 
     if (tx_ && tx_->isOpen())

--- a/src/map/packets/c2s/0x100_myroom_job.cpp
+++ b/src/map/packets/c2s/0x100_myroom_job.cpp
@@ -22,6 +22,7 @@
 #include "0x100_myroom_job.h"
 
 #include "ai/ai_container.h"
+#include "ai/states/item_state.h"
 #include "ai/states/magic_state.h"
 #include "entities/char_entity.h"
 #include "items/item_weapon.h"
@@ -164,8 +165,8 @@ void GP_CLI_COMMAND_MYROOM_JOB::process(MapSession* PSession, CCharEntity* PChar
 
     PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable | xi::StatusEffectFlag::Roll | xi::StatusEffectFlag::OnJobchange);
 
-    // Changing jobs interrupts any spell being cast.
-    if (PChar->PAI->IsCurrentState<CMagicState>())
+    // Changing jobs interrupts any spell being cast or item being used
+    if (PChar->PAI->IsCurrentState<CMagicState>() || PChar->PAI->IsCurrentState<CItemState>())
     {
         PChar->PAI->InterruptStates();
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Tested on retail but forgot to take a screenshot. 
Cancels item being used + add the relevant interrupt packet in the cleanup path for CItemState.

## Steps to test these changes
<img width="1408" height="299" alt="image" src="https://github.com/user-attachments/assets/5e52db80-0226-4ff4-8de3-9efcb773234a" />

<!-- Clear and detailed steps to test your changes here -->
