### PR TITLE
[lua] Mom the Adventurer - fix Daughter section zone check

### DIFF
--- a/scripts/quests/bastok/Mom_the_Adventurer.lua
+++ b/scripts/quests/bastok/Mom_the_Adventurer.lua
@@ -69,6 +69,8 @@ quest.sections =
                 end,
             },
 
+            ['Parnika'] = quest:event(232),
+
             onEventFinish =
             {
                 [233] = handleEventFinish,
@@ -135,6 +137,23 @@ quest.sections =
                 end,
             },
 
+            ['Parnika'] = quest:event(232),
+
+            onEventFinish =
+            {
+                [230] = function(player, csid, option, npc)
+                    if npcUtil.giveItem(player, xi.item.FIRE_CRYSTAL) then
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+
+                [233] = handleEventFinish,
+                [234] = handleEventFinish,
+            },
+        },
+
+        [xi.zone.BASTOK_MINES] =
+        {
             ['Roh_Latteh'] =
             {
                 onTrade = function(player, npc, trade)
@@ -154,15 +173,6 @@ quest.sections =
                     player:confirmTrade()
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_FROM_ROH_LATTEH)
                 end,
-
-                [230] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.FIRE_CRYSTAL) then
-                        quest:setVar(player, 'Prog', 1)
-                    end
-                end,
-
-                [233] = handleEventFinish,
-                [234] = handleEventFinish,
             },
         },
     },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes Quest: Mom the Adventurer zone check section for the Daughter (Bastok Mines instead of Markets) on the repeatable version of the quest.
- Adds Parnika pickpocket event text

## Steps to test these changes

!gotoid 17739826 (Nbu Latteh)
Accept Mom quest from Nbu Latteh
!additem copper_ring
!gotoid 17735700 (Roh Lettah)
Trade Copper Ring to Roh Lettah
!gotoid 17739826 (Nbu Latteh)
Talk to Nbu Latteh for quest reward
Talk again to see Mom quest isn't offered again
!zone Port Bastok
!gotoid 17739826 (Nbu Latteh)
Accept Mom quest from Nbu Latteh

!setfamelevel 1 2
!additem copper_ring
!gotoid 17735700 (Roh Lettah)
Trade Copper Ring to Roh Lettah
!gotoid 17739826 (Nbu Latteh)
Talk to Nbu Latteh for quest reward
!zone Port Bastok
!gotoid 17739826 (Nbu Latteh)
Talk again to see Mom quest isn't offered again, but Past Perfect is offered.