### PR TITLE
[lua] Add Shadowreign support to An Explorer's Footsteps

### DIFF
--- a/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
+++ b/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
@@ -8,23 +8,31 @@ local quest = Quest:new(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.AN_EXPLO
 
 local monumentTable =
 {
-    [xi.zone.WEST_RONFAURE        ] = {  0,   800 }, -- !pos -183.734 -12.6798 -395.7220 100
-    [xi.zone.EAST_RONFAURE        ] = {  1,   800 }, -- !pos   77.277  -2.894  -517.3760 101
-    [xi.zone.LA_THEINE_PLATEAU    ] = {  2,  1000 }, -- !pos  334.133  50.6223  141.1630 102
-    [xi.zone.VALKURM_DUNES        ] = {  3,  1000 }, -- !pos -311.299  -4.4211 -138.8780 103
-    [xi.zone.JUGNER_FOREST        ] = {  4,  1000 }, -- !pos  -65.976 -23.8312 -661.3620 104
-    [xi.zone.BATALLIA_DOWNS       ] = {  5, 10000 }, -- !pos  185.669   9.0476 -614.0250 105
-    [xi.zone.NORTH_GUSTABERG      ] = {  6,  3000 }, -- !pos -199.635  96.0547  505.6240 106
-    [xi.zone.SOUTH_GUSTABERG      ] = {  7,   800 }, -- !pos  520.064  -5.8831 -738.3560 107
-    [xi.zone.KONSCHTAT_HIGHLANDS  ] = {  8,  1000 }, -- !pos -102.355   7.9796  253.7059 108
-    [xi.zone.PASHHOW_MARSHLANDS   ] = {  9,  1000 }, -- !pos -300.672  21.6038  304.1790 109
-    [xi.zone.ROLANBERRY_FIELDS    ] = { 10,  3000 }, -- !pos  362.479 -34.8962 -398.9940 110
-    [xi.zone.WEST_SARUTABARUTA    ] = { 11,   800 }, -- !pos -205.593 -23.2401 -119.6700 115
-    [xi.zone.EAST_SARUTABARUTA    ] = { 12,   800 }, -- !pos  448.045  -7.8100  319.9799 116
-    [xi.zone.TAHRONGI_CANYON      ] = { 13,  1000 }, -- !pos -499.189  12.6524  373.5920 117
-    [xi.zone.BUBURIMU_PENINSULA   ] = { 14,  1000 }, -- !pos  320.755  -4.0779  368.7219 118
-    [xi.zone.MERIPHATAUD_MOUNTAINS] = { 15,  1000 }, -- !pos  450.741   2.1088 -290.7359 119
-    [xi.zone.SAUROMUGUE_CHAMPAIGN ] = { 16, 10000 }, -- !pos   77.544  -2.7476 -184.8030 120
+    [xi.zone.WEST_RONFAURE          ] = {  0,   800 }, -- !pos -183.734 -12.6798 -395.7220 100
+    [xi.zone.EAST_RONFAURE          ] = {  1,   800 }, -- !pos   77.277  -2.894  -517.3760 101
+    [xi.zone.EAST_RONFAURE_S        ] = {  1,   800 }, -- !pos   77.277  -2.894  -517.3760  81
+    [xi.zone.LA_THEINE_PLATEAU      ] = {  2,  1000 }, -- !pos  334.133  50.6223  141.1630 102
+    [xi.zone.VALKURM_DUNES          ] = {  3,  1000 }, -- !pos -311.299  -4.4211 -138.8780 103
+    [xi.zone.JUGNER_FOREST          ] = {  4,  1000 }, -- !pos  -65.976 -23.8312 -661.3620 104
+    [xi.zone.JUGNER_FOREST_S        ] = {  4,  1000 }, -- !pos  -65.976 -23.8312 -661.3620  82
+    [xi.zone.BATALLIA_DOWNS         ] = {  5, 10000 }, -- !pos  185.669   9.0476 -614.0250 105
+    [xi.zone.BATALLIA_DOWNS_S       ] = {  5, 10000 }, -- !pos  185.669   9.0476 -614.0250  84
+    [xi.zone.NORTH_GUSTABERG        ] = {  6,  3000 }, -- !pos -199.635  96.0547  505.6240 106
+    [xi.zone.SOUTH_GUSTABERG        ] = {  7,   800 }, -- !pos  520.064  -5.8831 -738.3560 107
+    [xi.zone.KONSCHTAT_HIGHLANDS    ] = {  8,  1000 }, -- !pos -102.355   7.9796  253.7059 108
+    [xi.zone.PASHHOW_MARSHLANDS     ] = {  9,  1000 }, -- !pos -300.672  21.6038  304.1790 109
+    [xi.zone.PASHHOW_MARSHLANDS_S   ] = {  9,  1000 }, -- !pos -300.672  21.6038  304.1790  90
+    [xi.zone.ROLANBERRY_FIELDS      ] = { 10,  3000 }, -- !pos  362.479 -34.8962 -398.9940 110
+    [xi.zone.ROLANBERRY_FIELDS_S    ] = { 10,  3000 }, -- !pos  362.479 -34.8962 -398.9940  91
+    [xi.zone.WEST_SARUTABARUTA      ] = { 11,   800 }, -- !pos -205.593 -23.2401 -119.6700 115
+    [xi.zone.WEST_SARUTABARUTA_S    ] = { 11,   800 }, -- !pos -205.593 -23.2401 -119.6700  95
+    [xi.zone.EAST_SARUTABARUTA      ] = { 12,   800 }, -- !pos  448.045  -7.8100  319.9799 116
+    [xi.zone.TAHRONGI_CANYON        ] = { 13,  1000 }, -- !pos -499.189  12.6524  373.5920 117
+    [xi.zone.BUBURIMU_PENINSULA     ] = { 14,  1000 }, -- !pos  320.755  -4.0779  368.7219 118
+    [xi.zone.MERIPHATAUD_MOUNTAINS  ] = { 15,  1000 }, -- !pos  450.741   2.1088 -290.7359 119
+    [xi.zone.MERIPHATAUD_MOUNTAINS_S] = { 15,  1000 }, -- !pos  450.741   2.1088 -290.7359  97
+    [xi.zone.SAUROMUGUE_CHAMPAIGN   ] = { 16, 10000 }, -- !pos   77.544  -2.7476 -184.8030 120
+    [xi.zone.SAUROMUGUE_CHAMPAIGN_S ] = { 16, 10000 }, -- !pos   77.544  -2.7476 -184.8030  98
 }
 
 local function abelardAccept(player, option)
@@ -126,23 +134,31 @@ quest.sections =
         end,
 
         -- Monuments
-        [xi.zone.WEST_RONFAURE        ] = handleStoneMonument,
-        [xi.zone.EAST_RONFAURE        ] = handleStoneMonument,
-        [xi.zone.LA_THEINE_PLATEAU    ] = handleStoneMonument,
-        [xi.zone.VALKURM_DUNES        ] = handleStoneMonument,
-        [xi.zone.JUGNER_FOREST        ] = handleStoneMonument,
-        [xi.zone.BATALLIA_DOWNS       ] = handleStoneMonument,
-        [xi.zone.NORTH_GUSTABERG      ] = handleStoneMonument,
-        [xi.zone.SOUTH_GUSTABERG      ] = handleStoneMonument,
-        [xi.zone.KONSCHTAT_HIGHLANDS  ] = handleStoneMonument,
-        [xi.zone.PASHHOW_MARSHLANDS   ] = handleStoneMonument,
-        [xi.zone.ROLANBERRY_FIELDS    ] = handleStoneMonument,
-        [xi.zone.WEST_SARUTABARUTA    ] = handleStoneMonument,
-        [xi.zone.EAST_SARUTABARUTA    ] = handleStoneMonument,
-        [xi.zone.TAHRONGI_CANYON      ] = handleStoneMonument,
-        [xi.zone.BUBURIMU_PENINSULA   ] = handleStoneMonument,
-        [xi.zone.MERIPHATAUD_MOUNTAINS] = handleStoneMonument,
-        [xi.zone.SAUROMUGUE_CHAMPAIGN ] = handleStoneMonument,
+        [xi.zone.WEST_RONFAURE          ] = handleStoneMonument,
+        [xi.zone.EAST_RONFAURE          ] = handleStoneMonument,
+        [xi.zone.EAST_RONFAURE_S        ] = handleStoneMonument,
+        [xi.zone.LA_THEINE_PLATEAU      ] = handleStoneMonument,
+        [xi.zone.VALKURM_DUNES          ] = handleStoneMonument,
+        [xi.zone.JUGNER_FOREST          ] = handleStoneMonument,
+        [xi.zone.JUGNER_FOREST_S        ] = handleStoneMonument,
+        [xi.zone.BATALLIA_DOWNS         ] = handleStoneMonument,
+        [xi.zone.BATALLIA_DOWNS_S       ] = handleStoneMonument,
+        [xi.zone.NORTH_GUSTABERG        ] = handleStoneMonument,
+        [xi.zone.SOUTH_GUSTABERG        ] = handleStoneMonument,
+        [xi.zone.KONSCHTAT_HIGHLANDS    ] = handleStoneMonument,
+        [xi.zone.PASHHOW_MARSHLANDS     ] = handleStoneMonument,
+        [xi.zone.PASHHOW_MARSHLANDS_S   ] = handleStoneMonument,
+        [xi.zone.ROLANBERRY_FIELDS      ] = handleStoneMonument,
+        [xi.zone.ROLANBERRY_FIELDS_S    ] = handleStoneMonument,
+        [xi.zone.WEST_SARUTABARUTA      ] = handleStoneMonument,
+        [xi.zone.WEST_SARUTABARUTA_S    ] = handleStoneMonument,
+        [xi.zone.EAST_SARUTABARUTA      ] = handleStoneMonument,
+        [xi.zone.TAHRONGI_CANYON        ] = handleStoneMonument,
+        [xi.zone.BUBURIMU_PENINSULA     ] = handleStoneMonument,
+        [xi.zone.MERIPHATAUD_MOUNTAINS  ] = handleStoneMonument,
+        [xi.zone.MERIPHATAUD_MOUNTAINS_S] = handleStoneMonument,
+        [xi.zone.SAUROMUGUE_CHAMPAIGN   ] = handleStoneMonument,
+        [xi.zone.SAUROMUGUE_CHAMPAIGN_S ] = handleStoneMonument,
 
         -- Quest giver
         [xi.zone.SELBINA] =

--- a/scripts/tests/quests/an_explorers_footsteps.lua
+++ b/scripts/tests/quests/an_explorers_footsteps.lua
@@ -1,0 +1,125 @@
+-----------------------------------
+-- An Explorer's Footsteps (Quest ID: otherAreas.AN_EXPLORERS_FOOTSTEPS)
+--
+-- Regression coverage for issue #10817: Stone Monuments in Shadowreign (past-era
+-- "[S]") zones don't respond to the Lump of Selbina Clay, even though retail lets
+-- you press the same monument in the past and turn the tablet in for credit.
+--
+-- Retail model (ffxiclopedia / bg-wiki, cross-checked against npc_list.sql coords):
+--   * 17 present-day monuments = the 17 quest slots.
+--   * 8 [S] zones hold the SAME monument as a present-day slot; Abelard credits
+--     them identically (Batallia Downs [S] -> slot 5, the zone in the issue).
+--   * 3 [S]-only zones (Vunkerl Inlet, Grauberg, Fort Karugo-Narugo) are NOT part
+--     of the quest -- pressing clay there yields no tablet according to ffxiclopedia.
+--
+-- Batallia's present-day monument slot index is 5 (xi.zone.BATALLIA_DOWNS in the
+-- quest's monumentTable). Both the present-day and [S] tablet must credit slot 5.
+-----------------------------------
+local batalliaSlot = 5
+
+describe("Quest: An Explorer's Footsteps", function()
+    ---@type CClientEntityPair
+    local player
+
+    -- Drop the player straight into the accepted state (activates the monument
+    -- section), unlock the past so [S] zone-ins don't collide with an expansion
+    -- cutscene (mirrors tests/missions/wotg.lua), and hand over one fresh clay.
+    local function acceptedWithClay()
+        player = xi.test.world:spawnPlayer()
+        player:setLevel(99)
+        player:addMission(xi.mission.log_id.ASA, xi.mission.id.asa.BURGEONING_DREAD)
+        player:addMission(xi.mission.log_id.ACP, xi.mission.id.acp.A_CRYSTALLINE_PROPHECY_FIN)
+        player:addMission(xi.mission.log_id.ROV, xi.mission.id.rov.A_RHAPSODY_FOR_THE_AGES)
+        player:addMission(xi.mission.log_id.SOA, xi.mission.id.soa.ABOMINATION)
+
+        player:addQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.AN_EXPLORERS_FOOTSTEPS)
+        player:addItem({ id = xi.item.LUMP_OF_SELBINA_CLAY, quantity = 1 })
+    end
+
+    -- Press the clay into the Stone Monument in the current zone.
+    local function pressClayAtMonument()
+        player.actions:tradeNpc('Stone_Monument', { xi.item.LUMP_OF_SELBINA_CLAY })
+    end
+
+    -- Turn the resulting Clay Tablet in to Abelard in Selbina. With TargetMonument
+    -- unset (0) and Batallia = slot 5, the "different monument than requested"
+    -- branch fires -> event 46, finished with option 0 (no follow-up/abort).
+    local function turnInToAbelard()
+        player:gotoZone(xi.zone.SELBINA)
+        player.actions:tradeNpc('Abelard', { xi.item.CLAY_TABLET }, { eventId = 46, finishOption = 0 })
+    end
+
+    before_each(function()
+        acceptedWithClay()
+    end)
+
+    -- Tier 1 (control): the present-day monument already works end to end.
+    it('credits the Batallia Downs monument tablet (present day)', function()
+        player:gotoZone(xi.zone.BATALLIA_DOWNS)
+        pressClayAtMonument()
+        player.assert:hasItem(xi.item.CLAY_TABLET)
+        player.assert.no:hasItem(xi.item.LUMP_OF_SELBINA_CLAY)
+
+        turnInToAbelard()
+        player.assert.no:hasItem(xi.item.CLAY_TABLET)
+        assert(player:getCharVar('[EF]MonumentCount') == 1, 'present-day tablet was not credited')
+        assert(utils.mask.getBit(player:getCharVar('[EF]MonumentBitmask'), batalliaSlot),
+            'present-day tablet credited the wrong monument slot')
+    end)
+
+    -- Tier 2 (#10817): the Shadowreign monument must behave identically.
+    -- FAILS on base -- the [S] monument gives no tablet, so there is nothing to
+    -- turn in and no credit is recorded.
+    it('credits the Batallia Downs (S) Shadowreign monument tablet identically', function()
+        player:gotoZone(xi.zone.BATALLIA_DOWNS_S)
+        pressClayAtMonument()
+        player.assert:hasItem(xi.item.CLAY_TABLET)
+        player.assert.no:hasItem(xi.item.LUMP_OF_SELBINA_CLAY)
+
+        turnInToAbelard()
+        player.assert.no:hasItem(xi.item.CLAY_TABLET)
+        assert(player:getCharVar('[EF]MonumentCount') == 1, 'Shadowreign tablet was not credited')
+        assert(utils.mask.getBit(player:getCharVar('[EF]MonumentBitmask'), batalliaSlot),
+            'Shadowreign tablet credited the wrong monument slot')
+    end)
+
+    -- Tier 3 (guard against over-reach): a [S]-only monument is not part of the
+    -- quest. Pressing clay must give no tablet and consume nothing. Passes on base
+    -- today and must keep passing after the fix.
+    it('leaves the Fort Karugo-Narugo (S) monument inert (not a quest monument)', function()
+        player:gotoZone(xi.zone.FORT_KARUGO_NARUGO_S)
+        pressClayAtMonument()
+        player.assert.no:hasItem(xi.item.CLAY_TABLET)
+        player.assert:hasItem(xi.item.LUMP_OF_SELBINA_CLAY)
+    end)
+
+    -- The two Batallia monuments are ONE slot, so a player who collected present-day Batallia can't double-dip via [S].
+    it('treats Batallia Downs and Batallia Downs (S) as one monument (no double credit)', function()
+        player:gotoZone(xi.zone.BATALLIA_DOWNS)
+        pressClayAtMonument()
+        turnInToAbelard()
+        assert(player:getCharVar('[EF]MonumentCount') == 1, 'present-day Batallia was not credited')
+
+        -- Same monument in the past -> Abelard rejects it as already-collected (event 45)
+        -- and hands the clay back instead of counting slot 5 a second time.
+        player:addItem({ id = xi.item.LUMP_OF_SELBINA_CLAY, quantity = 1 })
+        player:gotoZone(xi.zone.BATALLIA_DOWNS_S)
+        pressClayAtMonument()
+        player.assert:hasItem(xi.item.CLAY_TABLET)
+        player:gotoZone(xi.zone.SELBINA)
+        player.actions:tradeNpc('Abelard', { xi.item.CLAY_TABLET }, { eventId = 45, finishOption = 0 })
+        assert(player:getCharVar('[EF]MonumentCount') == 1, 'Batallia [S] double-credited an already-collected monument')
+    end)
+
+    -- Part B: examining a monument reads its inscription (event 900). Present-day works today.
+    it('reads the inscription (event 900) at the present-day Batallia monument', function()
+        player:gotoZone(xi.zone.BATALLIA_DOWNS)
+        player.entities:gotoAndTrigger('Stone_Monument', { eventId = 900 })
+    end)
+
+    -- Part B: the Shadowreign monument must read its inscription too. FAILS until DefaultActions is wired.
+    it('reads the inscription (event 900) at the Batallia Downs (S) monument', function()
+        player:gotoZone(xi.zone.BATALLIA_DOWNS_S)
+        player.entities:gotoAndTrigger('Stone_Monument', { eventId = 900 })
+    end)
+end)

