### PR TITLE
[module] Bard era module additions and settings

### DIFF
--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -1792,7 +1792,7 @@ status_effects:
       - on_zone
       - song
       - no_cancel
-    overwrite: higher
+    overwrite: equal_higher
     element:   light
     sort_key:  2000
 
@@ -1820,8 +1820,9 @@ status_effects:
       - on_zone
       - song
       - no_cancel
-    element:  earth
-    sort_key: 2000
+    overwrite: equal_higher
+    element:   earth
+    sort_key:  2000
 
   paeon:
     id: 195
@@ -2096,7 +2097,7 @@ status_effects:
       - no_loss_message
       - song
       - no_cancel
-    overwrite: higher
+    overwrite: equal_higher
     sort_key:  2000
 
   hymnus:

--- a/modules/era/lua/globals/job_utils/bard.lua
+++ b/modules/era/lua/globals/job_utils/bard.lua
@@ -1,0 +1,35 @@
+-----------------------------------
+-- Module: Bard Job Adjustments
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_job_utils_bard'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+-- Nightingale: Revert to merit-based recast reduction
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+m:addOverride('xi.job_utils.bard.useNightingale', function(player, target, ability, action)
+    local recastReduction = player:getMerit(xi.merit.NIGHTINGALE) - 150
+    action:setRecast(action:getRecast() - recastReduction)
+
+    player:addStatusEffect(xi.effect.NIGHTINGALE, { duration = 60, origin = player })
+
+    return xi.effect.NIGHTINGALE
+end)
+
+-- Troubadour: Revert to merit-based recast reduction
+m:addOverride('xi.job_utils.bard.useTroubadour', function(player, target, ability, action)
+    local recastReduction = player:getMerit(xi.merit.TROUBADOUR) - 150
+    action:setRecast(action:getRecast() - recastReduction)
+
+    player:addStatusEffect(xi.effect.TROUBADOUR, { duration = 60, origin = player })
+
+    return xi.effect.TROUBADOUR
+end)
+
+return m

--- a/modules/era/sql/abyssea/job_adjustments.sql
+++ b/modules/era/sql/abyssea/job_adjustments.sql
@@ -105,6 +105,17 @@ UPDATE zone_settings
 SET misc = misc | @MISC_MAZURKA
 WHERE (zonetype & (@TYPE_CITY | @TYPE_OUTDOORS)) <> 0;
 
+-- Pianissimo: Revert learned level from 20 to 45
+-- Source: https://forum.square-enix.com/ffxi/threads/29150-December-13-2012-%28JST%29-Version-Update
+UPDATE abilities SET level = 45 WHERE name = 'pianissimo';
+
+-- Nightingale: Revert recast from 10 to 20 minutes
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+UPDATE abilities SET recastTime = 1200 WHERE name = 'nightingale';
+
+-- Troubadour: Revert recast from 10 to 20 minutes
+UPDATE abilities SET recastTime = 1200 WHERE name = 'troubadour';
+
 ------------------------------------
 -- Samurai
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)

