### PR TITLE
[core] Only reset TP on legitimate swaps

### DIFF
--- a/scripts/specs/test/CClientEntityPairActions.lua
+++ b/scripts/specs/test/CClientEntityPairActions.lua
@@ -216,6 +216,17 @@ end
 function CClientEntityPairActions:setLockstyle(mode, items)
 end
 
+---@class EquipSetItem
+---@field index integer Inventory slot within the container
+---@field kind xi.slot Equipment slot to equip into
+---@field container? xi.inventoryLocation Source container (defaults to inventory)
+
+---Send an equipset packet to equip a list of items, targeting a specific copy by slot
+---@param entries EquipSetItem[] Items to equip
+---@return nil
+function CClientEntityPairActions:equipSet(entries)
+end
+
 ---Start a synthesis. Inventory slots are resolved automatically.
 ---@param crystal xi.item Crystal item ID
 ---@param ingredients xi.item[] Ingredient item IDs (1..8)

--- a/scripts/tests/systems/weapon_tp.lua
+++ b/scripts/tests/systems/weapon_tp.lua
@@ -1,0 +1,178 @@
+describe('Weapon TP', function()
+    ---@type CClientEntityPair
+    local player
+
+    it('same single weapon via equipset packet keeps TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        local slot = player:getItemInvSlot(xi.item.BRONZE_SWORD, 1)
+        assert(slot, 'sword not in inventory')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = slot, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+        assert(player:getTP() == 1000, string.format('single-copy TP=%d', player:getTP()))
+    end)
+
+    it('swapping to a different physical copy resets TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.BRONZE_SWORD)
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN), 'first copy not equipped')
+
+        local secondSlot = player:getItemInvSlot(xi.item.BRONZE_SWORD, 1)
+        assert(secondSlot, 'second copy not found')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = secondSlot, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+        assert(player:getTP() == 0, string.format('expected reset, TP=%d', player:getTP()))
+    end)
+
+    it('entry resolving to an empty slot keeps TP, weapon stays (sub present)', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.LAUAN_SHIELD)
+        player:addItem(xi.item.BRONZE_AXE)
+        local emptySlot = player:getItemInvSlot(xi.item.BRONZE_AXE, 1)
+        assert(emptySlot, 'filler axe not in inventory')
+        player:delItem(xi.item.BRONZE_AXE, 1)
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.LAUAN_SHIELD, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.MAIN), 'sword not equipped')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = emptySlot, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+        assert(player:getEquippedItem(xi.slot.MAIN), 'weapon should remain equipped')
+        assert(player:getTP() == 1000, string.format('TP wiped by empty entry, TP=%d', player:getTP()))
+    end)
+
+    it('entry for an unequippable item keeps TP, weapon stays', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.BRONZE_ROD)
+        local rodSlot = player:getItemInvSlot(xi.item.BRONZE_ROD, 1)
+        assert(rodSlot, 'rod not in inventory')
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        assert(player:getEquippedItem(xi.slot.MAIN), 'sword not equipped')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = rodSlot, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.BRONZE_SWORD, 'sword should remain equipped')
+        assert(player:getTP() == 1000, string.format('TP wiped by failed equip, TP=%d', player:getTP()))
+    end)
+
+    it('dual wield: re-apply same main+sub keeps TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.NIN, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.KUNAI)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:equipItem(xi.item.KUNAI, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BRONZE_KNIFE, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.MAIN), 'main not equipped')
+        assert(player:getEquippedItem(xi.slot.SUB), 'sub not equipped (DW setup failed)')
+
+        local mainSlot = player:getItemInvSlot(xi.item.KUNAI, 1)
+        local subSlot  = player:getItemInvSlot(xi.item.BRONZE_KNIFE, 1)
+        assert(mainSlot, 'katana not in inventory')
+        assert(subSlot, 'dagger not in inventory')
+
+        player:setTP(1000)
+        player.actions:equipSet(
+        {
+            { index = mainSlot, kind = xi.slot.MAIN, container = xi.inv.INVENTORY },
+            { index = subSlot,  kind = xi.slot.SUB,  container = xi.inv.INVENTORY },
+        })
+        assert(player:getTP() == 1000, string.format('DW re-apply TP=%d', player:getTP()))
+    end)
+
+    it('dual wield: swap sub to identical second copy resets TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.NIN, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.KUNAI)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:equipItem(xi.item.KUNAI, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BRONZE_KNIFE, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB), 'sub not equipped')
+
+        local secondKnife = player:getItemInvSlot(xi.item.BRONZE_KNIFE, 1)
+        assert(secondKnife, 'second dagger not found')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = secondKnife, kind = xi.slot.SUB, container = xi.inv.INVENTORY } })
+        assert(player:getTP() == 0, string.format('expected reset, DW copy TP=%d', player:getTP()))
+    end)
+
+    it('offhand weapon without Dual Wield: TP kept, shield stays', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:addItem(xi.item.LAUAN_SHIELD)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.LAUAN_SHIELD, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB):getID() == xi.item.LAUAN_SHIELD, 'shield not equipped')
+
+        local knifeSlot = player:getItemInvSlot(xi.item.BRONZE_KNIFE, 1)
+        assert(knifeSlot, 'dagger not in inventory')
+
+        player:setTP(1000)
+        player.actions:equipSet({ { index = knifeSlot, kind = xi.slot.SUB, container = xi.inv.INVENTORY } })
+        assert(player:getEquippedItem(xi.slot.SUB):getID() == xi.item.LAUAN_SHIELD, 'shield should remain equipped')
+        assert(player:getTP() == 1000, string.format('TP wiped by rejected offhand, TP=%d', player:getTP()))
+    end)
+
+    it('instrument -> instrument keeps TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.BRD, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.CORNETTE)
+        player:addItem(xi.item.FLUTE)
+        player:equipItem(xi.item.CORNETTE, nil, xi.slot.RANGED)
+
+        player:setTP(1000)
+        player:equipItem(xi.item.FLUTE, nil, xi.slot.RANGED)
+        assert(player:getTP() == 1000, string.format('instrument swap TP=%d', player:getTP()))
+    end)
+
+    it('unequipping an instrument entirely loses TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.BRD, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.CORNETTE)
+        player:equipItem(xi.item.CORNETTE, nil, xi.slot.RANGED)
+
+        player:setTP(1000)
+        player:unequipItem(xi.slot.RANGED)
+        assert(player:getTP() == 0, string.format('expected reset, instrument unequip TP=%d', player:getTP()))
+    end)
+
+    it('animator -> animator loses TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.PUP, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.ANIMATOR)
+        player:addItem(xi.item.TURBO_ANIMATOR)
+        player:equipItem(xi.item.ANIMATOR, nil, xi.slot.RANGED)
+
+        player:setTP(1000)
+        player:equipItem(xi.item.TURBO_ANIMATOR, nil, xi.slot.RANGED)
+        assert(player:getTP() == 0, string.format('expected reset, animator swap TP=%d', player:getTP()))
+    end)
+
+    it('bell -> bell keeps TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.GEO, level = 99, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.MATRE_BELL)
+        player:addItem(xi.item.FILIAE_BELL)
+        player:equipItem(xi.item.MATRE_BELL, nil, xi.slot.RANGED)
+
+        player:setTP(1000)
+        player:equipItem(xi.item.FILIAE_BELL, nil, xi.slot.RANGED)
+        assert(player:getTP() == 1000, string.format('bell swap TP=%d', player:getTP()))
+    end)
+
+    it('unequipping a bell entirely loses TP', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.GEO, level = 99, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.MATRE_BELL)
+        player:equipItem(xi.item.MATRE_BELL, nil, xi.slot.RANGED)
+
+        player:setTP(1000)
+        player:unequipItem(xi.slot.RANGED)
+        assert(player:getTP() == 0, string.format('expected reset, bell unequip TP=%d', player:getTP()))
+    end)
+end)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2253,7 +2253,12 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
                     PChar->look.ranged = 0;
                 }
                 PChar->m_Weapons[SLOT_RANGED] = nullptr;
