### PR TITLE
[lua] Allow Mobmod Commands To Be Used On Pets

### DIFF
--- a/scripts/commands/getmobmod.lua
+++ b/scripts/commands/getmobmod.lua
@@ -44,8 +44,17 @@ commandObj.onTrigger = function(player, id)
 
     -- validate target
     local effectTarget = player:getCursorTarget()
-    if not effectTarget or not effectTarget:isMob() then
-        error(player, 'Current target is not a MOB, which can not have mob mods.')
+
+    if not effectTarget then
+        error(player, 'No valid target found. Place cursor on a mob or pet')
+        return
+    end
+
+    if
+        effectTarget:isPC() or
+        effectTarget:isNPC()
+    then
+        error(player, 'Current target is not a Mob/Pet. Only Mobs/Pets can have mob mods.')
         return
     end
 

--- a/scripts/commands/setmobmod.lua
+++ b/scripts/commands/setmobmod.lua
@@ -31,12 +31,15 @@ commandObj.onTrigger = function(player, modifier, amount)
     local target = player:getCursorTarget()
 
     if not target or target:isNPC() then
-        error(player, 'No valid target found. Place cursor on a mob. ')
+        error(player, 'No valid target found. Place cursor on a mob or pet.')
         return
     end
 
-    if not target:isMob() then
-        error(player, 'No valid target found. Place cursor on a mob. ')
+    if
+        target:isPC() or
+        target:isNPC()
+    then
+        error(player, 'Current target is not a Mob/Pet. Only Mobs/Pets can have mob mods.')
         return
     end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Allows `!getmobmod` and `!setmobmod` GM commands to be used on pet entities.
- Mobmods are already allowed to be placed on pets in scripts/core, this just allows GMs to use the commands for testing.

## Steps to test these changes

1. !changejob SMN 75
2. Summon an avatar.
3. Use `!setmobmod BASE_DAMAGE_MULTIPLIER 100` on your pet.
4. Use `!getmobmod BASE_DAMAGE_MULTIPLIER` on your pet. See that it returns 100.

