### PR TITLE
[core] Validate targets by identity instead of targid / tidy AI states

### DIFF
--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -687,10 +687,13 @@ bool CTargetFind::isWithinRange(position_t* pos, float range)
     return distance(m_PBattleEntity->loc.p, *pos) <= range;
 }
 
-CBattleEntity* CTargetFind::getValidTarget(uint16 actionTargetID, uint16 validTargetFlags)
+auto CTargetFind::getValidTarget(const uint16 actionTargetID, const uint16 validTargetFlags) const -> CBattleEntity*
 {
-    CBattleEntity* PTarget = (CBattleEntity*)m_PBattleEntity->GetEntity(actionTargetID, TYPE_MOB | TYPE_PC | TYPE_PET | TYPE_TRUST);
+    return getValidTarget(dynamic_cast<CBattleEntity*>(m_PBattleEntity->GetEntity(actionTargetID, TYPE_MOB | TYPE_PC | TYPE_PET | TYPE_TRUST)), validTargetFlags);
+}
 
+auto CTargetFind::getValidTarget(CBattleEntity* PTarget, const uint16 validTargetFlags) const -> CBattleEntity*
+{
     if (PTarget == nullptr)
     {
         return nullptr;

--- a/src/map/ai/helpers/targetfind.h
+++ b/src/map/ai/helpers/targetfind.h
@@ -121,7 +121,8 @@ public:
     bool isWithinCone(position_t* pos);
     bool isWithinRange(position_t* pos, float range);
 
-    CBattleEntity* getValidTarget(uint16 actionTargetID, uint16 validTargetFlags);
+    auto getValidTarget(uint16 actionTargetID, uint16 validTargetFlags) const -> CBattleEntity*;
+    auto getValidTarget(CBattleEntity* PTarget, uint16 validTargetFlags) const -> CBattleEntity*;
 
     std::vector<CBattleEntity*> m_targets; // contains all found entities
 

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -156,12 +156,12 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abili
     }
 }
 
-CAbility* CAbilityState::GetAbility()
+auto CAbilityState::GetAbility() const -> CAbility*
 {
     return m_PAbility.get();
 }
 
-void CAbilityState::ApplyEnmity()
+void CAbilityState::ApplyEnmity() const
 {
     auto* PTarget = GetTarget();
     if (PTarget)
@@ -182,12 +182,12 @@ void CAbilityState::ApplyEnmity()
     }
 }
 
-bool CAbilityState::CanChangeState()
+auto CAbilityState::CanChangeState() -> bool
 {
     return IsCompleted();
 }
 
-bool CAbilityState::Update(timer::time_point tick)
+auto CAbilityState::Update(const timer::time_point tick) -> bool
 {
     // Rotate towards target during ability
     if (m_castTime > 0s && tick < GetEntryTime() + m_castTime)
@@ -242,7 +242,7 @@ bool CAbilityState::Update(timer::time_point tick)
     return false;
 }
 
-bool CAbilityState::CanUseAbility()
+auto CAbilityState::CanUseAbility() const -> bool
 {
     CAbility*    PAbility = GetAbility();
     CBaseEntity* PTarget  = GetTarget();
@@ -336,4 +336,18 @@ bool CAbilityState::CanUseAbility()
         // TODO: should luautils::OnAbilityCheck go here too?
     }
     return true;
+}
+
+auto CAbilityState::CanFollowPath() -> bool
+{
+    return true;
+}
+
+auto CAbilityState::CanInterrupt() -> bool
+{
+    return true;
+}
+
+void CAbilityState::Cleanup(timer::time_point tick)
+{
 }

--- a/src/map/ai/states/ability_state.h
+++ b/src/map/ai/states/ability_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CABILITY_STATE_H
-#define _CABILITY_STATE_H
+#pragma once
 
 #include "ability.h"
 #include "state.h"
@@ -30,35 +29,19 @@ class CAbilityState : public CState
 public:
     CAbilityState(CBattleEntity* PEntity, uint16 targid, uint16 abilityid);
 
-    CAbility* GetAbility();
-
-    void ApplyEnmity();
+    auto GetAbility() const -> CAbility*;
+    void ApplyEnmity() const;
 
 protected:
-    virtual bool CanChangeState() override;
-
-    virtual bool CanFollowPath() override
-    {
-        return true;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-
-    virtual void Cleanup(timer::time_point tick) override
-    {
-    }
-
-    bool CanUseAbility();
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanUseAbility() const -> bool;
 
 private:
     timer::duration           m_castTime{ 0s };
     CBattleEntity* const      m_PEntity;
     std::unique_ptr<CAbility> m_PAbility;
 };
-
-#endif

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -129,14 +129,14 @@ void CAttackState::UpdateTarget(CBaseEntity* target)
 void CAttackState::UpdateTarget(uint16 targid)
 {
     m_errorMsg.reset();
-    auto           newTargid{ m_PEntity->GetBattleTargetID() };
+    auto           newTarget{ m_PEntity->battleTarget() };
     CBattleEntity* PNewTarget{ nullptr };
-    if (newTargid != 0)
+    if (newTarget.isSet())
     {
-        PNewTarget = m_PEntity->IsValidTarget(newTargid, TARGET_ENEMY, m_errorMsg);
+        PNewTarget = m_PEntity->IsValidTarget(newTarget, TARGET_ENEMY, m_errorMsg);
         if (!PNewTarget)
         {
-            newTargid          = 0;
+            newTarget          = EntityID_t{};
             CCharEntity* PChar = dynamic_cast<CCharEntity*>(m_PEntity);
             if (PChar && PChar->hasAutoTargetEnabled())
             {
@@ -146,24 +146,24 @@ void CAttackState::UpdateTarget(uint16 targid)
                         distance(PChar->loc.p, PPotentialTarget.second->loc.p) <= 10)
                     {
                         std::unique_ptr<CBasicPacket> errMsg;
-                        if (PChar->IsValidTarget(PPotentialTarget.second->targid, TARGET_ENEMY, errMsg))
+                        if (PChar->IsValidTarget(EntityID_t(PPotentialTarget.second), TARGET_ENEMY, errMsg))
                         {
-                            newTargid = PPotentialTarget.second->targid;
+                            newTarget = EntityID_t(PPotentialTarget.second);
                             PChar->pushPacket<GP_SERV_COMMAND_ASSIST>(PChar, static_cast<CBattleEntity*>(PPotentialTarget.second));
                             break;
                         }
                     }
                 }
             }
-            m_PEntity->PAI->ChangeTarget(newTargid);
+            m_PEntity->PAI->ChangeTarget(newTarget.targid);
         }
     }
-    if (targid != newTargid)
+    if (targid != newTarget.targid)
     {
         if (targid != 0)
         {
             m_PEntity->OnChangeTarget(PNewTarget);
-            SetTarget(newTargid);
+            SetTarget(newTarget.targid);
             if (!PNewTarget)
             {
                 m_errorMsg.reset();
@@ -171,7 +171,7 @@ void CAttackState::UpdateTarget(uint16 targid)
             }
         }
     }
-    CState::UpdateTarget(m_PEntity->GetBattleTargetID());
+    CState::UpdateTarget(m_PEntity->GetBattleTarget());
 }
 
 auto CAttackState::CanAttack(CBattleEntity* PTarget) -> bool

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -29,7 +29,7 @@
 #include "packets/s2c/0x058_assist.h"
 #include "utils/battleutils.h"
 
-CAttackState::CAttackState(CBattleEntity* PEntity, uint16 targid)
+CAttackState::CAttackState(CBattleEntity* PEntity, const uint16 targid)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
 {
@@ -56,7 +56,7 @@ CAttackState::CAttackState(CBattleEntity* PEntity, uint16 targid)
     }
 }
 
