### PR TITLE
[lua, sql] Citipati and Xolotl Fixes

### DIFF
--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -82,13 +82,6 @@ zoneObject.onTriggerAreaLeave = function(player, triggerArea)
 end
 
 zoneObject.onGameHour = function()
-    -- Citipati is a night-only lottery NM (20:00-04:00); block its spawn during the day.
-    if VanadielHour() >= 4 and VanadielHour() < 20 then
-        DisallowRespawn(ID.mob.CITIPATI, true)
-    else
-        DisallowRespawn(ID.mob.CITIPATI, false)
-    end
-
     --[[
         the hard-coded id that was here was wrong. there are 22 miasmas in attohwa chasm
         starting at ID.npc.MIASMA_OFFSET. some are supposed to toggle open, but need retail test

--- a/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Citipati.lua
@@ -26,18 +26,10 @@ entity.onMobInitialize = function(mob)
 end
 
 entity.onMobSpawn = function(mob)
+    mob:setLocalVar('killed', 0)
     mob:setMod(xi.mod.BIND_RES_RANK, 10)
     mob:setMod(xi.mod.DARK_RES_RANK, 10)
     mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
-end
-
-entity.onMobRoam = function(mob)
-    -- Since DisallowRespawn() doesn't care about SPAWNTYPE_NIGHT we have to get creative
-    local totd = VanadielTOTD()
-    if totd ~= xi.time.NIGHT and totd ~= xi.time.MIDNIGHT then
-        mob:setLocalVar('doNotInvokeCooldown', 1)
-        DespawnMob(mob:getID())
-    end
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)
@@ -69,7 +61,20 @@ entity.onMobSpellChoose = function(mob, target, spellId)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        mob:setLocalVar('killed', 1)
+    end
+
     xi.hunts.checkHunt(mob, player, 278)
+end
+
+entity.onMobDespawn = function(mob)
+    -- Only a kill starts the 3-6 hour lottery cooldown. A natural despawn at the
+    -- end of his spawn window skips it, so placeholders can pop him again the
+    -- same or next night.
+    if mob:getLocalVar('killed') == 0 then
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+    end
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Xolotl.lua
@@ -105,6 +105,16 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
+    -- The pets' own dawn despawn relies on their roam tick, which stops running
+    -- once they are stuck following a despawned Xolotl. Clean up any pet that is
+    -- not engaged so they never outlive him (engaged pets persist, per retail).
+    for _, petId in ipairs(pets) do
+        local pet = GetMobByID(petId)
+        if pet and pet:isSpawned() and pet:isAlive() and not pet:isEngaged() then
+            DespawnMob(petId)
+        end
+    end
+
     -- Only set long respawn timer if killed, not if naturally despawned at dawn
     if mob:getLocalVar('killed') == 1 then
         mob:setRespawnTime(math.randomInt(75600, 86400))

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -1528,7 +1528,7 @@ INSERT INTO `mob_spawn_points` VALUES (16806158,0,'Corse','Corse',40,66,67,-393.
 INSERT INTO `mob_spawn_points` VALUES (16806159,0,'Monarch_Ogrefly','Monarch Ogrefly',31,65,67,-328.588,-4.705,-22.888,134,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (16806160,0,'Mummy','Mummy',38,62,64,-315.843,-4.239,-27.163,161,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (16806161,0,'Corse','Corse',40,66,67,-327.956,-12.811,45.807,157,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (16806162,0,'Citipati','Citipati',41,67,70,-327.763,-12.408,40.206,101,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (16806162,0,'Citipati','Citipati',41,67,70,-327.763,-12.408,40.206,101,20,4);
 INSERT INTO `mob_spawn_points` VALUES (16806163,0,'Tracker_Antlion','Tracker Antlion',33,71,73,-441.809,-4.232,33.199,85,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (16806164,0,'Sand_Lizard','Sand Lizard',30,66,68,-452.792,-4.406,7.103,197,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (16806165,0,'Mummy','Mummy',38,62,64,-469.216,-4.373,2.275,14,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It addresses two bugs, one with Citipati and one with Xolotl.

**Citipati**

[In a previous PR](https://github.com/LandSandBoat/server/pull/10316) I audited the NMs in Attohwa Chasm and players found some bugs with the spawn behavior. I have reworked the Citipati spawn guards. I think what was happening was that the zone.lua day hours check was causing him to spawn immediately (because it kept rerolling) even after he was killed. This new PR removes that and approaches the problem by putting despawn logic in his lua file instead.

**Xolotl**

I observed a malfunction where if a player was charmed, sometimes (not always) Xolotl's adds would break and lose the ability to act. I think it is related to how they follow him on roam, but if that really is the bug, then a fix for that is beyond my technical ability. The fix I have implemented here hardens the despawn logic for the pets so even if they do somehow break they still despawn no matter what.

## Steps to test these changes

!spawnmob the above and witness the appropriate behavior.
