### PR TITLE
[sql] Fix Sweeping Clusters so they aggro to magic

### DIFF
--- a/sql/mob_species_system.sql
+++ b/sql/mob_species_system.sql
@@ -110,7 +110,7 @@ INSERT INTO `mob_species_system` VALUES (55,'Knight',24,'Caturae',3,'Arcana',40,
 INSERT INTO `mob_species_system` VALUES (56,'Pawn',24,'Caturae',3,'Arcana',40,100,100,4,3,4,5,4,4,3,1,3,1,3,0.0,1,0);
 INSERT INTO `mob_species_system` VALUES (57,'Queen',24,'Caturae',3,'Arcana',40,100,100,4,3,4,5,4,4,3,1,3,1,3,0.0,1,0);
 INSERT INTO `mob_species_system` VALUES (58,'Rook',24,'Caturae',3,'Arcana',40,100,100,4,3,4,5,4,4,3,1,3,1,3,0.0,1,0);
-INSERT INTO `mob_species_system` VALUES (59,'Cluster',25,'Cluster',3,'Arcana',40,100,100,4,3,3,4,4,4,3,1,3,1,3,1.0,1,0);
+INSERT INTO `mob_species_system` VALUES (59,'Cluster',25,'Cluster',3,'Arcana',40,100,100,4,3,3,4,4,4,3,1,3,1,3,1.0,33,0);
 INSERT INTO `mob_species_system` VALUES (60,'Doll',26,'Doll',3,'Arcana',40,100,100,4,3,3,5,4,4,3,1,3,1,3,2.0,32,0);
 INSERT INTO `mob_species_system` VALUES (61,'Gargoyles',26,'Doll',3,'Arcana',40,100,100,4,3,3,5,4,4,3,1,3,1,3,2.0,32,0);
 INSERT INTO `mob_species_system` VALUES (62,'Evil_Weapon',27,'Evil_Weapon',3,'Arcana',40,100,100,6,3,5,4,1,4,2,1,3,1,3,3.0,34,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Makes the Sweeping Cluster aggro when casting magic.


## Steps to test these changes


Casting magic near the Sweeping Cluster.