-bool CAttackState::Update(timer::time_point tick)
+auto CAttackState::Update(timer::time_point tick) -> bool
 {
     auto* PTarget = static_cast<CBattleEntity*>(GetTarget());
     if (!PTarget || PTarget->isDead())
@@ -174,9 +174,9 @@ void CAttackState::UpdateTarget(uint16 targid)
     CState::UpdateTarget(m_PEntity->GetBattleTargetID());
 }
 
-bool CAttackState::CanAttack(CBattleEntity* PTarget)
+auto CAttackState::CanAttack(CBattleEntity* PTarget) -> bool
 {
-    auto ret = m_PEntity->CanAttack(PTarget, m_errorMsg);
+    const auto ret = m_PEntity->CanAttack(PTarget, m_errorMsg);
 
     if (ret && !m_errorMsg)
     {
@@ -185,7 +185,22 @@ bool CAttackState::CanAttack(CBattleEntity* PTarget)
     return ret;
 }
 
-bool CAttackState::AttackReady()
+auto CAttackState::AttackReady() const -> bool
 {
     return m_attackTime <= 0ms && m_PEntity->isAlive();
+}
+
+auto CAttackState::CanChangeState() -> bool
+{
+    return true;
+}
+
+auto CAttackState::CanFollowPath() -> bool
+{
+    return true;
+}
+
+auto CAttackState::CanInterrupt() -> bool
+{
+    return false;
 }

--- a/src/map/ai/states/attack_state.h
+++ b/src/map/ai/states/attack_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CATTACK_STATE_H
-#define _CATTACK_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -28,40 +27,20 @@ class CAttackState : public CState
 {
 public:
     CAttackState(CBattleEntity* PEntity, uint16 targid);
-
-    // state logic done per tick - returns whether to exit the state or not
-    virtual bool Update(timer::time_point tick) override;
-
-    virtual void Cleanup(timer::time_point tick) override;
-
-    // whether the state can be changed by normal means
-    virtual bool CanChangeState() override
-    {
-        return true;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return true;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
-
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
     void ResetAttackTimer();
 
 protected:
-    virtual void UpdateTarget(uint16 = 0) override;
-    virtual void UpdateTarget(CBaseEntity* target) override;
-    bool         CanAttack(CBattleEntity* PTarget);
-
-    bool AttackReady();
+    void UpdateTarget(uint16 = 0) override;
+    void UpdateTarget(CBaseEntity* target) override;
+    auto CanAttack(CBattleEntity* PTarget) -> bool;
+    auto AttackReady() const -> bool;
 
 private:
     CBattleEntity* const m_PEntity;
     timer::duration      m_attackTime{ 2s };
 };
-
-#endif

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -31,7 +31,7 @@
 namespace
 {
 
-static const timer::duration TIME_TO_SEND_RERAISE_MENU = 8s;
+static constexpr timer::duration TIME_TO_SEND_RERAISE_MENU = 8s;
 
 }
 
@@ -51,7 +51,7 @@ CDeathState::CDeathState(CBattleEntity* PEntity, timer::duration death_time)
     }
 }
 
