### PR TITLE
[lua] Fix Attohwa Chasm ??? not respawning after Alastor Antlion

### DIFF
--- a/scripts/mixins/families/antlion_ambush_no_rehide.lua
+++ b/scripts/mixins/families/antlion_ambush_no_rehide.lua
@@ -6,6 +6,25 @@ require('scripts/globals/mixins')
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
+-- Maximum time an antlion is allowed to stay buried after spawning, in seconds.
+-- Surfacing is normally driven by Pit Ambush completing, but that only happens if
+-- the mob engages. If it never does, the mob would remain untargetable, immobile
+-- and unkillable for the rest of the zone's uptime.
+local ambushTimeout = 30
+
+local function surface(mob)
+    if mob:getLocalVar('[Ambush]Done') ~= 0 then
+        return
+    end
+
+    mob:hideName(false)
+    mob:setUntargetable(false)
+    mob:setAutoAttackEnabled(true)
+    mob:setAnimationSub(1, false)
+    mob:setMobMod(xi.mobMod.NO_MOVE, 0)
+    mob:setLocalVar('[Ambush]Done', 1)
+end
+
 g_mixins.families.antlion_ambush_no_rehide = function(antlion)
     antlion:addListener('PRESPAWN', 'ANTLION_AMBUSH_PRESPAWN', function(mob)
         mob:hideName(true)
@@ -14,6 +33,14 @@ g_mixins.families.antlion_ambush_no_rehide = function(antlion)
         mob:setAnimationSub(0)
         mob:setMobMod(xi.mobMod.NO_MOVE, 1)
         -- mob:setStatus(xi.status.INVISIBLE) -- TODO: Implement once packet 0x00E is rewritten.
+    end)
+
+    -- Failsafe for an ambush that never starts at all, which would otherwise leave the
+    -- mob buried permanently and block anything waiting on it to despawn, such as a ???.
+    antlion:addListener('SPAWN', 'ANTLION_AMBUSH_SPAWN', function(mob)
+        mob:timer(ambushTimeout * 1000, function(mobArg)
+            surface(mobArg)
+        end)
     end)
 
     antlion:addListener('ENGAGE', 'ANTLION_AMBUSH_ENGAGE', function(mob, target)
@@ -26,12 +53,7 @@ g_mixins.families.antlion_ambush_no_rehide = function(antlion)
     -- Ensures an interupted pit ambush doesn't let the mob stay hidden underground
     antlion:addListener('WEAPONSKILL_STATE_EXIT', 'ANTLION_AMBUSH_FINISH', function(mob, skillId, wasExecuted)
         if skillId == xi.mobSkill.PIT_AMBUSH_1 then
-            mob:hideName(false)
-            mob:setUntargetable(false)
-            mob:setAutoAttackEnabled(true)
-            mob:setAnimationSub(1, false)
-            mob:setMobMod(xi.mobMod.NO_MOVE, 0)
-            mob:setLocalVar('[Ambush]Done', 1)
+            surface(mob)
         end
     end)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the issue where the '???' was not respawning.

There was more to it. Alastar was not spawning at all when the feeder anatlon used sand blast.  Since he never spawned it took it as he was never killed so the ??? would never respawn after killing the feeder and executioners.

## Steps to test these changes

Trade the Antlion Trap to the `???` at F-10 to spawn Feeler Antlion. Keep it alive and let it build TP until it uses Sand Blast

 Verified that Alastar was now spawning. Kill Alastar. Wait 5 minutes for ???
