### PR TITLE
[C++] [lua] Experience Points Cap setting

### DIFF
--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -75,6 +75,10 @@ xi.settings.map =
     -- When set to 10, if you are level 65 or below in a party with a level 75, you will receive no EXP.
     EXP_PARTY_GAP_NO_EXP = 0,
 
+    -- Multiplier that adjusts the cap on the amount of experience points a player can earn from a single monster.
+    -- Use .5 for WoTG experience points caps.
+    EXP_CAP_MULTIPLIER = 1.0,
+
     -- Capacity Point Settings
     CAPACITY_RATE = 1.0,
 

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5060,17 +5060,18 @@ void DistributeExperiencePoints(CCharEntity* PChar, CMobEntity* PMob)
                     }
 
                     // Per monster caps pulled from: https://ffxiclopedia.fandom.com/wiki/Experience_Points
+                    const float expCapMultiplier = settings::get<float>("map.EXP_CAP_MULTIPLIER");
                     if (memberlevel <= 50)
                     {
-                        exp = std::fmin(exp, 400.0f);
+                        exp = std::fmin(exp, 400.0f * expCapMultiplier);
                     }
                     else if (memberlevel <= 60)
                     {
-                        exp = std::fmin(exp, 500.0f);
+                        exp = std::fmin(exp, 500.0f * expCapMultiplier);
                     }
                     else
                     {
-                        exp = std::fmin(exp, 600.0f);
+                        exp = std::fmin(exp, 600.0f * expCapMultiplier);
                     }
 
                     if (mobCheck > EMobDifficulty::DecentChallenge)


### PR DESCRIPTION
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As the title says, it adds a setting to adjust the cap on how much experience points a player can earn from a single monster.
This amount was significantly increased in a Feb. 2011 update : https://wiki.ffo.jp/html/23370.html
Default is 1.0 , WoTG era setting is .5

## Steps to test these changes

Set to .5, see exp cap is now 300 @ 75