-bool CDeathState::Update(timer::time_point tick)
+auto CDeathState::Update(timer::time_point tick) -> bool
 {
     if (m_PEntity->objtype != TYPE_PC)
     {
@@ -61,10 +61,10 @@ bool CDeathState::Update(timer::time_point tick)
         }
         else
         {
-            auto time = GetEntryTime() + m_deathTime - std::chrono::seconds(m_PEntity->getMod(Mod::DESPAWN_TIME_REDUCTION));
+            const auto time = GetEntryTime() + m_deathTime - std::chrono::seconds(m_PEntity->getMod(Mod::DESPAWN_TIME_REDUCTION));
             if (tick > time)
             {
-                auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
+                const auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity);
                 // RAISABLE mobs should stay in death state indefinitely until raised
                 if (PMob && ((PMob->m_Behavior & xi::Behavior::Raisable) != xi::Behavior::None))
                 {
@@ -78,9 +78,8 @@ bool CDeathState::Update(timer::time_point tick)
     }
     else
     {
-        CCharEntity* PChar = static_cast<CCharEntity*>(m_PEntity);
-
-        auto time = GetEntryTime() + m_deathTime - std::chrono::seconds(m_PEntity->getMod(Mod::DESPAWN_TIME_REDUCTION));
+        auto*      PChar = static_cast<CCharEntity*>(m_PEntity);
+        const auto time  = GetEntryTime() + m_deathTime - std::chrono::seconds(m_PEntity->getMod(Mod::DESPAWN_TIME_REDUCTION));
 
         // exit state after 2 seconds on raise
         if (m_raiseAccepted && IsCompleted() && tick > m_raiseAcceptedTime + 2s)
@@ -123,4 +122,23 @@ void CDeathState::acceptRaise()
     m_raiseAcceptedTime = timer::now();
     m_raiseAccepted     = true;
     Complete();
+}
+
+void CDeathState::Cleanup(timer::time_point tick)
+{
+}
+
+auto CDeathState::CanChangeState() -> bool
+{
+    return false;
+}
+
+auto CDeathState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CDeathState::CanInterrupt() -> bool
+{
+    return false;
 }

--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CDEATH_STATE_H
-#define _CDEATH_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -29,29 +28,11 @@ class CDeathState : public CState
 public:
     CDeathState(CBattleEntity* PEntity, timer::duration death_time);
 
-    // state logic done per tick - returns whether to exit the state or not
-    virtual bool Update(timer::time_point tick) override;
-
-    virtual void Cleanup(timer::time_point tick) override
-    {
-    }
-
-    // whether the state can be changed by normal means
-    virtual bool CanChangeState() override
-    {
-        return false;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
-
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
     void allowSendRaise();
     void acceptRaise();
 
@@ -63,5 +44,3 @@ private:
     timer::time_point    m_raiseTime;
     timer::time_point    m_raiseAcceptedTime;
 };
-
-#endif

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -27,24 +27,24 @@
 #include "spawn_handler.h"
 #include "zone.h"
 
-CDespawnState::CDespawnState(CBaseEntity* _PEntity, bool instantDespawn)
-: CState(_PEntity, _PEntity->targid)
+CDespawnState::CDespawnState(CBaseEntity* PEntity, const bool instantDespawn)
+: CState(PEntity, PEntity->targid)
 , despawnTime_(timer::now() + (instantDespawn ? 0s : 3s))
 {
-    if (!instantDespawn && (_PEntity->status != xi::Status::Disappear && !((static_cast<CMobEntity*>(_PEntity)->m_Behavior & xi::Behavior::NoDespawn) != xi::Behavior::None)))
+    if (!instantDespawn && (PEntity->status != xi::Status::Disappear && !((static_cast<CMobEntity*>(PEntity)->m_Behavior & xi::Behavior::NoDespawn) != xi::Behavior::None)))
     {
-        _PEntity->loc.zone->PushPacket(_PEntity, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_SCHEDULOR>(_PEntity, _PEntity, FourCC::FadeOut));
+        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_SCHEDULOR>(PEntity, PEntity, FourCC::FadeOut));
     }
 
-    if (auto* PMob = dynamic_cast<CMobEntity*>(_PEntity); PMob && PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
+    if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity); PMob && PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
     {
         PMob->loc.zone->spawnHandler().registerForRespawn(PMob);
     }
 }
 
-bool CDespawnState::Update(timer::time_point tick)
+auto CDespawnState::Update(const timer::time_point tick) -> bool
 {
-    if (!IsCompleted() && !((static_cast<CMobEntity*>(m_PEntity)->m_Behavior & xi::Behavior::NoDespawn) != xi::Behavior::None))
+    if (!IsCompleted() && (static_cast<CMobEntity*>(m_PEntity)->m_Behavior & xi::Behavior::NoDespawn) == xi::Behavior::None)
     {
         if (tick >= despawnTime_)
         {
@@ -59,7 +59,17 @@ void CDespawnState::Cleanup(timer::time_point tick)
 {
 }
 
-bool CDespawnState::CanChangeState()
+auto CDespawnState::CanChangeState() -> bool
+{
+    return false;
+}
+
+auto CDespawnState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CDespawnState::CanInterrupt() -> bool
 {
     return false;
 }

--- a/src/map/ai/states/despawn_state.h
+++ b/src/map/ai/states/despawn_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CSPAWN_STATE_H
-#define _CSPAWN_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -28,22 +27,12 @@ class CDespawnState : public CState
 {
 public:
     CDespawnState(CBaseEntity* PEntity, bool instantDespawn);
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    virtual bool CanChangeState() override;
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
 
 private:
     timer::time_point despawnTime_;
 };
-
-#endif

--- a/src/map/ai/states/inactive_state.cpp
+++ b/src/map/ai/states/inactive_state.cpp
@@ -36,9 +36,9 @@ CInactiveState::CInactiveState(CBaseEntity* PEntity, timer::duration _duration, 
     }
 }
 
-bool CInactiveState::Update(timer::time_point tick)
+auto CInactiveState::Update(timer::time_point tick) -> bool
 {
-    auto* PBattleEntity{ dynamic_cast<CBattleEntity*>(m_PEntity) };
+    const auto* PBattleEntity{ dynamic_cast<CBattleEntity*>(m_PEntity) };
     if (PBattleEntity && m_duration == 0ms)
     {
         if (PBattleEntity->isDead())
@@ -58,4 +58,24 @@ bool CInactiveState::Update(timer::time_point tick)
 
 void CInactiveState::Cleanup(timer::time_point tick)
 {
+}
+
+auto CInactiveState::GetUntargetable() const -> bool
+{
+    return m_untargetable;
+}
+
+auto CInactiveState::CanChangeState() -> bool
+{
+    return m_canChangeState;
+}
+
+auto CInactiveState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CInactiveState::CanInterrupt() -> bool
+{
+    return false;
 }

--- a/src/map/ai/states/inactive_state.h
+++ b/src/map/ai/states/inactive_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CINACTIVE_STATE_H
-#define _CINACTIVE_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -29,34 +28,17 @@ class CInactiveState : public CState
 public:
     CInactiveState(CBaseEntity* PEntity, timer::duration _duration, bool canChangeState, bool untargetable);
 
-    bool GetUntargetable()
-    {
-        return m_untargetable;
-    }
+    auto GetUntargetable() const -> bool;
 
 protected:
-    virtual bool CanChangeState() override
-    {
-        return m_canChangeState;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
 
 private:
     timer::duration m_duration;
     bool            m_canChangeState{ false };
     bool            m_untargetable{ false };
 };
-
-#endif

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -213,7 +213,7 @@ auto CItemState::Update(const timer::time_point tick) -> bool
         {
             m_PEntity->PAI->EventHandler.triggerListener("ITEM_USE", m_PEntity, m_PItem, &action);
 
-            bool consumed = FinishItem(action);
+            const bool consumed = FinishItem(action);
             if (consumed)
             {
                 m_PItem = nullptr;
@@ -267,7 +267,7 @@ void CItemState::Cleanup(timer::time_point tick)
         m_PItem->setSubType(ITEM_UNLOCKED);
     }
 
-    auto* PItem = m_PEntity->getStorage(m_location)->GetItem(m_slot);
+    const auto* PItem = m_PEntity->getStorage(m_location)->GetItem(m_slot);
 
     if (PItem && PItem == m_PItem)
     {
@@ -293,8 +293,6 @@ void CItemState::TryInterrupt(CBattleEntity* PTarget)
     {
         return;
     }
-
-    // todo: interrupt on being hit
 
     if (PTarget)
     {
@@ -379,4 +377,14 @@ auto CItemState::HasMoved() const -> bool
 {
     return floorf(m_startPos.x * 10 + 0.5f) / 10 != floorf(m_PEntity->loc.p.x * 10 + 0.5f) / 10 ||
            floorf(m_startPos.z * 10 + 0.5f) / 10 != floorf(m_PEntity->loc.p.z * 10 + 0.5f) / 10;
+}
+
+auto CItemState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CItemState::CanInterrupt() -> bool
+{
+    return m_interruptable;
 }

--- a/src/map/ai/states/item_state.h
+++ b/src/map/ai/states/item_state.h
@@ -35,31 +35,21 @@ class CItemState : public CState
 public:
     CItemState(CCharEntity* PEntity, uint16 targid, uint8 loc, uint8 slotid);
     ~CItemState() override;
+
     void UpdateTarget(CBaseEntity* target) override;
     void UpdateTarget(uint16 targid) override;
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
     auto CanChangeState() -> bool override;
-
-    auto CanFollowPath() -> bool override
-    {
-        return false;
-    }
-
-    auto CanInterrupt() -> bool override
-    {
-        return m_interruptable;
-    }
-
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
     void TryInterrupt(CBattleEntity* PTarget) override;
-
-    CItemUsable* GetItem() const;
-
+    auto GetItem() const -> CItemUsable*;
     void InterruptItem(action_t& action);
     auto FinishItem(action_t& action) -> bool;
 
 protected:
-    bool HasMoved() const;
+    auto HasMoved() const -> bool;
 
     CCharEntity*        m_PEntity;
     CItemUsable*        m_PItem;

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -46,7 +46,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
 , m_PSpell(nullptr)
 , m_flags(flags)
 {
-    if (auto PMob = dynamic_cast<CMobEntity*>(m_PEntity))
+    if (const auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity))
     {
         if (PMob->getMobMod(xi::MobMod::NoSpellCost) > 0)
         {
@@ -138,11 +138,11 @@ CMagicState::CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid,
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
 }
 
-bool CMagicState::Update(timer::time_point tick)
+auto CMagicState::Update(timer::time_point tick) -> bool
 {
-    action_t action;
-    auto*    PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
-    auto     msg     = MsgBasic::IsInterrupted;
+    action_t   action;
+    auto*      PTarget = m_PEntity->IsValidTarget(m_targid, m_PSpell->getValidTarget(), m_errorMsg);
+    const auto msg     = MsgBasic::IsInterrupted;
 
     auto isTargetValid = [&]()
     {
@@ -329,17 +329,17 @@ void CMagicState::Cleanup(timer::time_point tick)
     }
 }
 
-bool CMagicState::CanChangeState()
+auto CMagicState::CanChangeState() -> bool
 {
     return false;
 }
 
-CSpell* CMagicState::GetSpell()
+auto CMagicState::GetSpell() const -> CSpell*
 {
     return m_PSpell.get();
 }
 
-bool CMagicState::CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast)
+auto CMagicState::CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast) -> bool
 {
     auto ret = m_PEntity->CanUseSpell(GetSpell());
 
@@ -435,7 +435,7 @@ bool CMagicState::CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast)
     return true;
 }
 
-bool CMagicState::HasCost()
+auto CMagicState::HasCost() -> bool
 {
     if (m_PSpell->getSpellGroup() == SPELLGROUP_NINJUTSU)
     {
@@ -492,7 +492,7 @@ void CMagicState::SpendCost()
     }
 }
 
-timer::duration CMagicState::GetRecast()
+auto CMagicState::GetRecast() const -> timer::duration
 {
     if (!m_PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Chainspell) && !m_PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Spontaneity) &&
         !m_instantCast)
@@ -502,7 +502,7 @@ timer::duration CMagicState::GetRecast()
     return 0s;
 }
 
-void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
+void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve) const
 {
     bool enmityApplied = false;
 
@@ -618,7 +618,7 @@ void CMagicState::ApplyEnmity(CBattleEntity* PTarget, int ce, int ve)
     }
 }
 
-bool CMagicState::HasMoved()
+auto CMagicState::HasMoved() const -> bool
 {
     // non-players can't get interrupted via movement due to edge case shenanigans seen from SE
     if (m_PEntity->objtype != TYPE_PC)
@@ -639,7 +639,27 @@ void CMagicState::TryInterrupt(CBattleEntity* PAttacker)
     }
 }
 
-void CMagicState::ApplyMagicCoverEnmity(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser, CMobEntity* PMob)
+void CMagicState::ApplyMagicCoverEnmity(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser, CMobEntity* PMob) const
 {
     PMob->PEnmityContainer->UpdateEnmityFromCover(PCoverAbilityTarget, PCoverAbilityUser);
+}
+
+auto CMagicState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CMagicState::CanInterrupt() -> bool
+{
+    return true;
+}
+
+void CMagicState::SetInstantCast(const bool bInstantCast)
+{
+    m_instantCast = bInstantCast;
+}
+
+auto CMagicState::IsInstantCast() const -> bool
+{
+    return m_instantCast;
 }

--- a/src/map/ai/states/magic_state.h
+++ b/src/map/ai/states/magic_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CMAGIC_STATE_H
-#define _CMAGIC_STATE_H
+#pragma once
 
 #include "spell.h"
 #include "state.h"
@@ -38,44 +37,25 @@ class CMagicState : public CState
 {
 public:
     CMagicState(CBattleEntity* PEntity, uint16 targid, SpellID spellid, uint8 flags = 0);
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    virtual bool CanChangeState() override;
 
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    CSpell*      GetSpell();
-    virtual void TryInterrupt(CBattleEntity* PAttacker) override;
-
-    void            SpendCost();
-    timer::duration GetRecast();
-    void            ApplyEnmity(CBattleEntity* PTarget, int ce, int ve);
-    void            ApplyMagicCoverEnmity(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser, CMobEntity* PMob);
-
-    void SetInstantCast(const bool bInstantCast)
-    {
-        m_instantCast = bInstantCast;
-    }
-
-    bool IsInstantCast()
-    {
-        return m_instantCast;
-    }
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto GetSpell() const -> CSpell*;
+    void TryInterrupt(CBattleEntity* PAttacker) override;
+    void SpendCost();
+    auto GetRecast() const -> timer::duration;
+    void ApplyEnmity(CBattleEntity* PTarget, int ce, int ve) const;
+    void ApplyMagicCoverEnmity(CBattleEntity* PCoverAbilityTarget, CBattleEntity* PCoverAbilityUser, CMobEntity* PMob) const;
+    void SetInstantCast(bool bInstantCast);
+    auto IsInstantCast() const -> bool;
 
 protected:
-    bool CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast);
-
-    bool HasCost();
-
-    bool HasMoved();
+    auto CanCastSpell(CBattleEntity* PTarget, bool isEndOfCast) -> bool;
+    auto HasCost() -> bool;
+    auto HasMoved() const -> bool;
 
     CBattleEntity* const    m_PEntity;
     std::unique_ptr<CSpell> m_PSpell;
@@ -85,5 +65,3 @@ protected:
     bool                    m_instantCast{ false };
     uint8                   m_flags{ 0 };
 };