--- a/scripts/zones/Batallia_Downs_[S]/DefaultActions.lua
+++ b/scripts/zones/Batallia_Downs_[S]/DefaultActions.lua
@@ -5,6 +5,7 @@ return {
     ['qm_maw']          = { messageSpecial = ID.text.NOTHING_HAPPENS },
     ['Eberhard']        = { event = 113 },
     ['Romualdo']        = { event = 102 },
+    ['Stone_Monument']  = { event = 900 },
     ['Thorben']         = { event = 108 },
     ['Underpass_Hatch'] = { messageSpecial = ID.text.NO_RESPONSE },
 }

--- a/scripts/zones/East_Ronfaure_[S]/DefaultActions.lua
+++ b/scripts/zones/East_Ronfaure_[S]/DefaultActions.lua
@@ -1,8 +1,9 @@
 local ID = zones[xi.zone.EAST_RONFAURE_S]
 
 return {
-    ['qm3']        = { event = 4 },
-    ['qm4']        = { event = 5 },
-    ['qm5']        = { event = 6 },
-    ['blank_cait'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm3']            = { event =   4 },
+    ['qm4']            = { event =   5 },
+    ['qm5']            = { event =   6 },
+    ['blank_cait']     = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Stone_Monument'] = { event = 900 },
 }

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/DefaultActions.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/DefaultActions.lua
@@ -1,5 +1,6 @@
 local ID = zones[xi.zone.FORT_KARUGO_NARUGO_S]
 
 return {
-    ['qm4'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm4']            = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Stone_Monument'] = { event = 900 },
 }

--- a/scripts/zones/Grauberg_[S]/DefaultActions.lua
+++ b/scripts/zones/Grauberg_[S]/DefaultActions.lua
@@ -5,8 +5,9 @@ return {
     ['qm2']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm3']               = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['qm_reset']          = { messageSpecial = ID.text.AIR_WARPED_AND_DISTORTED },
-    ['Emmerich']          = { event =  8 },
-    ['Vanja']             = { event =  9 },
-    ['Childerich']        = { event = 10 },
+    ['Emmerich']          = { event =   8 },
+    ['Stone_Monument']    = { event = 900 },
+    ['Vanja']             = { event =   9 },
+    ['Childerich']        = { event =  10 },
     ['Veridical_Conflux'] = { messageSpecial = ID.text.MYSTERIOUS_COLUMN_ROTATES },
 }

--- a/scripts/zones/Jugner_Forest_[S]/DefaultActions.lua
+++ b/scripts/zones/Jugner_Forest_[S]/DefaultActions.lua
@@ -9,4 +9,5 @@ return {
     ['Gate Sentry']        = { event = 253 },
     ['Glowing_Pebbles']    = { messageSpecial = ID.text.YOU_FIND_SPARKLING_STONE },
     ['Mossy_Stump']        = { messageSpecial = ID.text.NO_RESPONSE },
+    ['Stone_Monument']     = { event = 900 },
 }

--- a/scripts/zones/Meriphataud_Mountains_[S]/DefaultActions.lua
+++ b/scripts/zones/Meriphataud_Mountains_[S]/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.MERIPHATAUD_MOUNTAINS_S]
+
+return {
+    ['Stone_Monument'] = { event = 900 },
+}

