### PR TITLE
[lua] Move Atonement Clamp

### DIFF
--- a/modules/era/lua/actions/weaponskills/sword.lua
+++ b/modules/era/lua/actions/weaponskills/sword.lua
@@ -298,11 +298,10 @@ m:addOverride('xi.actions.weaponskills.atonement.onUseWeaponSkill', function(pla
         return calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.criticalHit, damage
     end
 
-    -- Regular damage formula
-    local dmg = target:getCE(player) * cePercent + target:getVE(player) * vePercent
+    -- Calculate damage based on target's CE and VE, clamped to the global damage cap.
+    damage = utils.clamp(target:getCE(player) * cePercent + target:getVE(player) * vePercent, 0, globalDamageCap)
 
     -- This is here to account for damage adjustments needed because it is breath damage.
-    damage = dmg
     damage = math.floor(damage * xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, false, false, true))
@@ -312,7 +311,6 @@ m:addOverride('xi.actions.weaponskills.atonement.onUseWeaponSkill', function(pla
         damage = damage * (100 + player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)) / 100
     end
 
-    damage = utils.clamp(damage, 0, globalDamageCap)
     calcParams.finalDmg = damage
 
     -- If one or more hits land, Atonement always counts as landing both hits.

--- a/scripts/actions/weaponskills/atonement.lua
+++ b/scripts/actions/weaponskills/atonement.lua
@@ -66,13 +66,13 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         return calcParams.tpHitsLanded, calcParams.extraHitsLanded, calcParams.criticalHit, damage
     end
 
-    -- Regular
-    local dmg = (target:getCE(player) + target:getVE(player)) / 6
-    -- tp affects enmity multiplier, 1.0 at 1k, 1.5 at 2k, 2.0 at 3k. Gorget/Belt adds 100 tp each.
+    -- Calculate damage based on target's CE and VE, clamped to the global damage cap.
+    damage = utils.clamp((target:getCE(player) + target:getVE(player)) / 6, 0, globalDamageCap)
+
+    -- TP affects enmity multiplier, 1.0 at 1k, 1.5 at 2k, 2.0 at 3k. Gorget/Belt adds 100 tp each.
     params.enmityMult = params.enmityMult + (tp + xi.combat.physical.calculateFTPBonus(player) * 1000 - 1000) / 2000
     params.enmityMult = utils.clamp(params.enmityMult, 1, 2) -- necessary because of Gorget/Belt bonus
 
-    damage = dmg
     damage = math.floor(damage * xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateAbsorption(target, xi.element.NONE, false, false, false, true))
     damage = math.floor(damage * xi.spells.damage.calculateNullification(target, xi.element.NONE, false, false, false, true))
@@ -82,7 +82,6 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
         damage = damage * (100 + player:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)) / 100
     end
 
-    damage = utils.clamp(damage, 0, globalDamageCap)
     calcParams.finalDmg = damage
 
     if damage > 0 then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Since Atonement is based off of Enmity, high amounts can allow its unmodified damage to become very high - we were clamping the damage of Atonement to the level-based global cap after applying all damage adjustments (effectively letting it bypass BDT and other damage modifiers at high enmity)

* Moves the clamp for the level based damage cap to before damage adjustments.

## Steps to test these changes

Fight Khimaira, use Atonement at 75 -> see 375 damage.
