### PR TITLE
[lua] Restrict kill types for Chaosbringer

### DIFF
--- a/scripts/items/chaosbringer.lua
+++ b/scripts/items/chaosbringer.lua
@@ -12,21 +12,20 @@ itemObject.onItemDrop = function(target, item, recycleBin)
 end
 
 itemObject.onItemEquip = function(target, item)
-    target:addListener('DEFEATED_MOB', 'CHAOSBRINGER_KILLS', function(mob, player, optParams)
+    target:addListener('ATTACK', 'CHAOSBRINGER_ATTACK', function(attacker, attackTarget, action)
         if
-            (player:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == xi.questStatus.QUEST_ACCEPTED or
-            player:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == xi.questStatus.QUEST_ACCEPTED) and
-            target:getCharVar('ChaosbringerKills') < 200 and
-            optParams.isKiller and
-            not optParams.isWeaponSkillKill
+            attackTarget:getHP() == 0 and
+            (attacker:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.BLADE_OF_DARKNESS) == xi.questStatus.QUEST_ACCEPTED or
+            attacker:getQuestStatus(xi.questLog.BASTOK, xi.quest.id.bastok.BLADE_OF_DEATH) == xi.questStatus.QUEST_ACCEPTED) and
+            attacker:getCharVar('ChaosbringerKills') < 200
         then
-            player:incrementCharVar('ChaosbringerKills', 1)
+            attacker:incrementCharVar('ChaosbringerKills', 1)
         end
     end)
 end
 
 itemObject.onItemUnequip = function(target, item)
-    target:removeListener('CHAOSBRINGER_KILLS')
+    target:removeListener('CHAOSBRINGER_ATTACK')
 end
 
 return itemObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Right now, any kill with Chaosbringer equipped, as long as it's not with a weaponskill, will grant a +1 kill. So you can cheese it with magic kills or ranged attack kills. This PR stops that.

It adds guards for:
- Pet kills
- Ranged attack kills
- Magic kills
- JobAbility kills

It does not add guards for AOE job abilities or AOE Physical BLU spells. If you counter attack after a job ability or magic, the counter attack won't register.

I opted to do listeners instead of updating optParams with an isMeleeKill. The isMeleeKill would require updating a local variable every time any mob on the server takes damage. I felt the few situations above that would not register a kill was worth it not to add that extra overhead to every time any mob on the server takes damage.

## Steps to test these changes

!additem chaosbringer
!addquest bastok BLADE_OF_DARKNESS
!checkvar ChaosbringerKills