### PR TITLE
[C++][lua] Conquest: Set rank of ties for first to lower value

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -753,11 +753,6 @@ local expRings =
     [xi.item.EMPEROR_BAND] = { chargesWhenFull = 3, costPerCharge = 200 },
 }
 
-local function conquestRanking()
-    -- computes part of argument 3 for gate guard events. represents the conquest standing of the 3 nations. Verified.
-    return GetNationRank(xi.nation.SANDORIA) + 4 * GetNationRank(xi.nation.BASTOK) + 16 * GetNationRank(xi.nation.WINDURST)
-end
-
 xi.conquest.toggleRegionalNPCs = function(zone)
     -- Show/Hide regional NPCs
     -- If there is a draw or a 1st place Alliance, those NPCs won't be available anywhere.
@@ -1411,7 +1406,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
     -- JEUNO OVERSEERS
     elseif guardType == xi.conquest.guard.CITY and guardNation == xi.nation.OTHER then
         local a1 = getArg1(player, guardNation, guardType)
-        local a3 = conquestRanking()
+        local a3 = GetConquestBalance()
         local a6 = getArg6(player)
         local a7 = player:getCP()
 
@@ -1421,7 +1416,7 @@ xi.conquest.overseerOnTrigger = function(player, npc, guardNation, guardType, gu
     elseif guardType <= xi.conquest.guard.FOREIGN then
         local a1 = getArg1(player, guardNation, guardType)
         local a2 = getExForceAvailable(player, npc, guardNation)
-        local a3 = conquestRanking()
+        local a3 = GetConquestBalance()
         local a4 = suppliesAvailableBitmask(player, guardNation)
         local a5 = player:getTeleport(guardNation)
         local a6 = getArg6(player)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -1576,22 +1576,35 @@ uint8 GetNationRank(uint8 nation)
 {
     TracyZoneScoped;
 
-    uint8 balance = conquest::GetBalance();
+    const uint8 balance  = conquest::GetBalance();
+    const uint8 sandoria = balance & 0x3U;
+    const uint8 bastok   = (balance >> 2) & 0x3U;
+    const uint8 windurst = (balance >> 4) & 0x3U;
+
+    uint8 rank = 0;
     switch (nation)
     {
         case NATION_SANDORIA:
-            balance &= 0x3U;
-            return balance;
+            rank = sandoria;
+            break;
         case NATION_BASTOK:
-            balance &= 0xCU;
-            balance >>= 2;
-            return balance;
+            rank = bastok;
+            break;
         case NATION_WINDURST:
-            balance >>= 4;
-            return balance;
+            rank = windurst;
+            break;
         default:
             return 0;
     }
+
+    // If two nations are tied for first, they are both read as second.
+    // If all three nations are tied for first, they all register as third.
+    if (rank == 1)
+    {
+        rank = static_cast<uint8>((sandoria == 1) + (bastok == 1) + (windurst == 1));
+    }
+
+    return rank;
 }
 
 uint8 GetConquestBalance()


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

In Conquest with the current implementation, if two or more nations are tied for first, they all get ranked first. Instead, they should be treated like they are in second place if two nations are tied, or in third place if three nations are tied. If two nations are tied for second, they should be treated as if they are second (current behavior).

This change is based off the Japanese Wiki (https://wiki.ffo.jp/html/498.html Regarding ties in ranking). 
I can not find any captures that confirm or deny this claim from the wiki. Implementing this change would affect new servers (all nations in third place) as well as normal shops balanced against the players.
This affects shops, signet duration, changing nation's price, and EF influence gain.

## Steps to test these changes

!setplayernation to change nations
!exec player:gainConquestInfluence(1000) to give conquest points
!updateconquest 0 to trigger conquest results.

Test with various combinations.