-
-#endif

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -36,7 +36,7 @@
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
 
-CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid, Maybe<timer::duration> castTimeOverride)
+CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const uint16 targid, const uint16 wsid, const Maybe<timer::duration> castTimeOverride)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
 , m_spentTP(0)
@@ -135,7 +135,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsi
     }
 }
 
-CMobSkill* CMobSkillState::GetSkill()
+auto CMobSkillState::GetSkill() const -> CMobSkill*
 {
     return m_PSkill.get();
 }
@@ -170,7 +170,7 @@ void CMobSkillState::SpendCost()
     }
 }
 
-bool CMobSkillState::Update(timer::time_point tick)
+auto CMobSkillState::Update(const timer::time_point tick) -> bool
 {
     // Reset the state for the current skill attempt
     m_skillSuccess = false;
@@ -305,4 +305,24 @@ void CMobSkillState::reduceTpOnInterrupt() const
             }
         }
     }
+}
+
+auto CMobSkillState::GetSpentTP() const -> int16
+{
+    return m_spentTP;
+}
+
+auto CMobSkillState::CanChangeState() -> bool
+{
+    return false;
+}
+
+auto CMobSkillState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CMobSkillState::CanInterrupt() -> bool
+{
+    return true;
 }

--- a/src/map/ai/states/mobskill_state.h
+++ b/src/map/ai/states/mobskill_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CMOBSKILL_TATE_H
-#define _CMOBSKILL_TATE_H
+#pragma once
 
 #include "mobskill.h"
 #include "state.h"
@@ -32,32 +31,17 @@ class CMobSkillState : public CState
 public:
     CMobSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid, Maybe<timer::duration> castTimeOverride);
 
-    CMobSkill* GetSkill();
-
-    int16 GetSpentTP()
-    {
-        return m_spentTP;
-    }
+    auto GetSkill() const -> CMobSkill*;
+    auto GetSpentTP() const -> int16;
 
 protected:
-    virtual bool CanChangeState() override
-    {
-        return false;
-    }
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
 
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    void         SpendCost();
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    void SpendCost();
 
 private:
     CBattleEntity* const       m_PEntity;
@@ -69,5 +53,3 @@ private:
 
     void reduceTpOnInterrupt() const;
 };
-
-#endif

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -106,7 +106,7 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid)
     SpendCost();
 }
 
-CPetSkill* CPetSkillState::GetPetSkill()
+auto CPetSkillState::GetPetSkill() const -> CPetSkill*
 {
     return m_PSkill.get();
 }
@@ -120,7 +120,7 @@ void CPetSkillState::SpendCost()
     }
 }
 
-bool CPetSkillState::Update(timer::time_point tick)
+auto CPetSkillState::Update(const timer::time_point tick) -> bool
 {
     // Reset the state for the current skill attempt
     m_skillSuccess = false;
@@ -216,4 +216,24 @@ void CPetSkillState::Cleanup(timer::time_point tick)
     {
         m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID(), IsCompleted());
     }
+}
+
+auto CPetSkillState::GetSpentTP() const -> int16
+{
+    return m_spentTP;
+}
+
+auto CPetSkillState::CanChangeState() -> bool
+{
+    return false;
+}
+
+auto CPetSkillState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CPetSkillState::CanInterrupt() -> bool
+{
+    return true;
 }

--- a/src/map/ai/states/petskill_state.h
+++ b/src/map/ai/states/petskill_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CPETSKILL_TATE_H
-#define _CPETSKILL_TATE_H
+#pragma once
 
 #include "petskill.h"
 #include "state.h"
@@ -32,32 +31,16 @@ class CPetSkillState : public CState
 public:
     CPetSkillState(CPetEntity* PEntity, uint16 targid, uint16 wsid);
 
-    CPetSkill* GetPetSkill();
-
-    int16 GetSpentTP()
-    {
-        return m_spentTP;
-    }
+    auto GetPetSkill() const -> CPetSkill*;
+    auto GetSpentTP() const -> int16;
 
 protected:
-    virtual bool CanChangeState() override
-    {
-        return false;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    void         SpendCost();
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    void SpendCost();
 
 private:
     CPetEntity* const          m_PEntity;
@@ -67,5 +50,3 @@ private:
     int16                      m_spentTP;
     bool                       m_skillSuccess{ false };
 };
-
-#endif

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -37,7 +37,7 @@
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
 
-CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
+CRangeState::CRangeState(CBattleEntity* PEntity, const uint16 targid)
 : CState(PEntity, targid)
 , m_PEntity(PEntity)
 {
@@ -85,8 +85,8 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
     // Rapid Shot
     if (m_PEntity->objtype == TYPE_PC || m_PEntity->objtype == TYPE_TRUST)
     {
-        CItemWeapon* weapon     = dynamic_cast<CItemWeapon*>(m_PEntity->m_Weapons[SLOT_RANGED]);
-        bool         isThrowing = weapon && weapon->isThrowing();
+        const CItemWeapon* weapon     = dynamic_cast<CItemWeapon*>(m_PEntity->m_Weapons[SLOT_RANGED]);
+        const bool         isThrowing = weapon && weapon->isThrowing();
         // Don't apply Rapid Shot to throwing weapons
         if (!isThrowing)
         {
@@ -146,16 +146,16 @@ CRangeState::CRangeState(CBattleEntity* PEntity, uint16 targid)
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
 }
 
-void CRangeState::SpendCost()
+void CRangeState::SpendCost() const
 {
 }
 
-bool CRangeState::CanChangeState()
+auto CRangeState::CanChangeState() -> bool
 {
     return false;
 }
 
-bool CRangeState::Update(timer::time_point tick)
+auto CRangeState::Update(const timer::time_point tick) -> bool
 {
     if (m_PEntity && m_PEntity->isAlive() && (tick > GetEntryTime() + m_aimTime && !IsCompleted()))
     {
@@ -222,7 +222,7 @@ void CRangeState::Cleanup(timer::time_point tick)
 {
 }
 
-bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
+auto CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, const bool isEndOfAttack) -> bool
 {
     if (!PTarget)
     {
@@ -305,7 +305,7 @@ bool CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack)
     return true;
 }
 
-bool CRangeState::HasMoved()
+auto CRangeState::HasMoved() const -> bool
 {
     if (m_PEntity->objtype != TYPE_PC)
     {
@@ -315,4 +315,24 @@ bool CRangeState::HasMoved()
     float charDistance = distance(m_startPos, m_PEntity->loc.p, true);
 
     return charDistance > 0.3;
+}
+
+auto CRangeState::IsRapidShot() const -> bool
+{
+    return m_rapidShot;
+}
+
+auto CRangeState::IsOutOfRange() const -> bool
+{
+    return m_isOutOfRange;
+}
+
+auto CRangeState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CRangeState::CanInterrupt() -> bool
+{
+    return true;
 }

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CRANGE_STATE_H
-#define _CRANGE_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -29,35 +28,18 @@ class CRangeState : public CState
 public:
     CRangeState(CBattleEntity* PEntity, uint16 targid);
 
-    void SpendCost();
-
-    bool IsRapidShot()
-    {
-        return m_rapidShot;
-    }
-
-    bool IsOutOfRange()
-    {
-        return m_isOutOfRange;
-    }
+    void SpendCost() const;
+    auto IsRapidShot() const -> bool;
+    auto IsOutOfRange() const -> bool;
 
 protected:
-    virtual bool CanChangeState() override;
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    bool         CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack);
-    bool         HasMoved();
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack) -> bool;
+    auto HasMoved() const -> bool;
 
     // This will likely need to be re-adjusted when states tick more precisely. Changed in 2012. https://wiki.ffo.jp/html/1734.html
 private:
@@ -70,5 +52,3 @@ private:
     position_t           m_startPos;
     bool                 m_isOutOfRange{ false }; // True if target moved out of range during aim time
 };
-
-#endif

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -22,15 +22,23 @@
 #include "state.h"
 #include "entities/base_entity.h"
 
-CState::CState(CBaseEntity* PEntity, uint16 _targid)
+CStateInitException::CStateInitException(std::unique_ptr<CBasicPacket> _msg)
+: std::exception()
+, packet(std::move(_msg))
+{
+}
+
+void CState::TryInterrupt(CBattleEntity* PAttacker)
+{
+}
+
+CState::CState(CBaseEntity* PEntity, const uint16 _targid)
 : m_PEntity(PEntity)
 , m_targid(_targid)
 {
-    // TODO: determine if this should go here;
-    // m_PTarget = m_PEntity->GetEntity(_targid);
 }
 
-void CState::UpdateTarget(uint16 targid)
+void CState::UpdateTarget(const uint16 targid)
 {
     m_PTarget = m_PEntity->GetEntity(targid);
 }
@@ -40,12 +48,12 @@ void CState::UpdateTarget(CBaseEntity* target)
     m_PTarget = target;
 }
 
-CBaseEntity* CState::GetTarget() const
+auto CState::GetTarget() const -> CBaseEntity*
 {
     return m_PTarget;
 }
 
-uint16 CState::GetTargetID() const
+auto CState::GetTargetID() const -> uint16
 {
     return m_targid;
 }
@@ -55,20 +63,9 @@ void CState::Complete()
     m_completed = true;
 }
 
-timer::time_point CState::GetEntryTime() const
+auto CState::GetEntryTime() const -> timer::time_point
 {
     return m_entryTime;
-}
-
-bool CState::WasExitDelayed()
-{
-    return m_wasDelayed;
-}
-
-void CState::DelayExitTime(std::chrono::milliseconds delayMilliseconds)
-{
-    m_entryTime += delayMilliseconds;
-    m_wasDelayed = true;
 }
 
 void CState::ResetEntryTime()
@@ -76,21 +73,21 @@ void CState::ResetEntryTime()
     m_entryTime = timer::now();
 }
 
-void CState::SetTarget(uint16 _targid)
+void CState::SetTarget(const uint16 targid)
 {
-    if (!m_PTarget || _targid != m_targid || (m_PTarget && m_PTarget->targid != _targid))
+    if (!m_PTarget || targid != m_targid || (m_PTarget && m_PTarget->targid != targid))
     {
-        m_targid = _targid;
-        UpdateTarget(_targid);
+        m_targid = targid;
+        UpdateTarget(targid);
     }
 }
 
-bool CState::HasErrorMsg() const
+auto CState::HasErrorMsg() const -> bool
 {
     return m_errorMsg != nullptr;
 }
 
-auto CState::GetErrorMsg() -> std::unique_ptr<CBasicPacket>
+auto CState::GetErrorMsg() const -> std::unique_ptr<CBasicPacket>
 {
     if (HasErrorMsg())
     {
@@ -102,13 +99,13 @@ auto CState::GetErrorMsg() -> std::unique_ptr<CBasicPacket>
     return std::unique_ptr<CBasicPacket>();
 }
 
-bool CState::DoUpdate(timer::time_point tick)
+auto CState::DoUpdate(const timer::time_point tick) -> bool
 {
     UpdateTarget(m_targid);
     return Update(tick);
 }
 
-bool CState::IsCompleted() const
+auto CState::IsCompleted() const -> bool
 {
     return m_completed;
 }

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -20,8 +20,7 @@
 ===========================================================================
 */
 
-#ifndef _CSTATE_H
-#define _CSTATE_H
+#pragma once
 
 #include "common/timer.h"
 #include "entities/base_entity.h"
@@ -33,11 +32,7 @@ class CBattleEntity;
 class CStateInitException : public std::exception
 {
 public:
-    explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg)
-    : std::exception()
-    , packet(std::move(_msg))
-    {
-    }
+    explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg);
 
     std::unique_ptr<CBasicPacket> packet;
 };
@@ -49,41 +44,36 @@ public:
 
     virtual ~CState() = default;
 
-    CBaseEntity* GetTarget() const;
-    void         SetTarget(uint16 targid);
+    auto GetTarget() const -> CBaseEntity*;
+    void SetTarget(uint16 targid);
 
-    bool HasErrorMsg() const;
+    auto HasErrorMsg() const -> bool;
+    auto GetErrorMsg() const -> std::unique_ptr<CBasicPacket>;
 
