### PR TITLE
[core] Warp players as corpses if dieing during warp

### DIFF
--- a/scripts/effects/teleport.lua
+++ b/scripts/effects/teleport.lua
@@ -16,6 +16,11 @@ effectObject.onEffectLose = function(target, effect)
         return
     end
 
+    if target:isDead() then
+        -- Retail doesn't port you if you are dead early into the animation.
+        return
+    end
+
     local destination = effect:getPower()
 
     if target:isMob() then

--- a/scripts/tests/systems/death_teleport.lua
+++ b/scripts/tests/systems/death_teleport.lua
@@ -26,7 +26,7 @@ describe('Death during a pending Warp effect', function()
         assert(player:getZoneID() == xi.zone.WEST_RONFAURE, 'death must not warp the player')
     end)
 
-    it('warps a corpse home but leaves it dead', function()
+    it('death cancels a pending Warp; the corpse stays where it fell', function()
         player:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.WARP, duration = 60, origin = player })
         assert(player:hasStatusEffect(xi.effect.TELEPORT), 'precondition: Warp effect is active')
 
@@ -36,7 +36,19 @@ describe('Death during a pending Warp effect', function()
 
         settle()
 
-        assert(player:getZoneID() == xi.zone.PORT_SAN_DORIA, 'the Warp should carry the player to their home point')
+        assert(player:getZoneID() == xi.zone.WEST_RONFAURE, 'dying during the animation cancels the port')
+        assert(player:isDead(), 'player should still be dead')
+    end)
+
+    it('a warp resolving on a corpse arrives dead, not revived', function()
+        player:setHP(0)
+        xi.test.world:tickEntity(player)
+        assert(player:isDead(), 'precondition: player is dead')
+
+        player:warp() -- direct warp on a corpse, bypassing the teleport effect guard
+        settle()
+
+        assert(player:getZoneID() == xi.zone.PORT_SAN_DORIA, 'the warp should carry the player home')
         assert(player:isDead(), 'player must arrive dead, not revived')
     end)
 end)

--- a/scripts/tests/systems/death_teleport.lua
+++ b/scripts/tests/systems/death_teleport.lua
@@ -1,0 +1,42 @@
+describe('Death during a pending Warp effect', function()
+    ---@type CClientEntityPair
+    local player
+
+    local function settle()
+        for _ = 1, 8 do
+            xi.test.world:skipTime(1)
+        end
+    end
+
+    before_each(function()
+        -- Home point in Port San d'Oria but die in West Ronfaure
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.PORT_SAN_DORIA, job = xi.job.WHM, level = 30 })
+        player:setHomePoint()
+
+        player:setPos(0, 0, 0, 0, xi.zone.WEST_RONFAURE)
+        settle()
+    end)
+
+    it('a normal death leaves the player dead where they fell', function()
+        player:setHP(0)
+        xi.test.world:tickEntity(player)
+        settle()
+
+        assert(player:isDead(), 'player should still be dead')
+        assert(player:getZoneID() == xi.zone.WEST_RONFAURE, 'death must not warp the player')
+    end)
+
+    it('warps a corpse home but leaves it dead', function()
+        player:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.WARP, duration = 60, origin = player })
+        assert(player:hasStatusEffect(xi.effect.TELEPORT), 'precondition: Warp effect is active')
+
+        player:setHP(0)
+        xi.test.world:tickEntity(player) -- death strips the death-flagged Warp effect
+        assert(not player:hasStatusEffect(xi.effect.TELEPORT), 'death should have removed the Warp effect')
+
+        settle()
+
+        assert(player:getZoneID() == xi.zone.PORT_SAN_DORIA, 'the Warp should carry the player to their home point')
+        assert(player:isDead(), 'player must arrive dead, not revived')
+    end)
+end)

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -225,7 +225,7 @@ CCharEntity::CCharEntity()
     PRecastContainer       = std::make_unique<CCharRecastContainer>(this);
     PLatentEffectContainer = new CLatentEffectContainer(this);
 
-    requestedWarp       = false;
+    requestedWarp       = WarpRequest::None;
     requestedZoneChange = false;
 
     retriggerLatents = false;
@@ -2139,7 +2139,7 @@ void CCharEntity::OnDeathTimer()
     TracyZoneScoped;
 
     charutils::SetCharVar(this, "expLost", 0);
-    requestedWarp = true; // zone entities will warp us on the next tick
+    requestedWarp = WarpRequest::HomePoint; // zone entities will warp us on the next tick
 }
 
 void CCharEntity::OnRaise()

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -228,6 +228,13 @@ enum CHAR_PERSIST : uint8
     EFFECTS  = 0x04,
 };
 
