### PR TITLE
Fix renamed equipped-model entities rendering their name as gear

### DIFF
--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -556,7 +556,12 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
     }
     // If the entity has been renamed, we have to re-send the name during every update.
     // Otherwise it will revert to it's default name (if applicable).
-    else if (PEntity->isRenamed)
+    //
+    // Excluded: entities the branch above spawns with the larger 0x56 layout. A
+    // MODEL_EQUIPPED look_t is memcpy'd to 0x30 and spans 0x30-0x43, so writing
+    // the name at 0x34 here would overwrite head/body/hands/legs/feet/main/sub/
+    // ranged. They already carry the renamed name from their spawn packet.
+    else if (PEntity->isRenamed && !(PEntity->look.size == MODEL_EQUIPPED && PEntity->targid >= 0x700))
     {
         updatemask |= UPDATE_NAME;
         ref<uint8>(0x0A) |= updatemask;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Stops a renamed trust/fellow-style entity from having its name written over its gear models in the 0x00E packet.

In `updateWith`, the spawn branch copies a `MODEL_EQUIPPED` `look_t` to 0x30. That look is 20 bytes, so it covers 0x30-0x43. The renamed branch underneath then writes the name at 0x34, which lands on top of head, body, hands, legs, feet, main, sub and ranged.

Most of the time you never see it, because a normal update doesn't set `UPDATE_LOOK` and the client ignores those bytes. It shows up when `CCharEntity::updateEntityPacket` merges a later update into a spawn packet that hasn't been flushed yet — the flag byte gets OR'd, `UPDATE_LOOK` is still set from the spawn, and the client reads the name text as gear model ids. A trust named "Tea" spawns with head = 'T','e', body = 'a',0 and nothing from main onward, so it also shows up with no weapon.

The spawn branch already handles these entities with the 0x56 layout that puts the name at 0x44, so they've got their name from the spawn packet and don't need the name re-sent on every update. This skips that re-send for exactly that case.

## Steps to test these changes

1. `renameEntity` a `MODEL_EQUIPPED` entity with targid >= 0x700 — a trust is the easiest one to reach.
2. Spawn it. Any time an update merges into the still-queued spawn packet, it comes out in random-looking gear with an empty weapon slot.
3. Zone. It looks correct again until the next time an update merges in.
4. With this change, the same entity keeps both its renamed name and its look.
