### PR TITLE
[docker,alpine] Use ninja-build instead of samurai

### DIFF
--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -71,9 +71,10 @@ apk --update-cache add \
     luajit-dev \
     make \
     mariadb-dev \
+    ninja-build \
+    ninja-is-really-ninja \
     openssl-dev \
     python3-dev \
-    samurai \
     zeromq-dev \
     zlib-dev \
     zstd-dev


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Swap from Samurai to Ninja. Samurai implements features up to Ninja 1.9, 1.11 is needed for C++20 modules.

## Steps to test these changes

[build](https://github.com/cocosolos/server/actions/runs/29963997894/job/89071391570)