+enum class WarpRequest : uint8
+{
+    None      = 0,
+    Warp      = 1, // Warp carrying existing state
+    HomePoint = 2, // Warp but revive
+};
+
 enum class CharRace : uint8
 {
     HumeMale       = 1,
@@ -445,8 +452,8 @@ public:
     // currency_t        m_currency;                 // conquest points, imperial standing points etc
     teleport_t teleport{}; // Outposts, Runic Portals, Homepoints, Survival Guides, Maws, etc.
 
-    bool requestedWarp       = false; // used in CLuaBaseEntity::warp(). This will be processed after the player's tick to warp.
-    bool requestedZoneChange = false; // used in CLueBaseEntity::setPos(). This will be processed after the player's tick to change zones.
+    WarpRequest requestedWarp       = WarpRequest::None; // see WarpRequest. This will be processed after the player's tick to warp.
+    bool        requestedZoneChange = false;             // used in CLueBaseEntity::setPos(). This will be processed after the player's tick to change zones.
 
     uint8 GetGender();
 

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -3629,7 +3629,7 @@ void CLuaBaseEntity::warp()
 
     if (auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity))
     {
-        PChar->requestedWarp = true;
+        PChar->requestedWarp = WarpRequest::Warp;
 
         // Save pet if any
         if (PChar->shouldPetPersistThroughZoning())

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -85,7 +85,7 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
             // TODO: work out how to drop player in moghouse that exits them to the zone they were in before this happened, like we used to.
             ShowWarning("GP_CLI_COMMAND_LOGIN: player tried to enter zone that was invalid or out of range");
             ShowWarning("GP_CLI_COMMAND_LOGIN: dumping player `%s` to homepoint!", PChar->getName());
-            PChar->requestedWarp = true; // Not a "request" but a demand
+            PChar->requestedWarp = WarpRequest::HomePoint; // Not a "request" but a demand
 
             // Save pet if any
             if (PChar->shouldPetPersistThroughZoning())

--- a/src/map/packets/c2s/0x01a_action.cpp
+++ b/src/map/packets/c2s/0x01a_action.cpp
@@ -369,7 +369,7 @@ void GP_CLI_COMMAND_ACTION::process(MapSession* PSession, CCharEntity* PChar) co
             }
 
             PChar->setCharVar("expLost", 0);
-            PChar->requestedWarp = true;
+            PChar->requestedWarp = WarpRequest::HomePoint;
         }
         break;
         case GP_CLI_COMMAND_ACTION_ACTIONID::Assist:

--- a/src/map/packets/c2s/0x0f0_rescue.cpp
+++ b/src/map/packets/c2s/0x0f0_rescue.cpp
@@ -52,5 +52,5 @@ void GP_CLI_COMMAND_RESCUE::process(MapSession* PSession, CCharEntity* PChar) co
     ShowInfoFmt("{} requested self-unstuck, warping them to their Home Point.", PChar->getName());
     const auto cooldown = settings::get<uint32>("map.SELF_UNSTUCK_COOLDOWN");
     charutils::SetCharVar(PChar, "[GM]SelfUnstuck", 1, earth_time::timestamp() + cooldown);
-    PChar->requestedWarp = true;
+    PChar->requestedWarp = WarpRequest::HomePoint;
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -7397,7 +7397,7 @@ auto SendToZone(CCharEntity* PChar, uint16 zoneId) -> bool
     }
 
     PChar->requestedZoneChange = true;
-    PChar->requestedWarp       = false; // a previous warp can get us here, which could infinitely loop. So un-request warp.
+    PChar->requestedWarp       = WarpRequest::None; // a previous warp can get us here, which could infinitely loop. So un-request warp.
 
     PChar->PSession->zone_ipp = {};
     PChar->pushPacket<GP_SERV_COMMAND_LOGOUT>(GP_GAME_LOGOUT_STATE::ZONECHANGE, IPP(ipp));
@@ -7463,7 +7463,7 @@ auto HomePoint(CCharEntity* PChar, bool resetHPMP) -> bool
     if (zoneutils::IsZoneAtPlayerCap(PChar->profile.home_point.destination, PChar->m_GMlevel > 0))
     {
         PChar->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::CouldNotEnter);
-        PChar->requestedWarp = false;
+        PChar->requestedWarp = WarpRequest::None;
         return false;
     }
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -1917,7 +1917,7 @@ auto CZoneEntities::charTick(CCharEntity* PChar, timer::time_point tick) -> Task
         }
     }
 
-    if (PChar->requestedZoneChange || PChar->requestedWarp || PChar->status == xi::Status::Shutdown)
+    if (PChar->requestedZoneChange || PChar->requestedWarp != WarpRequest::None || PChar->status == xi::Status::Shutdown)
     {
         m_charsToChangeZone.insert(PChar);
     }
@@ -2096,13 +2096,15 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
             charutils::ForceLogout(PChar);
             shouldErase = true;
         }
-        else if (PChar->requestedWarp)
+        else if (PChar->requestedWarp != WarpRequest::None)
         {
             const bool ready = co_await zoneutils::IsZoneReady(scheduler_, config_, PChar->profile.home_point.destination);
             if (ready)
             {
                 PChar->clearPacketList();
-                if (charutils::HomePoint(PChar, PChar->isDead()))
+
+                const bool revive = PChar->requestedWarp == WarpRequest::HomePoint && PChar->isDead();
+                if (charutils::HomePoint(PChar, revive))
                 {
                     shouldErase = true;
                 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Dieing while warping was treated as an automatic HP because the nuance didn't make it through the entities ticking logic. 
This meant you were robbed of a chance to get raised to recover your EXP.

This changes the flag to be an enum conveying the exact intent of the warp request and then ensuring players are not auto-raised during the processing.

## Steps to test these changes
!addeffect teleport 7 60
!hp 0

<img width="2357" height="1377" alt="image" src="https://github.com/user-attachments/assets/da7cdba9-fddd-424a-bf94-514eb3ad80f5" />

<!-- Clear and detailed steps to test your changes here -->