--- a/scripts/zones/Pashhow_Marshlands_[S]/DefaultActions.lua
+++ b/scripts/zones/Pashhow_Marshlands_[S]/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.PASHHOW_MARSHLANDS_S]
+
+return {
+    ['Stone_Monument'] = { event = 900 },
+}

--- a/scripts/zones/Rolanberry_Fields_[S]/DefaultActions.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/DefaultActions.lua
@@ -4,4 +4,5 @@ return {
     ['qm_maw']          = { messageSpecial = ID.text.NOTHING_HAPPENS },
     ['Merim-Kurim']     = { messageSpecial = ID.text.I_CANNOT_HELP_YOU_NOW },
     ['Rakula-Motakula'] = { messageSpecial = ID.text.I_CANNOT_HELP_YOU_NOW },
+    ['Stone_Monument']  = { event = 900 },
 }

--- a/scripts/zones/Sauromugue_Champaign_[S]/DefaultActions.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/DefaultActions.lua
@@ -1,6 +1,7 @@
 local ID = zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S]
 
 return {
-    ['qm_maw']       = { messageSpecial = ID.text.NOTHING_HAPPENS },
-    ['Bulwark_Gate'] = { messageSpecial = ID.text.DOOR_FIRMLY_SEALED },
+    ['qm_maw']         = { messageSpecial = ID.text.NOTHING_HAPPENS },
+    ['Bulwark_Gate']   = { messageSpecial = ID.text.DOOR_FIRMLY_SEALED },
+    ['Stone_Monument'] = { event = 900 },
 }

