### PR TITLE
[core, lua] Restrict Sanction/Sigil food bonus to relevant regions

### DIFF
--- a/data/enums/latent.yaml
+++ b/data/enums/latent.yaml
@@ -71,3 +71,5 @@ values:
   mainjob: 62 # mainjob - PARAM: JOBTYPE
   in_adoulin: 63
   in_garrison: 64 # while in an active Garrison
+  sanction_food_bonus: 65 # While in besieged region
+  sigil_food_bonus: 66 # While in campaign region

--- a/scripts/effects/sanction.lua
+++ b/scripts/effects/sanction.lua
@@ -14,7 +14,8 @@ effectObject.onEffectGain = function(target, effect)
     elseif power == 2 then
         target:addLatent(xi.latent.SANCTION_REFRESH_BONUS, 75, xi.mod.REFRESH, 1)
     elseif power == 3 then
-        target:addMod(xi.mod.FOOD_DURATION, 100)
+        -- TODO: Power varies with Imperial defense level
+        target:addLatent(xi.latent.SANCTION_FOOD_BONUS, 0, xi.mod.FOOD_DURATION, 100)
     end
 end
 
@@ -30,7 +31,7 @@ effectObject.onEffectLose = function(target, effect)
     elseif power == 2 then
         target:delLatent(xi.latent.SANCTION_REFRESH_BONUS, 75, xi.mod.REFRESH, 1)
     elseif power == 3 then
-        target:delMod(xi.mod.FOOD_DURATION, 100)
+        target:delLatent(xi.latent.SANCTION_FOOD_BONUS, 0, xi.mod.FOOD_DURATION, 100)
     end
 end
 

--- a/scripts/effects/sigil.lua
+++ b/scripts/effects/sigil.lua
@@ -18,7 +18,8 @@ effectObject.onEffectGain = function(target, effect)
     end
 
     if utils.mask.getBit(power, 3) then
-        target:addMod(xi.mod.FOOD_DURATION, 100)
+        -- TODO: Power varies with controlled areas
+        target:addLatent(xi.latent.SIGIL_FOOD_BONUS, 0, xi.mod.FOOD_DURATION, 100)
     end
 
     if utils.mask.getBit(power, 4) then
@@ -45,7 +46,7 @@ effectObject.onEffectLose = function(target, effect)
     end
 
     if utils.mask.getBit(power, 3) then
-        target:delMod(xi.mod.FOOD_DURATION, 100)
+        target:delLatent(xi.latent.SIGIL_FOOD_BONUS, 0, xi.mod.FOOD_DURATION, 100)
     end
 
     if utils.mask.getBit(power, 4) then

--- a/scripts/tests/systems/effects/sanction_food_duration.lua
+++ b/scripts/tests/systems/effects/sanction_food_duration.lua
@@ -1,0 +1,55 @@
+describe('Sanction food duration bonus', function()
+    describe('in an Aht Urhgan region', function()
+        local player
+
+        before_each(function()
+            player = xi.test.world:spawnPlayer(
+                {
+                    job   = xi.job.WAR,
+                    level = 75,
+                    zone  = xi.zone.AHT_URHGAN_WHITEGATE,
+                })
+        end)
+
+        it('grants FOOD_DURATION', function()
+            assert(player:getMod(xi.mod.FOOD_DURATION) == 0, 'should start with no bonus')
+
+            player:addStatusEffect(xi.effect.SANCTION, { power = 3, duration = 10800, origin = player })
+
+            player.assert
+                :hasEffect(xi.effect.SANCTION)
+                :hasModifier(xi.mod.FOOD_DURATION, 100)
+        end)
+
+        it('removes FOOD_DURATION when Sanction is lost', function()
+            player:addStatusEffect(xi.effect.SANCTION, { power = 3, duration = 10800, origin = player })
+            assert(player:getMod(xi.mod.FOOD_DURATION) == 100, 'bonus should be active in region')
+
+            player:delStatusEffect(xi.effect.SANCTION)
+            xi.test.world:tick()
+
+            assert(player:getMod(xi.mod.FOOD_DURATION) == 0, 'losing Sanction should remove the bonus')
+        end)
+    end)
+
+    describe('outside Aht Urhgan regions', function()
+        local player
+
+        before_each(function()
+            player = xi.test.world:spawnPlayer(
+                {
+                    job   = xi.job.WAR,
+                    level = 75,
+                    zone  = xi.zone.SOUTHERN_SAN_DORIA,
+                })
+        end)
+
+        it('does not grant FOOD_DURATION', function()
+            player:addStatusEffect(xi.effect.SANCTION, { power = 3, duration = 10800, origin = player })
+
+            player.assert:hasEffect(xi.effect.SANCTION)
+            assert(player:getMod(xi.mod.FOOD_DURATION) == 0,
+                'Sanction outside Aht Urhgan should not grant food duration, got ' .. tostring(player:getMod(xi.mod.FOOD_DURATION)))
+        end)
+    end)
+end)

