### PR TITLE
[lua] Fix Shrine of RuAvitau teleporters

### DIFF
--- a/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/Zone.lua
@@ -5,35 +5,35 @@
 local zoneObject = {}
 
 zoneObject.onInitialize = function(zone)
-    -- MAP 1
-    zone:registerCuboidTriggerArea(1, -21, 29, -61, -16, 31, -57)      --> F (H-10)
-    zone:registerCuboidTriggerArea(2, 16, 29, 57, 21, 31, 61)          --> E (H-7)
+    -- Map 1
+    zone:registerCuboidTriggerArea(1, -21, 29, -61, -16, 31, -57)       --> F (H-10)
+    zone:registerCuboidTriggerArea(2, 16, 29, 57, 21, 31, 61)           --> E (H-7)
 
-    -- MAP 3
-    zone:registerCuboidTriggerArea(3, -89, -19, 83, -83, -15, 89)      --> L (F-5)
-    zone:registerCuboidTriggerArea(3, -143, -19, -22, -137, -15, -16)  --> L (D-8)
-    zone:registerCuboidTriggerArea(4, -143, -19, 55, -137, -15, 62)    --> G (D-6)
-    zone:registerCuboidTriggerArea(4, 83, -19, -89, 89, -15, -83)      --> G (J-10)
-    zone:registerCuboidTriggerArea(5, -89, -19, -89, -83, -15, -83)    --> J (F-10)
-    zone:registerCuboidTriggerArea(6, 137, -19, -22, 143, -15, -16)    --> H (L-8)
-    zone:registerCuboidTriggerArea(7, 136, -19, 56, 142, -15, 62)      --> I (L-6)
-    zone:registerCuboidTriggerArea(8, 83, -19, 83, 89, -15, 89)        --> K (J-5)
+    -- Map 3
+    zone:registerCuboidTriggerArea(3, -89, -19, 83, -83, -15, 89)       --> L (F-5)
+    zone:registerCuboidTriggerArea(4, -143, -19, -22, -137, -15, -16)   --> L (D-8)
+    zone:registerCuboidTriggerArea(5, -143, -19, 55, -137, -15, 62)     --> G (D-6)
+    zone:registerCuboidTriggerArea(6, 83, -19, -89, 89, -15, -83)       --> G (J-10)
+    zone:registerCuboidTriggerArea(7, -89, -19, -89, -83, -15, -83)     --> J (F-10)
+    zone:registerCuboidTriggerArea(8, 137, -19, -22, 143, -15, -16)     --> H (L-8)
+    zone:registerCuboidTriggerArea(9, 136, -19, 56, 142, -15, 62)       --> I (L-6)
+    zone:registerCuboidTriggerArea(10, 83, -19, 83, 89, -15, 89)        --> K (J-5)
 
-    -- MAP 4
-    zone:registerCuboidTriggerArea(9, 723, 96, 723, 729, 100, 729)     --> L'(F-5)
-    zone:registerCuboidTriggerArea(10, 870, 96, 723, 876, 100, 729)    --> O (J-5)
-    zone:registerCuboidTriggerArea(6, 870, 96, 470, 876, 100, 476)     --> H (J-11)
-    zone:registerCuboidTriggerArea(11, 723, 96, 470, 729, 100, 476)    --> N (F-11)
+    -- Map 4
+    zone:registerCuboidTriggerArea(11, 723, 96, 723, 729, 100, 729)     --> L (F-5)
+    zone:registerCuboidTriggerArea(12, 870, 96, 723, 876, 100, 729)     --> O (J-5)
+    zone:registerCuboidTriggerArea(13, 870, 96, 470, 876, 100, 476)     --> H (J-11)
+    zone:registerCuboidTriggerArea(14, 723, 96, 470, 729, 100, 476)     --> N (F-11)
 
-    -- MAP 5
-    zone:registerCuboidTriggerArea(12, 817, -3, 57, 823, 1, 63)        --> D (I-7)
-    zone:registerCuboidTriggerArea(13, 736, -3, 16, 742, 1, 22)        --> P (F-8)
-    zone:registerCuboidTriggerArea(14, 857, -3, -23, 863, 1, -17)      --> M (J-9)
-    zone:registerCuboidTriggerArea(15, 776, -3, -63, 782, 1, -57)      --> C (G-10)
+    -- Map 5
+    zone:registerCuboidTriggerArea(15, 817, -3, 57, 823, 1, 63)         --> D (I-7)
+    zone:registerCuboidTriggerArea(16, 736, -3, 16, 742, 1, 22)         --> P (F-8)
+    zone:registerCuboidTriggerArea(17, 857, -3, -23, 863, 1, -17)       --> M (J-9)
+    zone:registerCuboidTriggerArea(18, 776, -3, -63, 782, 1, -57)       --> C (G-10)
 
-    -- MAP 6
-    zone:registerCuboidTriggerArea(2, 777, -103, -503, 783, -99, -497) --> E (G-6)
-    zone:registerCuboidTriggerArea(1, 816, -103, -503, 822, -99, -497) --> F (I-6)
+    -- Map 6
+    zone:registerCuboidTriggerArea(19, 777, -103, -503, 783, -99, -497) --> E (G-6)
+    zone:registerCuboidTriggerArea(20, 816, -103, -503, 822, -99, -497) --> F (I-6)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)
@@ -59,18 +59,23 @@ local teleportEventsByArea =
     [ 1] = 17, -- To F
     [ 2] = 16, -- To E
     [ 3] =  5, -- To L (Kirin)
-    [ 4] =  4, -- To G
-    [ 5] =  1, -- To J
-    [ 6] =  3, -- To H
-    [ 7] =  7, -- To I
-    [ 8] =  6, -- To K
-    [ 9] = 10, -- To L'
-    [10] = 11,
-    [11] =  8,
-    [12] = 15, -- To D
-    [13] = 14, -- To P
-    [14] = 13, -- To M
-    [15] = 12, -- To C
+    [ 4] =  5, -- To L (Kirin)
+    [ 5] =  4, -- To G
+    [ 6] =  4, -- To G
+    [ 7] =  1, -- To J
+    [ 8] =  3, -- To H
+    [ 9] =  7, -- To I
+    [10] =  6, -- To K
+    [11] = 10, -- To L'
+    [12] = 11, -- To O
+    [13] =  3, -- To H
+    [14] =  8, -- To N
+    [15] = 15, -- To D
+    [16] = 14, -- To P
+    [17] = 13, -- To M
+    [18] = 12, -- To C
+    [19] = 16, -- To E
+    [20] = 17, -- To F
 }
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When 2 or more ```zone:registerCuboidTriggerArea``` share the same ID, you get into an infinite loop of triggering the areas until you move out of the area. This fixes the issue.

## Steps to test these changes

!pos -86 -17 86 178
!pos -140 -17 -19 178

Use the teleporters and see you don't get stuck in an infinite loop and you go to the right locations.