### PR TITLE
[core] Fix attack timer skipping the tick it swings on

### DIFF
--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -63,6 +63,10 @@ bool CAttackState::Update(timer::time_point tick)
     {
         return true;
     }
+
+    // Subtract on every tick, including the one we swing on, or each swing costs an extra tick.
+    m_attackTime -= (m_PEntity->PAI->getTick() - m_PEntity->PAI->getPrevTick());
+
     if (AttackReady())
     {
         if (CanAttack(PTarget))
@@ -94,10 +98,10 @@ bool CAttackState::Update(timer::time_point tick)
             return true;
         }
     }
-    else
-    {
-        m_attackTime -= (m_PEntity->PAI->getTick() - m_PEntity->PAI->getPrevTick());
-    }
+
+    // Don't bank time while we can't swing. Sits after the swing so leftover time carries.
+    m_attackTime = std::max<timer::duration>(m_attackTime, 0ms);
+
     return false;
 }
 
@@ -183,5 +187,5 @@ bool CAttackState::CanAttack(CBattleEntity* PTarget)
 
 bool CAttackState::AttackReady()
 {
-    return m_attackTime < 0ms && m_PEntity->isAlive();
+    return m_attackTime <= 0ms && m_PEntity->isAlive();
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Auto attacks fire one server tick later than the weapon delay says. The elapsed-time subtraction sat in the `else` of the ready check, so the tick an entity swung on never got counted. Effective interval was always delay + 400ms.

Subtract on every tick instead, fire at exactly 0 rather than below it, and clamp at 0 so an entity that can't reach its target doesn't bank time and burst later.

Swings are still landing on the 400ms grid so they jitter but the average comes out right and looks pretty close to retail.

Should fix and close #9130 

## Steps to test these changes
200 delay
<img width="1324" height="157" alt="image" src="https://github.com/user-attachments/assets/15c09e32-6048-40e7-b7b9-07fbeb3747ca" />

Player using HF
<img width="661" height="206" alt="image" src="https://github.com/user-attachments/assets/f24f3fc4-dee5-4412-a4b0-f0b54aed10f4" />

<!-- Clear and detailed steps to test your changes here -->
