### PR TITLE
[lua] Add Marble Bridge Eatery restrictions

### DIFF
--- a/scripts/zones/Upper_Jeuno/Zone.lua
+++ b/scripts/zones/Upper_Jeuno/Zone.lua
@@ -5,6 +5,9 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
+    zone:registerCuboidTriggerArea(1, -112, -1, 80, -97.8, 0, 94)    -- Marble Bridge Eatery, main
+    zone:registerCuboidTriggerArea(2, -97.8, -1, 82, -96.9, 0, 86.5) -- Marble Bridge Eatery, nook
+
     xi.chocobo.initZone(zone)
 end
 

--- a/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
+++ b/scripts/zones/Upper_Jeuno/npcs/_6s1.lua
@@ -1,0 +1,97 @@
+-----------------------------------
+-- Area: Upper Jeuno
+--  NPC: Door: "Marble Bridge"
+-- !pos -96 -0.2 92 244
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+local checkType =
+{
+    NATION = 1,
+    JOB    = 2,
+    RACE   = 3,
+}
+
+local welcomeSchedule =
+{
+    [ 1] = { check = checkType.NATION, value  = xi.nation.SANDORIA },
+    [ 2] = { check = checkType.NATION, value  = xi.nation.BASTOK   },
+    [ 3] = { check = checkType.NATION, value  = xi.nation.WINDURST },
+    [ 4] = { check = checkType.JOB,    value  = xi.job.WAR },
+    [ 5] = { check = checkType.JOB,    value  = xi.job.MNK },
+    [ 6] = { check = checkType.JOB,    value  = xi.job.WHM },
+    [ 7] = { check = checkType.JOB,    value  = xi.job.BLM },
+    [ 8] = { check = checkType.JOB,    value  = xi.job.RDM },
+    [ 9] = { check = checkType.JOB,    value  = xi.job.THF },
+    [10] = { check = checkType.JOB,    value  = xi.job.PLD },
+    [11] = { check = checkType.JOB,    value  = xi.job.DRK },
+    [12] = { check = checkType.JOB,    value  = xi.job.BST },
+    [13] = { check = checkType.JOB,    value  = xi.job.BRD },
+    [14] = { check = checkType.JOB,    value  = xi.job.RNG },
+    [15] = { check = checkType.JOB,    value  = xi.job.SAM },
+    [16] = { check = checkType.JOB,    value  = xi.job.NIN },
+    [17] = { check = checkType.JOB,    value  = xi.job.DRG },
+    [18] = { check = checkType.JOB,    value  = xi.job.SMN },
+    [19] = { check = checkType.JOB,    value  = xi.job.BLU },
+    [20] = { check = checkType.JOB,    value  = xi.job.COR },
+    [21] = { check = checkType.JOB,    value  = xi.job.PUP },
+    [22] = { check = checkType.JOB,    value  = xi.job.DNC },
+    [23] = { check = checkType.JOB,    value  = xi.job.SCH },
+    [24] = { check = checkType.JOB,    value  = xi.job.GEO },
+    [25] = { check = checkType.JOB,    value  = xi.job.RUN },
+    [26] = { check = checkType.RACE,   values = { xi.race.HUME_M,   xi.race.HUME_F   } },
+    [27] = { check = checkType.RACE,   values = { xi.race.ELVAAN_M, xi.race.ELVAAN_F } },
+    [28] = { check = checkType.RACE,   values = { xi.race.TARU_M,   xi.race.TARU_F   } },
+    [29] = { check = checkType.RACE,   values = { xi.race.MITHRA                     } },
+    [30] = { check = checkType.RACE,   values = { xi.race.GALKA                      } },
+    [31] = { check = checkType.RACE,   values = { xi.race.HUME_M, xi.race.ELVAAN_M, xi.race.TARU_M, xi.race.GALKA  } }, -- Male
+    [32] = { check = checkType.RACE,   values = { xi.race.HUME_F, xi.race.ELVAAN_F, xi.race.TARU_F, xi.race.MITHRA } }, -- Female
+}
+
+entity.onSpawn = function(npc)
+    -- Closing time triggers at Vana'diel midnight.
+    npc:addPeriodicTrigger(0, 1440, 0)
+end
+
+entity.onTimeTrigger = function(npc, triggerID)
+    for _, player in pairs(npc:getZone():getPlayers()) do
+        if
+            player:isPlayerInTriggerArea(1) or
+            player:isPlayerInTriggerArea(2)
+        then
+            player:startEvent(127)
+        end
+    end
+end
+
+entity.onTrigger = function(player, npc)
+    local welcomedIndex = VanadielUniqueDay() % #welcomeSchedule
+    local today         = welcomeSchedule[welcomedIndex + 1]
+    local welcome       = 0
+
+    switch(today.check): caseof
+    {
+        [checkType.NATION] = function()
+            if today.value == player:getNation() then
+                welcome = 1
+            end
+        end,
+
+        [checkType.JOB] = function()
+            if today.value == player:getMainJob() then
+                welcome = 1
+            end
+        end,
+
+        [checkType.RACE] = function()
+            if utils.contains(player:getRace(), today.values) then
+                welcome = 1
+            end
+        end,
+    }
+
+    player:startEvent(124, welcomedIndex, welcome)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

You can only enter the Marble Bridge Eatery each day if you meet one of its 32 restrictions. The eatery expels you every night at midnight. This code implements that.

The order appears to follow that of the [Wiki](https://wiki.ffo.jp/html/4715.html). I verified five of the restrictions in this implementation matches retail: Summoners -> Blue Mage -> Corsair -> PUP -> Dancer.

As an aside, we should probably have an enum for gender.

## Steps to test these changes

Go into the eatery. Leave the eatery. Let midnight roll around so you are kicked out.
I also verified this change did not block CoP events.
