### PR TITLE
[lua] [sql] Implement Cerberus Mechanics

### DIFF
--- a/scripts/actions/mobskills/gates_of_hades.lua
+++ b/scripts/actions/mobskills/gates_of_hades.lua
@@ -8,11 +8,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:getHPP() < 25 then -- TODO: Move to mob scripts?
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)

--- a/scripts/actions/mobskills/lava_spit.lua
+++ b/scripts/actions/mobskills/lava_spit.lua
@@ -7,11 +7,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) then
-        return 1
-    else
-        return 0
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)

--- a/scripts/actions/mobskills/roar_cerberus.lua
+++ b/scripts/actions/mobskills/roar_cerberus.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Roar Cerberus (Emote)
+-- Description: Cerberus roars at the sky.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.msg.basic.NONE)
+
+    return 0
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/scorching_lash.lua
+++ b/scripts/actions/mobskills/scorching_lash.lua
@@ -9,11 +9,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if not target:isBehind(mob, 48) then
-        return 1
-    else
-        return 0
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)

--- a/scripts/actions/mobskills/sulfurous_breath.lua
+++ b/scripts/actions/mobskills/sulfurous_breath.lua
@@ -7,11 +7,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if target:isBehind(mob, 48) then
-        return 1
-    else
-        return 0
-    end
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -1027,7 +1027,10 @@ xi.mobSkill =
     FIRESPIT                      = 1733,
 
     LAVA_SPIT                     = 1785,
-
+    SULFUROUS_BREATH              = 1786,
+    SCORCHING_LASH                = 1787,
+    ULULATION                     = 1788,
+    MAGMA_HOPLON                  = 1789,
     GATES_OF_HADES                = 1790,
 
     VAMPIRIC_ROOT                 = 1793,
@@ -1053,6 +1056,7 @@ xi.mobSkill =
     PIT_AMBUSH_2                  = 1844,
     MANDIBULAR_BITE_2             = 1845,
 
+    ROAR_CERBERUS                 = 1892,
     -- SPIRIT_SURGE                  = 1893,
 
     FIRESPIT_BLUE_MAMOOLJA        = 1923, -- Ignores shadows

--- a/scripts/utils/utils.lua
+++ b/scripts/utils/utils.lua
@@ -1039,38 +1039,41 @@ table =
 }
 --]]
 ---@param target CBaseEntity
----@param table table
+---@param params table
 ---@return boolean
-function utils.drawIn(target, table)
-    if table.position then
-        local nextDrawIn = target:getLocalVar('[Draw-In]WaitTime')
-        local conditions = table.conditions and table.conditions or { true }
-        for _, condition in ipairs(conditions) do
-            if condition then
-                if nextDrawIn > 0 then
-                    if GetSystemTime() > nextDrawIn then
-                        local position = {}
-                        if table.position then
-                            position.x   = table.position.x and table.position.x or table.position[1]
-                            position.y   = table.position.y and table.position.y or table.position[2]
-                            position.z   = table.position.z and table.position.z or table.position[3]
-                            position.rot = table.position.rot and table.position.rot or table.position[4]
-                        end
+function utils.drawIn(target, params)
+    if not params.position then
+        target:setLocalVar('[Draw-In]WaitTime', 0)
+        return false
+    end
 
-                        local offset  = table.offset and table.offset or 0
-                        local degrees = table.degrees and table.degrees or 0
-
-                        DrawIn(target, position, offset, degrees)
-                        target:setLocalVar('[Draw-In]WaitTime', 0)
-                        return true
+    local nextDrawIn = target:getLocalVar('[Draw-In]WaitTime')
+    local conditions = params.conditions and params.conditions or { true }
+    for _, condition in ipairs(conditions) do
+        if condition then
+            if nextDrawIn > 0 then
+                if GetSystemTime() > nextDrawIn then
+                    local position = {}
+                    if params.position then
+                        position.x   = params.position.x and params.position.x or params.position[1]
+                        position.y   = params.position.y and params.position.y or params.position[2]
+                        position.z   = params.position.z and params.position.z or params.position[3]
+                        position.rot = params.position.rot and params.position.rot or params.position[4]
                     end
 
-                    return false
-                else
-                    local wait = table.wait and table.wait or 1
-                    target:setLocalVar('[Draw-In]WaitTime', GetSystemTime() + wait)
-                    return false
+                    local offset  = params.offset and params.offset or 0
+                    local degrees = params.degrees and params.degrees or 0
+
+                    DrawIn(target, position, offset, degrees)
+                    target:setLocalVar('[Draw-In]WaitTime', 0)
+                    return true
                 end
