### PR TITLE
[lua] Remove Hit Interrupt For Ranged Mobskills

### DIFF
--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -403,7 +403,6 @@ local function handleSingleRangedHit(mob, target, baseHitDamage, params)
     local hitGuarded               = xi.combat.physical.isGuarded(target, mob) and not params.skipGuard
     local isCritical               = false
     local hitBlocked               = false
-    local blockedWithShieldMastery = false
     local hitInfo                  = defaultHitInfo(hitNumber)
 
     ----------------------------------
@@ -451,10 +450,6 @@ local function handleSingleRangedHit(mob, target, baseHitDamage, params)
         hitBlocked = true
 
         hitDamage = hitDamage - xi.combat.physical.getDamageReductionForBlock(target, mob, hitDamage)
-
-        if target:getMod(xi.mod.SHIELD_MASTERY_TP) > 0 then
-            blockedWithShieldMastery = true
-        end
     end
 
     hitDamage = math.floor(hitDamage * xi.combat.damage.physicalElementSDT(target, params.damageType))
@@ -478,10 +473,6 @@ local function handleSingleRangedHit(mob, target, baseHitDamage, params)
 
     if hitDamage > 0 then
         target:trySkillUp(xi.skill.EVASION, target:getMainLvl())
-
-        if not blockedWithShieldMastery then
-            target:tryHitInterrupt(mob)
-        end
     end
 
     ----------------------------------


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Removes the ability for ranged mobskills to have a chance of interrupting magic casting when damage is greater than 0.

- Tested on retail with both mobskill type ranged attacks (Goblin, Gigas, etc) and humanoid type(Fomors) and they would not interrupt my casting.

- Note: Skills with Stun effects or knockback can still interrupt casting, this is just for interrupt chance for taking damage.

## Steps to test these changes

1. Go find a RNG mob like a Goblin, Gigas, or Lamia. (Do not use trolls, their ranged attacks are magical.)
2. Get hit by ranged attacks while casting.
3. See that casting is not interrupted.