-                if (((CItemWeapon*)PItem)->getSkillType() != xi::SkillType::StringInstrument && ((CItemWeapon*)PItem)->getSkillType() != xi::SkillType::WindInstrument)
+
+                // Instruments and Handbells being unequipped does not necessarily mean TP must be reset.
+                // The incoming item (or lack of) decides it.
+                const auto rangedSkill        = static_cast<CItemWeapon*>(PItem)->getSkillType();
+                const bool isRangedInstrument = rangedSkill == xi::SkillType::StringInstrument || rangedSkill == xi::SkillType::WindInstrument || rangedSkill == xi::SkillType::Handbell;
+                if (recalculate || !isRangedInstrument)
                 {
                     PChar->health.tp = 0;
                     PChar->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Aftermath);
@@ -3345,6 +3350,8 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         }
     }
 
+    bool equipSucceeded = false;
+
     if (slotID == 0)
     {
         CItemEquipment* PSubItem = PChar->getEquip(SLOT_SUB);
@@ -3362,6 +3369,8 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
         {
             if (!PItem->isSubType(ITEM_LOCKED) && EquipArmor(PChar, slotID, equipSlotID, containerID))
             {
+                equipSucceeded = true;
+
                 if (PItem->getScriptType() & SCRIPT_EQUIP)
                 {
                     PChar->m_EquipFlag |= PItem->getScriptType();
@@ -3408,10 +3417,16 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
 
     if (equipSlotID == SLOT_MAIN || equipSlotID == SLOT_RANGED || equipSlotID == SLOT_SUB)
     {
-        if (!PItem || !PItem->isType(ITEM_EQUIPMENT) ||
-            (((CItemWeapon*)PItem)->getSkillType() != xi::SkillType::StringInstrument && ((CItemWeapon*)PItem)->getSkillType() != xi::SkillType::WindInstrument))
+        // Instruments and Handbells swapping keeps TP.
+        // The outgoing instruments should have saved the TP in UnequipItem before getting here.
+        const bool isRangedInstrument =
+            PItem && PItem->isType(ITEM_EQUIPMENT) &&
+            (static_cast<CItemWeapon*>(PItem)->getSkillType() == xi::SkillType::StringInstrument ||
+             static_cast<CItemWeapon*>(PItem)->getSkillType() == xi::SkillType::WindInstrument ||
+             static_cast<CItemWeapon*>(PItem)->getSkillType() == xi::SkillType::Handbell);
+
+        if (equipSucceeded && !isRangedInstrument)
         {
-            // If the weapon ISN'T a wind based instrument or a string based instrument
             PChar->health.tp = 0;
             PChar->StatusEffectContainer->DelStatusEffect(xi::StatusEffect::Aftermath);
         }

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
@@ -46,6 +46,7 @@
 #include "map/packets/c2s/0x036_item_transfer.h"
 #include "map/packets/c2s/0x037_item_use.h"
 #include "map/packets/c2s/0x03a_item_stack.h"
+#include "map/packets/c2s/0x051_equipset_set.h"
 #include "map/packets/c2s/0x053_lockstyle.h"
 #include "map/packets/c2s/0x06e_group_solicit_req.h"
 #include "map/packets/c2s/0x074_group_solicit_res.h"
@@ -785,6 +786,40 @@ void CLuaClientEntityPairActions::setLockstyle(const uint8 mode, sol::optional<s
 }
 
 /************************************************************************
+ *  Function: equipSet()
+ *  Purpose : Emits the 0x51 equipset packet to equip a list of items.
+ *  Example : player.actions:equipSet({ { index = 1, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+ *  Notes   : Each entry: index (bag slot), kind (equip slot), container (bag id).
+ *            Targets a specific item copy by slot, unlike equipItem by item id.
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::equipSet(const sol::table& entries) const
+{
+    const auto packet = parent_->packets().createPacket<GP_CLI_COMMAND_EQUIPSET_SET>();
+    auto*      p      = packet->as<GP_CLI_COMMAND_EQUIPSET_SET>();
+    p->Count          = 0;
+
+    uint8 idx = 0;
+    for (const auto& [key, val] : entries)
+    {
+        if (!val.is<sol::table>() || idx >= 16)
+        {
+            break;
+        }
+
+        auto entry                  = val.as<sol::table>();
+        p->Equipment[idx].ItemIndex = entry.get_or<uint8_t>("index", 0);
+        p->Equipment[idx].EquipKind = entry.get_or<uint8_t>("kind", 0);
+        p->Equipment[idx].Category  = entry.get_or<uint8_t>("container", 0); // 0 == LOC_INVENTORY
+        ++idx;
+    }
+
+    p->Count = idx;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
  *  Function: craft()
  *  Purpose : Emits packet to start a synthesis with the given crystal +
  *            ingredient item IDs (looked up in the player's inventory).
@@ -1000,6 +1035,7 @@ void CLuaClientEntityPairActions::Register()
     SOL_REGISTER("sortContainer", CLuaClientEntityPairActions::sortContainer);
     SOL_REGISTER("dropItem", CLuaClientEntityPairActions::dropItem);
     SOL_REGISTER("setLockstyle", CLuaClientEntityPairActions::setLockstyle);
+    SOL_REGISTER("equipSet", CLuaClientEntityPairActions::equipSet);
     SOL_REGISTER("craft", CLuaClientEntityPairActions::craft);
     SOL_REGISTER("plantAdd", CLuaClientEntityPairActions::plantAdd);
     SOL_REGISTER("plantCheck", CLuaClientEntityPairActions::plantCheck);

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.h
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.h
@@ -68,6 +68,7 @@ public:
     void sortContainer(uint8 container) const;
     void dropItem(uint8 container, uint8 slot, uint32 quantity) const;
     void setLockstyle(uint8 mode, sol::optional<sol::table> items) const;
+    void equipSet(const sol::table& entries) const;
     void craft(uint16 crystalItemId, const sol::table& ingredients) const;
 
     void plantAdd(uint8 potContainer, uint8 potSlot, uint8 addContainer, uint8 addSlot) const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Resolves a handful of bugs:
- Does not reset TP if no swap occured (resolves issues with Dual Wield or same-weapon swaps with equipsets)
- Does not reset TP if swapping instruments to instruments (BRD/GEO) 

Adds relevant tests, all backed by retail testing
[tp_loss_scenarios_2026-7-20_23_57.zip](https://github.com/user-attachments/files/30217056/tp_loss_scenarios_2026-7-20_23_57.zip)


## Steps to test these changes
Tests included
<!-- Clear and detailed steps to test your changes here -->
