### PR TITLE
[lua] [sql] Implement Dainslaif's dINT proc rate scaling, implement bloodsword

### DIFF
--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -653,3 +653,15 @@ xi.additionalEffect.spikes = function(attacker, defender, damage, spikeEffect, p
     }
     ]]
 end
+
+---@param dStat number
+---@param dStatCap number
+---@param startingRate number
+---@param cappedRate number
+---@return number
+xi.additionalEffect.linearProcRate = function(dStat, dStatCap, startingRate, cappedRate)
+    local rate = (cappedRate / dStatCap) * math.min(dStat, dStatCap)
+
+    -- Minimum of 1% is observed on drain weapons. Needs more testing.
+    return math.max(math.floor(rate), 1) -- Rate is ultimately used against a random roll of integers so this is mostly just to indicate it's a whole percent.
+end

--- a/scripts/items/bloodsword.lua
+++ b/scripts/items/bloodsword.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- ID: 16580
+-- Item: Bloodsword
+-- Additional effect: en-drain
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, item)
+    local dStat = actor:getStat(xi.mod.INT) - target:getStat(xi.mod.INT)
+
+    local pTable =
+    {
+        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 1, 32),
+        basePower       = 40 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
+        attackType      = xi.attackType.PHYSICAL,
+        physicalElement = xi.damageType.SLASHING,
+        magicalElement  = xi.element.DARK,
+        canResist       = true,
+        lowestResist    = 0.5,
+        limitUndead     = true,
+        drainHP         = true,
+        overDrain       = true,
+        animation       = xi.subEffect.DARKNESS_DAMAGE,
+    }
+
+    return xi.combat.action.executeAddEffectDamage(actor, target, pTable)
+end
+
+return itemObject

--- a/scripts/items/dainslaif.lua
+++ b/scripts/items/dainslaif.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = 22, -- Observed rate is 21% which is close to (0.22 * .95) = 21%~ (resist roll failure)
+        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 1, 32),
         basePower       = 40 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/sql/item_mods.sql
+++ b/sql/item_mods.sql
@@ -32492,13 +32492,14 @@ INSERT INTO `item_mods` VALUES (16579,9,2);  -- DEX: 2
 INSERT INTO `item_mods` VALUES (16579,10,2); -- VIT: 2
 
 -- Bloodsword
-INSERT INTO `item_mods` VALUES (16580,8,4);   -- STR: 4
-INSERT INTO `item_mods` VALUES (16580,9,4);   -- DEX: 4
-INSERT INTO `item_mods` VALUES (16580,10,-8); -- VIT: -8
-INSERT INTO `item_mods` VALUES (16580,11,4);  -- AGI: 4
-INSERT INTO `item_mods` VALUES (16580,12,4);  -- INT: 4
-INSERT INTO `item_mods` VALUES (16580,13,-8); -- MND: -8
-INSERT INTO `item_mods` VALUES (16580,14,-8); -- CHR: -8
+INSERT INTO `item_mods` VALUES (16580,8,4);    -- STR: 4
+INSERT INTO `item_mods` VALUES (16580,9,4);    -- DEX: 4
+INSERT INTO `item_mods` VALUES (16580,10,-8);  -- VIT: -8
+INSERT INTO `item_mods` VALUES (16580,11,4);   -- AGI: 4
+INSERT INTO `item_mods` VALUES (16580,12,4);   -- INT: 4
+INSERT INTO `item_mods` VALUES (16580,13,-8);  -- MND: -8
+INSERT INTO `item_mods` VALUES (16580,14,-8);  -- CHR: -8
+INSERT INTO `item_mods` VALUES (16580,1181,1); -- ITEM_ADDEFFECT_SCRIPTED: 1
 
 -- Holy Sword
 INSERT INTO `item_mods` VALUES (16581,431,1);  -- ITEM_ADDEFFECT_TYPE: DAMAGE


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

See title

Bloodsword & Dainslaif are clones of eachother, so I decided to do a small PR for them.

<img width="1324" height="669" alt="image" src="https://github.com/user-attachments/assets/f6b86359-7f74-49c2-9ded-7e442297ae1f" />

## Steps to test these changes

USe bloodsword, see approximate dint scaling
