### PR TITLE
[lua] Fix elegy potency bug

### DIFF
--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -70,7 +70,7 @@ xi.spells.enfeebling.calculateSongPower = function(caster, spellEffect, basePowe
     if spellEffect == xi.effect.REQUIEM then
         power = power + utils.clamp(gearBoost - 1, 0, 20) + caster:getJobPointLevel(xi.jp.REQUIEM_EFFECT) * 3
     elseif spellEffect == xi.effect.ELEGY then
-        power = power + gearBoost * 6375 / 256 -- Simplified numbers of: 25.5 * 10000/1024
+        power = power + math.floor(gearBoost * 25.6) * 10000 / 1024
     elseif spellEffect == xi.effect.THRENODY then
         power = power + gearBoost * 5
     elseif spellEffect == xi.effect.NOCTURNE then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Elegy potency gain from Song+ gear (`ELEGY_EFFECT`/`ALL_SONGS_EFFECT`) being 10x too low. `gearBoost` was multiplied by `6375/256` instead of `63750/256`. Elegy power feeds `HASTE_MAGIC`, which is in /10000 units, so per-point gear potency is `25.5/1024 * 10000 ≈ 249`.

## Steps to test these changes

1. Cast Battlefield Elegy (base 2500 = 25% slow) with no Song+ gear; confirm ~25% slow
2. Equip ~10 points of `Elegy +` / `All Songs +` gear and recast
3. Confirm potency now scales up toward the 5000 (50% slow)

## Test Results
| Before | After |
|-|-|
| <img width="1764" height="85" alt="image" src="https://github.com/user-attachments/assets/3d8f537e-cb45-4a2f-9c1d-ed4f655457b3" /> | <img width="1764" height="81" alt="image" src="https://github.com/user-attachments/assets/f8f22f6a-1f61-47fc-8f90-dbbde3e23e16" /> |

Before almost no perceivable effect, after matches BG wiki's +2 chart, as well as the original comment `-- Simplified numbers of: 25.5 * 10000/1024`:
<img width="640" height="289" alt="image" src="https://github.com/user-attachments/assets/a70c97e5-677e-4074-9223-473e71213fb1" />

