### PR TITLE
[lua] Ghatsad frame/head level requirement fix

### DIFF
--- a/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
+++ b/scripts/zones/Aht_Urhgan_Whitegate/npcs/Ghatsad.lua
@@ -9,6 +9,22 @@ local ID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 ---@type TNpcEntity
 local entity = {}
 
+--cs 620 - new frame - param 6: itemid payment param 7: number of payment param 8: bitpack choices (bit 0 no thanks, bit 1 VE, bit 2 SS, bit 3 SW)
+--cs 621 - new frame (if canceled previous)
+--cs 622 - bring me mats
+--cs 624 - all mats, just need payment
+--cs 625 - thanks, have everything, come back later
+--cs 626 - come back later
+--cs 627 - automaton frame done (param 2: frame)
+--cs 628 - you can customise automaton by changing frame
+--cs 629 - you can alter automatons abilities and character by equipping attachments (what are these last 2 for?)
+--cs 900 - start soulsoother/spiritreaver
+--cs 901 - start second head
+--cs 902 - start work on chosen head
+--cs 903 - head almost done
+--cs 904 - give coffee
+--cs 905 - head complete
+
 -- Since every outcome includes a head, track number unlocked based on this.
 -- This is used to calculate the cost of additional items, and provide certain
 -- event parameters (numUnlockedHeads).
@@ -34,29 +50,9 @@ local unlockCost =
 -- combination that can be purchased (Valoredge, Sharpshot, Stormwaker)
 local headAndFrameItems =
 {
-    [2] =
-    {
-        xi.item.BRASS_SHEET,
-        xi.item.WAMOURA_COCOON,
-        xi.item.CHUNK_OF_IMPERIAL_CERMET,
-        xi.item.PATAS
-    },
-
-    [3] =
-    {
-        xi.item.PIECE_OF_ROSEWOOD_LUMBER,
-        xi.item.SQUARE_OF_KARAKUL_CLOTH,
-        xi.item.SQUARE_OF_KARAKUL_LEATHER,
-        xi.item.HEAVY_CROSSBOW
-    },
-
-    [4] =
-    {
-        xi.item.SPOOL_OF_GOLD_THREAD,
-        xi.item.SQUARE_OF_VELVET_CLOTH,
-        xi.item.SQUARE_OF_WAMOURA_CLOTH,
-        xi.item.BRASS_RING
-    },
+    [2] = { xi.item.BRASS_SHEET,              xi.item.WAMOURA_COCOON,          xi.item.CHUNK_OF_IMPERIAL_CERMET,  xi.item.PATAS          },
+    [3] = { xi.item.PIECE_OF_ROSEWOOD_LUMBER, xi.item.SQUARE_OF_KARAKUL_CLOTH, xi.item.SQUARE_OF_KARAKUL_LEATHER, xi.item.HEAVY_CROSSBOW },
+    [4] = { xi.item.SPOOL_OF_GOLD_THREAD,     xi.item.SQUARE_OF_VELVET_CLOTH,  xi.item.SQUARE_OF_WAMOURA_CLOTH,   xi.item.BRASS_RING     },
 }
 
 -- Depending on item traded, a random range is provided for number of
@@ -143,11 +139,11 @@ local function play_event902(player, newAttachmentStatus, waitDays)
 end
 
 entity.onTrade = function(player, npc, trade)
-    local attachmentStatus = player:getCharVar('PUP_AttachmentStatus')
-    local numUnlockedHeads = getNumUnlockedHeads(player)
+    local attachmentStatus   = player:getCharVar('PUP_AttachmentStatus')
+    local numUnlockedHeads   = getNumUnlockedHeads(player)
     local attachmentReadyDay = player:getCharVar('PUP_AttachmentReady')
-    local attachmentReady = attachmentReadyDay ~= 0 and attachmentReadyDay <= VanadielUniqueDay()
-    local tradeHasPayment = trade:getItemQty(unlockCost[numUnlockedHeads][1]) == unlockCost[numUnlockedHeads][2]
+    local attachmentReady    = attachmentReadyDay ~= 0 and attachmentReadyDay <= VanadielUniqueDay()
+    local tradeHasPayment    = trade:getItemQty(unlockCost[numUnlockedHeads][1]) == unlockCost[numUnlockedHeads][2]
 
     -- Initial Trade: Has Materials + Payment, or just Materials
     if attachmentStatus >= 2 and attachmentStatus <= 4 then
