### PR TITLE
[C++] Refresh character skills when activating a +skill latent effect

### DIFF
--- a/src/map/latent_effect.cpp
+++ b/src/map/latent_effect.cpp
@@ -126,6 +126,12 @@ bool CLatentEffect::ModOnItemOnly(xi::Mod modID)
     return false;
 }
 
+bool CLatentEffect::SkillMod(xi::Mod modID)
+{
+    return (modID >= xi::Mod::HTH && modID <= xi::Mod::STAFF) ||
+           (modID >= xi::Mod::AUTO_MELEE_SKILL && modID <= xi::Mod::HANDBELL_SKILL);
+}
+
 bool CLatentEffect::Activate()
 {
     if (!IsActivated())
@@ -148,6 +154,12 @@ bool CLatentEffect::Activate()
         else
         {
             m_POwner->addModifier(m_ModValue, m_ModPower);
+
+            if (SkillMod(GetModValue()))
+            {
+                CCharEntity* PChar = static_cast<CCharEntity*>(m_POwner);
+                charutils::BuildingCharSkillsTable(PChar);
+            }
         }
 
         m_Activated = true;
@@ -175,6 +187,12 @@ bool CLatentEffect::Deactivate()
         else
         {
             m_POwner->delModifier(m_ModValue, m_ModPower);
+
+            if (SkillMod(GetModValue()))
+            {
+                CCharEntity* PChar = static_cast<CCharEntity*>(m_POwner);
+                charutils::BuildingCharSkillsTable(PChar);
+            }
         }
 
         m_Activated = false;

--- a/src/map/latent_effect.h
+++ b/src/map/latent_effect.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -61,6 +61,7 @@ public:
     void SetModValue(xi::Mod value);
     void SetModPower(int16 power);
     bool ModOnItemOnly(xi::Mod modID);
+    bool SkillMod(xi::Mod modID);
     bool Activate();
     bool Deactivate();
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, if you activate a latent effect of a +skill item, that latent does not activate until the item is unequipped/equipped again. This PR sends the command to rebuild the characters skills immediately when a +skill latent is activated.

Edit: verified with captures that packets to update the stats sheet is not sent unless you *open* the character menu, so it was removed

## Steps to test these changes

Change job to 75 BRD 
Equip Melody Earring -> Cast Valor Minuet -> See no +evasion skill gained
Unequip / Re-Equip -> see +evasion skill gained

Rebuild this PR

check again -> see +evasion skill gained without having to re-equip.
