### PR TITLE
[C++] Adjust Ranged Attack State Delays

### DIFF
--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -157,6 +157,9 @@ xi.settings.main =
     -- VIT:DEF ratio. Applies to everything but mobs and charmed mobs. Those are hardcoded to 0.5.
     PLAYER_ALLIES_VIT_DEF_MULTIPLIER = 1.5, -- 1.5: 1 VIT = 1.5 DEF. This has been 0.5 in previous eras.
 
+    -- Ranged Attack Free Phase Delay (in milliseconds) - The delay before a ranged attack can be executed after the player puts away their weapon. Default is 500 milliseconds. (Use 1200 for pre-2012 setting)
+    RANGED_ATTACK_FREE_PHASE_DELAY = 500,
+
     USE_ADOULIN_WEAPON_SKILL_CHANGES = true,  -- true/false. Change to toggle new Adoulin weapon skill damage calculations
     DISABLE_PARTY_EXP_PENALTY        = false, -- true/false.
     ENABLE_IMMUNOBREAK               = true,  -- true/false. Allow/Disallow immunobreaks to happen.

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -26,6 +26,7 @@
 #include "action/action.h"
 #include "action/interrupts.h"
 #include "ai/ai_container.h"
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "entities/trust_entity.h"
 #include "enums/action/category.h"
@@ -72,6 +73,9 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
         throw CStateInitException(m_errorMsg->copy());
     }
 
+    // Configured in main. default : 500ms
+    m_freePhaseTimePlayer = std::chrono::milliseconds(settings::get<uint32>("main.RANGED_ATTACK_FREE_PHASE_DELAY"));
+
     // https://www.bg-wiki.com/ffxi/Delay#Ranged_Delay
     // GetRangedDelayReduction is 2 of the 3 steps of `Ranged Weapon Delay x (1 - Snapshot) x (1 - Velocity Shot) x (1 - Rapid Shot)`
     // If Rapid Shot fires it will do the third multiplicative step
@@ -115,7 +119,7 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
 
         if (distance(m_PEntity->loc.p, PTarget->loc.p) <= m_PEntity->GetMeleeRange(PTarget))
         {
-            m_freePhaseTime = 6500ms + std::chrono::milliseconds(xirand::GetRandomNumber(0, 1500)); // Seems to have a random factor on to when it can shoot next. 1 or 2 melee auto attacks
+            m_freePhaseTimeMob = 6500ms + std::chrono::milliseconds(xirand::GetRandomNumber(0, 1500)); // Seems to have a random factor on to when it can shoot next. 1 or 2 melee auto attacks
         }
     }
 
@@ -206,7 +210,7 @@ bool CRangeState::Update(timer::time_point tick)
         }
         else if (auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity))
         {
-            PMob->m_LastRangedAttackTime = GetEntryTime() + m_aimTime + m_freePhaseTime;
+            PMob->m_LastRangedAttackTime = GetEntryTime() + m_aimTime + m_freePhaseTimeMob;
         }
         return true;
     }
@@ -284,7 +288,7 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
     // make sure player is waiting the appropriate time between ranged attacks
     if (auto PChar = dynamic_cast<CCharEntity*>(m_PEntity))
     {
-        if (m_PEntity->PAI->getTick() - PChar->m_LastRangedAttackTime < m_freePhaseTime)
+        if (m_PEntity->PAI->getTick() - PChar->m_LastRangedAttackTime < m_freePhaseTimePlayer)
         {
             m_errorMsg = std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, 0, 0, MsgBasic::WaitLonger);
             return false;

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -59,11 +59,13 @@ protected:
     bool         CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack);
     bool         HasMoved();
 
+    // This will likely need to be re-adjusted when states tick more precisely. Changed in 2012. https://wiki.ffo.jp/html/1734.html
 private:
     CBattleEntity* const m_PEntity;
-    timer::duration      m_aimTime{};                  // The calculated "phase 1" delay based on weapon and job trait reductions
-    timer::duration      m_returnWeaponDelay = 1000ms; // Phase 2: Putting the weapon back after a shot (time between shot and being able to move)
-    timer::duration      m_freePhaseTime     = 1100ms; // Phase 3: The cooldown after a ranged attack is executed. (time after being able to move befer you stop getting "you must wait longer" when attempting to Range Attack again)
+    timer::duration      m_aimTime{};                  // Phase 1: Delay based on weapon and job trait reductions. 120 delay = 1000 milliseconds.
+    timer::duration      m_returnWeaponDelay = 800ms;  // Phase 2: Time to be locked in place while putting your weapon away after a shot.
+    timer::duration      m_freePhaseTimeMob  = 1100ms; // Phase 3 (mobs/trusts): Cooldown before a ranged attack can fire again.
+    timer::duration      m_freePhaseTimePlayer{};      // Phase 3 (players): Cooldown before a ranged attack can fire again, set from RANGED_ATTACK_FREE_PHASE_DELAY (Default 500ms)
     bool                 m_rapidShot{ false };
     position_t           m_startPos;
     bool                 m_isOutOfRange{ false }; // True if target moved out of range during aim time


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In 2012, ranged attack delays were updated so that ranged weapons could be more competitive with melee ones.  https://wiki.ffo.jp/html/27203.html

LSB was still using the old pre-2012 delay values, this PR updates them to mimic current retail.

All of my testing was done with Platoon Gun - which is a 600 delay ranged weapon. LSB currently converts 120 delay to 1 second and measuring time between ranged state packets, that matches up perfectly - my shots generally landed at right around 5 seconds. 

In testing, I was able to shoot a new round every 6.3s-6.6s depending on server ticks(I did this macro assisted with my keyboard to minimize error, but maybe could be done even more precisely with a addon) - subtracting the 5 seconds observed from packets, that leaves the phase 2 + phase 3 delay at around 1300 ms, which is what it is now set to. 

* Sets return weapon delay to 800 ms
* Splits mob and player free phase delay into different values (they were being shared before) and sets player free phase delay to 500ms.
* Adds a setting to change free phase delay (also known as phase 3) so that server operators may choose to use current retail or abyssea values. 

## Capture
https://youtu.be/vWyEp_BCG0k
[Ranged_Attack_Delay_-_Platoon_Gun_2026-7-21_18_58.zip](https://github.com/user-attachments/files/30248680/Ranged_Attack_Delay_-_Platoon_Gun_2026-7-21_18_58.zip)

I left a comment that this should be revisted once states are able to tick more precisely so that this can be even more accurate to retail. 


## Steps to test these changes

Equip ranged weapons, see you can fire a new round right after putting away your weapon - just like retail. Check mobs, see they ranged attack the same as they did before. 
