### PR TITLE
[lua][module] Correct module startup errors

### DIFF
--- a/modules/era/lua/globals/job_utils/paladin.lua
+++ b/modules/era/lua/globals/job_utils/paladin.lua
@@ -23,10 +23,7 @@ if not xi.module.isContentEnabled('ROV') then
     -- Stoneskin onEffectGain: Add defense buff when displayed as RAMPART
     m:addOverride('xi.effects.stoneskin.onEffectGain', function(target, effect)
         if effect:getIcon() == xi.effect.RAMPART then
-            effect:addMod(xi.mod.STONESKIN, effect:getSubPower())
             effect:addMod(xi.mod.DEF, effect:getPower())
-        else
-            effect:addMod(xi.mod.STONESKIN, effect:getPower())
         end
     end)
 end

--- a/modules/era/lua/zones/RoMaeve/Zone.lua
+++ b/modules/era/lua/zones/RoMaeve/Zone.lua
@@ -38,8 +38,8 @@ local function activateRoMaeve(zone)
     end
 
     -- Determine what the animation/status of the NPCs should be.
-    local doorStatus     = shouldDoorsOpen and xi.anim.OPEN_DOOR or xi.anim.CLOSE_DOOR
-    local fountainStatus = shouldFountainActivate and xi.anim.OPEN_DOOR or xi.anim.CLOSE_DOOR
+    local doorStatus     = shouldDoorsOpen and xi.animation.OPEN_DOOR or xi.animation.CLOSE_DOOR
+    local fountainStatus = shouldFountainActivate and xi.animation.OPEN_DOOR or xi.animation.CLOSE_DOOR
 
     -- Loop over the affected NPCs: Moongates, bridges and fountain
     for i = ID.npc.MOONGATE_OFFSET, ID.npc.MOONGATE_OFFSET + 7 do


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- xi.anim was changed to xi.animation, fixes that in Ro'maeve module logic

```
luautils::onGameHour: ./modules/era/lua/zones/RoMaeve/Zone.lua:41: attempt to index field 'anim' (a nil value)
```

- Stoneskin was recently reworked causing the Paladin rampart module to error. Corrects it to work without interacting with the stoneskin mod.

```
[07/25/26 12:17:28:683][map][error] luautils::onEffectGain: stack index 2, expected number, received nil: not a numeric type (bad argument into 'void(unsigned short, short)')
stack traceback:
	[C]: in function 'addMod'
	./modules/era/lua/globals/job_utils/paladin.lua:29: in function <./modules/era/lua/globals/job_utils/paladin.lua:24>
```

## Steps to test these changes

- Load all modules and restrict content
- See no errors on server startup
