### PR TITLE
[lua] Moment of Truth battlefield win event fix

### DIFF
--- a/scripts/battlefields/Jade_Sepulcher/moment_of_truth.lua
+++ b/scripts/battlefields/Jade_Sepulcher/moment_of_truth.lua
@@ -19,6 +19,19 @@ local content = BattlefieldQuest:new({
     requiredValue = 4,
 })
 
+function content:onBattlefieldWin(player, battlefield)
+    local status = player:getQuestStatus(self.questArea, self.quest)
+
+    if status == xi.questStatus.QUEST_ACCEPTED then
+        player:setLocalVar('battlefieldWin', battlefield:getID())
+    end
+
+    local _, clearTime, partySize = battlefield:getRecord()
+    local canSkipCS               = status == xi.questStatus.QUEST_COMPLETED and 1 or 0
+
+    player:startEvent(32001, battlefield:getArea(), clearTime, partySize, battlefield:getTimeInside(), player:getZoneID(), self.index, canSkipCS, 2)
+end
+
 content.groups =
 {
     {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the battlefield win CS trigger so it properly loads or skips if needed.
Players should be able to complete the quest now.

(The fight still needs to be coded to work like retail)

## Steps to test these changes

Beat Moment of Truth, don't get stuck anymore.
Complete the quest!