+
+                return false
+            else
+                local wait = params.wait and params.wait or 1
+                target:setLocalVar('[Draw-In]WaitTime', GetSystemTime() + wait)
+                return false
             end
         end
     end

--- a/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Cerberus.lua
@@ -5,57 +5,170 @@
 ---@type TMobEntity
 local entity = {}
 
+local drawInPositions =
+{
+    { 330.166, -23.909, -89.456 },
+    { 314.186, -24.180, -89.331 },
+    { 314.372, -23.985, -82.1   },
+    { 321.629, -24,     -90.936 },
+    { 329.969, -24,     -73.665 },
+    { 322.330, -24,     -82.168 },
+    { 331.026, -24,     -81.093 },
+    { 321.795, -23.978, -73.724 },
+}
+
+entity.spawnPoints =
+{
+    { x = 310.427, y = -24.142, z = -86.671 },
+    { x = 319.374, y = -24.007, z = -88.509 },
+    { x = 319.599, y = -23.992, z = -82.799 },
+    { x = 313.390, y = -23.871, z = -78.151 },
+    { x = 318.662, y = -23.890, z = -73.773 },
+    { x = 324.362, y = -24.269, z = -75.149 },
+    { x = 323.935, y = -24.000, z = -80.289 },
+    { x = 323.565, y = -24.000, z = -84.583 },
+    { x = 323.058, y = -23.995, z = -90.231 },
+    { x = 328.670, y = -23.984, z = -90.623 },
+    { x = 331.835, y = -23.889, z = -89.472 },
+    { x = 330.609, y = -24.054, z = -84.279 },
+    { x = 330.292, y = -24.000, z = -79.809 },
+    { x = 329.868, y = -24.109, z = -76.046 },
+}
+
+entity.onMobInitialize = function(mob)
+    mob:setRespawnTime(math.randomInt(48, 72) * 3600) -- 48 - 72 hours with 1 hour windows
+    xi.mob.updateNMSpawnPoint(mob)
+
+    mob:addImmunity(xi.immunity.LIGHT_SLEEP)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.PLAGUE)
+    mob:addImmunity(xi.immunity.SILENCE)
+
+    mob:setMobMod(xi.mobMod.GIL_MIN, 20000)
+    mob:setMobMod(xi.mobMod.GIL_MAX, 20000)
+
+    mob:addListener('TAKE_DAMAGE', 'CERBERUS_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
+        local damageAmount    = damage
+        local damageThreshold = math.max(1, math.floor(mob:getMaxHP() * 0.005))
+
+        if damageAmount < damageThreshold then
+            return
+        end
+
+        local dmgPhysical = mobArg:getMod(xi.mod.UDMGPHYS)
+        local dmgRanged   = mobArg:getMod(xi.mod.UDMGRANGE)
+        local dmgMagical  = mobArg:getMod(xi.mod.UDMGMAGIC)
+        local dmgBreath   = mobArg:getMod(xi.mod.UDMGBREATH)
+
+        local modifierAdjustment = math.floor(damageAmount / damageThreshold) * 50
+
+        if
+            attackType == xi.attackType.PHYSICAL or
+            attackType == xi.attackType.RANGED
+        then
+            dmgPhysical = utils.clamp(dmgPhysical - modifierAdjustment, -8500, 8500)
+            dmgRanged   = utils.clamp(dmgRanged - modifierAdjustment, -8500, 8500)
+            dmgMagical  = utils.clamp(dmgMagical + modifierAdjustment, -8500, 8500)
+            dmgBreath   = utils.clamp(dmgBreath + modifierAdjustment, -8500, 8500)
+        elseif
+            attackType == xi.attackType.MAGICAL or
+            attackType == xi.attackType.BREATH
+        then
+            dmgPhysical = utils.clamp(dmgPhysical + modifierAdjustment, -8500, 8500)
+            dmgRanged   = utils.clamp(dmgRanged + modifierAdjustment, -8500, 8500)
+            dmgMagical  = utils.clamp(dmgMagical - modifierAdjustment, -8500, 8500)
+            dmgBreath   = utils.clamp(dmgBreath - modifierAdjustment, -8500, 8500)
+        end
+
+        mobArg:setMod(xi.mod.UDMGPHYS, dmgPhysical)
+        mobArg:setMod(xi.mod.UDMGRANGE, dmgRanged)
+        mobArg:setMod(xi.mod.UDMGMAGIC, dmgMagical)
+        mobArg:setMod(xi.mod.UDMGBREATH, dmgBreath)
+    end)
+end
+
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
     mob:setMobMod(xi.mobMod.AOE_HIT_ALL, 1)