-    auto GetErrorMsg() -> std::unique_ptr<CBasicPacket>;
-
-    bool DoUpdate(timer::time_point tick);
+    auto DoUpdate(timer::time_point tick) -> bool;
 
     // try interrupt (on hit)
-    virtual void TryInterrupt(CBattleEntity* PAttacker)
-    {
-    }
+    virtual void TryInterrupt(CBattleEntity* PAttacker);
 
     // called when state completes
     virtual void Cleanup(timer::time_point tick) = 0;
     // whether the state can be changed by normal means
-    virtual bool CanChangeState() = 0;
-    virtual bool CanFollowPath()  = 0;
+    virtual auto CanChangeState() -> bool = 0;
+    virtual auto CanFollowPath() -> bool  = 0;
     // whether the state can be interrupted (including by stun/sleep)
-    virtual bool CanInterrupt() = 0;
-    bool         IsCompleted() const;
+    virtual auto CanInterrupt() -> bool = 0;
+    auto         IsCompleted() const -> bool;
     void         ResetEntryTime();
 
 protected:
     // state logic done per tick - returns whether to exit the state or not
-    virtual bool Update(timer::time_point tick) = 0;
+    virtual auto Update(timer::time_point tick) -> bool = 0;
     virtual void UpdateTarget(uint16 targid);
     virtual void UpdateTarget(CBaseEntity* target);
 
-    uint16            GetTargetID() const;
-    void              Complete();
-    timer::time_point GetEntryTime() const;
-    bool              WasExitDelayed();
-    void              DelayExitTime(std::chrono::milliseconds delayMilliseconds);
+    auto GetTargetID() const -> uint16;
+    void Complete();
+    auto GetEntryTime() const -> timer::time_point;
 
     std::unique_ptr<CBasicPacket> m_errorMsg;
 
@@ -93,8 +83,5 @@ protected:
 private:
     CBaseEntity*      m_PTarget{ nullptr };
     bool              m_completed{ false };
-    bool              m_wasDelayed{ false };
     timer::time_point m_entryTime{ timer::now() };
 };
-
-#endif

--- a/src/map/ai/states/synth_state.cpp
+++ b/src/map/ai/states/synth_state.cpp
@@ -26,7 +26,7 @@
 #include "ai/ai_container.h"
 #include "utils/synthutils.h"
 
-CSynthState::CSynthState(CCharEntity* PChar, xi::SkillType skill)
+CSynthState::CSynthState(CCharEntity* PChar, const xi::SkillType skill)
 : CState(PChar, PChar->targid)
 , m_PEntity(PChar)
 {
@@ -61,7 +61,7 @@ CSynthState::CSynthState(CCharEntity* PChar, xi::SkillType skill)
     }
 }
 
-bool CSynthState::Update(timer::time_point tick)
+auto CSynthState::Update(timer::time_point tick) -> bool
 {
     // Exit state if dead
     if (m_PEntity->isDead())
@@ -75,30 +75,32 @@ bool CSynthState::Update(timer::time_point tick)
         synthutils::sendSynthDone(m_PEntity);
         return true;
     }
-    else
-    {
-        m_synthFinishTime -= (m_PEntity->PAI->getTick() - m_PEntity->PAI->getPrevTick());
-    }
+
+    m_synthFinishTime -= (m_PEntity->PAI->getTick() - m_PEntity->PAI->getPrevTick());
     return false;
 }
 
-void CSynthState::Cleanup(timer::time_point tick)
+void CSynthState::Cleanup(const timer::time_point tick)
 {
     std::ignore = tick;
 }
 
-void CSynthState::UpdateTarget(CBaseEntity* target)
+auto CSynthState::SynthReady() const -> bool
 {
-    std::ignore = target;
+    return m_synthFinishTime <= 0ms && m_PEntity->isAlive();
 }
 
-// stub
-void CSynthState::UpdateTarget(uint16 targid)
+auto CSynthState::CanChangeState() -> bool
 {
-    std::ignore = targid;
+    return false;
 }
 
-bool CSynthState::SynthReady()
+auto CSynthState::CanFollowPath() -> bool
 {
-    return m_synthFinishTime < 0ms && m_PEntity->isAlive();
+    return false;
+}
+
+auto CSynthState::CanInterrupt() -> bool
+{
+    return false;
 }

--- a/src/map/ai/states/synth_state.h
+++ b/src/map/ai/states/synth_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CSYNTH_STATE_H
-#define _CSYNTH_STATE_H
+#pragma once
 
 #include "entities/battle_entity.h"
 #include "state.h"
@@ -30,36 +29,16 @@ class CSynthState : public CState
 public:
     CSynthState(CCharEntity* PChar, xi::SkillType skill);
 
-    // state logic done per tick - returns whether to exit the state or not
-    virtual bool Update(timer::time_point tick) override;
-
-    virtual void Cleanup(timer::time_point tick) override;
-
-    // whether the state can be changed by normal means
-    virtual bool CanChangeState() override
-    {
-        return false;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
 
 protected:
-    virtual void UpdateTarget(uint16 = 0) override;
-    virtual void UpdateTarget(CBaseEntity* target) override;
-
-    bool SynthReady();
+    auto SynthReady() const -> bool;
 
 private:
     CCharEntity* const m_PEntity;
     timer::duration    m_synthFinishTime{ 16s };
 };
-
-#endif

--- a/src/map/ai/states/trigger_state.cpp
+++ b/src/map/ai/states/trigger_state.cpp
@@ -23,17 +23,17 @@
 
 #include "entities/char_entity.h"
 
-CTriggerState::CTriggerState(CBaseEntity* PEntity, uint16 targid, bool door)
+CTriggerState::CTriggerState(CBaseEntity* PEntity, const uint16 targid, const bool door)
 : CState(PEntity, targid)
 , door(door)
 {
 }
 
-bool CTriggerState::Update(timer::time_point tick)
+auto CTriggerState::Update(const timer::time_point tick) -> bool
 {
     if (!IsCompleted())
     {
-        auto* PChar = dynamic_cast<CCharEntity*>(GetTarget());
+        const auto* PChar = dynamic_cast<CCharEntity*>(GetTarget());
         if (PChar && door && m_PEntity->animation == xi::Animation::CloseDoor)
         {
             close                = true;
@@ -58,12 +58,21 @@ bool CTriggerState::Update(timer::time_point tick)
     return false;
 }
 
-bool CTriggerState::CanChangeState()
+auto CTriggerState::CanChangeState() -> bool
 {
     return false;
 }
 
-bool CTriggerState::CanFollowPath()
+auto CTriggerState::CanFollowPath() -> bool
 {
     return false;
+}
+
+auto CTriggerState::CanInterrupt() -> bool
+{
+    return false;
+}
+
+void CTriggerState::Cleanup(timer::time_point tick)
+{
 }

--- a/src/map/ai/states/trigger_state.h
+++ b/src/map/ai/states/trigger_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CTRIGGER_STATE_H
-#define _CTRIGGER_STATE_H
+#pragma once
 
 #include "state.h"
 
@@ -28,23 +27,14 @@ class CTriggerState : public CState
 {
 public:
     CTriggerState(CBaseEntity* PEntity, uint16 targid, bool door = false);
-    virtual bool Update(timer::time_point tick) override;
 
-    virtual void Cleanup(timer::time_point tick) override
-    {
-    }
-
-    virtual bool CanChangeState() override;
-    virtual bool CanFollowPath() override;
-
-    virtual bool CanInterrupt() override
-    {
-        return false;
-    }
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
 
 private:
     bool close{ false };
     bool door{ false };
 };
-
-#endif

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -44,8 +44,8 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
         throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(PEntity, PEntity, 0, 0, MsgBasic::CannotUseWeaponskill));
     }
 
