### PR TITLE
[map] CHARREQ2: despawn stale out-of-range entity records instead of updating them

### DIFF
--- a/src/map/packets/c2s/0x017_charreq2.cpp
+++ b/src/map/packets/c2s/0x017_charreq2.cpp
@@ -92,6 +92,33 @@ void GP_CLI_COMMAND_CHARREQ2::process(MapSession* PSession, CCharEntity* PChar) 
         if (dist > CHARREQ2_SYNC_RANGE)
         {
             ShowWarningFmt("GP_CLI_COMMAND_CHARREQ2 from {}: target {} ({}) is {:.1f}y away (beyond {}y)", PChar->getName(), PTarget->getName(), PTarget->id, dist, CHARREQ2_SYNC_RANGE);
+
+            // The client is asking about an entity the server no longer tracks as visible
+            // to it (a stale record from before it left range). Answering with an update
+            // sustains the record and the client re-requests forever; answer with a despawn
+            // so it drops the record. Grid sync respawns the entity when back in range.
+            const auto* spawnList = [&]() -> const SpawnIDList_t*
+            {
+                switch (PTarget->objtype)
+                {
+                    case TYPE_PC:
+                        return &PChar->SpawnPCList;
+                    case TYPE_MOB:
+                        return &PChar->SpawnMOBList;
+                    case TYPE_PET:
+                        return &PChar->SpawnPETList;
+                    case TYPE_TRUST:
+                        return &PChar->SpawnTRUSTList;
+                    default:
+                        return &PChar->SpawnNPCList;
+                }
+            }();
+
+            if (spawnList->find(PTarget->id) == spawnList->end())
+            {
+                PChar->updateEntityPacket(PTarget, ENTITY_DESPAWN, UPDATE_NONE);
+                continue;
+            }
         }
 
         if (PTarget->objtype == TYPE_PC)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes an endless client request loop in `GP_CLI_COMMAND_CHARREQ2` (0x017) handling.

**Symptom:** After a character moves more than `CHARREQ2_SYNC_RANGE` (50y) away from entities it has seen (easy to reproduce with city NPCs, e.g. Upper Jeuno), the client can be left holding a stale record of those entities and re-sends `GP_CLI_COMMAND_CHARREQ2` for them roughly every 3.5 seconds, indefinitely. With the handler's current warning logging, the map console fills with pairs of lines like:

```
GP_CLI_COMMAND_CHARREQ2 from Driftwood: ActIndex=34 UniqueNo2=17772578 UniqueNo3=17772578 Flg=15 Flg2=15
GP_CLI_COMMAND_CHARREQ2 from Driftwood: target Kayle (17772578) is 55.2y away (beyond 50y)
```

repeating for the same entities every ~3.5s for as long as the character stays logged in. The requests also periodically hit the packet rate limiter (`Rate-limiting packet GP_CLI_COMMAND_CHARREQ2 (0x017)`).

**Cause:** The handler currently answers out-of-range requests with a full entity update (`ENTITY_UPDATE` / `UPDATE_ALL_MOB`, or `ENTITY_SPAWN` / `UPDATE_ALL_CHAR` for PCs). This sustains the client's stale record without resolving it, so the client keeps asking.

**Fix:** When the requested target is beyond `CHARREQ2_SYNC_RANGE` **and** is not present in the character's server-side spawn list for its entity type (i.e. the server does not consider it visible to this client), answer with `ENTITY_DESPAWN` / `UPDATE_NONE` so the client drops the stale record. The regular grid sync (`syncSpawnListWithGrid`) respawns the entity normally as soon as it comes back into range.

Entities the server still tracks for the character — including always-relevant entities, which remain in the spawn lists — are unaffected and keep the existing behavior.

## Steps to test these changes

1. Log in and stand near several NPCs in a city zone (tested in Upper Jeuno near the Auction House).
2. Walk more than 50y away from them and observe the map server console.
3. Before this change: `GP_CLI_COMMAND_CHARREQ2` warnings for the same out-of-range NPCs repeat every ~3.5 seconds indefinitely (left running 20+ minutes with no end), with intermittent rate-limiting warnings.
4. After this change: at most one request per stale entity appears, answered with a despawn; the log then goes quiet. Verified over a multi-hour session including zoning, cutscenes, and returning within range of the affected NPCs (they spawn back in normally via grid sync).
5. Party/spawn behavior around the 50y boundary was exercised by walking in and out of range repeatedly — entities despawn/respawn client-side as expected.