--- a/scripts/zones/Vunkerl_Inlet_[S]/DefaultActions.lua
+++ b/scripts/zones/Vunkerl_Inlet_[S]/DefaultActions.lua
@@ -3,6 +3,7 @@ local ID = zones[xi.zone.VUNKERL_INLET_S]
 return {
     ['Leadavox']          = { event = 100 },
     ['Leafy_Patch']       = { event = 106 },
+    ['Stone_Monument']    = { event = 900 },
     ['Toppled_Cresset_1'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Toppled_Cresset_2'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Underbrush']        = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },

--- a/scripts/zones/West_Sarutabaruta_[S]/DefaultActions.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/DefaultActions.lua
@@ -1,0 +1,5 @@
+-- local ID = zones[xi.zone.WEST_SARUTABARUTA_S]
+
+return {
+    ['Stone_Monument'] = { event = 900 },
+}


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #10817.

The Stone Monuments for *An Explorer's Footsteps* only functioned in present-day zones. In the Wings of the Goddess past ("[S]") zones the monuments were targetable but inert — trading Selbina Clay produced no Clay Tablet, and examining them showed no inscription.

Retail behavior (ffxiclopedia / bg-wiki, cross-checked against the monument coordinates in `npc_list.sql`):

- **8 [S] zones hold the same monument as a present-day slot** — East Ronfaure, Jugner Forest, Batallia Downs, Pashhow Marshlands, Rolanberry Fields, West Sarutabaruta, Meriphataud Mountains, Sauromugue Champaign. Each is mapped to its present-day twin's slot index and gil, so Abelard credits the tablet identically — and a player can't double-dip the same monument across eras.
- **The 3 [S]-only zones** — Vunkerl Inlet, Grauberg, Fort Karugo-Narugo — are not part of the quest and are left inert. *Note:* the wikis disagree on the clay trade at these: bg-wiki says you get a useless tablet Abelard won't accept, ffxiclopedia says you get no tablet at all. I kept the conservative "no tablet" (matches current behavior); happy to change it if a reviewer has a retail capture either way.
- **Examining any monument reads its inscription (event 900).** Wired into `DefaultActions.lua` for all 11 [S] zones. Verified in-game that event 900 renders in Batallia Downs [S] and all three past-only zones.

Includes an `xi_test` suite covering present-day credit, [S] credit, the no-double-credit rule, the inert orphan, and the inscription trigger.

## Steps to test these changes

**Automated:**
- `./xi_test --filter "An Explorer's Footsteps"` — 6 cases pass.

**Manual (in-game):**
1. Start *An Explorer's Footsteps* from Abelard in Selbina and obtain Selbina Clay.
2. Travel to a Shadowreign twin zone (e.g. Batallia Downs [S]) and **examine** the Stone Monument → the inscription plays.
3. **Trade** the Selbina Clay to it → receive a Clay Tablet.
4. Return to Abelard and trade the tablet → credited identically to the present-day Batallia Downs monument (10,000g).
5. Examine a monument in a [S]-only zone (Vunkerl Inlet / Grauberg / Fort Karugo-Narugo) → the inscription plays, but trading clay does nothing (not a quest monument).
