### PR TITLE
[lua] Fix Synthesis Support subPower

### DIFF
--- a/scripts/globals/hobbies/crafting/image_support.lua
+++ b/scripts/globals/hobbies/crafting/image_support.lua
@@ -70,7 +70,7 @@ local function advancedImageSupport(player, effectId)
     if effectId == xi.effect.FISHING_IMAGERY then
         player:addStatusEffect(effectId, { power = 2, duration = 7200, origin = player })
     else
-        player:addStatusEffect(effectId, { power = 3, duration = 480, origin = player, subType = 10 })
+        player:addStatusEffect(effectId, { power = 3, duration = 480, origin = player, subPower = 10 })
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes advanced synthesis image support never reducing the per-ingredient material-loss chance on a break.

`advancedImageSupport` in `scripts/globals/hobbies/crafting/image_support.lua` granted the imagery effect with the reduction value in `subType` (which maps to the status effect's `subID`), but the imagery effects (e.g. `scripts/effects/woodworking_imagery.lua`) read `effect:getSubPower()` to populate `xi.mod.SYNTH_MATERIAL_LOSS_<craft>`. Since `subPower` was never set, `getSubPower()` returned 0, so `breakTypeReduction` in `synthutils.cpp handleMaterialLoss` was always 0 and the intended ~10-point break-chance reduction never applied.

The fix passes the value as `subPower` instead of `subType`, so the per-craft `SYNTH_MATERIAL_LOSS` mod is set to 10 and the reduction is applied.

## Steps to test these changes

1. Get advanced image support from an image support NPC (e.g. Ulycille for Woodworking).
2. Confirm the character has the imagery effect and that `xi.mod.SYNTH_MATERIAL_LOSS_WOODWORKING` is now 10 (previously 0).
3. Perform synths likely to break and observe that materials are lost less often than with no image support (break chance reduced by ~10 points).
4. Confirm the +3 craft skill bonus still applies as before.
