### PR TITLE
[tools] Custom YAML formatter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,8 @@
 *.h text eol=lf
 *.sql text eol=lf
 *.sh text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
 
 # Retaining CRLF line ends in the documentation dir (for now..)
 *.txt text eol=crlf

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -196,31 +196,50 @@ jobs:
         id: changed
         run: |
           mapfile -t changed_files < changed-files.txt
-          data_files=()
+          yaml_files=()
+          other_files=()
           for f in "${changed_files[@]}"; do
-            if [[ $f == data/* ]]; then
-              data_files+=("$f")
+            if [[ $f == data/*.yaml || $f == data/*.yml ]]; then
+              yaml_files+=("$f")
+            elif [[ $f == data/* ]]; then
+              other_files+=("$f")
             fi
           done
-          echo "files=${data_files[*]}" >> "$GITHUB_OUTPUT"
-          echo "Changed data files: ${data_files[*]}"
+          echo "yaml=${yaml_files[*]}" >> "$GITHUB_OUTPUT"
+          echo "other=${other_files[*]}" >> "$GITHUB_OUTPUT"
+          echo "Changed YAML: ${yaml_files[*]}"
+          echo "Changed other: ${other_files[*]}"
 
       - uses: actions/checkout@v6
-        if: steps.changed.outputs.files != ''
+        if: steps.changed.outputs.yaml != '' || steps.changed.outputs.other != ''
+
+      - name: Setup Python
+        if: steps.changed.outputs.yaml != ''
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Install Python dependencies
+        if: steps.changed.outputs.yaml != ''
+        run: python -m pip install pyyaml ruamel.yaml
+
+      - name: Check YAML formatting
+        if: steps.changed.outputs.yaml != ''
+        run: python tools/yaml/format.py ${{ steps.changed.outputs.yaml }} --check
 
       - name: Cache prettier results
-        if: steps.changed.outputs.files != ''
+        if: steps.changed.outputs.other != ''
         uses: actions/cache@v5
         with:
           path: /tmp/prettier-cache
-          key: prettier-cache-${{ hashFiles('data/**/*.yaml', 'data/**/*.json') }}
+          key: prettier-cache-${{ hashFiles('data/**/*.json') }}
           restore-keys: prettier-cache-
 
       - name: Run prettier
-        if: steps.changed.outputs.files != ''
+        if: steps.changed.outputs.other != ''
         run: |
           set +e
-          FAILED=$(npx --yes prettier@3 --cache --cache-strategy content --cache-location /tmp/prettier-cache --list-different ${{ steps.changed.outputs.files }})
+          FAILED=$(npx --yes prettier@3 --cache --cache-strategy content --cache-location /tmp/prettier-cache --list-different ${{ steps.changed.outputs.other }})
           set -e
           if [ -z "$FAILED" ]; then
             echo "All files use Prettier code style!"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,10 @@
 *.codegen.json
 *.codegen.lua
 
+# YAML is formatted by tools/yaml/format.py
+*.yaml
+*.yml
+
 build/
 build*/
 cmake-*/

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,14 +2,5 @@
   "tabWidth": 2,
   "useTabs": false,
   "printWidth": 120,
-  "endOfLine": "lf",
-  "overrides": [
-    {
-      "files": ["**/*.yaml", "**/*.yml"],
-      "options": {
-        "singleQuote": false,
-        "bracketSpacing": true
-      }
-    }
-  ]
+  "endOfLine": "lf"
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -13,6 +13,7 @@
         "jeff-hykin.better-cpp-syntax",
         "bierner.github-markdown-preview",
         "esbenp.prettier-vscode",
-        "redhat.vscode-yaml"
+        "redhat.vscode-yaml",
+        "jkillian.custom-local-formatters"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -356,12 +356,19 @@
         "editor.formatOnSave": true
     },
     "[yaml]": {
-        "editor.defaultFormatter": "esbenp.prettier-vscode"
+        "editor.defaultFormatter": "jkillian.custom-local-formatters",
+        "editor.formatOnSave": true
     },
     "[json]": {
         "editor.defaultFormatter": "esbenp.prettier-vscode"
     },
     "yaml.format.enable": false,
+    "customLocalFormatters.formatters": [
+        {
+            "command": "python tools/yaml/format.py --stdin",
+            "languages": ["yaml"]
+        }
+    ],
     "files.associations": {
         "algorithm": "cpp",
         "any": "cpp",

--- a/data/enums/allegiance.yaml
+++ b/data/enums/allegiance.yaml
@@ -7,10 +7,10 @@ meta:
     table: xi.allegiance
 
 values:
-  mob: 0
-  player: 1
+  mob:       0
+  player:    1
   san_doria: 2
-  bastok: 3
-  windurst: 4
-  wyverns: 5
-  griffons: 6
+  bastok:    3
+  windurst:  4
+  wyverns:   5
+  griffons:  6

--- a/data/enums/animation.yaml
+++ b/data/enums/animation.yaml
@@ -7,47 +7,47 @@ meta:
     table: xi.animation
 
 values:
-  none: 0
-  attack: 1
-  despawn: 2
-  death: 3
-  event: 4
-  chocobo: 5
-  fishing: 6
-  open_door: 8
-  close_door: 9
-  elevator_up: 10
-  elevator_down: 11
-  fishing_npc: 32
-  healing: 33
-  fishing_fish: 38
-  fishing_caught: 39
-  fishing_rod_break: 40
-  fishing_line_break: 41
-  fishing_monster: 42
-  fishing_stop: 43
-  synth: 44
-  sit: 47
-  ranged: 48
-  fishing_start: 50
-  new_fishing_start: 56
-  new_fishing_fish: 57
-  new_fishing_caught: 58
-  new_fishing_rod_break: 59
+  none:                   0
+  attack:                 1
+  despawn:                2
+  death:                  3
+  event:                  4
+  chocobo:                5
+  fishing:                6
+  open_door:              8
+  close_door:             9
+  elevator_up:            10
+  elevator_down:          11
+  fishing_npc:            32
+  healing:                33
+  fishing_fish:           38
+  fishing_caught:         39
+  fishing_rod_break:      40
+  fishing_line_break:     41
+  fishing_monster:        42
+  fishing_stop:           43
+  synth:                  44
+  sit:                    47
+  ranged:                 48
+  fishing_start:          50
+  new_fishing_start:      56
+  new_fishing_fish:       57
+  new_fishing_caught:     58
+  new_fishing_rod_break:  59
   new_fishing_line_break: 60
-  new_fishing_monster: 61
-  new_fishing_stop: 62
+  new_fishing_monster:    61
+  new_fishing_stop:       62
   # 63 through 73 are used with /sitchair
-  sitchair_0: 63
-  sitchair_1: 64
-  sitchair_2: 65
-  sitchair_3: 66
-  sitchair_4: 67
-  sitchair_5: 68
-  sitchair_6: 69
-  sitchair_7: 70
-  sitchair_8: 71
-  sitchair_9: 72
+  sitchair_0:  63
+  sitchair_1:  64
+  sitchair_2:  65
+  sitchair_3:  66
+  sitchair_4:  67
+  sitchair_5:  68
+  sitchair_6:  69
+  sitchair_7:  70
+  sitchair_8:  71
+  sitchair_9:  72
   sitchair_10: 73
-  mount: 85
-  trust: 90 # trust NPC spawn-in animation
+  mount:       85
+  trust:       90 # trust NPC spawn-in animation

--- a/data/enums/attack_type.yaml
+++ b/data/enums/attack_type.yaml
@@ -7,9 +7,9 @@ meta:
     table: xi.attackType
 
 values:
-  none: 0
+  none:     0
   physical: 1
-  magical: 2
-  ranged: 3
-  breath: 4
-  special: 5
+  magical:  2
+  ranged:   3
+  breath:   4
+  special:  5

--- a/data/enums/behavior.yaml
+++ b/data/enums/behavior.yaml
@@ -8,10 +8,10 @@ meta:
     table: xi.behavior
 
 values:
-  none: 0x000
-  no_despawn: 0x001 # mob does not despawn on death
-  standback: 0x002 # mob will standback forever
-  raisable: 0x004 # mob can be raised via Raise spells
-  no_assist: 0x008 # mob can not be targeted by helpful magic from players (cure, protect, etc)
+  none:         0x000
+  no_despawn:   0x001 # mob does not despawn on death
+  standback:    0x002 # mob will standback forever
+  raisable:     0x004 # mob can be raised via Raise spells
+  no_assist:    0x008 # mob can not be targeted by helpful magic from players (cure, protect, etc)
   aggro_ambush: 0x200 # mob aggroes by ambush
-  no_turn: 0x400 # mob does not turn to face target
+  no_turn:      0x400 # mob does not turn to face target

--- a/data/enums/claim_type.yaml
+++ b/data/enums/claim_type.yaml
@@ -7,6 +7,6 @@ meta:
     table: xi.claimType
 
 values:
-  exclusive: 0 # Regular exclusive claim behavior. Only one entity and related group can attack.
+  exclusive:     0 # Regular exclusive claim behavior. Only one entity and related group can attack.
   non_exclusive: 1 # Regular claim behavior but multiple unrelated entities can attack and compete for claim. Rewards distributed to last claiming entity.
-  unclaimable: 2 # Mob cannot be claimed. Multiple unrelated entities can attack. Rewards will not be distributed.
+  unclaimable:   2 # Mob cannot be claimed. Multiple unrelated entities can attack. Rewards will not be distributed.

--- a/data/enums/damage_type.yaml
+++ b/data/enums/damage_type.yaml
@@ -7,17 +7,17 @@ meta:
     table: xi.damageType
 
 values:
-  none: 0
-  piercing: 1
-  slashing: 2
-  blunt: 3
+  none:         0
+  piercing:     1
+  slashing:     2
+  blunt:        3
   hand_to_hand: 4
-  elemental: 5
-  fire: 6
-  ice: 7
-  wind: 8
-  earth: 9
-  thunder: 10
-  water: 11
-  light: 12
-  dark: 13
+  elemental:    5
+  fire:         6
+  ice:          7
+  wind:         8
+  earth:        9
+  thunder:      10
+  water:        11
+  light:        12
+  dark:         13

--- a/data/enums/detects.yaml
+++ b/data/enums/detects.yaml
@@ -8,14 +8,14 @@ meta:
     table: xi.detects
 
 values:
-  none: 0x000
-  sight: 0x001
-  hearing: 0x002
+  none:              0x000
+  sight:             0x001
+  hearing:           0x002
   sight_and_hearing: 0x003
-  lowhp: 0x004
-  none1: 0x008
-  none2: 0x010
-  magic: 0x020
-  weaponskill: 0x040
-  jobability: 0x080
-  scent: 0x100
+  lowhp:             0x004
+  none1:             0x008
+  none2:             0x010
+  magic:             0x020
+  weaponskill:       0x040
+  jobability:        0x080
+  scent:             0x100

--- a/data/enums/ecosystem.yaml
+++ b/data/enums/ecosystem.yaml
@@ -7,26 +7,26 @@ meta:
     table: xi.ecosystem
 
 values:
-  unclassified: 0
-  amorph: 1
-  aquan: 2
-  arcana: 3
+  unclassified:    0
+  amorph:          1
+  aquan:           2
+  arcana:          3
   archaic_machine: 4
-  beast: 5
-  beastmen: 6
-  bird: 7
-  demon: 8
-  dragon: 9
-  elemental: 10
-  empty: 11
-  humanoid: 12
-  lizard: 13
-  luminian: 14
-  luminion: 15
-  plantoid: 16
-  supreme_beings: 17
-  undead: 18
-  vermin: 19
-  voragean: 20
-  structures: 21
-  weapons: 22
+  beast:           5
+  beastmen:        6
+  bird:            7
+  demon:           8
+  dragon:          9
+  elemental:       10
+  empty:           11
+  humanoid:        12
+  lizard:          13
+  luminian:        14
+  luminion:        15
+  plantoid:        16
+  supreme_beings:  17
+  undead:          18
+  vermin:          19
+  voragean:        20
+  structures:      21
+  weapons:         22

--- a/data/enums/effect_overwrite.yaml
+++ b/data/enums/effect_overwrite.yaml
@@ -7,9 +7,9 @@ meta:
     table: xi.effectOverwrite
 
 values:
-  equal_higher: 0 # only overwrite if equal or higher (tier, power)
-  higher: 1 # only overwrite if higher (tier, power)
-  never: 2 # never overwrite
-  always: 3 # always overwrite no matter
+  equal_higher:     0 # only overwrite if equal or higher (tier, power)
+  higher:           1 # only overwrite if higher (tier, power)
+  never:            2 # never overwrite
+  always:           3 # always overwrite no matter
   ignore_duplicate: 4 # ignore dupes
-  tier_higher: 5 # only overwrite if tier is higher (regardless of power)
+  tier_higher:      5 # only overwrite if tier is higher (regardless of power)

--- a/data/enums/element.yaml
+++ b/data/enums/element.yaml
@@ -7,12 +7,12 @@ meta:
     table: xi.element
 
 values:
-  none: 0
-  fire: 1
-  ice: 2
-  wind: 3
-  earth: 4
+  none:    0
+  fire:    1
+  ice:     2
+  wind:    3
+  earth:   4
   thunder: 5
-  water: 6
-  light: 7
-  dark: 8
+  water:   6
+  light:   7
+  dark:    8

--- a/data/enums/entity_flags.yaml
+++ b/data/enums/entity_flags.yaml
@@ -8,14 +8,14 @@ meta:
     table: xi.entityFlags
 
 values:
-  none: 0x000
+  none:      0x000
   info_icon: 0x001 # (I) Icon next to name
   # TODO: Flags 0x002, 0x004 and 0x008 do different things for different entities.
   #     : It isn't one-size-fits-all, and different combinations may do different things.
   #     : It'll need to be researched more.
   # alt_appearance: 0x002
-  hide_name: 0x008
+  hide_name:     0x008
   call_for_help: 0x020
-  hide_model: 0x080
-  hide_hp: 0x100
-  untargetable: 0x800
+  hide_model:    0x080
+  hide_hp:       0x100
+  untargetable:  0x800

--- a/data/enums/immunity.yaml
+++ b/data/enums/immunity.yaml
@@ -8,22 +8,22 @@ meta:
     table: xi.immunity
 
 values:
-  none: 0x00000000
-  addle: 0x00000001
-  gravity: 0x00000002
-  bind: 0x00000004
-  stun: 0x00000008
-  silence: 0x00000010
-  paralyze: 0x00000020
-  blind: 0x00000040
-  slow: 0x00000080
-  poison: 0x00000100
-  elegy: 0x00000200
-  requiem: 0x00000400
+  none:        0x00000000
+  addle:       0x00000001
+  gravity:     0x00000002
+  bind:        0x00000004
+  stun:        0x00000008
+  silence:     0x00000010
+  paralyze:    0x00000020
+  blind:       0x00000040
+  slow:        0x00000080
+  poison:      0x00000100
+  elegy:       0x00000200
+  requiem:     0x00000400
   light_sleep: 0x00000800
-  dark_sleep: 0x00001000
-  aspir: 0x00002000
-  terror: 0x00004000
-  dispel: 0x00008000
-  petrify: 0x00010000
-  plague: 0x00020000
+  dark_sleep:  0x00001000
+  aspir:       0x00002000
+  terror:      0x00004000
+  dispel:      0x00008000
+  petrify:     0x00010000
+  plague:      0x00020000

--- a/data/enums/latent.yaml
+++ b/data/enums/latent.yaml
@@ -7,69 +7,69 @@ meta:
     table: xi.latent
 
 values:
-  hp_under_percent: 0 # hp less than or equal to % - PARAM: HP PERCENT
-  hp_over_percent: 1 # hp more than % - PARAM: HP PERCENT
-  hp_under_tp_under_100: 2 # hp less than or equal to %, tp under 100 - PARAM: HP PERCENT
-  hp_over_tp_under_100: 3 # hp more than %, tp over 100 - PARAM: HP PERCENT
-  mp_under_percent: 4 # mp less than or equal to % - PARAM: MP PERCENT
-  mp_under: 5 # mp less than # - PARAM: MP #
-  tp_under: 6 # tp under # and during WS - PARAM: TP VALUE
-  tp_over: 7 # tp over # - PARAM: TP VALUE
-  subjob: 8 # subjob - PARAM: JOBTYPE
-  pet_id: 9 # pettype - PARAM: PETID
-  weapon_drawn: 10 # weapon drawn
-  weapon_sheathed: 11 # weapon sheathed
-  signet_bonus: 12 # While in conquest region and engaged to an even match or less target
-  status_effect_active: 13 # status effect on player - PARAM: EFFECTID
-  no_food_active: 14 # no food effects active on player
-  party_members: 15 # party size # - PARAM: # OF MEMBERS
-  party_members_in_zone: 16 # party size # and members in zone - PARAM: # OF MEMBERS
-  sanction_regen_bonus: 17 # While in besieged region and HP is less than PARAM%
+  hp_under_percent:       0  # hp less than or equal to % - PARAM: HP PERCENT
+  hp_over_percent:        1  # hp more than % - PARAM: HP PERCENT
+  hp_under_tp_under_100:  2  # hp less than or equal to %, tp under 100 - PARAM: HP PERCENT
+  hp_over_tp_under_100:   3  # hp more than %, tp over 100 - PARAM: HP PERCENT
+  mp_under_percent:       4  # mp less than or equal to % - PARAM: MP PERCENT
+  mp_under:               5  # mp less than # - PARAM: MP #
+  tp_under:               6  # tp under # and during WS - PARAM: TP VALUE
+  tp_over:                7  # tp over # - PARAM: TP VALUE
+  subjob:                 8  # subjob - PARAM: JOBTYPE
+  pet_id:                 9  # pettype - PARAM: PETID
+  weapon_drawn:           10 # weapon drawn
+  weapon_sheathed:        11 # weapon sheathed
+  signet_bonus:           12 # While in conquest region and engaged to an even match or less target
+  status_effect_active:   13 # status effect on player - PARAM: EFFECTID
+  no_food_active:         14 # no food effects active on player
+  party_members:          15 # party size # - PARAM: # OF MEMBERS
+  party_members_in_zone:  16 # party size # and members in zone - PARAM: # OF MEMBERS
+  sanction_regen_bonus:   17 # While in besieged region and HP is less than PARAM%
   sanction_refresh_bonus: 18 # While in besieged region and MP is less than PARAM%
-  sigil_regen_bonus: 19 # While in campaign region and HP is less than PARAM%
-  sigil_refresh_bonus: 20 # While in campaign region and MP is less than PARAM%
-  avatar_in_party: 21 # party has a specific avatar - PARAM: same as globals/pets.lua (21 for any avatar)
-  job_in_party: 22 # party has job - PARAM: JOBTYPE
-  zone: 23 # in zone - PARAM: zoneid
-  synth_trainee: 24 # synth skill under 40 + no support: PARAM: 48: FISH, 49: WOOD, 50: SMITH, 51: GOLDSMITH, 52: CLOTH, 53: LEATHER, 54: BONE, 55: ALCHEMY, 56: COOKING
-  song_roll_active: 25 # any song or roll active
-  time_of_day: 26 # PARAM: 0: DAYTIME 1: NIGHTTIME 2: DUSK-DAWN
-  hour_of_day: 27 # PARAM: 1: NEW DAY, 2: DAWN, 3: DAY, 4: DUSK, 5: EVENING, 6: DEAD OF NIGHT
-  firesday: 28
-  earthsday: 29
-  watersday: 30
-  windsday: 31
-  darksday: 32
-  iceday: 34
-  lightningsday: 35
-  lightsday: 36
-  moon_phase: 37 # PARAM: 0: New Moon, 1: Waxing Crescent, 2: First Quarter, 3: Waxing Gibbous, 4: Full Moon, 5: Waning Gibbous, 6: Last Quarter, 7: Waning Crescent
-  job_multiple: 38 # PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
-  job_multiple_at_night: 39 # PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
-  equipped_in_slot: 40 # When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
-  during_ws: 41 # During WS
-  weather_condition: 42 # See Weather.h for WEATHER enum
-  weapon_drawn_hp_under: 43 # PARAM: HP PERCENT
-  nation_citizen: 44 # Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
-  mp_under_visible_gear: 45 # mp less than or equal to %, calculated using MP bonuses from visible gear only
-  hp_over_visible_gear: 46 # hp more than or equal to %, calculated using HP bonuses from visible gear only
-  weapon_broken: 47
-  in_dynamis: 48
-  food_active: 49 # food effect (foodId) active - PARAM: FOOD ITEMID
-  job_level_below: 50 # PARAM: level
-  job_level_above: 51 # PARAM: level
-  weather_element: 52 # PARAM: 0: NONE, 1: FIRE, 2: ICE, 3: WIND 4: EARTH, 5: THUNDER, 6: WATER, 7: LIGHT, 8: DARK
-  nation_control: 53 # checks if player region is under nation's control - PARAM: 0: Under own nation's control, 1: Outside own nation's control
-  zone_home_nation: 54 # in zone and citizen of nation (aketons)
-  mp_over: 55 # mp greater than # - PARAM: MP #
-  weapon_drawn_mp_over: 56 # while weapon is drawn and mp greater than # - PARAM: MP #
-  eleven_roll_active: 57 # corsair roll of 11 active
-  in_assault: 58 # is in an Instance battle in a TOAU zone
-  vs_ecosystem: 59 # Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
-  vs_species: 60 # Vs. Specific Species ID (e.g. Vs. Korrigan: Accuracy+3)
-  vs_family: 61 # Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
-  mainjob: 62 # mainjob - PARAM: JOBTYPE
-  in_adoulin: 63
-  in_garrison: 64 # while in an active Garrison
-  sanction_food_bonus: 65 # While in besieged region
-  sigil_food_bonus: 66 # While in campaign region
+  sigil_regen_bonus:      19 # While in campaign region and HP is less than PARAM%
+  sigil_refresh_bonus:    20 # While in campaign region and MP is less than PARAM%
+  avatar_in_party:        21 # party has a specific avatar - PARAM: same as globals/pets.lua (21 for any avatar)
+  job_in_party:           22 # party has job - PARAM: JOBTYPE
+  zone:                   23 # in zone - PARAM: zoneid
+  synth_trainee:          24 # synth skill under 40 + no support: PARAM: 48: FISH, 49: WOOD, 50: SMITH, 51: GOLDSMITH, 52: CLOTH, 53: LEATHER, 54: BONE, 55: ALCHEMY, 56: COOKING
+  song_roll_active:       25 # any song or roll active
+  time_of_day:            26 # PARAM: 0: DAYTIME 1: NIGHTTIME 2: DUSK-DAWN
+  hour_of_day:            27 # PARAM: 1: NEW DAY, 2: DAWN, 3: DAY, 4: DUSK, 5: EVENING, 6: DEAD OF NIGHT
+  firesday:               28
+  earthsday:              29
+  watersday:              30
+  windsday:               31
+  darksday:               32
+  iceday:                 34
+  lightningsday:          35
+  lightsday:              36
+  moon_phase:             37 # PARAM: 0: New Moon, 1: Waxing Crescent, 2: First Quarter, 3: Waxing Gibbous, 4: Full Moon, 5: Waning Gibbous, 6: Last Quarter, 7: Waning Crescent
+  job_multiple:           38 # PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
+  job_multiple_at_night:  39 # PARAM: 0: ODD, 2: EVEN, 3-X: DIVISOR
+  equipped_in_slot:       40 # When item is equipped in the specified slot (e.g. Dweomer Knife, Erlking's Sword, etc.) PARAM: slotID
+  during_ws:              41 # During WS
+  weather_condition:      42 # See Weather.h for WEATHER enum
+  weapon_drawn_hp_under:  43 # PARAM: HP PERCENT
+  nation_citizen:         44 # Triggered by player being citizen of nation matching param: 0 San d'Oria, 1 Bastok, 2 Windurst
+  mp_under_visible_gear:  45 # mp less than or equal to %, calculated using MP bonuses from visible gear only
+  hp_over_visible_gear:   46 # hp more than or equal to %, calculated using HP bonuses from visible gear only
+  weapon_broken:          47
+  in_dynamis:             48
+  food_active:            49 # food effect (foodId) active - PARAM: FOOD ITEMID
+  job_level_below:        50 # PARAM: level
+  job_level_above:        51 # PARAM: level
+  weather_element:        52 # PARAM: 0: NONE, 1: FIRE, 2: ICE, 3: WIND 4: EARTH, 5: THUNDER, 6: WATER, 7: LIGHT, 8: DARK
+  nation_control:         53 # checks if player region is under nation's control - PARAM: 0: Under own nation's control, 1: Outside own nation's control
+  zone_home_nation:       54 # in zone and citizen of nation (aketons)
+  mp_over:                55 # mp greater than # - PARAM: MP #
+  weapon_drawn_mp_over:   56 # while weapon is drawn and mp greater than # - PARAM: MP #
+  eleven_roll_active:     57 # corsair roll of 11 active
+  in_assault:             58 # is in an Instance battle in a TOAU zone
+  vs_ecosystem:           59 # Vs. Specific Ecosystem ID (e.g. Vs. Plantoid: Accuracy+3)
+  vs_species:             60 # Vs. Specific Species ID (e.g. Vs. Korrigan: Accuracy+3)
+  vs_family:              61 # Vs. Specific Family ID (e.g. Vs. Mandragora: Accuracy+3)
+  mainjob:                62 # mainjob - PARAM: JOBTYPE
+  in_adoulin:             63
+  in_garrison:            64 # while in an active Garrison
+  sanction_food_bonus:    65 # While in besieged region
+  sigil_food_bonus:       66 # While in campaign region

--- a/data/enums/mob_mod.yaml
+++ b/data/enums/mob_mod.yaml
@@ -7,101 +7,101 @@ meta:
     table: xi.mobMod
 
 values:
-  none: 0
-  gil_min: 1 # minimum gil drop -- spawn mod only
-  gil_max: 2 # maximum gil drop -- spawn mod only
-  mp_base: 3 # Give mob mp. Used for mobs that are not mages, wyverns, avatars
-  sight_range: 4 # sight range
-  sound_range: 5 # sound range
-  buff_chance: 6 # % chance to buff (combat only)
-  ga_chance: 7 # % chance to use -ga spell
-  heal_chance: 8 # % chance to use heal
-  hp_heal_chance: 9 # can cast cures below this HP %
-  sublink: 10 # Sub link group. Enables mobs from different families to link if they share a SUBLINK value.
-  link_radius: 11 # link radius
-  sees_through_illusion: 12 # Mob can see through the Illusion effect that grants effects similar to Sneak & Invisible without this mod and allows aggro (see Viscious Liquid in mamook)
-  severe_spell_chance: 13 # % chance to use a severe spell like death or impact
-  skill_list: 14 # uses given mob skill list
-  mug_gil: 15 # amount gil carried for mugging
-  detection: 16 # Overrides mob family's detection method. In order to set to override to none an unused bit must be set such as xi::Detects::None1.
-  no_despawn: 17 # do not despawn when too far from spawn. Gob Diggers have this.
-  var: 18 # temp var for whatever. Gets cleared on spawn
-  can_shield_block: 19 # toggle shield use for mobs without physical shields (trusts)
-  no_h2h_penalty: 20 # Disables H2H penalty in base damage calculation when set to non-zero
-  pet_spell_list: 21 # set pet spell list
-  na_chance: 22 # % chance to cast -na
-  immunity: 23 # immune to set status effects. This only works from the db, not scripts
-  gradual_rage: 24 # (!) TODO: NOT YET IMPLEMENTED -- gradually rages
-  build_resist: 25 # (!) TODO: NOT YET IMPLEMENTED -- builds resistance to given effects
-  superlink: 26 # super link group. Only use this in scripts! Must be defined in onMobInitialize if relevant mobs are different families
-  spell_list: 27 # set spell list
-  exp_bonus: 28 # bonus exp (bonus / 100) negative values reduce exp.
-  assist: 29 # mobs will assist me
-  special_skill: 30 # give special skill
-  roam_distance: 31 # distance allowed to roam from spawn
-  dont_roam_home: 32 # Allow mobs to roam any distance from spawn. Useful for mobs with scripted roaming behavior.
-  special_cool: 33 # cool down for special
-  magic_cool: 34 # cool down for magic
-  standback_cool: 35 # cool down time for standing back (casting spell while not in attack range)
-  roam_cool: 36 # cool down time in seconds after roaming
-  always_aggro: 37 # aggro regardless of level. Spheroids
-  no_drops: 38 # If set monster cannot drop any items, not even seals.
-  share_pos: 39 # share a pos with another mob (eald'narche exoplates)
-  teleport_cd: 40 # cooldown for teleport abilities (tarutaru AA, angra mainyu, eald'narche)
-  teleport_start: 41 # mobskill ID to begin teleport
-  teleport_end: 42 # mobskill ID to end teleport
-  teleport_type: 43 # teleport type - 1: on cooldown, 2 - to close distance
-  dual_wield: 44 # enables a mob to use their offhand in attacks
-  add_effect: 45 # enables additional effect script to process on mobs attacks
-  auto_spikes: 46 # enables additional effect script to process when mob is attacked
-  spawn_leash: 47 # forces a mob to not move farther from its spawn than its leash distance
-  share_target: 48 # mob always targets same target as ID in this var
-  check_as_nm: 49 # If set , mob will check as a NM
-  roam_reset_facing: 50 # Resume facing the default spawn rotation after roaming home.
-  roam_turns: 51 # Maximum amount of turns during a roam
-  roam_rate: 52 # Roaming frequency. roam_cool - rand(roam_cool / (roam_rate / 10))
-  behavior: 53 # Add behaviors to mob
-  gil_bonus: 54 # Allow mob to drop gil. Multiplier to gil dropped by mob (bonus / 100) * total
-  idle_despawn: 55 # Time (in seconds) to despawn after being idle
-  hp_standback: 56 # mob will always standback with hp % higher to value
-  magic_delay: 57 # Amount of seconds mob waits before casting first spell
-  special_delay: 58 # Amount of seconds mob waits before using first special
-  base_damage_modifier: 59 # Add a flat modifer mob a mob's base damage. This is subject to multiplication by MOBMOD_BASE_DAMAGE_MULTIPLIER.
-  spawn_animationsub: 60 # reset animationsub to this on spawn
-  hp_scale: 61 # Scale the mobs max HP. ( hp_scale / 100 ) * maxhp
-  no_standback: 62 # Mob will never standback
-  attack_skill_list: 63 # skill list to use in place of regular attacks
-  charmable: 64 # mob is charmable
-  no_move: 65 # Mob will not be able to move
-  multi_hit: 66 # Mob will have as many swings as defined.
-  no_aggro: 67 # If set, mob cannot aggro until unset.
-  alli_hate: 68 # Range around target to add alliance member to enmity list.
-  no_link: 69 # If set, mob cannot link until unset.
-  no_rest: 70 # Mob cannot regain hp (e.g. re-burrowing antlions during ENM).
-  leader: 71 # Used for mob following. Positive number is how many followers a leader has. A negative number is the distance from this mob ID to the leader ID.
-  magic_range: 72 # magic aggro range
+  none:                   0
+  gil_min:                1  # minimum gil drop -- spawn mod only
+  gil_max:                2  # maximum gil drop -- spawn mod only
+  mp_base:                3  # Give mob mp. Used for mobs that are not mages, wyverns, avatars
+  sight_range:            4  # sight range
+  sound_range:            5  # sound range
+  buff_chance:            6  # % chance to buff (combat only)
+  ga_chance:              7  # % chance to use -ga spell
+  heal_chance:            8  # % chance to use heal
+  hp_heal_chance:         9  # can cast cures below this HP %
+  sublink:                10 # Sub link group. Enables mobs from different families to link if they share a SUBLINK value.
+  link_radius:            11 # link radius
+  sees_through_illusion:  12 # Mob can see through the Illusion effect that grants effects similar to Sneak & Invisible without this mod and allows aggro (see Viscious Liquid in mamook)
+  severe_spell_chance:    13 # % chance to use a severe spell like death or impact
+  skill_list:             14 # uses given mob skill list
+  mug_gil:                15 # amount gil carried for mugging
+  detection:              16 # Overrides mob family's detection method. In order to set to override to none an unused bit must be set such as xi::Detects::None1.
+  no_despawn:             17 # do not despawn when too far from spawn. Gob Diggers have this.
+  var:                    18 # temp var for whatever. Gets cleared on spawn
+  can_shield_block:       19 # toggle shield use for mobs without physical shields (trusts)
+  no_h2h_penalty:         20 # Disables H2H penalty in base damage calculation when set to non-zero
+  pet_spell_list:         21 # set pet spell list
+  na_chance:              22 # % chance to cast -na
+  immunity:               23 # immune to set status effects. This only works from the db, not scripts
+  gradual_rage:           24 # (!) TODO: NOT YET IMPLEMENTED -- gradually rages
+  build_resist:           25 # (!) TODO: NOT YET IMPLEMENTED -- builds resistance to given effects
+  superlink:              26 # super link group. Only use this in scripts! Must be defined in onMobInitialize if relevant mobs are different families
+  spell_list:             27 # set spell list
+  exp_bonus:              28 # bonus exp (bonus / 100) negative values reduce exp.
+  assist:                 29 # mobs will assist me
+  special_skill:          30 # give special skill
+  roam_distance:          31 # distance allowed to roam from spawn
+  dont_roam_home:         32 # Allow mobs to roam any distance from spawn. Useful for mobs with scripted roaming behavior.
+  special_cool:           33 # cool down for special
+  magic_cool:             34 # cool down for magic
+  standback_cool:         35 # cool down time for standing back (casting spell while not in attack range)
+  roam_cool:              36 # cool down time in seconds after roaming
+  always_aggro:           37 # aggro regardless of level. Spheroids
+  no_drops:               38 # If set monster cannot drop any items, not even seals.
+  share_pos:              39 # share a pos with another mob (eald'narche exoplates)
+  teleport_cd:            40 # cooldown for teleport abilities (tarutaru AA, angra mainyu, eald'narche)
+  teleport_start:         41 # mobskill ID to begin teleport
+  teleport_end:           42 # mobskill ID to end teleport
+  teleport_type:          43 # teleport type - 1: on cooldown, 2 - to close distance
+  dual_wield:             44 # enables a mob to use their offhand in attacks
+  add_effect:             45 # enables additional effect script to process on mobs attacks
+  auto_spikes:            46 # enables additional effect script to process when mob is attacked
+  spawn_leash:            47 # forces a mob to not move farther from its spawn than its leash distance
+  share_target:           48 # mob always targets same target as ID in this var
+  check_as_nm:            49 # If set , mob will check as a NM
+  roam_reset_facing:      50 # Resume facing the default spawn rotation after roaming home.
+  roam_turns:             51 # Maximum amount of turns during a roam
+  roam_rate:              52 # Roaming frequency. roam_cool - rand(roam_cool / (roam_rate / 10))
+  behavior:               53 # Add behaviors to mob
+  gil_bonus:              54 # Allow mob to drop gil. Multiplier to gil dropped by mob (bonus / 100) * total
+  idle_despawn:           55 # Time (in seconds) to despawn after being idle
+  hp_standback:           56 # mob will always standback with hp % higher to value
+  magic_delay:            57 # Amount of seconds mob waits before casting first spell
+  special_delay:          58 # Amount of seconds mob waits before using first special
+  base_damage_modifier:   59 # Add a flat modifer mob a mob's base damage. This is subject to multiplication by MOBMOD_BASE_DAMAGE_MULTIPLIER.
+  spawn_animationsub:     60 # reset animationsub to this on spawn
+  hp_scale:               61 # Scale the mobs max HP. ( hp_scale / 100 ) * maxhp
+  no_standback:           62 # Mob will never standback
+  attack_skill_list:      63 # skill list to use in place of regular attacks
+  charmable:              64 # mob is charmable
+  no_move:                65 # Mob will not be able to move
+  multi_hit:              66 # Mob will have as many swings as defined.
+  no_aggro:               67 # If set, mob cannot aggro until unset.
+  alli_hate:              68 # Range around target to add alliance member to enmity list.
+  no_link:                69 # If set, mob cannot link until unset.
+  no_rest:                70 # Mob cannot regain hp (e.g. re-burrowing antlions during ENM).
+  leader:                 71 # Used for mob following. Positive number is how many followers a leader has. A negative number is the distance from this mob ID to the leader ID.
+  magic_range:            72 # magic aggro range
   target_distance_offset: 73 # Adjusts how close a mob will move to it's target. 12 = 1.2 yalm. Positive values to go closer, negative farther.
-  one_way_linking: 74 # Will link with other mobs in its party (typically the same mob family) while roaming, but will not let others link with it once engaged
-  can_parry: 75 # Check if a mob is allowed to have parry rank (Rank Value 1-5)
-  no_widescan: 76 # Disables widescan for a specific mob
-  trust_distance: 77 # TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
-  standback_range: 78 # Applies a specific standback range for the mob
-  cannot_guard: 79 # Check if the mob does not guard(despite being a MNK or PUP mob)
-  skip_allegiance_check: 80 # Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
-  ability_response: 81 # Mob can respond to player ability use with onPlayerAbilityUse()
-  run_speed_mult: 82 # Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
-  claim_type: 83 # Changes the claim behavior of the mob. See xi::ClaimType enum.
-  no_spell_cost: 84 # Mob does not use MP when casting spells
-  astral_pet_offset: 85 # If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
+  one_way_linking:        74 # Will link with other mobs in its party (typically the same mob family) while roaming, but will not let others link with it once engaged
+  can_parry:              75 # Check if a mob is allowed to have parry rank (Rank Value 1-5)
+  no_widescan:            76 # Disables widescan for a specific mob
+  trust_distance:         77 # TRUSTS ONLY: Set movement type/distance. See trust.lua for details.
+  standback_range:        78 # Applies a specific standback range for the mob
+  cannot_guard:           79 # Check if the mob does not guard(despite being a MNK or PUP mob)
+  skip_allegiance_check:  80 # Skip the allegiance check for valid target (allows for example a mob to cast a TARGET_ENEMY spell on itself)
+  ability_response:       81 # Mob can respond to player ability use with onPlayerAbilityUse()
+  run_speed_mult:         82 # Multiplier for the speed of a mob while running (generally when the target is out of range) 100 = 1.00x
+  claim_type:             83 # Changes the claim behavior of the mob. See xi::ClaimType enum.
+  no_spell_cost:          84 # Mob does not use MP when casting spells
+  astral_pet_offset:      85 # If non-zero, defines the offset from main mob's ID for astral flow (if zero, will assume offset of 2)
   base_damage_multiplier: 86 # Multiplies the mob's base damage. Example: 150 = x1.5. MOBMOD_DAMAGE_OFFSET/MOBMOD_RANGED_DAMAGE_OFFSET are not subject to multiplication.
-  damage_offset: 87 # Adds or subtracts the mob's base damage offset.
-  ranged_damage_offset: 88 # Adds or subtracts the mob's ranged base damage offset.
-  avatar_petid: 89 # A value from xi.petId to select model/ability from when owner uses astral flow
-  avatar_astral_delay: 90 # Number of milliseconds to delay AF after avatar spawn
-  h2h_single_swing: 91 # Mob will have only one swing per attack even as MNK with H2H skill
-  aoe_hit_all: 92 # Mob AoE can hit any player regardless of enmity
-  ranged_attack_range: 93 # Max range for ranged auto attacks. Mob will move closer if target is beyond this range.
-  follow_leash_range: 94 # Distance the leader can walk before their followers start moving. Applied to followers.
-  follow_stop_range: 95 # Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
-  trust_shield_size: 96 # TRUSTS ONLY: Set the size of the mob's shield. 3 = Default size, only used for trusts that use shields.
-  bodyguard: 97 # Charmed mob defends its master similar to an avatar. (Maiden's Virelai)
+  damage_offset:          87 # Adds or subtracts the mob's base damage offset.
+  ranged_damage_offset:   88 # Adds or subtracts the mob's ranged base damage offset.
+  avatar_petid:           89 # A value from xi.petId to select model/ability from when owner uses astral flow
+  avatar_astral_delay:    90 # Number of milliseconds to delay AF after avatar spawn
+  h2h_single_swing:       91 # Mob will have only one swing per attack even as MNK with H2H skill
+  aoe_hit_all:            92 # Mob AoE can hit any player regardless of enmity
+  ranged_attack_range:    93 # Max range for ranged auto attacks. Mob will move closer if target is beyond this range.
+  follow_leash_range:     94 # Distance the leader can walk before their followers start moving. Applied to followers.
+  follow_stop_range:      95 # Distance the followers attempt to stop at once their leader stops moving. Applied to followers.
+  trust_shield_size:      96 # TRUSTS ONLY: Set the size of the mob's shield. 3 = Default size, only used for trusts that use shields.
+  bodyguard:              97 # Charmed mob defends its master similar to an avatar. (Maiden's Virelai)

--- a/data/enums/mob_type.yaml
+++ b/data/enums/mob_type.yaml
@@ -8,10 +8,10 @@ meta:
     table: xi.mobType
 
 values:
-  normal: 0x00
-  unused: 0x01 # available for use
-  notorious: 0x02
-  fished: 0x04
-  called: 0x08
+  normal:      0x00
+  unused:      0x01 # available for use
+  notorious:   0x02
+  fished:      0x04
+  called:      0x08
   battlefield: 0x10
-  event: 0x20
+  event:       0x20

--- a/data/enums/name_vis.yaml
+++ b/data/enums/name_vis.yaml
@@ -8,7 +8,7 @@ meta:
     table: xi.nameVis
 
 values:
-  none: 0x00
-  icon: 0x01 # (I) Icon next to name
-  hide_name: 0x08
+  none:        0x00
+  icon:        0x01 # (I) Icon next to name
+  hide_name:   0x08
   ghost_phase: 0x80

--- a/data/enums/roam_flag.yaml
+++ b/data/enums/roam_flag.yaml
@@ -8,16 +8,16 @@ meta:
     table: xi.roamFlag
 
 values:
-  none: 0x000
-  none0: 0x001
-  none1: 0x002
-  none2: 0x004
-  none3: 0x008
-  none4: 0x010
-  none5: 0x020
-  worm: 0x040 # pop up and down when moving
-  ambush: 0x080 # stays hidden until someone comes close (antlion)
+  none:     0x000
+  none0:    0x001
+  none1:    0x002
+  none2:    0x004
+  none3:    0x008
+  none4:    0x010
+  none5:    0x020
+  worm:     0x040 # pop up and down when moving
+  ambush:   0x080 # stays hidden until someone comes close (antlion)
   scripted: 0x100 # calls lua method for roaming logic
-  ignore: 0x200 # ignore all hate, except linking hate
-  stealth: 0x400 # stays name hidden and untargetable until someone comes close (chigoe)
-  follow: 0x800 # follows a player when sighted for a little while
+  ignore:   0x200 # ignore all hate, except linking hate
+  stealth:  0x400 # stays name hidden and untargetable until someone comes close (chigoe)
+  follow:   0x800 # follows a player when sighted for a little while

--- a/data/enums/skill_type.yaml
+++ b/data/enums/skill_type.yaml
@@ -8,58 +8,58 @@ meta:
 
 values:
   # Combat Skills
-  none: 0
+  none:         0
   hand_to_hand: 1
-  dagger: 2
-  sword: 3
-  great_sword: 4
-  axe: 5
-  great_axe: 6
-  scythe: 7
-  polearm: 8
-  katana: 9
+  dagger:       2
+  sword:        3
+  great_sword:  4
+  axe:          5
+  great_axe:    6
+  scythe:       7
+  polearm:      8
+  katana:       9
   great_katana: 10
-  club: 11
-  staff: 12
+  club:         11
+  staff:        12
   # 13-21 unused
-  automaton_melee: 22
+  automaton_melee:  22
   automaton_ranged: 23
-  automaton_magic: 24
-  archery: 25
-  marksmanship: 26
-  throwing: 27
+  automaton_magic:  24
+  archery:          25
+  marksmanship:     26
+  throwing:         27
   # Defensive Skills
-  guard: 28
+  guard:   28
   evasion: 29
-  shield: 30
-  parry: 31
+  shield:  30
+  parry:   31
   # Magic Skills
-  divine_magic: 32
-  healing_magic: 33
-  enhancing_magic: 34
-  enfeebling_magic: 35
-  elemental_magic: 36
-  dark_magic: 37
-  summoning_magic: 38
-  ninjutsu: 39
-  singing: 40
+  divine_magic:      32
+  healing_magic:     33
+  enhancing_magic:   34
+  enfeebling_magic:  35
+  elemental_magic:   36
+  dark_magic:        37
+  summoning_magic:   38
+  ninjutsu:          39
+  singing:           40
   string_instrument: 41
-  wind_instrument: 42
-  blue_magic: 43
-  geomancy: 44
-  handbell: 45
+  wind_instrument:   42
+  blue_magic:        43
+  geomancy:          44
+  handbell:          45
   # 46-47 unused
   # Crafting Skills
-  fishing: 48
-  woodworking: 49
-  smithing: 50
+  fishing:      48
+  woodworking:  49
+  smithing:     50
   goldsmithing: 51
-  clothcraft: 52
+  clothcraft:   52
   leathercraft: 53
-  bonecraft: 54
-  alchemy: 55
-  cooking: 56
-  synergy: 57
+  bonecraft:    54
+  alchemy:      55
+  cooking:      56
+  synergy:      57
   # Other Skills
   rid: 58
   dig: 59

--- a/data/enums/spawn_animation.yaml
+++ b/data/enums/spawn_animation.yaml
@@ -7,5 +7,5 @@ meta:
     table: xi.spawnAnimation
 
 values:
-  normal: 0
+  normal:  0
   special: 1

--- a/data/enums/spawn_type.yaml
+++ b/data/enums/spawn_type.yaml
@@ -8,12 +8,12 @@ meta:
     table: xi.spawnType
 
 values:
-  normal: 0x00 # 00:00-24:00
-  at_night: 0x01 # 20:00-04:00
+  normal:     0x00 # 00:00-24:00
+  at_night:   0x01 # 20:00-04:00
   at_evening: 0x02 # 18:00-06:00
-  weather: 0x04
-  fog: 0x08 # 02:00-07:00
-  moonphase: 0x10
-  lottery: 0x20
-  windowed: 0x40
-  scripted: 0x80 # scripted spawn
+  weather:    0x04
+  fog:        0x08 # 02:00-07:00
+  moonphase:  0x10
+  lottery:    0x20
+  windowed:   0x40
+  scripted:   0x80 # scripted spawn

--- a/data/enums/status.yaml
+++ b/data/enums/status.yaml
@@ -7,11 +7,11 @@ meta:
     table: xi.status
 
 values:
-  normal: 0
-  update: 1
-  disappear: 2
-  invisible: 3
-  status_4: 4
+  normal:        0
+  update:        1
+  disappear:     2
+  invisible:     3
+  status_4:      4
   cutscene_only: 6
-  status_18: 18
-  shutdown: 20
+  status_18:     18
+  shutdown:      20

--- a/data/enums/status_effect_flag.yaml
+++ b/data/enums/status_effect_flag.yaml
@@ -8,35 +8,35 @@ meta:
     table: xi.effectFlag
 
 values:
-  none: 0x00000000
-  dispelable: 0x00000001
-  erasable: 0x00000002
-  attack: 0x00000004
-  empathy: 0x00000008
-  damage: 0x00000010
-  death: 0x00000020
-  magic_begin: 0x00000040
-  magic_end: 0x00000080
-  on_zone: 0x00000100
+  none:            0x00000000
+  dispelable:      0x00000001
+  erasable:        0x00000002
+  attack:          0x00000004
+  empathy:         0x00000008
+  damage:          0x00000010
+  death:           0x00000020
+  magic_begin:     0x00000040
+  magic_end:       0x00000080
+  on_zone:         0x00000100
   no_loss_message: 0x00000200
-  invisible: 0x00000400
-  detectable: 0x00000800
-  no_rest: 0x00001000
-  prevent_action: 0x00002000
-  waltzable: 0x00004000
-  food: 0x00008000
-  song: 0x00010000
-  roll: 0x00020000
-  synth_support: 0x00040000
-  confrontation: 0x00080000
-  logout: 0x00100000
-  bloodpact: 0x00200000
-  on_jobchange: 0x00400000
-  no_cancel: 0x00800000
-  influence: 0x01000000
-  offline_tick: 0x02000000
-  aura: 0x04000000
-  hide_timer: 0x08000000
-  on_zone_pathos: 0x10000000
+  invisible:       0x00000400
+  detectable:      0x00000800
+  no_rest:         0x00001000
+  prevent_action:  0x00002000
+  waltzable:       0x00004000
+  food:            0x00008000
+  song:            0x00010000
+  roll:            0x00020000
+  synth_support:   0x00040000
+  confrontation:   0x00080000
+  logout:          0x00100000
+  bloodpact:       0x00200000
+  on_jobchange:    0x00400000
+  no_cancel:       0x00800000
+  influence:       0x01000000
+  offline_tick:    0x02000000
+  aura:            0x04000000
+  hide_timer:      0x08000000
+  on_zone_pathos:  0x10000000
   always_expiring: 0x20000000
-  on_attack: 0x40000000
+  on_attack:       0x40000000

--- a/data/enums/weather.yaml
+++ b/data/enums/weather.yaml
@@ -7,23 +7,23 @@ meta:
     table: xi.weather
 
 values:
-  none: 0
-  sunshine: 1
-  clouds: 2
-  fog: 3
-  hot_spell: 4
-  heat_wave: 5
-  rain: 6
-  squall: 7
-  dust_storm: 8
-  sand_storm: 9
-  wind: 10
-  gales: 11
-  snow: 12
-  blizzards: 13
-  thunder: 14
+  none:          0
+  sunshine:      1
+  clouds:        2
+  fog:           3
+  hot_spell:     4
+  heat_wave:     5
+  rain:          6
+  squall:        7
+  dust_storm:    8
+  sand_storm:    9
+  wind:          10
+  gales:         11
+  snow:          12
+  blizzards:     13
+  thunder:       14
   thunderstorms: 15
-  auroras: 16
+  auroras:       16
   stellar_glare: 17
-  gloom: 18
-  darkness: 19
+  gloom:         18
+  darkness:      19

--- a/data/enums/zone_misc.yaml
+++ b/data/enums/zone_misc.yaml
@@ -8,19 +8,19 @@ meta:
     table: xi.zoneMisc
 
 values:
-  none: 0x0000 # Able to be used in any area
-  escape: 0x0001 # Ability to use Escape Spell
-  fellow: 0x0002 # Ability to summon Fellow NPC
-  mount: 0x0004 # Ability to use Chocobos and mounts
-  mazurka: 0x0008 # Ability to use Mazurka Spell
-  tractor: 0x0010 # Ability to use Tractor Spell
-  mogmenu: 0x0020 # Ability to communicate with Nomad Moogle (menu access mog house)
-  costume: 0x0040 # Ability to use a Costumes
-  pet: 0x0080 # Ability to summon Pets
-  treasure: 0x0100 # Presence in the global zone TreasurePool
-  auction_house: 0x0200 # Ability to use the auction house
-  yell: 0x0400 # Send and receive /yell commands
-  trust: 0x0800 # Ability to summon Trust NPC
+  none:             0x0000 # Able to be used in any area
+  escape:           0x0001 # Ability to use Escape Spell
+  fellow:           0x0002 # Ability to summon Fellow NPC
+  mount:            0x0004 # Ability to use Chocobos and mounts
+  mazurka:          0x0008 # Ability to use Mazurka Spell
+  tractor:          0x0010 # Ability to use Tractor Spell
+  mogmenu:          0x0020 # Ability to communicate with Nomad Moogle (menu access mog house)
+  costume:          0x0040 # Ability to use a Costumes
+  pet:              0x0080 # Ability to summon Pets
+  treasure:         0x0100 # Presence in the global zone TreasurePool
+  auction_house:    0x0200 # Ability to use the auction house
+  yell:             0x0400 # Send and receive /yell commands
+  trust:            0x0800 # Ability to summon Trust NPC
   los_player_block: 0x1000 # Players can't use magic/JAs through walls if this is set
-  los_off: 0x2000 # Zone should not have LoS checks
-  assist: 0x4000 # Send and receive /assiste, /assistj commands
+  los_off:          0x2000 # Zone should not have LoS checks
+  assist:           0x4000 # Send and receive /assiste, /assistj commands

--- a/data/enums/zone_type.yaml
+++ b/data/enums/zone_type.yaml
@@ -8,13 +8,13 @@ meta:
     table: xi.zoneType
 
 values:
-  unknown: 0x0000
-  city: 0x0001
-  outdoors: 0x0002
-  dungeon: 0x0004
-  signet: 0x0008
-  sanction: 0x0010
-  sigil: 0x0020
-  ionis: 0x0040
-  dynamis: 0x0080
+  unknown:   0x0000
+  city:      0x0001
+  outdoors:  0x0002
+  dungeon:   0x0004
+  signet:    0x0008
+  sanction:  0x0010
+  sigil:     0x0020
+  ionis:     0x0040
+  dynamis:   0x0080
   instanced: 0x0100

--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -4,7 +4,7 @@ meta:
   enum:
     cpp:
       underlying: uint16_t
-      class: StatusEffect
+      class:      StatusEffect
     lua:
       table: xi.effect
 
@@ -20,23 +20,23 @@ status_effects:
     id: 1
     flags:
       - no_cancel
-    overwrite: always
-    min_duration: 1
+    overwrite:           always
+    min_duration:        1
     wear_off_message_id: 204
 
   sleep_i:
-    id: 2
+    id:   2
     name: sleep
     flags:
       - damage
       - death
       - no_cancel
-    exclusion_group: sleep_i
-    negative: sleep_ii
-    overwrite: higher
-    block: lullaby
-    element: dark
-    min_duration: 1
+    exclusion_group:     sleep_i
+    negative:            sleep_ii
+    overwrite:           higher
+    block:               lullaby
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   poison:
@@ -45,9 +45,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: never
-    element: water
-    min_duration: 1
+    overwrite:           never
+    element:             water
+    min_duration:        1
     wear_off_message_id: 204
 
   paralysis:
@@ -56,9 +56,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: higher
-    element: ice
-    min_duration: 1
+    overwrite:           higher
+    element:             ice
+    min_duration:        1
     wear_off_message_id: 204
 
   blindness:
@@ -67,9 +67,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: higher
-    element: dark
-    min_duration: 1
+    overwrite:           higher
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   silence:
@@ -78,9 +78,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: never
-    element: wind
-    min_duration: 1
+    overwrite:           never
+    element:             wind
+    min_duration:        1
     wear_off_message_id: 204
 
   petrification:
@@ -88,11 +88,11 @@ status_effects:
     flags:
       - death
       - no_cancel
-    exclusion_group: petrification
-    overwrite: never
-    block: stun
-    element: earth
-    min_duration: 1
+    exclusion_group:     petrification
+    overwrite:           never
+    block:               stun
+    element:             earth
+    min_duration:        1
     wear_off_message_id: 204
 
   disease:
@@ -102,23 +102,23 @@ status_effects:
       - no_rest
       - waltzable
       - no_cancel
-    exclusion_group: disease
-    overwrite: never
-    element: fire
-    min_duration: 1
+    exclusion_group:     disease
+    overwrite:           never
+    element:             fire
+    min_duration:        1
     wear_off_message_id: 204
 
   curse_i:
-    id: 9
+    id:   9
     name: curse
     flags:
       - death
       - waltzable
       - no_cancel
-    exclusion_group: curse_i
-    overwrite: never
-    element: dark
-    min_duration: 1
+    exclusion_group:     curse_i
+    overwrite:           never
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   stun:
@@ -127,10 +127,10 @@ status_effects:
       - erasable
       - death
       - no_cancel
-    overwrite: never
-    block: petrification
-    element: thunder
-    min_duration: 1
+    overwrite:           never
+    block:               petrification
+    element:             thunder
+    min_duration:        1
     wear_off_message_id: 204
 
   bind:
@@ -140,9 +140,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: never
-    element: ice
-    min_duration: 1
+    overwrite:           never
+    element:             ice
+    min_duration:        1
     wear_off_message_id: 204
 
   weight:
@@ -152,10 +152,10 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    negative: flee
-    overwrite: higher
-    element: wind
-    min_duration: 1
+    negative:            flee
+    overwrite:           higher
+    element:             wind
+    min_duration:        1
     wear_off_message_id: 204
 
   slow:
@@ -165,19 +165,19 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    negative: haste
-    overwrite: higher
-    element: earth
+    negative:     haste
+    overwrite:    higher
+    element:      earth
     min_duration: 1
 
   charm_i:
-    id: 14
+    id:   14
     name: charm
     flags:
       - death
       - no_cancel
-    overwrite: never
-    element: light
+    overwrite:           never
+    element:             light
     wear_off_message_id: 204
 
   doom:
@@ -185,9 +185,9 @@ status_effects:
     flags:
       - death
       - no_cancel
-    overwrite: never
-    element: dark
-    min_duration: 1
+    overwrite:           never
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   amnesia:
@@ -195,19 +195,19 @@ status_effects:
     flags:
       - death
       - no_cancel
-    overwrite: never
-    element: fire
-    min_duration: 1
+    overwrite:           never
+    element:             fire
+    min_duration:        1
     wear_off_message_id: 204
 
   charm_ii:
-    id: 17
+    id:   17
     name: charm
     flags:
       - death
       - no_cancel
-    overwrite: never
-    element: light
+    overwrite:           never
+    element:             light
     wear_off_message_id: 204
 
   gradual_petrification:
@@ -215,37 +215,37 @@ status_effects:
     flags:
       - death
       - no_cancel
-    exclusion_group: petrification
-    overwrite: never
-    element: earth
-    min_duration: 1
+    exclusion_group:     petrification
+    overwrite:           never
+    element:             earth
+    min_duration:        1
     wear_off_message_id: 204
 
   sleep_ii:
-    id: 19
+    id:   19
     name: sleep
     flags:
       - damage
       - death
       - no_cancel
-    exclusion_group: sleep_i
-    overwrite: higher
-    element: dark
-    min_duration: 1
+    exclusion_group:     sleep_i
+    overwrite:           higher
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   # Zombie
   curse_ii:
-    id: 20
+    id:   20
     name: curse
     flags:
       - death
       - no_rest
       - no_cancel
-    exclusion_group: curse_i
-    overwrite: never
-    element: dark
-    min_duration: 1
+    exclusion_group:     curse_i
+    overwrite:           never
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   addle:
@@ -256,8 +256,8 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    overwrite: never
-    element: fire
+    overwrite:    never
+    element:      fire
     min_duration: 1
 
   intimidate:
@@ -265,8 +265,8 @@ status_effects:
     flags:
       - death
       - no_cancel
-    overwrite: never
-    min_duration: 1
+    overwrite:           never
+    min_duration:        1
     wear_off_message_id: 204
 
   kaustra:
@@ -275,7 +275,7 @@ status_effects:
       - death
       - on_zone
       - no_cancel
-    negative: embrava
+    negative:            embrava
     wear_off_message_id: 204
 
   terror:
@@ -283,9 +283,9 @@ status_effects:
     flags:
       - death
       - no_cancel
-    exclusion_group: petrification
-    element: dark
-    min_duration: 1
+    exclusion_group:     petrification
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   mute:
@@ -293,10 +293,10 @@ status_effects:
     flags:
       - death
       - no_cancel
-    overwrite: never
-    remove: silence
-    element: wind
-    min_duration: 1
+    overwrite:           never
+    remove:              silence
+    element:             wind
+    min_duration:        1
     wear_off_message_id: 204
 
   bane:
@@ -305,10 +305,10 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    overwrite: never
-    remove: curse_i
-    element: dark
-    min_duration: 1
+    overwrite:           never
+    remove:              curse_i
+    element:             dark
+    min_duration:        1
     wear_off_message_id: 204
 
   plague:
@@ -318,10 +318,10 @@ status_effects:
       - no_rest
       - waltzable
       - no_cancel
-    exclusion_group: disease
-    overwrite: never
-    element: fire
-    min_duration: 1
+    exclusion_group:     disease
+    overwrite:           never
+    element:             fire
+    min_duration:        1
     wear_off_message_id: 204
 
   flee:
@@ -331,7 +331,7 @@ status_effects:
       - empathy
       - death
     negative: weight
-    element: wind
+    element:  wind
 
   haste:
     id: 33
@@ -340,7 +340,7 @@ status_effects:
       - empathy
       - death
     negative: slow
-    element: wind
+    element:  wind
     sort_key: 100
 
   blaze_spikes:
@@ -350,8 +350,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: fire
-    sort_key: 800
+    element:         fire
+    sort_key:        800
 
   ice_spikes:
     id: 35
@@ -360,8 +360,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: ice
-    sort_key: 800
+    element:         ice
+    sort_key:        800
 
   blink:
     id: 36
@@ -370,9 +370,9 @@ status_effects:
       - empathy
       - death
     exclusion_group: blink
-    block: copy_image
-    element: wind
-    sort_key: 50
+    block:           copy_image
+    element:         wind
+    sort_key:        50
 
   stoneskin:
     id: 37
@@ -381,8 +381,8 @@ status_effects:
       - empathy
       - death
     overwrite: tier_higher
-    element: earth
-    sort_key: 600
+    element:   earth
+    sort_key:  600
 
   shock_spikes:
     id: 38
@@ -391,8 +391,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: thunder
-    sort_key: 800
+    element:         thunder
+    sort_key:        800
 
   aquaveil:
     id: 39
@@ -400,7 +400,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    element: water
+    element:  water
     sort_key: 650
 
   protect:
@@ -409,7 +409,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    element: light
+    element:  light
     sort_key: 200
 
   shell:
@@ -418,7 +418,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    element: light
+    element:  light
     sort_key: 250
 
   regen:
@@ -427,7 +427,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    element: light
+    element:  light
     sort_key: 700
 
   refresh:
@@ -436,7 +436,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    element: light
+    element:  light
     sort_key: 750
 
   mighty_strikes:
@@ -503,7 +503,7 @@ status_effects:
       - on_zone
       - on_jobchange
     exclusion_group: enfire
-    element: dark
+    element:         dark
 
   soul_voice:
     id: 52
@@ -620,8 +620,8 @@ status_effects:
     flags:
       - dispelable
       - death
-    remove: blink
-    element: wind
+    remove:   blink
+    element:  wind
     sort_key: 50
 
   third_eye:
@@ -637,7 +637,7 @@ status_effects:
       - dispelable
       - empathy
       - death
-    remove: blood_rage
+    remove:   blood_rage
     sort_key: 400
 
   invisible:
@@ -652,8 +652,8 @@ status_effects:
       - detectable
       - logout
     overwrite: never
-    element: wind
-    sort_key: 850
+    element:   wind
+    sort_key:  850
 
   deodorize:
     id: 70
@@ -665,8 +665,8 @@ status_effects:
       - detectable
       - logout
     overwrite: never
-    element: wind
-    sort_key: 1100
+    element:   wind
+    sort_key:  1100
 
   sneak:
     id: 71
@@ -678,8 +678,8 @@ status_effects:
       - detectable
       - logout
     overwrite: never
-    element: wind
-    sort_key: 1150
+    element:   wind
+    sort_key:  1150
 
   sharpshot:
     id: 72
@@ -758,7 +758,7 @@ status_effects:
       - death
       - on_zone
     negative: str_down
-    element: fire
+    element:  fire
 
   dex_boost:
     id: 81
@@ -768,7 +768,7 @@ status_effects:
       - death
       - on_zone
     negative: dex_down
-    element: thunder
+    element:  thunder
 
   vit_boost:
     id: 82
@@ -778,7 +778,7 @@ status_effects:
       - death
       - on_zone
     negative: vit_down
-    element: earth
+    element:  earth
 
   agi_boost:
     id: 83
@@ -788,7 +788,7 @@ status_effects:
       - death
       - on_zone
     negative: agi_down
-    element: wind
+    element:  wind
 
   int_boost:
     id: 84
@@ -798,7 +798,7 @@ status_effects:
       - death
       - on_zone
     negative: int_down
-    element: ice
+    element:  ice
 
   mnd_boost:
     id: 85
@@ -808,7 +808,7 @@ status_effects:
       - death
       - on_zone
     negative: mnd_down
-    element: water
+    element:  water
 
   chr_boost:
     id: 86
@@ -818,7 +818,7 @@ status_effects:
       - death
       - on_zone
     negative: chr_down
-    element: light
+    element:  light
 
   trick_attack:
     id: 87
@@ -836,7 +836,7 @@ status_effects:
       - death
       - on_zone
     negative: max_hp_down
-    element: light
+    element:  light
 
   max_mp_boost:
     id: 89
@@ -846,7 +846,7 @@ status_effects:
       - death
       - on_zone
     negative: max_mp_down
-    element: dark
+    element:  dark
 
   accuracy_boost:
     id: 90
@@ -856,7 +856,7 @@ status_effects:
       - death
       - on_zone
     negative: accuracy_down
-    element: thunder
+    element:  thunder
 
   attack_boost:
     id: 91
@@ -866,7 +866,7 @@ status_effects:
       - death
       - on_zone
     negative: attack_down
-    element: fire
+    element:  fire
 
   evasion_boost:
     id: 92
@@ -876,7 +876,7 @@ status_effects:
       - death
       - on_zone
     negative: evasion_down
-    element: wind
+    element:  wind
 
   defense_boost:
     id: 93
@@ -886,7 +886,7 @@ status_effects:
       - death
       - on_zone
     negative: defense_down
-    element: earth
+    element:  earth
 
   enfire:
     id: 94
@@ -896,9 +896,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: fire
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         fire
+    sort_key:        1200
 
   enblizzard:
     id: 95
@@ -908,9 +908,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: ice
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         ice
+    sort_key:        1200
 
   enaero:
     id: 96
@@ -920,9 +920,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: wind
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         wind
+    sort_key:        1200
 
   enstone:
     id: 97
@@ -932,9 +932,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: earth
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         earth
+    sort_key:        1200
 
   enthunder:
     id: 98
@@ -944,9 +944,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: thunder
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         thunder
+    sort_key:        1200
 
   enwater:
     id: 99
@@ -956,9 +956,9 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: water
-    sort_key: 1200
+    negative:        blood_weapon
+    element:         water
+    sort_key:        1200
 
   barfire:
     id: 100
@@ -967,8 +967,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: water
-    sort_key: 500
+    element:         water
+    sort_key:        500
 
   barblizzard:
     id: 101
@@ -977,8 +977,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: fire
-    sort_key: 500
+    element:         fire
+    sort_key:        500
 
   baraero:
     id: 102
@@ -987,8 +987,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: ice
-    sort_key: 500
+    element:         ice
+    sort_key:        500
 
   barstone:
     id: 103
@@ -997,8 +997,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: wind
-    sort_key: 500
+    element:         wind
+    sort_key:        500
 
   barthunder:
     id: 104
@@ -1007,8 +1007,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: earth
-    sort_key: 500
+    element:         earth
+    sort_key:        500
 
   barwater:
     id: 105
@@ -1017,8 +1017,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barfire
-    element: thunder
-    sort_key: 500
+    element:         thunder
+    sort_key:        500
 
   barsleep:
     id: 106
@@ -1027,8 +1027,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: light
-    sort_key: 500
+    element:         light
+    sort_key:        500
 
   barpoison:
     id: 107
@@ -1037,8 +1037,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: thunder
-    sort_key: 500
+    element:         thunder
+    sort_key:        500
 
   barparalyze:
     id: 108
@@ -1047,8 +1047,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: fire
-    sort_key: 500
+    element:         fire
+    sort_key:        500
 
   barblind:
     id: 109
@@ -1057,8 +1057,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: light
-    sort_key: 500
+    element:         light
+    sort_key:        500
 
   barsilence:
     id: 110
@@ -1067,8 +1067,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: ice
-    sort_key: 500
+    element:         ice
+    sort_key:        500
 
   barpetrify:
     id: 111
@@ -1077,8 +1077,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: wind
-    sort_key: 500
+    element:         wind
+    sort_key:        500
 
   barvirus:
     id: 112
@@ -1087,8 +1087,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    element: water
-    sort_key: 500
+    element:         water
+    sort_key:        500
 
   reraise:
     id: 113
@@ -1096,7 +1096,7 @@ status_effects:
       - empathy
       - death
       - on_jobchange
-    element: light
+    element:  light
     sort_key: 900
 
   cover:
@@ -1119,7 +1119,7 @@ status_effects:
       - dispelable
       - death
       - on_zone
-    element: light
+    element:  light
     sort_key: 1050
 
   warding_circle:
@@ -1137,7 +1137,7 @@ status_effects:
       - death
 
   str_boost_ii:
-    id: 119
+    id:   119
     name: str_boost
     flags:
       - dispelable
@@ -1148,7 +1148,7 @@ status_effects:
     element: fire
 
   dex_boost_ii:
-    id: 120
+    id:   120
     name: dex_boost
     flags:
       - dispelable
@@ -1159,7 +1159,7 @@ status_effects:
     element: thunder
 
   vit_boost_ii:
-    id: 121
+    id:   121
     name: vit_boost
     flags:
       - dispelable
@@ -1170,7 +1170,7 @@ status_effects:
     element: earth
 
   agi_boost_ii:
-    id: 122
+    id:   122
     name: agi_boost
     flags:
       - dispelable
@@ -1181,7 +1181,7 @@ status_effects:
     element: wind
 
   int_boost_ii:
-    id: 123
+    id:   123
     name: int_boost
     flags:
       - dispelable
@@ -1192,7 +1192,7 @@ status_effects:
     element: ice
 
   mnd_boost_ii:
-    id: 124
+    id:   124
     name: mnd_boost
     flags:
       - dispelable
@@ -1203,7 +1203,7 @@ status_effects:
     element: water
 
   chr_boost_ii:
-    id: 125
+    id:   125
     name: chr_boost
     flags:
       - dispelable
@@ -1235,8 +1235,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: drown
-    remove: frost
+    block:   drown
+    remove:  frost
     element: fire
 
   frost:
@@ -1246,8 +1246,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: burn
-    remove: choke
+    block:   burn
+    remove:  choke
     element: ice
 
   choke:
@@ -1257,8 +1257,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: frost
-    remove: rasp
+    block:   frost
+    remove:  rasp
     element: wind
 
   rasp:
@@ -1268,8 +1268,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: choke
-    remove: shock
+    block:   choke
+    remove:  shock
     element: earth
 
   shock:
@@ -1279,8 +1279,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: rasp
-    remove: drown
+    block:   rasp
+    remove:  drown
     element: thunder
 
   drown:
@@ -1290,8 +1290,8 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    block: shock
-    remove: burn
+    block:   shock
+    remove:  burn
     element: water
 
   dia:
@@ -1301,9 +1301,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    negative: dia
+    negative:  dia
     overwrite: higher
-    element: light
+    element:   light
 
   bio:
     id: 135
@@ -1312,9 +1312,9 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    negative: dia
+    negative:  dia
     overwrite: higher
-    element: dark
+    element:   dark
 
   str_down:
     id: 136
@@ -1323,7 +1323,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: str_boost
+    remove:  str_boost
     element: water
 
   dex_down:
@@ -1333,7 +1333,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: dex_boost
+    remove:  dex_boost
     element: earth
 
   vit_down:
@@ -1343,7 +1343,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: vit_boost
+    remove:  vit_boost
     element: wind
 
   agi_down:
@@ -1353,7 +1353,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: agi_boost
+    remove:  agi_boost
     element: ice
 
   int_down:
@@ -1363,7 +1363,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: int_boost
+    remove:  int_boost
     element: fire
 
   mnd_down:
@@ -1373,7 +1373,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: mnd_boost
+    remove:  mnd_boost
     element: thunder
 
   chr_down:
@@ -1383,7 +1383,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: chr_boost
+    remove:  chr_boost
     element: dark
 
   level_restriction:
@@ -1400,7 +1400,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: max_hp_boost
+    remove:  max_hp_boost
     element: dark
 
   max_mp_down:
@@ -1410,7 +1410,7 @@ status_effects:
       - death
       - waltzable
       - no_cancel
-    remove: max_mp_boost
+    remove:  max_mp_boost
     element: light
 
   accuracy_down:
@@ -1421,7 +1421,7 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    remove: accuracy_boost
+    remove:  accuracy_boost
     element: earth
 
   attack_down:
@@ -1432,7 +1432,7 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    remove: attack_boost
+    remove:  attack_boost
     element: water
 
   evasion_down:
@@ -1443,7 +1443,7 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    remove: evasion_boost
+    remove:  evasion_boost
     element: ice
 
   defense_down:
@@ -1454,7 +1454,7 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    remove: defense_boost
+    remove:  defense_boost
     element: wind
 
   physical_shield:
@@ -1486,7 +1486,7 @@ status_effects:
       - death
       - no_cancel
     exclusion_group: blaze_spikes
-    sort_key: 800
+    sort_key:        800
 
   shining_ruby:
     id: 154
@@ -1511,8 +1511,8 @@ status_effects:
       - on_zone
       - waltzable
       - no_cancel
-    overwrite: higher
-    element: light
+    overwrite:           higher
+    element:             light
     wear_off_message_id: 204
 
   sj_restriction:
@@ -1555,7 +1555,7 @@ status_effects:
       - death
       - on_zone
       - no_cancel
-    overwrite: ignore_duplicate
+    overwrite:           ignore_duplicate
     wear_off_message_id: 204
 
   azure_lore:
@@ -1637,7 +1637,7 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    sort_key: 800
+    sort_key:        800
 
   magic_acc_down:
     id: 174
@@ -1671,7 +1671,7 @@ status_effects:
     wear_off_message_id: 204
 
   encumbrance_ii:
-    id: 177
+    id:   177
     name: encumbrance
     flags:
       - on_zone
@@ -1793,8 +1793,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: higher
-    element: light
-    sort_key: 2000
+    element:   light
+    sort_key:  2000
 
   lullaby:
     id: 193
@@ -1805,12 +1805,12 @@ status_effects:
       - song
       - no_cancel
     exclusion_group: sleep_i
-    negative: sleep_ii
-    overwrite: never
-    block: sleep_i
-    element: light
-    min_duration: 1
-    sort_key: 2000
+    negative:        sleep_ii
+    overwrite:       never
+    block:           sleep_i
+    element:         light
+    min_duration:    1
+    sort_key:        2000
 
   elegy:
     id: 194
@@ -1820,7 +1820,7 @@ status_effects:
       - on_zone
       - song
       - no_cancel
-    element: earth
+    element:  earth
     sort_key: 2000
 
   paeon:
@@ -1833,8 +1833,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    element: light
-    sort_key: 2000
+    element:   light
+    sort_key:  2000
 
   ballad:
     id: 196
@@ -1846,8 +1846,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    element: light
-    sort_key: 2000
+    element:   light
+    sort_key:  2000
 
   minne:
     id: 197
@@ -1859,8 +1859,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    element: earth
-    sort_key: 2000
+    element:   earth
+    sort_key:  2000
 
   minuet:
     id: 198
@@ -1872,8 +1872,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    element: fire
-    sort_key: 2000
+    element:   fire
+    sort_key:  2000
 
   madrigal:
     id: 199
@@ -1885,8 +1885,8 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    element: thunder
-    sort_key: 2000
+    element:   thunder
+    sort_key:  2000
 
   prelude:
     id: 200
@@ -1898,7 +1898,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   mambo:
     id: 201
@@ -1910,7 +1910,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   aubade:
     id: 202
@@ -1922,7 +1922,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   pastoral:
     id: 203
@@ -1934,7 +1934,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   hum:
     id: 204
@@ -1945,7 +1945,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   fantasia:
     id: 205
@@ -1957,7 +1957,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   operetta:
     id: 206
@@ -1969,7 +1969,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   capriccio:
     id: 207
@@ -1981,7 +1981,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   serenade:
     id: 208
@@ -1992,7 +1992,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   round:
     id: 209
@@ -2004,7 +2004,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   gavotte:
     id: 210
@@ -2016,7 +2016,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   fugue:
     id: 211
@@ -2027,7 +2027,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   rhapsody:
     id: 212
@@ -2038,7 +2038,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   aria:
     id: 213
@@ -2049,7 +2049,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   march:
     id: 214
@@ -2061,7 +2061,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   etude:
     id: 215
@@ -2073,7 +2073,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   carol:
     id: 216
@@ -2085,7 +2085,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   threnody:
     id: 217
@@ -2097,7 +2097,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: higher
-    sort_key: 2000
+    sort_key:  2000
 
   hymnus:
     id: 218
@@ -2109,7 +2109,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   mazurka:
     id: 219
@@ -2134,7 +2134,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   dirge:
     id: 221
@@ -2146,7 +2146,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   scherzo:
     id: 222
@@ -2158,7 +2158,7 @@ status_effects:
       - song
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   nocturne:
     id: 223
@@ -2167,7 +2167,7 @@ status_effects:
       - on_zone
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2000
+    sort_key:  2000
 
   store_tp:
     id: 227
@@ -2206,14 +2206,14 @@ status_effects:
       - on_jobchange
 
   auto_regen:
-    id: 233
+    id:   233
     name: auto-regen
     flags:
       - death
     overwrite: ignore_duplicate
 
   auto_refresh:
-    id: 234
+    id:   234
     name: auto-refresh
     flags:
       - death
@@ -2292,7 +2292,7 @@ status_effects:
     exclusion_group: imagery_1
 
   imagery_1:
-    id: 244
+    id:   244
     name: imagery
     flags:
       - death
@@ -2300,7 +2300,7 @@ status_effects:
     exclusion_group: imagery_1
 
   imagery_2:
-    id: 245
+    id:   245
     name: imagery
     flags:
       - death
@@ -2308,7 +2308,7 @@ status_effects:
     exclusion_group: imagery_1
 
   imagery_3:
-    id: 246
+    id:   246
     name: imagery
     flags:
       - death
@@ -2316,7 +2316,7 @@ status_effects:
     exclusion_group: imagery_1
 
   imagery_4:
-    id: 247
+    id:   247
     name: imagery
     flags:
       - death
@@ -2324,7 +2324,7 @@ status_effects:
     exclusion_group: imagery_1
 
   imagery_5:
-    id: 248
+    id:   248
     name: imagery
     flags:
       - death
@@ -2397,7 +2397,7 @@ status_effects:
       - no_rest
 
   encumbrance_i:
-    id: 259
+    id:   259
     name: encumbrance
     flags:
       - no_cancel
@@ -2515,8 +2515,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: light
+    negative:        blood_weapon
+    element:         light
 
   auspice:
     id: 275
@@ -2525,8 +2525,8 @@ status_effects:
       - on_zone
       - on_jobchange
     exclusion_group: enfire
-    negative: blood_weapon
-    element: light
+    negative:        blood_weapon
+    element:         light
 
   confrontation:
     id: 276
@@ -2545,8 +2545,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: fire
+    negative:        blood_weapon
+    element:         fire
 
   enblizzard_ii:
     id: 278
@@ -2556,8 +2556,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: ice
+    negative:        blood_weapon
+    element:         ice
 
   enaero_ii:
     id: 279
@@ -2567,8 +2567,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: wind
+    negative:        blood_weapon
+    element:         wind
 
   enstone_ii:
     id: 280
@@ -2578,8 +2578,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: earth
+    negative:        blood_weapon
+    element:         earth
 
   enthunder_ii:
     id: 281
@@ -2589,8 +2589,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: thunder
+    negative:        blood_weapon
+    element:         thunder
 
   enwater_ii:
     id: 282
@@ -2600,8 +2600,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: water
+    negative:        blood_weapon
+    element:         water
 
   perfect_defense:
     id: 283
@@ -2631,7 +2631,7 @@ status_effects:
       - empathy
       - death
     exclusion_group: barsleep
-    sort_key: 500
+    sort_key:        500
 
   atma:
     id: 287
@@ -2649,8 +2649,8 @@ status_effects:
       - death
       - on_zone
     exclusion_group: enfire
-    negative: blood_weapon
-    element: dark
+    negative:        blood_weapon
+    element:         dark
 
   enmity_boost:
     id: 289
@@ -2721,7 +2721,7 @@ status_effects:
     block: poison
 
   crit_hit_evasion_down:
-    id: 298
+    id:   298
     name: critical_hit_evasion_down
     flags:
       - erasable
@@ -2747,7 +2747,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   ice_maneuver:
     id: 301
@@ -2759,7 +2759,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   wind_maneuver:
     id: 302
@@ -2771,7 +2771,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   earth_maneuver:
     id: 303
@@ -2783,7 +2783,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   thunder_maneuver:
     id: 304
@@ -2795,7 +2795,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   water_maneuver:
     id: 305
@@ -2807,7 +2807,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   light_maneuver:
     id: 306
@@ -2819,7 +2819,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   dark_maneuver:
     id: 307
@@ -2831,10 +2831,10 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 3000
+    sort_key:  3000
 
   double_up_chance:
-    id: 308
+    id:   308
     name: double-up_chance
     flags:
       - death
@@ -2850,7 +2850,7 @@ status_effects:
       - on_zone
       - no_cancel
     overwrite: ignore_duplicate
-    sort_key: 2050
+    sort_key:  2050
 
   fighters_roll:
     id: 310
@@ -3525,7 +3525,7 @@ status_effects:
       - no_cancel
 
   finishing_move_1:
-    id: 381
+    id:   381
     name: finishing_move
     flags:
       - death
@@ -3534,7 +3534,7 @@ status_effects:
       - no_cancel
 
   finishing_move_2:
-    id: 382
+    id:   382
     name: finishing_move
     flags:
       - death
@@ -3543,7 +3543,7 @@ status_effects:
       - no_cancel
 
   finishing_move_3:
-    id: 383
+    id:   383
     name: finishing_move
     flags:
       - death
@@ -3552,7 +3552,7 @@ status_effects:
       - no_cancel
 
   finishing_move_4:
-    id: 384
+    id:   384
     name: finishing_move
     flags:
       - death
@@ -3561,7 +3561,7 @@ status_effects:
       - no_cancel
 
   finishing_move_5:
-    id: 385
+    id:   385
     name: finishing_move
     flags:
       - death
@@ -3976,31 +3976,31 @@ status_effects:
       - on_jobchange
 
   copy_image_2:
-    id: 444
+    id:   444
     name: copy_image
     flags:
       - death
       - on_jobchange
     exclusion_group: blink
-    sort_key: 50
+    sort_key:        50
 
   copy_image_3:
-    id: 445
+    id:   445
     name: copy_image
     flags:
       - death
       - on_jobchange
     exclusion_group: blink
-    sort_key: 50
+    sort_key:        50
 
   copy_image_4:
-    id: 446
+    id:   446
     name: copy_image
     flags:
       - death
       - on_jobchange
     exclusion_group: blink
-    sort_key: 50
+    sort_key:        50
 
   multi_shots:
     id: 447
@@ -4040,7 +4040,7 @@ status_effects:
       - no_cancel
 
   divine_caress_i:
-    id: 453
+    id:   453
     name: divine_caress
     flags:
       - death
@@ -4081,7 +4081,7 @@ status_effects:
       - on_jobchange
 
   divine_caress_ii:
-    id: 459
+    id:   459
     name: divine_caress
     flags:
       - death
@@ -4236,7 +4236,7 @@ status_effects:
 
   # DRK 95
   scarlet_delirium_1:
-    id: 480
+    id:   480
     name: scarlet_delirium
     flags:
       - death
@@ -4531,7 +4531,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: fire
+    element:   fire
 
   gelus:
     id: 524
@@ -4543,7 +4543,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: ice
+    element:   ice
 
   flabra:
     id: 525
@@ -4555,7 +4555,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: wind
+    element:   wind
 
   tellus:
     id: 526
@@ -4567,7 +4567,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: earth
+    element:   earth
 
   sulpor:
     id: 527
@@ -4579,7 +4579,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: thunder
+    element:   thunder
 
   unda:
     id: 528
@@ -4591,7 +4591,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: water
+    element:   water
 
   lux:
     id: 529
@@ -4603,7 +4603,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: light
+    element:   light
 
   tenebrae:
     id: 530
@@ -4615,7 +4615,7 @@ status_effects:
       - on_jobchange
       - no_cancel
     overwrite: ignore_duplicate
-    element: dark
+    element:   dark
 
   vallation:
     id: 531
@@ -4639,7 +4639,7 @@ status_effects:
       - on_jobchange
 
   embolden:
-    id: 534
+    id:   534
     name: embolden
     flags:
       - death
@@ -4951,8 +4951,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: water
-    sort_key: 800
+    element:         water
+    sort_key:        800
 
   fast_cast:
     id: 574
@@ -5031,7 +5031,7 @@ status_effects:
       - on_jobchange
 
   costume_ii:
-    id: 585
+    id:   585
     name: costume
     flags:
       - death
@@ -5052,7 +5052,7 @@ status_effects:
       - on_zone
 
   finishing_move_6:
-    id: 588
+    id:   588
     name: finishing_move
     flags:
       - death
@@ -5181,8 +5181,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: wind
-    sort_key: 800
+    element:         wind
+    sort_key:        800
 
   clod_spikes:
     id: 606
@@ -5191,8 +5191,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: earth
-    sort_key: 800
+    element:         earth
+    sort_key:        800
 
   glint_spikes:
     id: 607
@@ -5201,8 +5201,8 @@ status_effects:
       - empathy
       - death
     exclusion_group: blaze_spikes
-    element: light
-    sort_key: 800
+    element:         light
+    sort_key:        800
 
   negate_virus:
     id: 608
@@ -5226,7 +5226,7 @@ status_effects:
       - on_zone
 
   magic_evasion_boost:
-    id: 611
+    id:   611
     name: magic_evasion_boost
     flags:
       - death
@@ -5254,7 +5254,7 @@ status_effects:
       - hide_timer
 
   boost_ii:
-    id: 615
+    id:   615
     name: boost
     flags:
       - attack
@@ -5475,7 +5475,7 @@ status_effects:
 
   # (Unimplemented)
   prowess_crystal_yield:
-    id: 779
+    id:   779
     name: prowess_crystal_yeild
     flags:
       - on_zone
@@ -5625,7 +5625,7 @@ status_effects:
 
   # Elemental resistance down
   elementalres_down:
-    id: 802
+    id:   802
     name: elemental_resistance_down
     flags:
       - death

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,6 +2,7 @@ mariadb
 gitpython
 pylint
 pyyaml
+ruamel.yaml
 colorama
 zmq
 black

--- a/tools/yaml/format.py
+++ b/tools/yaml/format.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""
+Format data YAML: ruamel round-trip to normalize structure (2-space indent,
+single quotes, flow spacing, drop null keys), then a text pass to align
+value/comment columns per contiguous block.
+
+Usage: python3 tools/yaml/format.py [paths...] [--check]
+       python3 tools/yaml/format.py --stdin < in.yaml > out.yaml
+  paths   : files or directories to format (default: data/)
+  --check : only check formatting, do not modify files (exit 1 if any differ)
+  --stdin : format stdin to stdout, for editor integration
+
+Requires ruamel.yaml and pyyaml (tools/requirements.txt); CI runs --check.
+"""
+
+import difflib
+import os
+import sys
+from collections import namedtuple
+from io import StringIO
+from pathlib import Path
+
+REEXEC_GUARD = "LSB_FORMAT_YAML_REEXEC"
+
+
+def cmake_python():
+    """
+    Interpreter CMake configured for the build (from CMakeCache.txt), or None.
+    The build installs tools/requirements.txt into it, so it is a good fallback
+    when an editor launches a python that lacks the deps.
+    """
+    root = Path(__file__).resolve().parents[2]
+    globs = (
+        "build*/CMakeCache.txt",
+        "build*/*/CMakeCache.txt",
+        "cmake-*/CMakeCache.txt",
+        "out/*/CMakeCache.txt",
+    )
+    caches = sorted(
+        (c for g in globs for c in root.glob(g)),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    for cache in caches:
+        try:
+            for line in cache.read_text(encoding="utf-8", errors="ignore").splitlines():
+                if "Python_EXECUTABLE:" in line and "=" in line:
+                    path = line.split("=", 1)[1].strip()
+                    if path and "NOTFOUND" not in path and Path(path).is_file():
+                        return path
+        except OSError:
+            continue
+    return None
+
+
+try:
+    import yaml as pyyaml
+    from ruamel.yaml import YAML
+except ImportError as exc:
+    # Retry through the build's interpreter, which has the deps installed.
+    build_python = None if os.environ.get(REEXEC_GUARD) else cmake_python()
+    if build_python and Path(build_python).resolve() != Path(sys.executable).resolve():
+        os.environ[REEXEC_GUARD] = "1"
+        os.execv(
+            build_python, [build_python, str(Path(__file__).resolve()), *sys.argv[1:]]
+        )
+    if "--stdin" in sys.argv[1:]:  # echo back so an editor never blanks the buffer
+        sys.stdout.buffer.write(sys.stdin.buffer.read())
+    sys.stderr.write(
+        f"format: missing dependency ({exc}) for interpreter {sys.executable}\n"
+        f"  run: {sys.executable} -m pip install -r tools/requirements.txt\n"
+    )
+    raise SystemExit(1)
+
+
+class FormatError(Exception):
+    """A file could not be safely formatted; reported per-file, never fatal."""
+
+
+def drop_null_keys(node):
+    """Recursively delete null-valued mapping keys in place; sequence items are
+    left alone (dropping them would shift indices)."""
+    if isinstance(node, dict):
+        for key in [k for k, v in node.items() if v is None]:
+            del node[key]
+        for value in node.values():
+            drop_null_keys(value)
+    elif isinstance(node, list):
+        for value in node:
+            drop_null_keys(value)
+
+
+def normalize(text):
+    ruamel = YAML()
+    ruamel.indent(mapping=2, sequence=4, offset=2)
+    ruamel.width = 4096  # never wrap
+    ruamel.preserve_quotes = False  # normalize quote style
+    data = ruamel.load(text)
+    drop_null_keys(data)
+    buf = StringIO()
+    ruamel.dump(data, buf)
+    return buf.getvalue()
+
+
+def split_comment(text):
+    """Split a line body into (code, comment) honoring quotes; comment keeps '#'."""
+    in_single = in_double = False
+    for i, ch in enumerate(text):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif (
+                ch == "#"
+                and not (in_single or in_double)
+                and (i == 0 or text[i - 1].isspace())
+        ):
+            return text[:i].rstrip(), text[i:]
+    return text.rstrip(), None
+
+
+KV = namedtuple("KV", "keycol has_dash key value comment")
+
+
+def parse_kv(line):
+    """
+    Return a KV for a scalar `key: value` line (optionally a `- key: value`
+    sequence item), else None so the line breaks the current alignment run.
+    """
+    stripped = line.lstrip(" ")
+    keycol = len(line) - len(stripped)
+    has_dash = stripped.startswith("- ")
+    if has_dash:
+        stripped = stripped[2:]
+        keycol += 2
+    if not stripped or stripped.startswith("#"):
+        return None
+    code, comment = split_comment(stripped)
+    sep = code.find(": ")  # -1 for a block opener `key:` or non-mapping line
+    key, value = code[:sep], code[sep + 2:].strip()
+    if sep == -1 or not key or not value or ":" in key:
+        return None
+    return KV(keycol, has_dash, key, value, comment)
+
+
+def align(text):
+    out = []
+    run = []  # a run of KVs sharing a keycol, aligned together
+
+    def flush():
+        if not run:
+            return
+        key_width = max(len(entry.key) for entry in run)
+        has_comment = any(entry.comment for entry in run)
+        value_width = max(len(entry.value) for entry in run) if has_comment else 0
+        for entry in run:
+            indent = (
+                " " * (entry.keycol - 2) + "- "
+                if entry.has_dash
+                else " " * entry.keycol
+            )
+            out_line = (
+                    indent
+                    + (entry.key + ": ").ljust(key_width + 2)
+                    + entry.value.ljust(value_width)
+            )
+            if entry.comment:
+                out_line += " " + entry.comment
+            out.append(out_line.rstrip())
+        run.clear()
+
+    block_indent = None  # set while inside a `|` / `>` block scalar body
+    prev_blank = False
+    for line in text.split("\n"):
+        stripped = line.lstrip(" ")
+        lead = len(line) - len(stripped)
+        if block_indent is not None:
+            if stripped == "" or lead > block_indent:
+                out.append(line)  # block body is kept verbatim
+                prev_blank = False
+                continue
+            block_indent = None
+        if stripped == "":
+            flush()
+            if not prev_blank:  # at most one blank line in a row
+                out.append("")
+            prev_blank = True
+            continue
+        prev_blank = False
+        kv = parse_kv(line)
+        if kv is None:
+            flush()
+            out.append(line)
+            continue
+        if run and run[0].keycol != kv.keycol:
+            flush()
+        run.append(kv)
+        if kv.value[0] in "|>":  # value opens a block scalar
+            flush()
+            block_indent = lead
+    flush()
+    return "\n".join(out)
+
+
+def parse_docs(text, what):
+    try:
+        return list(pyyaml.safe_load_all(text))
+    except pyyaml.YAMLError as exc:
+        raise FormatError(f"{what}: {exc}") from exc
+
+
+def format_text(text):
+    before = parse_docs(text, "invalid YAML")
+    if len(before) > 1:
+        raise FormatError("multi-document files (`---`) are not supported")
+    if all(doc is None for doc in before):
+        return text  # empty or comment-only
+    result = align(normalize(text))
+    after = parse_docs(result, "formatting produced invalid YAML")
+    drop_null_keys(before)  # nulls are dropped above; ignore them in the compare
+    drop_null_keys(after)
+    if before != after:
+        raise FormatError("formatting altered document semantics")
+    return result
+
+
+def iter_yaml(paths):
+    for raw in paths:
+        path = Path(raw)
+        yield from sorted(path.rglob("*.yaml")) if path.is_dir() else [path]
+
+
+def format_stdin():
+    # Raw byte I/O: keeps LF from becoming CRLF under Windows text mode, and on
+    # failure echoes the input back rather than emitting nothing.
+    text = sys.stdin.buffer.read().decode("utf-8")
+    try:
+        out = format_text(text)
+        code = 0
+    except FormatError as exc:
+        sys.stderr.write(f"format: {exc}\n")
+        out = text
+        code = 1
+    sys.stdout.buffer.write(out.encode("utf-8"))
+    return code
+
+
+def main(argv):
+    if "--stdin" in argv:
+        return format_stdin()
+    check = "--check" in argv
+    paths = [a for a in argv if a != "--check"] or ["data"]
+    changed, errors = [], []
+    for path in iter_yaml(paths):
+        try:
+            original = path.read_text(encoding="utf-8")
+            result = format_text(original)
+        except FileNotFoundError:
+            continue  # deleted/renamed in a changed-files list; nothing to format
+        except (OSError, FormatError) as exc:
+            print(f"{path}: {exc} -- skipped", file=sys.stderr)
+            errors.append(path)
+            continue
+        if result == original:
+            continue
+        changed.append(path)
+        if check:
+            sys.stdout.writelines(
+                difflib.unified_diff(
+                    original.splitlines(keepends=True),
+                    result.splitlines(keepends=True),
+                    fromfile=str(path),
+                    tofile=f"{path} (formatted)",
+                )
+            )
+        else:
+            path.write_text(result, encoding="utf-8", newline="\n")
+            print(f"formatted {path}")
+    if check and changed:
+        print(
+            f"\n{len(changed)} file(s) need formatting. Run: python tools/yaml/format.py"
+        )
+    return 1 if errors or (check and changed) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/yaml/test_format.py
+++ b/tools/yaml/test_format.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Golden tests for tools/yaml/format.py. Run: python tools/yaml/test_format.py"""
+
+import textwrap
+
+import format as fmt
+
+CASES = {
+    "aligns values and comments": (
+        """
+        values:
+          a: 1  # short
+          longer_key: 2  # tail
+        """,
+        """
+        values:
+          a:          1 # short
+          longer_key: 2 # tail
+        """,
+    ),
+    "reindents to two spaces": (
+        """
+        top:
+            deep: 1
+            deeper:
+                x: 2
+        """,
+        """
+        top:
+          deep: 1
+          deeper:
+            x: 2
+        """,
+    ),
+    "normalizes quotes and flow spacing": (
+        """
+        v:
+          a: 'x'
+          b: { m: 1,n: 2 }
+        """,
+        """
+        v:
+          a: x
+          b: {m: 1, n: 2}
+        """,
+    ),
+    "collapses blank lines, trims trailing ws": (
+        "a: 1   \n\n\n\nb: 2\n",
+        "a: 1\n\nb: 2\n",
+    ),
+    "leaves block scalar bodies verbatim": (
+        """
+        s:
+          body: |
+            keep:  spacing
+
+            and blanks
+          n: 3
+        """,
+        """
+        s:
+          body: |
+            keep:  spacing
+
+            and blanks
+          n: 3
+        """,
+    ),
+    "drops null-valued keys": (
+        """
+        item:
+          name: a
+          alias: null
+          empty:
+          count: 3
+        """,
+        """
+        item:
+          name:  a
+          count: 3
+        """,
+    ),
+    "aligns dash-line sequence keys": (
+        """
+        items:
+          - id: 1
+            name: a
+          - id: 2
+            name: bb
+        """,
+        """
+        items:
+          - id:   1
+            name: a
+          - id:   2
+            name: bb
+        """,
+    ),
+}
+
+
+def dedent(block):
+    return textwrap.dedent(block).lstrip("\n")
+
+
+def main():
+    failures = 0
+    for name, (raw, expected) in CASES.items():
+        got = fmt.format_text(dedent(raw))
+        want = dedent(expected)
+        if got == want:
+            print(f"  ok   {name}")
+
+        else:
+            failures += 1
+            print(f"  FAIL {name}")
+            print(f"    expected:\n{want!r}")
+            print(f"    got:\n{got!r}")
+
+    # idempotency: formatting the output again is a fixed point
+    for name, (_, expected) in CASES.items():
+        want = dedent(expected)
+        if fmt.format_text(want) != want:
+            failures += 1
+            print(f"  FAIL not idempotent: {name}")
+
+    # multi-document is refused, not crashed
+    try:
+        fmt.format_text("a: 1\n---\nb: 2\n")
+        failures += 1
+        print("  FAIL multi-doc should raise FormatError")
+
+    except fmt.FormatError:
+        print("  ok   multi-doc refused")
+
+    # empty / comment-only / explicit-null files are left untouched, not corrupted
+    for label, text in [
+        ("empty", ""),
+        ("comment-only", "# just a header comment\n"),
+        ("explicit null", "~\n"),
+    ]:
+        if fmt.format_text(text) == text:
+            print(f"  ok   {label} left as-is")
+
+        else:
+            failures += 1
+            print(f"  FAIL {label} was rewritten to {fmt.format_text(text)!r}")
+
+    print(f"\n{'PASS' if not failures else f'{failures} FAILURE(S)'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Problem: `prettier` is incredibly opinionated and doesn't support certain properties desired in this repository (namely vertical alignment) - in fact, there's no meaningfully supported formatter that support it today.

I looked far and wide for dozens of hours into the various options and how similar repositories handle it and found a handful of patterns, such as not caring about alignment to begin with or bundling a custom native formatter.

I've looked into various options for bundling our own formatter that would support alignment while keeping the most important parts of `prettier` and landed on a custom 200 lines Python script making use of `ruamel` - a pyyaml fork that preserves comments and contains certain formatting options.

I've tested the integration with `VSCode` through the extension `jkillian.custom-local-formatters` and was reasonably happy with the results.

Downsides include:
- It's 200 lines to support forever that will require tweaks as we discover other formatting issues
- It requires a new Python dependency

Alternatives I've considered:
- Run prettier and then another small script just for alignment
  - Rejected on fears of both scripts just fighting and triggering various file watchers as they update in turn
- Building the formatter as a C++ binary in-repo
  - A very tempting option but now we have a build dependency before formatting and I'd have to rewrite a lot of formatting options included in ruamel
- Building the formatter as a Rust/Go binary out of repo
  - Distribution concerns, a little unclear how we'd get users to install it
- yamlfmt: does not support alignment, not meaningfully supported
- dprint: does not support alignment
- Python with pyyaml: strips comments, not as many formatting options built-in
- Trusting human alignment/formatting: **Never, not a chance**

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