--- a/scripts/actions/abilities/nightingale.lua
+++ b/scripts/actions/abilities/nightingale.lua
@@ -12,8 +12,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return 0, 0
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.bard.useNightingale(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.bard.useNightingale(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/actions/abilities/troubadour.lua
+++ b/scripts/actions/abilities/troubadour.lua
@@ -12,8 +12,8 @@ abilityObject.onAbilityCheck = function(player, target, ability)
     return 0, 0
 end
 
-abilityObject.onUseAbility = function(player, target, ability)
-    return xi.job_utils.bard.useTroubadour(player, target, ability)
+abilityObject.onUseAbility = function(player, target, ability, action)
+    return xi.job_utils.bard.useTroubadour(player, target, ability, action)
 end
 
 return abilityObject

--- a/scripts/combat/basic/magic_hit_rate.lua
+++ b/scripts/combat/basic/magic_hit_rate.lua
@@ -201,6 +201,7 @@ local function magicAccuracyFromMerits(actor, params)
 
         [xi.job.BRD] = function()
             if
+                xi.settings.main.ENABLE_BRD_MODERN_EFFECTS and
                 params.skillType == xi.skill.SINGING and
                 actor:hasStatusEffect(xi.effect.TROUBADOUR)
             then

--- a/scripts/globals/job_utils/bard.lua
+++ b/scripts/globals/job_utils/bard.lua
@@ -35,13 +35,13 @@ xi.job_utils.bard.usePianissimo = function(player, target, ability)
     return xi.effect.PIANISSIMO
 end
 
-xi.job_utils.bard.useNightingale = function(player, target, ability)
+xi.job_utils.bard.useNightingale = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.NIGHTINGALE, { duration = 60, origin = player })
 
     return xi.effect.NIGHTINGALE
 end
 
-xi.job_utils.bard.useTroubadour = function(player, target, ability)
+xi.job_utils.bard.useTroubadour = function(player, target, ability, action)
     player:addStatusEffect(xi.effect.TROUBADOUR, { duration = 60, origin = player })
 
     return xi.effect.TROUBADOUR

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -162,7 +162,6 @@ xi.settings.main =
 
     USE_ADOULIN_WEAPON_SKILL_CHANGES = true,  -- true/false. Change to toggle new Adoulin weapon skill damage calculations
     ENABLE_IMMUNOBREAK               = true,  -- true/false. Allow/Disallow immunobreaks to happen.
-    ENABLE_SMN_MAGIC_CAST_TIME_MERIT = true,  -- true/false. If false, the Summoning Magic Casting Time merit has no effect on cast time (pre-2012 behavior).
 
     -- TRUSTS
     ENABLE_TRUST_CASTING           = 1,
@@ -251,7 +250,11 @@ xi.settings.main =
     SNEAK_INVIS_DURATION_MULTIPLIER = 1,     -- multiplies duration of sneak, invis, deodorize to reduce player torture. 1 = retail behavior.
     USE_OLD_CURE_FORMULA            = false, -- true/false. if true, uses older cure formula (3*MND + VIT + 3*(healing skill/5)) // cure 6 will use the newer formula
     USE_OLD_MAGIC_DAMAGE            = false, -- true/false. if true, uses older magic damage formulas
-    USE_OLD_COUNTERSTANCE           = false, -- true/false. if true, Counterstance DEF = 1 + VIT/2 (+ Minne); gear/Protect ignored
+
+    -- JOB SPECIFIC SETTINGS
+    USE_OLD_COUNTERSTANCE            = false, -- true/false. (MNK) if true, Counterstance DEF = 1 + VIT/2 (+ Minne); gear/Protect ignored
+    ENABLE_SMN_MAGIC_CAST_TIME_MERIT = true,  -- true/false. (SMN) If false, the Summoning Magic Casting Time merit has no effect on cast time (pre-2012 behavior).
+    ENABLE_BRD_MODERN_EFFECTS        = true,  -- true/false. (BRD) If false, reverts modern additions: Nightingale instant song casts, Troubadour per-merit song accuracy, and Pianissimo's halved song cast time.
 
     -- CELEBRATIONS
     EXPLORER_MOOGLE_LV              = 10, -- Enables Explorer Moogle teleports and sets required level. Zero to disable.

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5530,14 +5530,15 @@ timer::duration CalculateSpellCastTime(CBattleEntity* PEntity, CMagicState* PMag
     {
         if (PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Pianissimo))
         {
-            if (PSpell->getAOE() == SPELLAOE_PIANISSIMO)
+            if (settings::get<bool>("main.ENABLE_BRD_MODERN_EFFECTS") && PSpell->getAOE() == SPELLAOE_PIANISSIMO)
             {
                 cast = base / 2;
             }
         }
         if (PEntity->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Nightingale))
         {
-            if (PEntity->objtype == TYPE_PC &&
+            if (settings::get<bool>("main.ENABLE_BRD_MODERN_EFFECTS") &&
+                PEntity->objtype == TYPE_PC &&
                 xirand::GetRandomNumber(100) < ((CCharEntity*)PEntity)->PMeritPoints->GetMeritValue(xi::Merit::Nightingale, (CCharEntity*)PEntity) - 25)
             {
                 return 0s;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds several new additions to era modules to revert functionality of Bard merits, and Pianissimo to their pre-Abyssea behavior
- Adjustments to Elegy/Requiem/Threnody to allow them to overwrite the same effect with equal potencies

With Horn > Horn > Piccolo 
<img width="459" height="247" alt="image" src="https://github.com/user-attachments/assets/1dd1c846-919c-4e48-a4b7-8cc9117e3af0" />

Piccolo all of 1st image > Piccolo First Cast on 2nd Image > No piccolo
<img width="473" height="436" alt="image" src="https://github.com/user-attachments/assets/e624ceb6-56f6-472f-8e58-bef8b7b376d7" />
<img width="476" height="149" alt="image" src="https://github.com/user-attachments/assets/1a63e23c-aa7f-49b5-a51b-abf43e6ef7f7" />

Requiem with the same instrument
<img width="520" height="146" alt="image" src="https://github.com/user-attachments/assets/fcc03fd7-561b-4b24-bbc3-2d346f33a123" />

## Steps to test these changes

- Load modules, and set new setting to false in main.lua
- See that merited nightingale and troubadour no longer have their new rank effects (instant cast/increased accuracy)