@@ -197,144 +193,126 @@ entity.onTrade = function(player, npc, trade)
             end
         end
 
-    -- Imperial Coffee Trade to reduce time remaining
+    -- Imperial Coffee Trade to reduce time remaining.
     elseif
         (attachmentStatus == 12 or attachmentStatus == 13) and
         not attachmentReady and
-        player:getCharVar('PUP_nextCoffeeTrade') <= VanadielUniqueDay()
+        player:getCharVar('PUP_nextCoffeeTrade') <= VanadielUniqueDay() and
+        npcUtil.tradeMatches(trade, { { xi.item.CUP_OF_IMPERIAL_COFFEE, 1 } })
     then
-        if npcUtil.tradeHasExactly(trade, xi.item.CUP_OF_IMPERIAL_COFFEE) then
-            player:confirmTrade()
-            player:setCharVar('PUP_AttachmentReady', player:getCharVar('PUP_AttachmentReady') - 1)
-            player:setCharVar('PUP_nextCoffeeTrade', VanadielUniqueDay() + 1)
-            player:startEvent(904)
-        end
+        player:startEvent(904)
     end
 end
 
 entity.onTrigger = function(player, npc)
-    --cs 620 - new frame - param 6: itemid payment param 7: number of payment param 8: bitpack choices (bit 0 no thanks, bit 1 VE, bit 2 SS, bit 3 SW)
-    --cs 621 - new frame (if canceled previous)
-    --cs 622 - bring me mats
-    --cs 624 - all mats, just need payment
-    --cs 625 - thanks, have everything, come back later
-    --cs 626 - come back later
-    --cs 627 - automaton frame done (param 2: frame)
-    --cs 628 - you can customise automaton by changing frame
-    --cs 629 - you can alter automatons abilities and character by equipping attachments (what are these last 2 for?)
-    --cs 900 - start soulsoother/spiritreaver
-    --cs 901 - start second head
-    --cs 902 - start work on chosen head
-    --cs 903 - head almost done
-    --cs 904 - give coffee
-    --cs 905 - head complete
-
-    local automatonName = player:getAutomatonName()
-    local numUnlockedHeads = getNumUnlockedHeads(player)
-    local attachmentStatus = player:getCharVar('PUP_AttachmentStatus')
-    local unlockedAttachments = getHeadMask(player)
-    local attachmentReadyDay = player:getCharVar('PUP_AttachmentReady')
-    local attachmentReady = attachmentReadyDay ~= 0 and attachmentReadyDay <= VanadielUniqueDay()
-    local attachmentDaysRemaining = attachmentReadyDay - VanadielUniqueDay()
-
-    --[[
-        attachment status:
-        0 - none
-        1 - declined a new frame
-        2 - accepted valoredge
-        3 - accepted sharphot
-        4 - accepted stormwaker
-        5 - paid mats for valoredge
-        6 - paid mats for sharpshot
-        7 - paid mats for stormwaker
-        8 - paid mats + coins for valoredge
-        9 - paid mats + coins for sharpshot
-        10 - paid mats + coins for stormwaker
-        11 - asked about soulsoother/spiritreaver
-        12 - paid for soulsoother
-        13 - paid for spiritreaver
-        14 - asked about soulsoother/spiritreaver (after obtaining the first)
-    ]]
-
-    if
-        player:hasCompletedQuest(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.NO_STRINGS_ATTACHED) and
-        player:getMainJob() == xi.job.PUP
-    then
-        local requiredLevel = numUnlockedHeads * 10
-
-        -- Has not Accepted or Declined a new Head (or Head/Frame combination)
-        if attachmentStatus == 0 and player:getMainLvl() >= requiredLevel then
-            if numUnlockedHeads < 3 then
-                player:startEventString(620, automatonName, automatonName, automatonName, automatonName, numUnlockedHeads, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2], unlockedAttachments)
-            elseif numUnlockedHeads == 3 then
-                player:startEventString(900, automatonName, automatonName, automatonName, automatonName, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-            elseif numUnlockedHeads == 4 then
-                if unlockedAttachments == 30 then
-                    player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 1, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-                elseif unlockedAttachments == 46 then
-                    player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-                end
-            end
-
-        -- Declined a new Head or Head/Frame combination
-        elseif attachmentStatus == 1 then
-            player:startEvent(621, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2], unlockedAttachments)
-
-        -- Paid in Full (Mats & Currency) for Head/Frame Combination
-        elseif attachmentStatus >= 8 and attachmentStatus <= 10 then
-            if not attachmentReady then
-                player:startEvent(626)
-            else
-                local param6 = attachmentStatus - 7
-
-                player:startEventString(627, automatonName, automatonName, automatonName, automatonName, 0, param6)
-            end
-
-        -- Accepted a Head/Frame Combination, but has not provided any payment
-        elseif attachmentStatus >= 2 and attachmentStatus <= 4 then
-            local option = player:getCharVar('PUP_AttachmentOption')
-            player:startEvent(622, 0, option, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-
-        -- Paid Mats for Head/Frame Combination, but needs to provide Currency
-        elseif attachmentStatus >= 5 and attachmentStatus <= 7 then
-            player:startEvent(624, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-
-        -- Asked about Soulsoother/Spiritreaver Head
-        elseif attachmentStatus == 11 and numUnlockedHeads == 3 then
-            player:startEventString(900, automatonName, automatonName, automatonName, automatonName, 0, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-
-        -- Paid for Soulsoother/Spiritreaver Head
-        elseif attachmentStatus == 12 or attachmentStatus == 13 then
-            if not attachmentReady then
-                player:startEvent(903, attachmentDaysRemaining, 1)
-            else
-                if attachmentDaysRemaining > 0 then
-                    player:startEvent(903, attachmentDaysRemaining, 0)
-                else
-                    player:startEvent(905, attachmentStatus - 12)
-                end
-            end
-
-        -- Ask about other head, after obtaining one already (Spiritreaver or Soulsoother)
-        elseif attachmentStatus == 14 then
-            if unlockedAttachments == 30 then
-                player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 1, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-            elseif unlockedAttachments == 46 then
-                player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 0, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
-            end
-
-            -- Default PUP actions after first Unlock
-            elseif numUnlockedHeads > 0 then
-                local rand = math.randomInt(1, 2)
-                if rand == 1 then
-                    player:startEvent(628)
-                else
-                    player:startEventString(629, automatonName, automatonName, automatonName, automatonName)
-                end
-        end
-    -- Default Action
-    else
+    if not player:hasCompletedQuest(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.NO_STRINGS_ATTACHED) then
         player:startEvent(256)
+        return
+    end
+
+    if player:getMainJob() ~= xi.job.PUP then
+        player:startEvent(256)
+        return
+    end
+
+    local automatonName       = player:getAutomatonName()
+    local numUnlockedHeads    = getNumUnlockedHeads(player)
+    local attachmentStatus    = player:getCharVar('PUP_AttachmentStatus')
+    local unlockedAttachments = getHeadMask(player)
+    local attachmentReadyDay  = player:getCharVar('PUP_AttachmentReady')
+    local attachmentReady     = attachmentReadyDay ~= 0 and attachmentReadyDay <= VanadielUniqueDay()
+
+    -- attachment status:
+    --  0 - none
+    --  1 - declined a new frame
+    --  2 - accepted valoredge
+    --  3 - accepted sharphot
+    --  4 - accepted stormwaker
+    --  5 - paid mats for valoredge
+    --  6 - paid mats for sharpshot
+    --  7 - paid mats for stormwaker
+    --  8 - paid mats + coins for valoredge
+    --  9 - paid mats + coins for sharpshot
+    -- 10 - paid mats + coins for stormwaker
+    -- 11 - asked about soulsoother/spiritreaver
+    -- 12 - paid for soulsoother
+    -- 13 - paid for spiritreaver
+    -- 14 - asked about soulsoother/spiritreaver (after obtaining the first)
+
+    -- Has not Accepted or Declined a new Head (or Head/Frame combination)
+    if
+        attachmentStatus == 0 and
+        player:getMainLvl() >= 10 + numUnlockedHeads * 10
+    then
+        if numUnlockedHeads < 3 then
+            player:startEventString(620, automatonName, automatonName, automatonName, automatonName, numUnlockedHeads, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2], unlockedAttachments)
+        elseif numUnlockedHeads == 3 then
+            player:startEventString(900, automatonName, automatonName, automatonName, automatonName, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+        elseif numUnlockedHeads == 4 then
+            if unlockedAttachments == 30 then
+                player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 1, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+            elseif unlockedAttachments == 46 then
+                player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+            end
+        end
+
+    -- Declined a new Head or Head/Frame combination
+    elseif attachmentStatus == 1 then
+        player:startEvent(621, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2], unlockedAttachments)
+
+    -- Accepted a Head/Frame Combination, but has not provided any payment
+    elseif attachmentStatus >= 2 and attachmentStatus <= 4 then
+        local option = player:getCharVar('PUP_AttachmentOption')
+        player:startEvent(622, 0, option, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+
+    -- Paid Mats for Head/Frame Combination, but needs to provide Currency
+    elseif attachmentStatus >= 5 and attachmentStatus <= 7 then
+        player:startEvent(624, 0, 0, 0, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+
+    -- Paid in Full (Mats & Currency) for Head/Frame Combination
+    elseif attachmentStatus >= 8 and attachmentStatus <= 10 then
+        if not attachmentReady then
+            player:startEvent(626)
+        else
+            local param6 = attachmentStatus - 7
+
+            player:startEventString(627, automatonName, automatonName, automatonName, automatonName, 0, param6)
+        end
+
+    -- Asked about Soulsoother/Spiritreaver Head
+    elseif attachmentStatus == 11 and numUnlockedHeads == 3 then
+        player:startEventString(900, automatonName, automatonName, automatonName, automatonName, 0, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+
+    -- Paid for Soulsoother/Spiritreaver Head
+    elseif attachmentStatus == 12 or attachmentStatus == 13 then
+        local attachmentDaysRemaining = attachmentReadyDay - VanadielUniqueDay()
+
+        if not attachmentReady then
+            player:startEvent(903, attachmentDaysRemaining, 1)
+        else
+            if attachmentDaysRemaining > 0 then
+                player:startEvent(903, attachmentDaysRemaining, 0)
+            else
+                player:startEvent(905, attachmentStatus - 12)
+            end
+        end
+
+    -- Ask about other head, after obtaining one already (Spiritreaver or Soulsoother)
+    elseif attachmentStatus == 14 then
+        if unlockedAttachments == 30 then
+            player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 1, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+        elseif unlockedAttachments == 46 then
+            player:startEventString(901, automatonName, automatonName, automatonName, automatonName, 0, 0, 1, 0, 0, unlockCost[numUnlockedHeads][1], unlockCost[numUnlockedHeads][2])
+        end
+
+    -- Default PUP actions after first Unlock
+    elseif numUnlockedHeads > 0 then
+        local rand = math.randomInt(1, 2)
+        if rand == 1 then
+            player:startEvent(628)
+        else
+            player:startEventString(629, automatonName, automatonName, automatonName, automatonName)
+        end
     end
 end
 
@@ -379,6 +357,13 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:setCharVar('PUP_AttachmentStatus', 11)
     elseif csid == 901 then
         player:setCharVar('PUP_AttachmentStatus', 14)
+
+    -- Coffee trade.
+    elseif csid == 904 then
+        player:setCharVar('PUP_AttachmentReady', player:getCharVar('PUP_AttachmentReady') - 1)
+        player:setCharVar('PUP_nextCoffeeTrade', VanadielUniqueDay() + 1)
+        player:tradeComplete()
+
     elseif csid == 905 then
         local attachmentStatus = player:getCharVar('PUP_AttachmentStatus')
         local unlockedAttachments = getHeadMask(player)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds 10 levels to the levelrequirement for each frame/head, bring it to level 10, 20, 30, 40 and 50.

## Steps to test these changes

!zone Aht Urgan
!gotoname Ghatsad
!changejob pup 1
Ghastsad should not offer to build a frame
!changejob pup 10
Ghatsad should offer first frame
!additems and trade Ghatsad materials
!addtime 86400 (or multiples for head)
Receive frame

Repeat for pup 20, 30 , 40, 50