### PR TITLE
[sql] Fix BLU Auto Refresh trait value

### DIFF
--- a/sql/blue_traits.sql
+++ b/sql/blue_traits.sql
@@ -80,7 +80,7 @@ INSERT INTO `blue_traits` VALUES (13,4,6,29,12,2,0);     -- Magic Defense Bonus 
 INSERT INTO `blue_traits` VALUES (13,6,6,29,14,3,0);     -- Magic Defense Bonus (3)
 INSERT INTO `blue_traits` VALUES (13,8,6,29,16,4,1);     -- Magic Defense Bonus (4) (JP only)
 INSERT INTO `blue_traits` VALUES (13,10,6,29,18,5,1);    -- Magic Defense Bonus (5) (JP only)
-INSERT INTO `blue_traits` VALUES (14,2,10,369,1,1,0);    -- Auto Refresh (1) -- Only tier available to BLU
+INSERT INTO `blue_traits` VALUES (14,8,10,369,1,1,0);    -- Auto Refresh (1) -- Only tier available to BLU
 INSERT INTO `blue_traits` VALUES (15,2,7,1095,30,1,0);   -- Max HP Boost (1)
 INSERT INTO `blue_traits` VALUES (15,4,7,1095,60,2,0);   -- Max HP Boost (2)
 INSERT INTO `blue_traits` VALUES (15,6,7,1095,120,3,0);  -- Max HP Boost (3)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Set point value was 2 for auto refresh when it should have been 8. The spell trait values are already correct.

## Steps to test these changes

Set 7 set point worth of auto refresh, don't get auto refresh. set 8 and get it.