+
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 200)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 15)
+    mob:setMod(xi.mod.DEF, 486)
+    mob:setMod(xi.mod.ATT, 615)
+    mob:setMod(xi.mod.REGAIN, 10)
+
+    mob:setMod(xi.mod.FIRE_RES_RANK, 7)
+    mob:setMod(xi.mod.ICE_RES_RANK, 7)
+    mob:setMod(xi.mod.WIND_RES_RANK, 7)
+    mob:setMod(xi.mod.EARTH_RES_RANK, 7)
+    mob:setMod(xi.mod.THUNDER_RES_RANK, 7)
+    mob:setMod(xi.mod.WATER_RES_RANK, 7)
+    mob:setMod(xi.mod.LIGHT_RES_RANK, 7)
+    mob:setMod(xi.mod.DARK_RES_RANK, 7)
+
+    mob:setMod(xi.mod.BIND_RES_RANK, 7)
+    mob:setMod(xi.mod.BLIND_RES_RANK, 7)
+    mob:setMod(xi.mod.GRAVITY_RES_RANK, 7)
+    mob:setMod(xi.mod.PARALYZE_RES_RANK, 7)
+    mob:setMod(xi.mod.POISON_RES_RANK, 7)
+    mob:setMod(xi.mod.SLOW_RES_RANK, 7)
+
+    mob:setMod(xi.mod.UDMGBREATH, -1250)
+    mob:setMod(xi.mod.UDMGMAGIC, -1250)
+
+    mob:setMod(xi.mod.CURSE_MEVA, 1000)
+end
+
+entity.onMobRoam = function(mob)
+    local currentTime = GetSystemTime()
+    if currentTime < mob:getLocalVar('roarTimer') then
+        return
+    end
+
+    mob:useMobAbility(xi.mobSkill.ROAR_CERBERUS)
+    mob:setLocalVar('roarTimer', currentTime + math.random(150, 210))
 end
 
 entity.onMobFight = function(mob, target)
-    local targetPos = target:getPos()
-    local spawnPos  = mob:getSpawnPos()
-    local arenaBoundaries =
-    {
-        { { 335, -92 }, { 332, -94 } },
-    }
-
-    local drawInPositions =
-    {
-        { 330.166, -23.909, -89.456, targetPos.rot },
-        { 314.186, -24.180, -89.331, targetPos.rot },
-        { 314.372, -23.985,   -82.1, targetPos.rot },
-        { 321.629,     -24, -90.936, targetPos.rot },
-        { 329.969,     -24, -73.665, targetPos.rot },
-        { 322.330,     -24, -82.168, targetPos.rot },
-        { 331.026,     -24, -81.093, targetPos.rot },
-        { 321.795, -23.978, -73.724, targetPos.rot },
-    }
-
-    local drawInTable =
-    {
-        conditions =
-        {
-            target:getZPos() > -70,
-            target:getXPos() < 310,
-            not utils.sameSideOfLine(arenaBoundaries[1], targetPos, spawnPos),
-        },
-        position = utils.randomEntry(drawInPositions),
-        wait = 2,
-    }
-    for _, condition in ipairs(drawInTable.conditions) do
-        if condition then
-            mob:setMobMod(xi.mobMod.NO_MOVE, 1)
-            utils.drawIn(target, drawInTable)
-            break
-        else
-            mob:setMobMod(xi.mobMod.NO_MOVE, 0)
-        end
-    end
-
     if mob:getHPP() > 25 then
         mob:setMod(xi.mod.REGAIN, 10)
     else
-        mob:setMod(xi.mod.REGAIN, 70)
+        mob:setMod(xi.mod.REGAIN, 60)
     end
