### PR TITLE
[lua,sql][module] Various spell module adjustments for era behavior

### DIFF
--- a/modules/era/lua/actions/spells/spell_adjustments.lua
+++ b/modules/era/lua/actions/spells/spell_adjustments.lua
@@ -46,17 +46,6 @@ m:addOverride('xi.actions.spells.white.diaga.onSpellCast', function(caster, targ
     return castEraDia(caster, target, spell, 1, 1, 60, 5)
 end)
 
--- TODO: Blind II / Blind
--- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
---  - Remove fixed 180 duration, revert to between 80 and 300 seconds
---  - Potency: Blind: (User INT - Opponent MND + 60)/4   Blind II: (User INT - Opponent MND + 100)/4
-
--- TODO: Paralyze / Paralyze II
---  - Remove fixed 120 duration, revert to between 30 and 120 seconds
-
--- TODO: Poison / Poison II / Poisonga
---  - Revert potencies to pre-RoV values
-
 -----------------------------------
 -- Dark Magic
 -----------------------------------
@@ -121,76 +110,60 @@ m:addOverride('xi.effects.dread_spikes.onEffectGain', function(target, effect)
     effect:setDuration(60000)
 end)
 
--- TODO Absorb-STAT: Add decay tick and set 90 second duration to boost effects
--- TODO Drain II: Set duration of max HP boost to 60 seconds.
--- Source:
---   Decay Removal: http://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
---   Duration Change: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
-
------------------------------------
--- Singing
------------------------------------
-
--- TODO (pending exposure of pTables in magic scripts):
--- Update scripts/globals/spells/enhancing_song.lua pTable entries:
--- Source: https://forum.square-enix.com/ffxi/threads/55899-September.-10-2019-%28JST%29-Version-Update?p=619588&viewfull=1#post619588
---  xi.magic.spell.FOE_SIRVENTE      : MERIT_ID 0 -> xi.merit.FOE_SIRVENTE,      POWER_BASE 35 -> 0
---  xi.magic.spell.ADVENTURERS_DIRGE : MERIT_ID 0 -> xi.merit.ADVENTURERS_DIRGE, POWER_BASE 32 -> 5
-
---  POWER_CAP value: current -> target:
---  Source: https://forum.square-enix.com/ffxi/threads/52095-Feb.-10-2017-%28JST%29-Version-Update
---  xi.magic.spell.FIRE_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.ICE_CAROL        : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.WIND_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.EARTH_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.LIGHTNING_CAROL  : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.WATER_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.LIGHT_CAROL      : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.DARK_CAROL       : POWER_CAP 80  -> 50, MULTIPLIER 8   -> 5
---  xi.magic.spell.SWORD_MADRIGAL   : POWER_CAP 45  -> 15, MULTIPLIER 4.5 -> 2, DIVISOR 18 -> 23.25, SKILL_REQUIREMENT 85 -> 40
---  xi.magic.spell.BLADE_MADRIGAL   : POWER_CAP 60  -> 30, MULTIPLIER 6   -> 2
---  xi.magic.spell.SHEEPFOE_MAMBO   : POWER_CAP 48  -> 15, MULTIPLIER 5   -> 2.5
---  xi.magic.spell.DRAGONFOE_MAMBO  : POWER_CAP 72  -> 23, MULTIPLIER 7   -> 2.5
---  xi.magic.spell.ADVANCING_MARCH  : POWER_CAP 108 -> 64, MULTIPLIER 11  -> 16
---  xi.magic.spell.VICTORY_MARCH    : POWER_CAP 163 -> 96, POWER_BASE 43  -> 53
---  xi.magic.spell.KNIGHTS_MINNE    : POWER_CAP 30  -> 13, MULTIPLIER 3   -> 2.5, DIVISOR 10  -> 15, POWER_BASE 8  -> 5
---  xi.magic.spell.KNIGHTS_MINNE_II : POWER_CAP 69  -> 27, MULTIPLIER 7   -> 2.5, DIVISOR 10  -> 15, POWER_BASE 12 -> 6
---  xi.magic.spell.KNIGHTS_MINNE_III: POWER_CAP 108 -> 40, MULTIPLIER 11  -> 2.5, DIVISOR 10  -> 15, POWER_BASE 18 -> 10
---  xi.magic.spell.KNIGHTS_MINNE_IV : POWER_CAP 164 -> 48, MULTIPLIER 16  -> 2.5, DIVISOR 10  -> 15, POWER_BASE 30 -> 12
---  xi.magic.spell.VALOR_MINUET     : POWER_CAP 30  -> 16, MULTIPLIER 3   -> 2.5, DIVISOR 4.3 -> 6
---  xi.magic.spell.VALOR_MINUET_II  : POWER_CAP 69  -> 32, MULTIPLIER 6   -> 2.5, DIVISOR 3.9 -> 6, SKILL_REQUIREMENT 100 -> 85
---  xi.magic.spell.VALOR_MINUET_III : POWER_CAP 108 -> 48, MULTIPLIER 9   -> 2.5, DIVISOR 3.5 -> 6
---  xi.magic.spell.VALOR_MINUET_IV  : POWER_CAP 164 -> 56, MULTIPLIER 11  -> 2.5, DIVISOR 3.3 -> 15, POWER_BASE 31 -> 29
---  xi.magic.spell.HUNTERS_PRELUDE  : POWER_CAP 45  -> 15, MULTIPLIER 4.5 -> 2
---  xi.magic.spell.ARCHERS_PRELUDE  : POWER_CAP 60  -> 30, MULTIPLIER 6   -> 2
-
------------------------------------
--- Ninjutsu
------------------------------------
-
--- San Spells: Add +5 Magic Attack and +5 Magic Accuracy per merit rank
--- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
-local sanSpellOverrides =
+-- Absorb-STAT: Revert to a fixed 90s duration with a decaying tick.
+-- Source: http://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
+local absorbStatOverrides =
 {
-    { path = 'xi.actions.spells.ninjutsu.katon_san.onSpellCast',  merit = xi.merit.KATON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.hyoton_san.onSpellCast', merit = xi.merit.HYOTON_SAN },
-    { path = 'xi.actions.spells.ninjutsu.huton_san.onSpellCast',  merit = xi.merit.HUTON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.doton_san.onSpellCast',  merit = xi.merit.DOTON_SAN  },
-    { path = 'xi.actions.spells.ninjutsu.raiton_san.onSpellCast', merit = xi.merit.RAITON_SAN },
-    { path = 'xi.actions.spells.ninjutsu.suiton_san.onSpellCast', merit = xi.merit.SUITON_SAN },
+    { path = 'xi.actions.spells.black.absorb-str.onSpellCast', boostEffect = xi.effect.STR_BOOST,      downEffect = xi.effect.STR_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-dex.onSpellCast', boostEffect = xi.effect.DEX_BOOST,      downEffect = xi.effect.DEX_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-vit.onSpellCast', boostEffect = xi.effect.VIT_BOOST,      downEffect = xi.effect.VIT_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-agi.onSpellCast', boostEffect = xi.effect.AGI_BOOST,      downEffect = xi.effect.AGI_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-int.onSpellCast', boostEffect = xi.effect.INT_BOOST,      downEffect = xi.effect.INT_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-mnd.onSpellCast', boostEffect = xi.effect.MND_BOOST,      downEffect = xi.effect.MND_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-chr.onSpellCast', boostEffect = xi.effect.CHR_BOOST,      downEffect = xi.effect.CHR_DOWN      },
+    { path = 'xi.actions.spells.black.absorb-acc.onSpellCast', boostEffect = xi.effect.ACCURACY_BOOST, downEffect = xi.effect.ACCURACY_DOWN },
 }
 
-for _, entry in ipairs(sanSpellOverrides) do
+for _, entry in ipairs(absorbStatOverrides) do
     m:addOverride(entry.path, function(caster, target, spell)
-        local meritBonus = caster:getMerit(entry.merit)
-        caster:addMod(xi.mod.MATT, meritBonus)
-        caster:addMod(xi.mod.MACC, meritBonus)
+        local previousBoost      = caster:getStatusEffect(entry.boostEffect)
+        local previousBoostStart = previousBoost and previousBoost:getStartTime() or nil
+        local previousDown       = target:getStatusEffect(entry.downEffect)
+        local previousDownStart  = previousDown and previousDown:getStartTime() or nil
 
-        local damage = super(caster, target, spell)
+        local result = super(caster, target, spell)
 
-        caster:delMod(xi.mod.MATT, meritBonus)
-        caster:delMod(xi.mod.MACC, meritBonus)
+        local boost = caster:getStatusEffect(entry.boostEffect)
+        if boost and boost:getStartTime() ~= previousBoostStart then
+            boost:setDuration(90000)
+            boost:setTick(10000)
+        end
 
-        return damage
+        local down = target:getStatusEffect(entry.downEffect)
+        if down and down:getStartTime() ~= previousDownStart then
+            down:setDuration(90000)
+            down:setTick(10000)
+        end
+
+        return result
     end)
 end
+
+-- Drain II: Revert Max HP Boost duration from 3 minutes to 1 minute.
+-- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
+m:addOverride('xi.actions.spells.black.drain_ii.onSpellCast', function(caster, target, spell)
+    local previousBoost    = caster:getStatusEffect(xi.effect.MAX_HP_BOOST)
+    local previousSubPower = previousBoost and previousBoost:getSubPower() or 0
+
+    local result = super(caster, target, spell)
+
+    local currentBoost = caster:getStatusEffect(xi.effect.MAX_HP_BOOST)
+    if
+        currentBoost and
+        currentBoost:getSubPower() > previousSubPower
+    then
+        currentBoost:setDuration(60000)
+    end
+
+    return result
+end)

--- a/modules/era/lua/globals/job_utils/ninja.lua
+++ b/modules/era/lua/globals/job_utils/ninja.lua
@@ -36,12 +36,6 @@ m:addOverrideByEra('xi.effects.sange.onEffectGain', {
     end,
 })
 
--- TODO: Detection Spell Durations (SoA era)
--- Source: https://forum.square-enix.com/ffxi/threads/39564-Jan-21-2014-%28JST%29-Version-Update
---   Tonko Ichi:  420 seconds -> 180 seconds
---   Tonko Ni:    600 seconds -> 300 seconds
---   Monomi Ichi: 420 seconds -> 180 seconds
-
 -- Mijin Gakure: Now applies weakness and normal HP gain on raise
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(07/20/2009)
 m:addOverrideByEra('xi.job_utils.ninja.useMijinGakure', {

--- a/modules/era/sql/rov/job_adjustments.sql
+++ b/modules/era/sql/rov/job_adjustments.sql
@@ -26,11 +26,6 @@ UPDATE traits SET level = 55 WHERE name = 'max hp boost' AND job = 2 AND rank = 
 UPDATE traits SET level = 70 WHERE name = 'max hp boost' AND job = 2 AND rank = 4;
 
 ------------------------------------
--- White Mage
--- Source: https://forum.square-enix.com/ffxi/threads/46531-Mar-26-2015-%28JST%29-Version-Update
-------------------------------------
-
-------------------------------------
 -- Paladin
 ------------------------------------
 

--- a/modules/era/sql/rov/spell_adjustments.sql
+++ b/modules/era/sql/rov/spell_adjustments.sql
@@ -45,3 +45,24 @@ UPDATE spell_list SET castTime = 6000 WHERE name = 'shellra_v';
 -- Remove PLD from Banishga
 -- Source: https://forum.square-enix.com/ffxi/threads/56243
 UPDATE spell_list SET jobs = 0x00000F00000000000000000000000000000000000000 WHERE name = 'banishga';
+
+------------------------------------
+-- Elemental Magic
+------------------------------------
+
+-- Set casting time to 12 seconds for all Ancient Magic spells
+-- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
+UPDATE spell_list SET castTime = 12000 WHERE name = 'flare';
+UPDATE spell_list SET castTime = 12000 WHERE name = 'freeze';
+UPDATE spell_list SET castTime = 12000 WHERE name = 'tornado';
+UPDATE spell_list SET castTime = 12000 WHERE name = 'quake';
+UPDATE spell_list SET castTime = 12000 WHERE name = 'burst';
+UPDATE spell_list SET castTime = 12000 WHERE name = 'flood';
+
+-- Set casting time to 10 seconds for all Ancient Magic II spells
+UPDATE spell_list SET castTime = 10000 WHERE name = 'flare_ii';
+UPDATE spell_list SET castTime = 10000 WHERE name = 'freeze_ii';
+UPDATE spell_list SET castTime = 10000 WHERE name = 'tornado_ii';
+UPDATE spell_list SET castTime = 10000 WHERE name = 'quake_ii';
+UPDATE spell_list SET castTime = 10000 WHERE name = 'burst_ii';
+UPDATE spell_list SET castTime = 10000 WHERE name = 'flood_ii';

--- a/modules/era/sql/soa/spell_adjustments.sql
+++ b/modules/era/sql/soa/spell_adjustments.sql
@@ -1,13 +1,12 @@
 ------------------------------------
--- Seekers of Adoulin Job SQL Adjustments
--- This module reverts relevant SQL tables for jobs to their pre-Abyssea values
-------------------------------------
--- Source : https://forum.square-enix.com/ffxi/threads/35228-July-9-2013-%28JST%29-Version-Update
+-- Seekers of Adoulin Spell SQL Adjustments
+-- This module reverts relevant SQL tables for jobs to their pre-SoA values
 ------------------------------------
 
 ------------------------------------
 -- Elemental Magic Adjustments (RDM / BLM / SCH related)
 -- Reverts MP cost, cast time, and recast time for Tier I-IV elemental nukes, Tier I-III -ga nukes, and Ancient Magic I & II
+-- Source : https://forum.square-enix.com/ffxi/threads/35228-July-9-2013-%28JST%29-Version-Update
 ------------------------------------
 
 -- Earth
@@ -75,3 +74,20 @@ UPDATE spell_list SET mpCost = 193, castTime = 6000,  recastTime = 26000 WHERE n
 UPDATE spell_list SET mpCost = 322, castTime = 7750,  recastTime = 34000 WHERE name = 'thundaga_iii';
 UPDATE spell_list SET mpCost = 352, castTime = 18500, recastTime = 43250 WHERE name = 'burst';
 UPDATE spell_list SET mpCost = 287, recastTime = 90000 WHERE name = 'burst_ii';
+
+------------------------------------
+-- Dark Magic Adjustments
+-- Reverts cast time of absorb spells back to a 2 second cast time
+-- Source : https://forum.square-enix.com/ffxi/threads/43706-Aug-12-2014-%28JST%29-Version-Update
+------------------------------------
+
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-acc';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-attri';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-str';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-dex';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-vit';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-agi';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-int';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-mnd';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-chr';
+UPDATE spell_list SET castTime = 2000 WHERE name = 'absorb-tp';


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements several spell related modules to implement era behavior:
  - Absorb spell decay and cast time
  - Drain II max hp buff duration
  - Ancient Magic cast times

## Steps to test these changes

- Load modules
- See that ancient magic takes longer to cast
- See that absorbs delay and take longer to cast
