### PR TITLE
[C++] Update LoadPet with frame check

### DIFF
--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -1754,6 +1754,17 @@ void LoadPet(CBattleEntity* PMaster, uint32 PetID, bool spawningFromZone)
         return;
     }
 
+    // Ensure a stowed automaton frame always matches the current automaton frame of the master.
+    if (PMaster->objtype == TYPE_PC &&
+        (PetID == PETID_HARLEQUINFRAME || PetID == PETID_VALOREDGEFRAME || PetID == PETID_SHARPSHOTFRAME || PetID == PETID_STORMWAKERFRAME))
+    {
+        const auto frameEquipped = static_cast<CCharEntity*>(PMaster)->getAutomatonFrame();
+        if (frameEquipped >= AutomatonFrame::Harlequin && frameEquipped <= AutomatonFrame::Stormwaker)
+        {
+            PetID = static_cast<uint32>(PETID_HARLEQUINFRAME) + static_cast<uint32>(frameEquipped) - static_cast<uint32>(AutomatonFrame::Harlequin);
+        }
+    }
+
     auto maybePetData = std::find_if(
         g_PPetList.begin(),
         g_PPetList.end(),


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When you stow a automaton after zoning into town and change your frame, the stored petID can become stale (storing your old frame) and LoadPet doesn't refresh it when it's called - this fix rechecks it to make sure that it hasn't gone stale. 

## Steps to test these changes

Summon Automaton -> Zone into town -> Switch frames -> See weaponskills used match up with frame (best one to test is going from Harlequin to Valoredge)
