### PR TITLE
[sql] [lua] Adjust several mob TP abilities

### DIFF
--- a/scripts/actions/mobskills/death_scissors.lua
+++ b/scripts/actions/mobskills/death_scissors.lua
@@ -21,11 +21,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.shadowBehavior   = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     params.attackMultiplier = { 2.5, 2.5, 2.5 }
     params.canCrit          = true
-    params.criticalChance   = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
-
-    if mob:getPool() == xi.mobPool.KING_VINEGARROON then
-        params.criticalChance = { 1.00, 1.00, 1.00 }
-    end
+    params.criticalChance   = { 1.00, 1.00, 1.00 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/hell_slash.lua
+++ b/scripts/actions/mobskills/hell_slash.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     params.canCrit        = true
-    params.criticalChance = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
+    params.criticalChance = { 1.00, 1.00, 1.00 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/screwdriver.lua
+++ b/scripts/actions/mobskills/screwdriver.lua
@@ -20,7 +20,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     params.canCrit        = true
-    params.criticalChance = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
+    params.criticalChance = { 1.00, 1.00, 1.00 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -376,15 +376,15 @@ INSERT INTO `mob_skills` VALUES (344,88,'sticky_thread',4,0.0,12.0,2000,1500,4,0
 INSERT INTO `mob_skills` VALUES (345,89,'poison_breath_crawler',4,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (346,90,'cocoon',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (347,889,'velocious_blade',0,0.0,3.0,2000,1500,4,0,0,0,0,0,0); -- sword form only
-INSERT INTO `mob_skills` VALUES (348,92,'numbing_breath',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (349,93,'cold_breath',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (350,94,'mandible_bite',0,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
-INSERT INTO `mob_skills` VALUES (351,95,'poison_sting',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (348,92,'numbing_breath',4,0.0,15.0,3433,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (349,93,'cold_breath',4,0.0,15.0,3400,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (350,94,'mandible_bite',0,0.0,7.0,1983,1000,4,0,0,2,0,0,0);
+INSERT INTO `mob_skills` VALUES (351,95,'poison_sting',0,0.0,7.0,1516,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (352,96,'stunning_tail',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (353,97,'death_scissors',0,0.0,9.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (354,98,'wild_rage',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (355,99,'earth_pounder',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (356,100,'sharp_strike',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (353,97,'death_scissors',0,0.0,9.0,2266,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (354,98,'wild_rage',1,0.0,15.0,2800,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (355,99,'earth_pounder',1,0.0,15.0,2200,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (356,100,'sharp_strike',0,0.0,7.0,2650,1000,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (357,825,'heavy_blow',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (358,826,'heavy_whisk',4,0.0,7.0,2000,1500,4,0,0,2,0,0,0);
 INSERT INTO `mob_skills` VALUES (359,827,'bionic_boost',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
@@ -477,12 +477,12 @@ INSERT INTO `mob_skills` VALUES (445,189,'scissor_guard',0,0.0,7.0,2000,1500,1,0
 -- INSERT INTO `mob_skills` VALUES (446,190,'intimidate',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (447,893,'percussive_foin',4,0.0,10.0,2000,1500,4,0,0,1,0,0,0); -- polearm form only
 INSERT INTO `mob_skills` VALUES (448,192,'metallic_body',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (449,193,'intimidate',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (450,194,'aqua_ball',2,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (451,195,'splash_breath',4,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (452,196,'screwdriver',0,0.0,9.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (453,197,'water_wall',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (454,198,'water_shield',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (449,193,'intimidate',4,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (450,194,'aqua_ball',2,0.0,12.0,1600,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (451,195,'splash_breath',4,0.0,12.0,3033,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (452,196,'screwdriver',0,0.0,9.0,4166,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (453,197,'water_wall',0,0.0,7.0,2116,1000,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (454,198,'water_shield',0,0.0,7.0,2333,1000,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (455,199,'aqua_lens',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (456,200,'tentacle',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (457,894,'gravity_wheel',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0); -- polearm form only
@@ -500,20 +500,20 @@ INSERT INTO `mob_skills` VALUES (468,212,'dirty_claw',0,0.0,7.0,2000,1500,4,0,0,
 INSERT INTO `mob_skills` VALUES (469,213,'shadow_claw',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (470,214,'methane_breath',4,0.0,12.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (471,896,'mind_wall',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0); -- staff form only
-INSERT INTO `mob_skills` VALUES (472,216,'grave_reel',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (473,217,'ectosmash',0,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (474,218,'fear_touch',0,0.0,7.0,3000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (475,219,'terror_touch',0,0.0,7.0,3000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (476,220,'curse',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (477,221,'dark_sphere',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (478,222,'hell_slash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (479,223,'horror_cloud',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (472,216,'grave_reel',1,0.0,15.0,4000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (473,217,'ectosmash',0,0.0,15.0,5000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (474,218,'fear_touch',0,0.0,7.0,3550,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (475,219,'terror_touch',0,0.0,7.0,3983,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (476,220,'curse',1,0.0,15.0,2250,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (477,221,'dark_sphere',0,0.0,7.0,2683,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (478,222,'hell_slash',0,0.0,7.0,3116,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (479,223,'horror_cloud',0,0.0,7.0,2466,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (480,288,'petrifactive_breath',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (481,225,'frenzied_rage',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (482,290,'pounce',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (483,291,'charged_whisker',1,0.0,12.5,2000,2000,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (484,228,'black_cloud',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (485,229,'blood_saber',1,0.0,15.0,2000,700,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (484,228,'black_cloud',1,0.0,15.0,3533,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (485,229,'blood_saber',1,0.0,15.0,3250,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (486,230,'whip_tongue',0,0.0,7.0,2000,1500,4,0,0,1,0,0,0);
 INSERT INTO `mob_skills` VALUES (487,897,'transmogrification',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0); -- hand form only
 INSERT INTO `mob_skills` VALUES (488,232,'acid_breath',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
@@ -841,15 +841,15 @@ INSERT INTO `mob_skills` VALUES (809,481,'aqua_breath',4,0.0,10.0,2000,1500,4,0,
 INSERT INTO `mob_skills` VALUES (810,482,'sickle_slash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (811,483,'acid_spray',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (812,484,'spider_web',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (813,485,'dispelling_wind',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (814,486,'deadly_drive',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (815,487,'wind_wall',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (816,488,'fang_rush',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (817,489,'dread_shriek',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (818,490,'tail_crush',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (813,485,'dispelling_wind',1,0.0,10.0,1883,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (814,486,'deadly_drive',0,0.0,7.0,3666,500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (815,487,'wind_wall',0,0.0,7.0,2200,1000,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (816,488,'fang_rush',0,0.0,7.0,2766,400,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (817,489,'dread_shriek',1,0.0,15.0,1833,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (818,490,'tail_crush',0,0.0,7.0,2600,500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (819,491,'blizzard_breath',4,0.0,18.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (820,492,'thunder_breath',4,0.0,18.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (821,493,'radiant_breath',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (821,493,'radiant_breath',4,0.0,15.0,4000,3000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (822,494,'chaos_breath',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (823,495,'fire_blade',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (824,496,'frost_blade',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the TP abilities of Scorpions, Wyverns, Skeletons, Ghosts, and Pugils to reflect their actual ready times.

This also adjusts the animation lockout time per the packet sheet.  I have tested these changes and as usual, they line up very well.

While testing Skeletons, Pugils, and Scorpions, Captain confirmed that every single time these abilities landed, they crit.
So this changes all 3 of those abilities to have a 100% crit rate.

https://www.dropbox.com/scl/fo/2phrrbhg8qwv1xvpcfyrs/AEXJN-qvuwl0VjJNeXj2e8E?rlkey=s5jwol9b0t01wx85b4dtph6ct&st=kldd9h27&dl=0

https://docs.google.com/spreadsheets/d/1Dq6WCR3Uedov3MNcGY7BYK1JrNDk4XVaDhoLU74c8tw/edit?gid=0#gid=0

## Steps to test these changes

!tp 3000 some stuff.
