### PR TITLE
[lua] Promyvion Entry Requirements Bugfix

### DIFF
--- a/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Dem/ancient_flames_beckon.lua
@@ -27,7 +27,9 @@ function content:entryRequirement(player, npc, isRegistrant, trade)
     local promathiaMission    = player:getCurrentMission(xi.mission.log_id.COP)
     local currentRequirements = promathiaMission == xi.mission.id.cop.BELOW_THE_ARKS or
         (promathiaMission == xi.mission.id.cop.THE_MOTHERCRYSTALS and not player:hasKeyItem(xi.ki.LIGHT_OF_DEM))
-    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or currentRequirements
+    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or
+        player:hasKeyItem(xi.ki.LIGHT_OF_DEM) or
+        currentRequirements
 
     return (not isRegistrant and nonRegistrantReqs) or currentRequirements
 end

--- a/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Holla/ancient_flames_beckon.lua
@@ -27,7 +27,9 @@ function content:entryRequirement(player, npc, isRegistrant, trade)
     local promathiaMission    = player:getCurrentMission(xi.mission.log_id.COP)
     local currentRequirements = promathiaMission == xi.mission.id.cop.BELOW_THE_ARKS or
         (promathiaMission == xi.mission.id.cop.THE_MOTHERCRYSTALS and not player:hasKeyItem(xi.ki.LIGHT_OF_HOLLA))
-    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or currentRequirements
+    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or
+        player:hasKeyItem(xi.ki.LIGHT_OF_HOLLA) or
+        currentRequirements
 
     return (not isRegistrant and nonRegistrantReqs) or currentRequirements
 end

--- a/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
+++ b/scripts/battlefields/Spire_of_Mea/ancient_flames_beckon.lua
@@ -27,7 +27,9 @@ function content:entryRequirement(player, npc, isRegistrant, trade)
     local promathiaMission    = player:getCurrentMission(xi.mission.log_id.COP)
     local currentRequirements = promathiaMission == xi.mission.id.cop.BELOW_THE_ARKS or
         (promathiaMission == xi.mission.id.cop.THE_MOTHERCRYSTALS and not player:hasKeyItem(xi.ki.LIGHT_OF_MEA))
-    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or currentRequirements
+    local nonRegistrantReqs   = player:hasCompletedMission(xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or
+        player:hasKeyItem(xi.ki.LIGHT_OF_MEA) or
+        currentRequirements
 
     return (not isRegistrant and nonRegistrantReqs) or currentRequirements
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes a loophole where someone who is on the Promyvion missions (but has beaten that specific battlefield) can not help with additional fights. (For instance if they brought more than 6 and planned on doing the fight twice)

## Steps to test these changes

Be on Promyvion Holla mission -> beat it. 
Try to help someone on Promyvion Holla -> be able to enter.
