### PR TITLE
[lua] Correct Rock Bottom trade requirements

### DIFF
--- a/scripts/quests/ahtUrhgan/Rock_Bottom.lua
+++ b/scripts/quests/ahtUrhgan/Rock_Bottom.lua
@@ -45,13 +45,16 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         quest:getVar(player, 'Prog') == 1 and
-                        npcUtil.tradeHasExactly(trade, xi.item.PICKAXE)
+                        npcUtil.tradeMatches(trade, { { xi.item.PICKAXE, 1 } })
                     then
                         return quest:progressEvent(8)
                     elseif
                         not player:needToZone() and
                         quest:getVar(player, 'Prog') == 2 and
-                        npcUtil.tradeHas(trade, { xi.item.MYTHRIL_PICK, xi.item.MYTHRIL_PICK_HQ }, true)
+                        (
+                            npcUtil.tradeMatches(trade, { { xi.item.MYTHRIL_PICK, 1 } }) or
+                            npcUtil.tradeMatches(trade, { { xi.item.MYTHRIL_PICK_HQ, 1 } })
+                        )
                     then
                         return quest:progressEvent(9, { [0] = trade:getItemId() })
                     end
@@ -72,7 +75,11 @@ quest.sections =
                 [9] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:tradeComplete()
-                        npcUtil.giveKeyItem(player, xi.ki.MAP_OF_MOUNT_ZHAYOLM)
+                        if player:hasKeyItem(xi.ki.MAP_OF_MOUNT_ZHAYOLM) then
+                            npcUtil.giveCurrency(player, 'gil', 2000)
+                        else
+                            npcUtil.giveKeyItem(player, xi.ki.MAP_OF_MOUNT_ZHAYOLM)
+                        end
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Quest Rock Bottom is not supposed to take the pickaxe on trade and accept either a Mythril Pick or Mythril Pick +1. This corrects that quest.

Also rewards 2000 gil if you already have the map (per capture).

Video: https://youtu.be/ArdHKhoesZM

## Steps to test these changes

!additem pickaxe
!additem mythril_pick
!pos 838 -14.5 232 61
Run the quest.