-    auto  target_flags = battleutils::isValidSelfTargetWeaponskill(wsid) ? TARGET_SELF : TARGET_ENEMY;
-    auto* PTarget      = m_PEntity->IsValidTarget(m_targid, target_flags, m_errorMsg);
+    const auto targetFlags = battleutils::isValidSelfTargetWeaponskill(wsid) ? TARGET_SELF : TARGET_ENEMY;
+    auto*      PTarget     = m_PEntity->IsValidTarget(m_targid, targetFlags, m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
@@ -86,7 +86,7 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
 }
 
-CWeaponSkill* CWeaponSkillState::GetSkill()
+auto CWeaponSkillState::GetSkill() const -> CWeaponSkill*
 {
     return m_PSkill.get();
 }
@@ -125,7 +125,7 @@ void CWeaponSkillState::SpendCost()
     m_spent = tp;
 }
 
-bool CWeaponSkillState::Update(timer::time_point tick)
+auto CWeaponSkillState::Update(const timer::time_point tick) -> bool
 {
     if (!m_PEntity)
     {
@@ -152,7 +152,7 @@ bool CWeaponSkillState::Update(timer::time_point tick)
             // Reset Restraint bonus and trackers on weaponskill use
             if (m_PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Restraint))
             {
-                uint16 WSBonus = m_PEntity->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Restraint)->GetPower();
+                const uint16 WSBonus = m_PEntity->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Restraint)->GetPower();
                 m_PEntity->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Restraint)->SetPower(0);
                 m_PEntity->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Restraint)->SetSubPower(0);
                 m_PEntity->delModifier(Mod::ALL_WSDMG_FIRST_HIT, WSBonus);
@@ -161,11 +161,11 @@ bool CWeaponSkillState::Update(timer::time_point tick)
             if (action.actiontype == ActionCategory::SkillFinish) // category changes upon being out of range. This does not count for RoE and delay is not increased beyond the normal delay.
             {
                 // only send lua the WS events if we are in range
-                uint32 weaponskillVar    = PTarget->GetLocalVar("weaponskillHit");
-                uint32 weaponskillDamage = weaponskillVar & 0xFFFFFF;
+                const uint32 weaponskillVar    = PTarget->GetLocalVar("weaponskillHit");
+                uint32       weaponskillDamage = weaponskillVar & 0xFFFFFF;
 
                 m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_USE", m_PEntity, PTarget, m_PSkill.get(), m_spent, &action, weaponskillDamage);
-                for (auto& actionTarget : action.targets)
+                for (const auto& actionTarget : action.targets)
                 {
                     auto* PActionTarget = dynamic_cast<CBattleEntity*>(zoneutils::GetEntity(actionTarget.actorId));
                     if (PActionTarget)
@@ -185,8 +185,8 @@ bool CWeaponSkillState::Update(timer::time_point tick)
             // There used to be specific handling here for the Weaponskill interrupt, but it was assumed and should not be reintroduced without a test and a proper capture.
         }
 
-        auto delay   = m_PSkill->getAnimationTime(); // TODO: Is delay time a fixed number if the weaponskill is used out of range?
-        m_finishTime = tick + delay;
+        const auto delay = m_PSkill->getAnimationTime(); // TODO: Is delay time a fixed number if the weaponskill is used out of range?
+        m_finishTime     = tick + delay;
         Complete();
     }
     else if (tick > m_finishTime)
@@ -201,7 +201,7 @@ bool CWeaponSkillState::Update(timer::time_point tick)
     return false;
 }
 
-void CWeaponSkillState::Cleanup(timer::time_point tick)
+void CWeaponSkillState::Cleanup(const timer::time_point tick)
 {
     if (!m_PEntity)
     {
@@ -223,4 +223,24 @@ void CWeaponSkillState::Cleanup(timer::time_point tick)
     {
         m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_EXIT", m_PEntity, m_PSkill->getID(), IsCompleted());
     }
+}
+
+auto CWeaponSkillState::GetSpentTP() const -> int16
+{
+    return m_spent;
+}
+
+auto CWeaponSkillState::CanChangeState() -> bool
+{
+    return false;
+}
+
+auto CWeaponSkillState::CanFollowPath() -> bool
+{
+    return false;
+}
+
+auto CWeaponSkillState::CanInterrupt() -> bool
+{
+    return true;
 }

--- a/src/map/ai/states/weaponskill_state.h
+++ b/src/map/ai/states/weaponskill_state.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CWEAPONSKILL_STATE_H
-#define _CWEAPONSKILL_STATE_H
+#pragma once
 
 #include "state.h"
 #include "weapon_skill.h"
@@ -30,32 +29,16 @@ class CWeaponSkillState : public CState
 public:
     CWeaponSkillState(CBattleEntity* PEntity, uint16 targid, uint16 wsid);
 
-    CWeaponSkill* GetSkill();
-
-    int16 GetSpentTP()
-    {
-        return m_spent;
-    }
+    auto GetSkill() const -> CWeaponSkill*;
+    auto GetSpentTP() const -> int16;
 
 protected:
-    virtual bool CanChangeState() override
-    {
-        return false;
-    }
-
-    virtual bool CanFollowPath() override
-    {
-        return false;
-    }
-
-    virtual bool CanInterrupt() override
-    {
-        return true;
-    }
-
-    virtual bool Update(timer::time_point tick) override;
-    virtual void Cleanup(timer::time_point tick) override;
-    void         SpendCost();
+    auto CanChangeState() -> bool override;
+    auto CanFollowPath() -> bool override;
+    auto CanInterrupt() -> bool override;
+    auto Update(timer::time_point tick) -> bool override;
+    void Cleanup(timer::time_point tick) override;
+    void SpendCost();
 
 private:
     CBattleEntity* const          m_PEntity;
@@ -63,5 +46,3 @@ private:
     timer::time_point             m_finishTime;
     int16                         m_spent{ 0 };
 };
-
-#endif

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -1029,8 +1029,7 @@ auto CBattleEntity::takeDamage(int32 amount, CBattleEntity* attacker /* = nullpt
 
     if (attacker)
     {
-        lastAttackerId_.id     = attacker->id;
-        lastAttackerId_.targid = attacker->targid;
+        lastAttackerId_ = EntityID_t(attacker);
     }
     else
     {

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -3639,6 +3639,11 @@ void CBattleEntity::OnChangeTarget(CBattleEntity* PTarget)
 {
 }
 
+auto CBattleEntity::battleTarget() const -> EntityID_t
+{
+    return battleTarget_;
+}
+
 void CBattleEntity::setBattleTarget(const Maybe<EntityID_t>& target)
 {
     battleTarget_ = target.value_or(EntityID_t{});
@@ -4008,12 +4013,19 @@ bool CBattleEntity::OnAttack(CAttackState& state, action_t& action)
     return true;
 }
 
-CBattleEntity* CBattleEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg)
+auto CBattleEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*
 {
     TracyZoneScoped;
 
     auto* PTarget = PAI->TargetFind->getValidTarget(targid, validTargetFlags);
     return PTarget;
+}
+
+auto CBattleEntity::IsValidTarget(EntityID_t target, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*
+{
+    TracyZoneScoped;
+
+    return PAI->TargetFind->getValidTarget(target.resolve<CBattleEntity>(), validTargetFlags);
 }
 
 void CBattleEntity::OnEngage(CAttackState& state)

--- a/src/map/entities/battle_entity.h
+++ b/src/map/entities/battle_entity.h
@@ -352,6 +352,7 @@ public:
     virtual void Die();
     uint16       GetBattleTargetID() const;
 
+    auto battleTarget() const -> EntityID_t;
     void setBattleTarget(const Maybe<EntityID_t>& target);
     auto GetBattleTarget() const -> CBattleEntity*;
 
@@ -367,10 +368,13 @@ public:
     }
 
     /* Returns whether to call Attack or not (which includes error messages) */
-    virtual bool           CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg);
-    virtual CBattleEntity* IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg);
-    virtual void           OnEngage(CAttackState&);
-    virtual void           OnDisengage(CAttackState&);
+    virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg);
+
+    virtual auto IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*;
+    virtual auto IsValidTarget(EntityID_t target, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*;
+
+    virtual void OnEngage(CAttackState&);
+    virtual void OnDisengage(CAttackState&);
     /* Casting */
     virtual void OnCastFinished(CMagicState&, action_t&);
     virtual void OnCastInterrupted(CMagicState&, action_t&, MsgBasic msg, bool blockedCast);

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2343,11 +2343,23 @@ auto CCharEntity::OnItemFinish(CItemState& state, action_t& action) -> bool
     return true;
 }
 
-CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg)
+auto CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*
 {
     TracyZoneScoped;
 
-    auto* PTarget = CBattleEntity::IsValidTarget(targid, validTargetFlags, errMsg);
+    return applyTargetRestrictions(GetEntity(targid, TYPE_MOB | TYPE_PC | TYPE_PET | TYPE_TRUST), validTargetFlags, errMsg);
+}
+
+auto CCharEntity::IsValidTarget(EntityID_t target, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*
+{
+    TracyZoneScoped;
+
+    return applyTargetRestrictions(target.resolve(), validTargetFlags, errMsg);
+}
+
+auto CCharEntity::applyTargetRestrictions(CBaseEntity* PResolved, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*
+{
+    auto* PTarget = PAI->TargetFind->getValidTarget(dynamic_cast<CBattleEntity*>(PResolved), validTargetFlags);
     if (PTarget)
     {
         if (PTarget->objtype == TYPE_PC && charutils::IsAidBlocked(this, static_cast<CCharEntity*>(PTarget)))
@@ -2376,7 +2388,7 @@ CBattleEntity* CCharEntity::IsValidTarget(uint16 targid, uint16 validTargetFlags
     else
     {
         // Check if target is a BEHAVIOR_NO_ASSIST mob with player allegiance
-        auto* PEntity = GetEntity(targid, TYPE_MOB | TYPE_PC | TYPE_PET | TYPE_TRUST);
+        auto* PEntity = PResolved;
         if (PEntity && PEntity->objtype == TYPE_MOB && static_cast<CMobEntity*>(PEntity)->allegiance == xi::Allegiance::Player &&
             ((static_cast<CMobEntity*>(PEntity)->m_Behavior & xi::Behavior::NoAssist) != xi::Behavior::None))
         {

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2394,7 +2394,7 @@ void CCharEntity::Die()
 {
     TracyZoneScoped;
 
-    if (auto* PLastAttacker = GetEntity(lastAttackerId_.targid); PLastAttacker && PLastAttacker->id == lastAttackerId_.id)
+    if (auto* PLastAttacker = lastAttackerId_.resolve())
     {
         loc.zone->PushPacket(this, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(PLastAttacker, this, 0, 0, MsgBasic::PlayerDefeatedBy));
     }

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -725,19 +725,20 @@ public:
     void SetMoghancement(uint16 moghancementID);
 
     /* State callbacks */
-    bool           CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
-    bool           OnAttack(CAttackState&, action_t&) override;
-    bool           OnAttackError(CAttackState&) override;
-    CBattleEntity* IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) override;
-    void           OnChangeTarget(CBattleEntity* PNewTarget) override;
-    void           OnEngage(CAttackState&) override;
-    void           OnDisengage(CAttackState&) override;
-    void           OnCastFinished(CMagicState&, action_t&) override;
-    void           OnCastInterrupted(CMagicState&, action_t&, MsgBasic msg, bool blockedCast) override;
-    void           OnWeaponSkillFinished(CWeaponSkillState&, action_t&) override;
-    void           OnAbility(CAbilityState&, action_t&) override;
-    void           OnDeathTimer() override;
-    void           OnRaise() override;
+    bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
+    bool OnAttack(CAttackState&, action_t&) override;
+    bool OnAttackError(CAttackState&) override;
+    auto IsValidTarget(uint16 targid, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity* override;
+    auto IsValidTarget(EntityID_t target, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity* override;
+    void OnChangeTarget(CBattleEntity* PNewTarget) override;
+    void OnEngage(CAttackState&) override;
+    void OnDisengage(CAttackState&) override;
+    void OnCastFinished(CMagicState&, action_t&) override;
+    void OnCastInterrupted(CMagicState&, action_t&, MsgBasic msg, bool blockedCast) override;
+    void OnWeaponSkillFinished(CWeaponSkillState&, action_t&) override;
+    void OnAbility(CAbilityState&, action_t&) override;
+    void OnDeathTimer() override;
+    void OnRaise() override;
 
     auto OnItemFinish(CItemState&, action_t&) -> bool;
 
@@ -764,6 +765,8 @@ protected:
     void changeMoghancement(uint16 moghancementID, bool isAdding);
 
 private:
+    auto applyTargetRestrictions(CBaseEntity* PResolved, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*;
+
     CCraftState                               craftState_{};
     std::vector<std::unique_ptr<Transaction>> transactions_;
 

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -1285,7 +1285,7 @@ void CMobEntity::Die()
     {
         if (static_cast<CMobEntity*>(PEntity)->isDead())
         {
-            if (auto* PLastAttacker = GetEntity(lastAttackerId_.targid); PLastAttacker && PLastAttacker->id == lastAttackerId_.id)
+            if (auto* PLastAttacker = lastAttackerId_.resolve())
             {
                 loc.zone->PushPacket(this, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(PLastAttacker, this, 0, 0, MsgBasic::DefeatsTarget));
             }

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -496,9 +496,10 @@ void CMobEntity::setMobMod(xi::MobMod type, int16 value)
     m_mobModStat[type] = value;
 }
 
-int16 CMobEntity::getMobMod(xi::MobMod type)
+auto CMobEntity::getMobMod(xi::MobMod type) const -> int16
 {
-    return m_mobModStat[type];
+    const auto it = m_mobModStat.find(type);
+    return it != m_mobModStat.end() ? it->second : 0;
 }
 
 void CMobEntity::addMobMod(xi::MobMod type, int16 value)

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -100,13 +100,13 @@ public:
     auto GetEligibleSeals() -> std::vector<uint16>;
     auto GetEligibleGeodes() const -> std::vector<uint16>;
 
-    void  setMobMod(xi::MobMod type, int16 value);
-    int16 getMobMod(xi::MobMod type);
-    void  addMobMod(xi::MobMod type, int16 value);
-    void  defaultMobMod(xi::MobMod type, int16 value); // set value if value has not been already set
-    void  resetMobMod(xi::MobMod type);                // resets mob mod to original value
-    void  saveMobModifiers();                          // save current state of modifiers
-    void  restoreMobModifiers();                       // restore to saved state
+    void setMobMod(xi::MobMod type, int16 value);
+    auto getMobMod(xi::MobMod type) const -> int16;
+    void addMobMod(xi::MobMod type, int16 value);
+    void defaultMobMod(xi::MobMod type, int16 value); // set value if value has not been already set
+    void resetMobMod(xi::MobMod type);                // resets mob mod to original value
+    void saveMobModifiers();                          // save current state of modifiers
+    void restoreMobModifiers();                       // restore to saved state
 
     void SetCallForHelpFlag(bool call);
     bool GetCallForHelpFlag() const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds various overloads to TargetFinding/validation to make the EntityID_t migration easier.
- CMobEntity::getMobMod is now const
- Tidy all state files (pragma, trailing returns, const, implementations moved to .cpp)

## Steps to test these changes
There should be no changes whatsoever...

<!-- Clear and detailed steps to test your changes here -->