+
+    if
+        target:getZPos() <= -70 and
+        target:getXPos() >= 310 and
+        utils.sameSideOfLine({ { 335, -92 }, { 332, -94 } }, target:getPos(), mob:getSpawnPos())
+    then
+        mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+        return
+    end
+
+    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
+
+    local pos = utils.randomEntry(drawInPositions)
+    utils.drawIn(target, { position = { pos[1], pos[2], pos[3], target:getRotPos() }, wait = 2 })
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.ULULATION,
+        xi.mobSkill.MAGMA_HOPLON,
+    }
+
+    if target:isInfront(mob, 128) then
+        table.insert(skillList, xi.mobSkill.LAVA_SPIT)
+        table.insert(skillList, xi.mobSkill.SULFUROUS_BREATH)
+        table.insert(skillList, xi.mobSkill.SCORCHING_LASH)
+    end
+
+    if mob:getHPP() < 25 then
+        table.insert(skillList, xi.mobSkill.GATES_OF_HADES)
+    end
+
+    return skillList[math.randomInt(1, #skillList)]
 end
 
 entity.onMobDisengage = function(mob)

--- a/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
+++ b/scripts/zones/Mount_Zhayolm/mobs/Sarameya.lua
@@ -26,6 +26,26 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('[rage]timer', 3600) -- 60 minutes
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.ULULATION,
+        xi.mobSkill.MAGMA_HOPLON,
+    }
+
+    if target:isInfront(mob, 128) then
+        table.insert(skillList, xi.mobSkill.LAVA_SPIT)
+        table.insert(skillList, xi.mobSkill.SULFUROUS_BREATH)
+        table.insert(skillList, xi.mobSkill.SCORCHING_LASH)
+    end
+
+    if mob:getHPP() < 25 then
+        table.insert(skillList, xi.mobSkill.GATES_OF_HADES)
+    end
+
+    return skillList[math.randomInt(1, #skillList)]
+end
+
 entity.onMobFight = function(mob, target)
     local hpp = mob:getHPP()
     local useChainspell = false

--- a/scripts/zones/Nyzul_Isle/mobs/Cerberus.lua
+++ b/scripts/zones/Nyzul_Isle/mobs/Cerberus.lua
@@ -31,6 +31,26 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 15)
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList =
+    {
+        xi.mobSkill.ULULATION,
+        xi.mobSkill.MAGMA_HOPLON,
+    }
+
+    if target:isInfront(mob, 128) then
+        table.insert(skillList, xi.mobSkill.LAVA_SPIT)
+        table.insert(skillList, xi.mobSkill.SULFUROUS_BREATH)
+        table.insert(skillList, xi.mobSkill.SCORCHING_LASH)
+    end
+
+    if mob:getHPP() < 25 then
+        table.insert(skillList, xi.mobSkill.GATES_OF_HADES)
+    end
+
+    return skillList[math.randomInt(1, #skillList)]
+end
+
 entity.onMobFight = function(mob, target)
     if mob:getHPP() > 25 then
         mob:setMod(xi.mod.REGAIN, 10)

--- a/sql/mob_pool_mods.sql
+++ b/sql/mob_pool_mods.sql
@@ -65,11 +65,6 @@ INSERT INTO `mob_pool_mods` VALUES (459,430,20,0); -- QUAD_ATTACK: 20
 -- Bugbby
 INSERT INTO `mob_pool_mods` VALUES (559,62,-50,0);   -- ATTP: -50
 
--- Cerberus
-INSERT INTO `mob_pool_mods` VALUES (680,1,322,0);   -- DEF: 322
-INSERT INTO `mob_pool_mods` VALUES (680,31,200,0);  -- MEVA: 200
-INSERT INTO `mob_pool_mods` VALUES (680,251,-50,0); -- STUNRES: -50
-
 -- Citipati
 INSERT INTO `mob_pool_mods` VALUES (733,302,5,0); -- TRIPLE_ATTACK: 5
 

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1920,7 +1920,7 @@ INSERT INTO `mob_skills` VALUES (1856,1600,'omega_javelin',0,0.0,7.0,2000,1500,4
 -- INSERT INTO `mob_skills` VALUES (1889,1633,'spirit_vacuum',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1890,1634,'sound_vacuum',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1891,1218,'provoke',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1892,1229,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0); -- This is a unnamed skill for the Cerberus "Howl" Animation
+INSERT INTO `mob_skills` VALUES (1892,1229,'roar_cerberus',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1893,438,'spirit_surge',0,0.0,7.0,2000,0,1,2,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1894,1241,'potent_lunge',0,0.0,7.0,2000,1500,4,0,0,3,0,0,0);
 INSERT INTO `mob_skills` VALUES (1895,1242,'overthrow',0,0.0,7.0,2000,1500,4,0,0,6,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR Implements Cerberus Mechanics, Res ranks, and general stats.
Removes the conditionals on Cerberus's TP abilities and move it to the individual mob luas.

This implements Cerberus's see-saw damage taken mechanic.  Every time Cerb takes .5% of its damage in HP, it divides that damage by .5% of its health and reduces the damage it takes from that type (and its partner type) by 1% for each whole number, then increases the damage taken of its opposing types.  (Tanaka foresaw atonement paladins, what a visionary.)
On one side is Physical and Ranged PDT, and the other is Magic and Breath.

Implements Cerb's roar.

Delete mob pool mods heresy.

https://youtu.be/tQRlCS7CQwQ
https://youtu.be/Zxm8zwmZU7w
https://youtu.be/4CTZCdYe25w

## Steps to test these changes

Hug the Hound