--- a/src/map/latent_effect_container.cpp
+++ b/src/map/latent_effect_container.cpp
@@ -327,6 +327,8 @@ void CLatentEffectContainer::CheckLatentsStatusEffect()
                 case xi::Latent::WeatherElement:
                 case xi::Latent::NationControl:
                 case xi::Latent::InGarrison:
+                case xi::Latent::SanctionFoodBonus:
+                case xi::Latent::SigilFoodBonus:
                     return ProcessLatentEffect(latentEffect);
                     break;
                 default:
@@ -677,6 +679,8 @@ void CLatentEffectContainer::CheckLatentsZone()
                 case xi::Latent::NationControl:
                 case xi::Latent::NationCitizen:
                 case xi::Latent::ZoneHomeNation:
+                case xi::Latent::SanctionFoodBonus:
+                case xi::Latent::SigilFoodBonus:
                     return ProcessLatentEffect(latentEffect);
                     break;
                 default:
@@ -860,6 +864,16 @@ auto CLatentEffectContainer::ProcessLatentEffect(CLatentEffect& latentEffect, bo
                          m_POwner->loc.zone->GetRegionID() >= REGION_TYPE::RONFAURE_FRONT &&
                          m_POwner->loc.zone->GetRegionID() <= REGION_TYPE::VALDEAUNIA_FRONT &&
                          ((float)m_POwner->health.mp / m_POwner->health.maxmp) * 100 < latentEffect.GetConditionsValue();
+            break;
+        case xi::Latent::SanctionFoodBonus:
+            expression = m_POwner->loc.zone != nullptr &&
+                         m_POwner->loc.zone->GetRegionID() >= REGION_TYPE::WEST_AHT_URHGAN &&
+                         m_POwner->loc.zone->GetRegionID() <= REGION_TYPE::ALZADAAL;
+            break;
+        case xi::Latent::SigilFoodBonus:
+            expression = m_POwner->loc.zone != nullptr &&
+                         m_POwner->loc.zone->GetRegionID() >= REGION_TYPE::RONFAURE_FRONT &&
+                         m_POwner->loc.zone->GetRegionID() <= REGION_TYPE::VALDEAUNIA_FRONT;
             break;
         case xi::Latent::StatusEffectActive:
             expression = m_POwner->StatusEffectContainer->HasStatusEffect(static_cast<xi::StatusEffect>(latentEffect.GetConditionsValue()));


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves the food bonus of Sanction and Sigil under a latent so that the food duration bonus is only available when eating food in the right zones.

Didnt bother to take a capture because its simple to reproduce but this is me eating a Coeurl Sub in Port San d'Oria with Sanction + Bonus

<img width="1389" height="1842" alt="Screenshot 2026-07-20 201235" src="https://github.com/user-attachments/assets/68a0744a-aca0-465c-8c61-dd08c4b231b0" />


## Steps to test these changes
Tests included.
<!-- Clear and detailed steps to test your changes here -->
