### PR TITLE
[C++]  Remove NavMesh snap on zone transition

### DIFF
--- a/src/map/packets/c2s/0x05e_maprect.cpp
+++ b/src/map/packets/c2s/0x05e_maprect.cpp
@@ -278,12 +278,6 @@ void GP_CLI_COMMAND_MAPRECT::process(MapSession* PSession, CCharEntity* PChar) c
                     PChar->loc.destination = PZoneLine->destinationZoneId;
                     PChar->loc.p           = PZoneLine->nextSpawnPosition();
 
-                    // Snap to navmesh for elevation on uneven zonelines
-                    if (PDestination)
-                    {
-                        PDestination->navMesh()->snapToValidPosition(PChar->loc.p);
-                    }
-
                     charutils::SavePrevZoneLineID(PChar, PZoneLine->zoneLineId);
                 }
             }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

With the current implementation, when zoning from Boneyard Gully to Attohwa Chasm, 5/8 of the zone in points would be past the zone line and immediately send you back to Boneyard Gully. This is because snapToValidPosition was placing the player in a x/z coordinate past the zone line. 

This was tested at a handful of zone lines with elevation change, and there were not any issues with the player spawning below the map. If it's discovered later that this change reintroduces the issue of a player appearing below, we can snap with a copied position_t, possibly with something like
```
if (PDestination)
{
        position_t snap = PChar->loc.p;
        PDestination->navMesh()->snapToValidPosition(snap);
        PChar->loc.p.y = snap.y;
}
```

## Steps to test these changes

Zone from Boneyard Gully to Attohwa Chasm
