### PR TITLE
[Combat] Make magic hit rate global function use a table of parameters

### DIFF
--- a/scripts/actions/abilities/modus_veritas.lua
+++ b/scripts/actions/abilities/modus_veritas.lua
@@ -14,32 +14,31 @@ end
 
 abilityObject.onUseAbility = function(player, target, ability)
     local helix = target:getStatusEffect(xi.effect.HELIX)
-
-    if helix ~= nil then
-        local mvPower = helix:getSubPower()
-        local resist  = xi.combat.magicHitRate.calculateResistRate(player, target, 0, xi.skill.ELEMENTAL_MAGIC, 0, xi.element.NONE, 0, 0, 0)
-        -- Doesn't work against NMs apparently
-        if mvPower > 0 or resist < 0.25 or target:isNM() then -- Don't let Modus Veritas stack to prevent abuse
-            ability:setMsg(xi.msg.basic.JA_MISS) --Miss
-            return 0
-        else
-            -- Double power and halve remaining time
-            local mvMerits           = player:getMerit(xi.merit.MODUS_VERITAS_DURATION)
-            local durationMultiplier = 0.5 + (0.05 * mvMerits)
-            mvPower = mvPower + 1
-
-            local helixPower = helix:getPower() * 2 + (3 * player:getJobPointLevel(xi.jp.MODUS_VERITAS_EFFECT))
-            local duration   = helix:getDuration()
-            local remaining  = math.floor(helix:getTimeRemaining() / 1000) -- from milliseconds
-
-            duration = (duration-remaining) + math.floor(remaining * durationMultiplier)
-            helix:setSubPower(mvPower)
-            helix:setPower(helixPower)
-            helix:setDuration(duration * 1000) -- back to milliseconds
-        end
-    else
+    if not helix then
         ability:setMsg(xi.msg.basic.JA_NO_EFFECT_2) -- No effect
+        return 0
     end
+
+    local mvPower = helix:getSubPower()
+    local params  = { skillType = xi.skill.ELEMENTAL_MAGIC }
+    local resist  = xi.combat.magicHitRate.calculateResistRate(player, target, params)
+
+    -- Doesn't work against NMs apparently
+    if mvPower > 0 or resist < 0.25 or target:isNM() then -- Don't let Modus Veritas stack to prevent abuse
+        ability:setMsg(xi.msg.basic.JA_MISS) --Miss
+        return 0
+    end
+
+    -- Double power and halve remaining time
+    local durationMultiplier = 0.5 + 0.05 * player:getMerit(xi.merit.MODUS_VERITAS_DURATION)
+    local helixPower         = 2 * helix:getPower() + 3 * player:getJobPointLevel(xi.jp.MODUS_VERITAS_EFFECT)
+    local duration           = helix:getDuration()
+    local remaining          = math.floor(helix:getTimeRemaining() / 1000) -- from milliseconds
+
+    duration = duration - remaining + math.floor(remaining * durationMultiplier)
+    helix:setSubPower(mvPower + 1)
+    helix:setPower(helixPower)
+    helix:setDuration(duration * 1000) -- back to milliseconds
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/chaotic_strike.lua
+++ b/scripts/actions/abilities/pets/chaotic_strike.lua
@@ -35,7 +35,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.STUN, power = 1, duration = 12, origin = pet },
+            [1] = { effectId = xi.effect.STUN, power = 1, duration = 12 },
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/crescent_fang.lua
+++ b/scripts/actions/abilities/pets/crescent_fang.lua
@@ -31,7 +31,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.PARALYSIS, power = 22, duration = 60, origin = pet }, -- TODO: Capture power
+            [1] = { effectId = xi.effect.PARALYSIS, power = 22, duration = 60 }, -- TODO: Capture power
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/eerie_eye.lua
+++ b/scripts/actions/abilities/pets/eerie_eye.lua
@@ -11,37 +11,15 @@ end
 
 abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     xi.job_utils.summoner.onUseBloodPact(target, petskill, summoner, action)
-    local returnEffect = xi.effect.NONE
-    local duration = 30
-    local ele = xi.element.LIGHT
-    local bonus = pet:getStat(xi.mod.CHR) - target:getStat(xi.mod.CHR) - 10
-    if summoner ~= nil and summoner:isPC() then
-        bonus = bonus + xi.summon.getSummoningSkillOverCap(pet)
-    end
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, xi.skill.ENFEEBLING_MAGIC, 0, ele, 0, 0, bonus)
-    -- https://wikiwiki.jp/ffxi/%E5%8F%AC%E5%96%9A%E9%AD%94%E6%B3%95
-    -- TL;DR base 30s silence and 10s amnesia (also amnesia is fire element)
-    if resist >= 0.5 then --Do it!
-        if target:addStatusEffect(xi.effect.SILENCE, { power = 1, duration = duration * resist, origin = pet }) then
-            petskill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
-            local resist2 = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, xi.skill.ENFEEBLING_MAGIC, 0, xi.element.FIRE, 0, 0, bonus)
-            if
-                resist2 >= 0.5 and
-                target:addStatusEffect(xi.effect.AMNESIA, { power = 1, duration = duration * resist2 / 3, origin = pet })
-            then
-                returnEffect = xi.effect.AMNESIA
-            else
-                returnEffect = xi.effect.SILENCE
-            end
-        else
-            petskill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
-        end
-    else
-        petskill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
-    end
+    -- Effects table.
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SILENCE, power = 1, duration = 30, magicalElement = xi.element.LIGHT, actorStat = xi.mod.CHR, bonusMacc = xi.summon.getSummoningSkillOverCap(pet) },
+        [2] = { effectId = xi.effect.AMNESIA, power = 1, duration = 15, magicalElement = xi.element.FIRE,  actorStat = xi.mod.CHR, bonusMacc = xi.summon.getSummoningSkillOverCap(pet) },
+    }
 
-    return returnEffect
+    return xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, {})
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/megalith_throw.lua
+++ b/scripts/actions/abilities/pets/megalith_throw.lua
@@ -37,7 +37,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 120, tier = 8, origin = pet }, -- TODO: Capture Slow tier
+            [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 120, tier = 8 }, -- TODO: Capture Slow tier
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/mewing_lullaby.lua
+++ b/scripts/actions/abilities/pets/mewing_lullaby.lua
@@ -15,31 +15,13 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     -- Apply TP reset on target. (Secondary effect. Cannot miss.)
     target:setTP(0)
 
-    -- Check nullification.
-    if
-        xi.data.statusEffect.isTargetImmune(target, xi.effect.SLEEP_I, xi.element.LIGHT) or
-        xi.data.statusEffect.isTargetResistant(pet, target, xi.effect.SLEEP_I) or
-        xi.data.statusEffect.isEffectNullified(target, xi.effect.SLEEP_I, 0) or
-        target:hasStatusEffect(xi.effect.SLEEP_I)
-    then
-        petskill:setMsg(xi.msg.basic.JA_NO_EFFECT_2)
-        return xi.effect.SLEEP_I
-    end
+    -- Effects table.
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLEEP_I, power = 1, duration = 90, magicalElement = xi.element.LIGHT, actorStat = xi.mod.CHR, bonusMacc = xi.summon.getSummoningSkillOverCap(pet) },
+    }
 
-    -- Check resistance.
-    local bonusMacc  = xi.summon.getSummoningSkillOverCap(pet)
-    local resistRate = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, 0, 0, xi.element.LIGHT, xi.mod.CHR, xi.effect.SLEEP_I, bonusMacc)
-    if resistRate < 0.5 then
-        petskill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
-        return xi.effect.SLEEP_I
-    end
-
-    local duration = math.floor(90 * resistRate)
-
-    petskill:setMsg(xi.msg.basic.JA_GAIN_EFFECT)
-    target:addStatusEffect(xi.effect.SLEEP_I, { power = 1, duration = duration, origin = pet })
-
-    return xi.effect.SLEEP_I
+    return xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, {})
 end
 
 return abilityObject

--- a/scripts/actions/abilities/pets/moonlit_charge.lua
+++ b/scripts/actions/abilities/pets/moonlit_charge.lua
@@ -34,7 +34,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.BLINDNESS, power = 25, duration = 60, origin = pet },
+            [1] = { effectId = xi.effect.BLINDNESS, power = 25, duration = 60 },
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/mountain_buster.lua
+++ b/scripts/actions/abilities/pets/mountain_buster.lua
@@ -33,7 +33,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.BIND, power = 1, duration = math.randomInt(13, 60), origin = pet }, -- TODO: Get additional captures.
+            [1] = { effectId = xi.effect.BIND, power = 1, duration = math.randomInt(13, 60) }, -- TODO: Get additional captures.
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/nightmare.lua
+++ b/scripts/actions/abilities/pets/nightmare.lua
@@ -28,8 +28,15 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     end
 
     -- Check resistance.
-    local bonusMacc  = xi.summon.getSummoningSkillOverCap(pet)
-    local resistRate = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, 0, 0, xi.element.DARK, xi.mod.INT, xi.effect.SLEEP_I, bonusMacc)
+    local params =
+    {
+        effectId       = xi.effect.SLEEP_I,
+        magicalElement = xi.element.DARK,
+        bonusMacc      = xi.summon.getSummoningSkillOverCap(pet),
+        actorStat      = xi.mod.INT,
+    }
+
+    local resistRate = xi.combat.magicHitRate.calculateResistRate(pet, target, params)
     if resistRate < 0.5 then
         petskill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
         return xi.effect.SLEEP_I

--- a/scripts/actions/abilities/pets/poison_nails.lua
+++ b/scripts/actions/abilities/pets/poison_nails.lua
@@ -34,7 +34,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.POISON, power = 1, tick = 3, duration = 90, tier = 1, origin = pet },
+            [1] = { effectId = xi.effect.POISON, power = 1, tick = 3, duration = 90, tier = 1 },
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/rock_buster.lua
+++ b/scripts/actions/abilities/pets/rock_buster.lua
@@ -33,7 +33,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.BIND, power = 1, duration = 120, origin = pet }, -- TODO: Capture duration
+            [1] = { effectId = xi.effect.BIND, power = 1, duration = 120 }, -- TODO: Capture duration
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/rock_throw.lua
+++ b/scripts/actions/abilities/pets/rock_throw.lua
@@ -37,7 +37,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 120, tier = 8, origin = pet }, -- TODO: Capture Slow tier
+            [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 120, tier = 8 }, -- TODO: Capture Slow tier
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/shock_strike.lua
+++ b/scripts/actions/abilities/pets/shock_strike.lua
@@ -36,7 +36,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.STUN, power = 1, duration = 12, origin = pet },
+            [1] = { effectId = xi.effect.STUN, power = 1, duration = 12 },
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/abilities/pets/sleepga.lua
+++ b/scripts/actions/abilities/pets/sleepga.lua
@@ -28,8 +28,15 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     end
 
     -- Check resist.
-    local bonus    = xi.summon.getSummoningSkillOverCap(pet)
-    local resist   = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, 0, 0, xi.element.DARK, xi.mod.INT, xi.effect.SLEEP_I, bonus)
+    local params =
+    {
+        effectId       = xi.effect.SLEEP_I,
+        magicalElement = xi.element.DARK,
+        bonusMacc      = xi.summon.getSummoningSkillOverCap(pet),
+        actorStat      = xi.mod.INT,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, params)
     if resist < 0.5 then
         petskill:setMsg(xi.msg.basic.JA_MISS_2) -- resist message
         return xi.effect.SLEEP_I

--- a/scripts/actions/abilities/pets/sonic_buffet.lua
+++ b/scripts/actions/abilities/pets/sonic_buffet.lua
@@ -35,8 +35,16 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
     end
 
     -- Note: This dispel is Wind based rather than Dark.
-    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, 0, 0, 0, xi.element.WIND, 0, 0, 0)
-    if resist > 0.0625 then -- Is there _any_ circumstance wherein a dispel adds a message? Based on testing it seems the ability is magic damage only visibly.
+    local maccParams =
+    {
+        effectId       = xi.effect.NONE,
+        magicalElement = xi.element.WIND,
+        bonusMacc      = xi.summon.getSummoningSkillOverCap(pet),
+        actorStat      = xi.mod.INT,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(pet, target, maccParams)
+    if resist >= 0.5 then
         target:dispelStatusEffect()
     end
 

--- a/scripts/actions/abilities/pets/tail_whip.lua
+++ b/scripts/actions/abilities/pets/tail_whip.lua
@@ -33,7 +33,7 @@ abilityObject.onPetAbility = function(target, pet, petskill, summoner, action)
 
         local effectTable =
         {
-            [1] = { effectId = xi.effect.WEIGHT, power = 50, duration = 120, tier = 1, origin = pet }, -- TODO: Capture power/duration/tier
+            [1] = { effectId = xi.effect.WEIGHT, power = 50, duration = 120, tier = 1 }, -- TODO: Capture power/duration/tier
         }
 
         xi.combat.action.executeMobskillStatusEffect(pet, target, petskill, effectTable, { messageBypass = true })

--- a/scripts/actions/mobskills/cold_wave.lua
+++ b/scripts/actions/mobskills/cold_wave.lua
@@ -61,7 +61,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     local effectTable =
     {
-        [1] = { effectId = xi.effect.FROST, power = power, tick = 3, duration = 180, tier = 1, },
+        [1] = { effectId = xi.effect.FROST, power = power, tick = 3, duration = 180, tier = 1 },
     }
 
     return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})

--- a/scripts/actions/mobskills/dominion_slash.lua
+++ b/scripts/actions/mobskills/dominion_slash.lua
@@ -30,12 +30,16 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
         xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 60)
 
-        -- TODO: Capture/verify this mechanic. If real, check to see if it can resist. We should probably make a new function for this is it can be resisted.
-        -- Due to conflicting information, making the dispel resistable.  Correct/tweak if wrong.
-        -- Dispel has no status effect or resistance gear, so 0s instead of nulls.
-        local resistRate = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, xi.element.LIGHT, xi.mod.INT, xi.effect.NONE, 0)
+        local maccParams =
+        {
+            effectId       = xi.effect.NONE,
+            magicalElement = xi.element.LIGHT,
+            actorStat      = xi.mod.INT,
+        }
 
-        if resistRate >= 0.25 then
+        local resistRate = xi.combat.magicHitRate.calculateResistRate(mob, target, maccParams)
+
+        if resistRate >= 0.5 then
             target:dispelStatusEffect()
         end
     end

--- a/scripts/actions/mobskills/heat_wave.lua
+++ b/scripts/actions/mobskills/heat_wave.lua
@@ -62,7 +62,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
     local effectTable =
     {
-        [1] = { effectId = xi.effect.BURN, power = power, tick = 3, duration = 180, tier = 1, },
+        [1] = { effectId = xi.effect.BURN, power = power, tick = 3, duration = 180, tier = 1 },
     }
 
     return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})

--- a/scripts/actions/mobskills/nuclear_waste.lua
+++ b/scripts/actions/mobskills/nuclear_waste.lua
@@ -11,7 +11,14 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     mob:setLocalVar('nuclearWaste', 1)
-    local resist = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, xi.effect.ELEMENTALRES_DOWN, 0)
+
+    local params =
+    {
+        effectId  = xi.effect.ELEMENTALRES_DOWN,
+        actorStat = xi.mod.INT,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(mob, target, params)
     if resist >= 0.25 then
         target:addStatusEffect(xi.effect.ELEMENTALRES_DOWN, { power = 50, duration = 60, origin = mob, icon = 0 })
         skill:setMsg(xi.msg.basic.NONE)

--- a/scripts/actions/mobskills/spider_web.lua
+++ b/scripts/actions/mobskills/spider_web.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local effectTable =
     {
-        [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 90, tier = 8, },
+        [1] = { effectId = xi.effect.SLOW, power = 3000, duration = 90, tier = 8 },
     }
 
     return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})

--- a/scripts/actions/spells/black/death.lua
+++ b/scripts/actions/spells/black/death.lua
@@ -25,7 +25,14 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:isNM() and
             not target:hasStatusEffect(xi.effect.MAGIC_SHIELD)
         then
-            local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, 0, xi.element.DARK, 0, 0, 0)
+            local params =
+            {
+                magicalElement = xi.element.DARK,
+                skillType      = xi.skill.DARK_MAGIC,
+                spellGroup     = xi.magic.spellGroup.BLACK,
+            }
+
+            local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
 
             if resistRate == 1 then
                 instaDeath = true

--- a/scripts/actions/spells/black/impact.lua
+++ b/scripts/actions/spells/black/impact.lua
@@ -25,7 +25,15 @@ spellObject.onSpellCast = function(caster, target, spell)
         [7] = { xi.effect.CHR_DOWN, xi.mod.CHR },
     }
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), 0, 0, xi.element.DARK, xi.mod.INT, 0, 0)
+    local params =
+    {
+        magicalElement = xi.element.DARK,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.ELEMENTAL_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
 
     for i = 1, 7 do
         local effectId = effectTable[i][1]

--- a/scripts/actions/spells/blue/1000_needles.lua
+++ b/scripts/actions/spells/blue/1000_needles.lua
@@ -44,7 +44,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc = 1.0
 
     local damage = 1000
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, xi.element.LIGHT, xi.mod.INT, 0, -50)
+    local maccParams =
+    {
+        magicalElement = xi.element.LIGHT,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+        bonusMacc      = -50
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     if resist == 1 then
         local targets = spell:getTotalTargets()
         damage = damage / targets

--- a/scripts/actions/spells/blue/auroral_drape.lua
+++ b/scripts/actions/spells/blue/auroral_drape.lua
@@ -31,7 +31,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.isGaze          = false
     params.isConal         = false
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, 0, 0)
+    local maccParams =
+    {
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
 
     -- Handle status effects.
     -- Not sure if there's a better way to implement both status effects

--- a/scripts/actions/spells/blue/blank_gaze.lua
+++ b/scripts/actions/spells/blue/blank_gaze.lua
@@ -21,7 +21,15 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local effect = xi.effect.NONE
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, xi.element.LIGHT, xi.mod.INT, xi.effect.NONE, 0)
+    local params =
+    {
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
 
     if resist >= 0.25 then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/actions/spells/blue/cold_wave.lua
+++ b/scripts/actions/spells/blue/cold_wave.lua
@@ -22,13 +22,23 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
     params.ecosystem = xi.ecosystem.ARCANA
-    params.effect = xi.effect.FROST
+    params.effect    = xi.effect.FROST
     params.attribute = xi.mod.INT
     params.skillType = xi.skill.BLUE_MAGIC
     local tick = 3
     local duration = 60
     local resistThreshold = 0.5
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, xi.effect.FROST, 0)
+
+    local maccParams =
+    {
+        effectId       = xi.effect.FROST,
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
 
     -- Cannot apply if target has Burn
     if target:getStatusEffect(xi.effect.BURN) ~= nil then

--- a/scripts/actions/spells/blue/corrosive_ooze.lua
+++ b/scripts/actions/spells/blue/corrosive_ooze.lua
@@ -39,7 +39,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc = 0.0
 
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, 0, 0)
+    local maccParams =
+    {
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
 
     if resist >= 0.5 then
         target:addStatusEffect(xi.effect.DEFENSE_DOWN, { power = 5, duration = 90 * resist, origin = caster })

--- a/scripts/actions/spells/blue/enervation.lua
+++ b/scripts/actions/spells/blue/enervation.lua
@@ -24,7 +24,17 @@ spellObject.onSpellCast = function(caster, target, spell)
     local resistThreshold = 0.5
     local returnEffect    = xi.effect.DEFENSE_DOWN
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, xi.effect.DEFENSE_DOWN, 0)
+    local params =
+    {
+        effectId       = xi.effect.DEFENSE_DOWN,
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
+
     if resist >= resistThreshold then
 
         local actionOne = target:addStatusEffect(xi.effect.DEFENSE_DOWN, { power = 10, duration = duration * resist, origin = caster })

--- a/scripts/actions/spells/blue/feather_tickle.lua
+++ b/scripts/actions/spells/blue/feather_tickle.lua
@@ -23,7 +23,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     local power           = 1500
     local resistThreshold = 0.5
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, 0, 0)
+    local params =
+    {
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
+
     if resist >= resistThreshold then
         if target:getTP() == 0 then
             spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/actions/spells/blue/geist_wall.lua
+++ b/scripts/actions/spells/blue/geist_wall.lua
@@ -20,11 +20,20 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local resistThreshold = 0.25
-    local effect          = xi.effect.NONE
+    local effect = xi.effect.NONE
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, xi.effect.NONE, 0)
-    if resist >= resistThreshold then
+    local params =
+    {
+        effectId       = xi.effect.NONE,
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
+
+    if resist >= 0.5 then
         effect = target:dispelStatusEffect()
         spell:setMsg(xi.msg.basic.MAGIC_ERASE)
         if effect == xi.effect.NONE then

--- a/scripts/actions/spells/blue/light_of_penance.lua
+++ b/scripts/actions/spells/blue/light_of_penance.lua
@@ -23,7 +23,17 @@ spellObject.onSpellCast = function(caster, target, spell)
     local duration     = 30
     local returnEffect = xi.effect.BLINDNESS
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, xi.effect.BLINDNESS, 0)
+    local params =
+    {
+        effectId       = xi.effect.BLINDNESS,
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
+
     if resist >= 0.5 then
 
         spell:setMsg(xi.msg.basic.MAGIC_TP_REDUCE) -- this doesn't seem to do much

--- a/scripts/actions/spells/blue/rending_deluge.lua
+++ b/scripts/actions/spells/blue/rending_deluge.lua
@@ -42,8 +42,18 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.mnd_wsc = 0.0
     params.chr_wsc = 0.0
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, xi.effect.NONE, 0)
-    if resist > 0.0625 then
+    local maccParams =
+    {
+        effectId       = xi.effect.NONE,
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
+
+    if resist >= 0.5 then
         target:dispelStatusEffect()
     end
 

--- a/scripts/actions/spells/blue/voracious_trunk.lua
+++ b/scripts/actions/spells/blue/voracious_trunk.lua
@@ -20,7 +20,15 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local stolen = 0
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, spell:getSpellGroup(), xi.skill.BLUE_MAGIC, 0, spell:getElement(), xi.mod.INT, 0, 0)
+    local params =
+    {
+        magicalElement = spell:getElement(),
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spell:getSpellGroup(),
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, params)
 
     if resist >= 0.5 then
         stolen = caster:stealStatusEffect(target)

--- a/scripts/actions/weaponskills/death_blossom.lua
+++ b/scripts/actions/weaponskills/death_blossom.lua
@@ -35,9 +35,15 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local effectId      = xi.effect.MAGIC_EVASION_DOWN
     local actionElement = xi.element.THUNDER
     local power         = 10
-    local skillType     = xi.skill.SWORD
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist) -- TODO: Chance of lowering magic evasion varies with TP.
+    local maccParams =
+    {
+        effectId       = xi.effect.MAGIC_EVASION_DOWN,
+        magicalElement = xi.element.THUNDER,
+        skillType      = xi.skill.SWORD,
+    }
+
+    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+    local duration = math.floor(60 * resist) -- TODO: Chance of lowering magic evasion varies with TP.
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/actions/weaponskills/gale_axe.lua
+++ b/scripts/actions/weaponskills/gale_axe.lua
@@ -30,9 +30,15 @@ weaponskillObject.onUseWeaponSkill = function(player, target, wsID, tp, primary,
     local effectId      = xi.effect.CHOKE
     local actionElement = xi.element.WIND
     local power         = 5
-    local skillType     = xi.skill.AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist)
+    local maccParams =
+    {
+        effectId       = xi.effect.CHOKE,
+        magicalElement = xi.element.WIND,
+        skillType      = xi.skill.AXE,
+    }
+
+    local resist   = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+    local duration = math.floor(60 * resist)
     xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
 
     return tpHits, extraHits, criticalHit, damage

--- a/scripts/combat/action_additional_effect_damage.lua
+++ b/scripts/combat/action_additional_effect_damage.lua
@@ -49,7 +49,7 @@ local function validateParameters(actor, target, fedData)
     params.actorStat       = fedData.actorStat or 0
     params.targetStat      = fedData.targetStat or params.actorStat        -- Currently unused. For future use.
     params.skillRank       = fedData.skillRank or xi.skillRank.A_PLUS
-    params.macc            = fedData.macc or 0
+    params.bonusMacc       = fedData.bonusMacc or 0
 
     -- Multiplier properties.
     params.canMAB          = fedData.canMAB or false
@@ -130,7 +130,7 @@ xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     end
 
     -- Early return: Effect is resisted.
-    local multiplierResist = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, 0, 0, params.skillRank, params.magicalElement, params.actorStat, 0, params.macc) or 1
+    local multiplierResist = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, params) or 1
     if multiplierResist < params.lowestResist then
         return 0, 0, 0
     end

--- a/scripts/combat/action_additional_effect_status.lua
+++ b/scripts/combat/action_additional_effect_status.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Global file for additional effects (Status Effects)
 -----------------------------------
-require('scripts/combat/magic_hit_rate')
------------------------------------
 xi = xi or {}
 xi.combat = xi.combat or {}
 xi.combat.action = xi.combat.action or {}
@@ -58,11 +56,11 @@ local function validateParameters(actor, target, fedData)
     params.resistRate      = fedData.resistRate or 0
 
     -- Action properties.
-    params.element         = fedData.element or xi.element.NONE     -- None, Fire, Ice, Wind, Earth, Thunder, Water, Light, Dark.
+    params.magicalElement  = fedData.magicalElement or xi.data.statusEffect.getAssociatedElement(params.effectId, xi.element.NONE)
     params.actorStat       = fedData.actorStat or 0
-    params.targetStat      = fedData.targetStat or params.actorStat        -- Currently unused. For future use.
+    params.targetStat      = fedData.targetStat or params.actorStat
     params.skillRank       = fedData.skillRank or xi.skillRank.A_PLUS
-    params.macc            = fedData.macc or 0
+    params.bonusMacc       = fedData.bonusMacc or 0
 
     -- Optional behavior.
     params.resetEmnity     = fedData.resetEmnity or false -- Currently unused. For future use.
@@ -156,7 +154,7 @@ xi.combat.action.executeAddEffectEnfeeblement = function(actor, target, fedData)
     end
 
     -- Early return: Target is immune.
-    if xi.data.statusEffect.isTargetImmune(params.aeTarget, params.effectId, params.element) then
+    if xi.data.statusEffect.isTargetImmune(params.aeTarget, params.effectId, params.magicalElement) then
         return 0, 0, 0
     end
 
@@ -171,7 +169,7 @@ xi.combat.action.executeAddEffectEnfeeblement = function(actor, target, fedData)
     end
 
     -- Early return: Resist rate too high.
-    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, 0, 0, params.skillRank, params.element, params.actorStat, params.effectId, params.macc)
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, params)
     if not xi.data.statusEffect.isResistRateSuccessfull(params.effectId, resistanceRate, params.resistRate) then
         return 0, 0, 0
     end
@@ -211,7 +209,7 @@ xi.combat.action.executeAddEffectDispel = function(actor, target, fedData)
     end
 
     -- Early return: Resist rate too high.
-    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, 0, 0, params.skillRank, params.element, params.actorStat, params.effectId, params.macc)
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, params)
     if not xi.data.statusEffect.isResistRateSuccessfull(params.effectId, resistanceRate, params.resistRate) then
         return 0, 0, 0
     end

--- a/scripts/combat/action_mobskill_status_effect.lua
+++ b/scripts/combat/action_mobskill_status_effect.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Global file for mobskills that apply status effects.
 -----------------------------------
-require('scripts/combat/magic_hit_rate')
------------------------------------
 xi = xi or {}
 xi.combat = xi.combat or {}
 xi.combat.action = xi.combat.action or {}
@@ -25,20 +23,21 @@ local function validateEffectParameters(fedData)
     local params = {}
 
     -- Status effect application parameters.
-    params.effectId   = fedData.effectId or 0
-    params.power      = fedData.power or 0
-    params.tick       = fedData.tick or 0
-    params.duration   = fedData.duration or 0
-    params.subType    = fedData.subType or 0
-    params.subPower   = fedData.subPower or 0
-    params.tier       = fedData.tier or 0
+    params.effectId       = fedData.effectId or 0
+    params.power          = fedData.power or 0
+    params.tick           = fedData.tick or 0
+    params.duration       = fedData.duration or 0
+    params.subType        = fedData.subType or 0
+    params.subPower       = fedData.subPower or 0
+    params.tier           = fedData.tier or 0
 
     -- Calculation parameters.
-    params.element    = fedData.element or xi.data.statusEffect.getAssociatedElement(params.effectId, xi.element.NONE)
-    params.rank       = fedData.rank or xi.skillRank.A_PLUS -- The skill rank used for macc.
-    params.stat       = fedData.stat or xi.mod.INT          -- Stat used for macc.
-    params.macc       = fedData.macc or 0                   -- Flat macc bonus addition.
-    params.resistRate = fedData.resistRate or 0
+    params.magicalElement = fedData.magicalElement or xi.data.statusEffect.getAssociatedElement(params.effectId, xi.element.NONE)
+    params.skillRank      = fedData.skillRank or xi.skillRank.A_PLUS -- The skill rank used for macc.
+    params.actorStat      = fedData.actorStat or xi.mod.INT          -- Stat used for macc.
+    params.targetStat     = fedData.targetStat or params.actorStat
+    params.bonusMacc      = fedData.bonusMacc or 0                   -- Flat macc bonus addition.
+    params.resistRate     = fedData.resistRate or 0
 
     return params
 end
@@ -68,7 +67,7 @@ local function handleStatusEffect(actor, target, params)
     end
 
     -- Check immunity.
-    if xi.data.statusEffect.isTargetImmune(target, params.effectId, params.element) then
+    if xi.data.statusEffect.isTargetImmune(target, params.effectId, params.magicalElement) then
         return step.IMMUNE_CHECK
 
     -- Check resist traits.
@@ -81,7 +80,7 @@ local function handleStatusEffect(actor, target, params)
     end
 
     -- Calculate resist state.
-    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, 0, params.rank, params.element, params.stat, params.effectId, params.macc)
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(actor, target, params)
     if not xi.data.statusEffect.isResistRateSuccessfull(params.effectId, resistanceRate, params.resistRate) then
         return step.RESIST_RATE_CHECK
     end

--- a/scripts/combat/action_spikes_damage.lua
+++ b/scripts/combat/action_spikes_damage.lua
@@ -43,7 +43,7 @@ local function validateParameters(actor, target, fedData)
     params.actorStat       = fedData.actorStat or 0
     params.targetStat      = fedData.targetStat or params.actorStat        -- Currently unused. For future use.
     params.skillRank       = fedData.skillRank or 0
-    params.macc            = fedData.macc or 0
+    params.bonusMacc       = fedData.bonusMacc or 0
 
     -- Multiplier properties.
     params.canMAB          = fedData.canMAB or false
@@ -91,7 +91,7 @@ xi.combat.action.executeSpikesDamage = function(actor, target, fedData)
     end
 
     -- Early return: Effect is resisted.
-    local multiplierResist = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, 0, 0, params.skillRank, params.magicalElement, params.actorStat, 0, params.macc) or 1
+    local multiplierResist = params.canResist and xi.combat.magicHitRate.calculateResistRate(actor, params.aeTarget, params) or 1
     if multiplierResist < params.lowestResist then
         return 0, 0, 0
     end

--- a/scripts/combat/basic/magic_hit_rate.lua
+++ b/scripts/combat/basic/magic_hit_rate.lua
@@ -1,8 +1,6 @@
 -----------------------------------
 -- Global file for magic based skills magic hit rate.
 -----------------------------------
--- NOTE: Remove dependency to magic burst by feeding if its a magic burst directly. Then move file to scripts/combat/basic.
------------------------------------
 xi = xi or {}
 xi.combat = xi.combat or {}
 xi.combat.magicHitRate = xi.combat.magicHitRate or {}
@@ -281,7 +279,7 @@ end
 
 -- Magic Accuracy from Magic Burst.
 local function magicAccuracyFromMagicBurst(target, params)
-    if params.actorStat == 0 then
+    if params.magicalElement == xi.element.NONE then
         return 0
     end
 
@@ -537,19 +535,7 @@ local function validateParameters(actor, target, fedData)
     return params
 end
 
-xi.combat.magicHitRate.calculateResistRate = function(actor, target, spellGroup, skillType, skillRank, actionElement, statUsed, effectId, bonusMacc)
-    local fedData = -- Temporal measure: Table fed parameters. TODO: Feed a table to this function directly.
-    {
-        effectId       = utils.defaultIfNil(effectId, 0),
-        magicalElement = utils.defaultIfNil(actionElement, 0),
-        bonusMacc      = utils.defaultIfNil(bonusMacc, 0),
-        magicBurstTier = utils.defaultIfNil(xi.combat.magicBurst.getMagicBurstTier(target, actionElement), 0),
-        actorStat      = utils.defaultIfNil(statUsed, 0),
-        skillType      = utils.defaultIfNil(skillType, 0),
-        skillRank      = utils.defaultIfNil(skillRank, 0),
-        spellGroup     = utils.defaultIfNil(spellGroup, 0),
-    }
-
+xi.combat.magicHitRate.calculateResistRate = function(actor, target, fedData)
     -- Validate fed parameters.
     local params = validateParameters(actor, target, fedData)
 

--- a/scripts/combat/skillchain.lua
+++ b/scripts/combat/skillchain.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Global file for skillchain calculations.
 -----------------------------------
-require('scripts/combat/magic_hit_rate')
 require('scripts/globals/spells/damage_spell')
 -----------------------------------
 xi = xi or {}

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -182,7 +182,14 @@ xi.additionalEffect.procFunctions[xi.additionalEffect.procType.DEBUFF] = functio
     end
 
     -- Early return: Regular resist rate.
-    local resistRate = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, 0, xi.skillRank.A, actionElement, xi.mod.INT, effectId, 0)
+    local maccParams =
+    {
+        effectId       = effectId,
+        skillRank      = xi.skillRank.A,
+        magicalElement = actionElement,
+        actorStat      = xi.mod.INT,
+    }
+    local resistRate = xi.combat.magicHitRate.calculateResistRate(actor, target, maccParams)
     if resistRate < 0.5 then
         return 0, 0, 0
     end

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -410,7 +410,16 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     -- Final D value
     local finalDamage    = (initialD + wsc) * (params.multiplier + azureBonus + correlationMultiplier) + statBonus
 
-    finalDamage = math.floor(finalDamage * xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, params.attribute, 0, 0))
+    local maccParams =
+    {
+        magicalElement = spellElement,
+        magicBurstTier = skillchainCount,
+        actorStat      = params.attribute,
+        skillType      = skillType,
+        spellGroup     = spellGroup,
+    }
+
+    finalDamage = math.floor(finalDamage * xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateElementalStaffBonus(caster, spellElement))
     finalDamage = math.floor(finalDamage * xi.combat.damage.magicalElementSDT(target, spellElement))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateDayAndWeather(caster, spellElement, false))
@@ -468,7 +477,16 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     local skillType       = xi.skill.BLUE_MAGIC
     local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
 
-    finalDamage = math.floor(finalDamage * xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, params.attribute, 0, 0))
+    local maccParams =
+    {
+        magicalElement = spellElement,
+        magicBurstTier = skillchainCount,
+        actorStat      = params.attribute,
+        skillType      = skillType,
+        spellGroup     = spellGroup,
+    }
+
+    finalDamage = math.floor(finalDamage * xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateElementalStaffBonus(caster, spellElement))
     finalDamage = math.floor(finalDamage * xi.combat.damage.magicalElementSDT(target, spellElement))
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateDayAndWeather(caster, spellElement, false))
@@ -548,6 +566,13 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
     local attackType   = params.attackType or xi.attackType.NONE
     local damageType   = params.damageType or xi.damageType.NONE
 
+    local maccParams =
+    {
+        magicalElement = spellElement,
+        skillType      = xi.skill.BLUE_MAGIC,
+        spellGroup     = spellFamily,
+    }
+
     -- Multipliers
     local correlationMultiplier       = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0)
     local breathSDT                   = 1 + caster:getMod(xi.mod.BREATH_DMG_DEALT) / 100
@@ -556,7 +581,7 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
     local targetMagicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true)
     local elementalStaffBonus         = xi.spells.damage.calculateElementalStaffBonus(caster, spellElement)
     local elementalAffinityBonus      = xi.spells.damage.calculateElementalAffinityBonus(caster, spellElement)
-    local resistTier                  = xi.combat.magicHitRate.calculateResistRate(caster, target, spellFamily, xi.skill.BLUE_MAGIC, 0, spellElement, 0, 0, 0)
+    local resistTier                  = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     local additionalResistTier        = xi.spells.damage.calculateAdditionalResistTier(caster, target, spellElement)
     local elementalSDT                = xi.combat.damage.magicalElementSDT(target, spellElement)
     local dayAndWeather               = xi.spells.damage.calculateDayAndWeather(caster, spellElement, false)
@@ -726,7 +751,16 @@ xi.spells.blue.useEnfeeblingSpell = function(caster, target, spell, params)
     end
 
     -- Early return: Regular resist.
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, 0, xi.skill.BLUE_MAGIC, 0, spellElement, xi.mod.INT, 0, 0)
+    local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
+    local maccParams =
+    {
+        magicalElement = spellElement,
+        magicBurstTier = skillchainCount,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.BLUE_MAGIC,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     if resist < params.resistThreshold then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return effect
@@ -734,8 +768,6 @@ xi.spells.blue.useEnfeeblingSpell = function(caster, target, spell, params)
 
     if target:addStatusEffect(effect, { power = params.power, duration = math.floor(params.duration * resist), origin = caster, tick = params.tick }) then
         -- Add "Magic Burst!" message
-        local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
-
         if skillchainCount > 0 then
             spell:setMsg(xi.msg.basic.MAGIC_BURST_ENFEEB_IS)
             caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)
@@ -790,7 +822,14 @@ xi.spells.blue.applyBlueAdditionalEffect = function(caster, target, params, effe
     end
 
     -- Calculate resist and early return.
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, 0, xi.skill.BLUE_MAGIC, 0, element, stat, 0, 0)
+    local maccParams =
+    {
+        magicalElement = element,
+        actorStat      = stat,
+        skillType      = xi.skill.BLUE_MAGIC,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
 
     if resist <= 0.25 then
         return

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -475,7 +475,7 @@ xi.job_utils.beastmaster.useTame = function(player, target, ability)
         return 0
     end
 
-    local resist = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
+    local resist = xi.combat.magicHitRate.calculateResistRate(player, target, { actorStat = xi.mod.INT })
 
     if resist <= 0.25 then
         ability:setMsg(xi.msg.basic.JA_MISS_2)
@@ -749,7 +749,15 @@ xi.job_utils.beastmaster.useFeralHowl = function(player, target, ability, action
         ability:setMsg(xi.msg.basic.JA_MISS_2)
     else
         -- modAcc returns 5 per merit level (5, 10, 15, 20, 25), providing 5% accuracy bonus per merit
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.B_MINUS, xi.element.DARK, xi.mod.CHR, xi.effect.TERROR, modAcc)
+        local params =
+        {
+            effectId       = xi.effect.TERROR,
+            skillRank      = xi.skillRank.B_MINUS,
+            magicalElement = xi.element.DARK,
+            actorStat      = xi.mod.CHR,
+            bonusMacc      = modAcc,
+        }
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, params)
 
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.TERROR, resistanceRate, 0) then
             target:addStatusEffect(xi.effect.TERROR, { power = 1, duration = duration * resistanceRate, origin = player })

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -1011,8 +1011,14 @@ xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
     target:updateClaim(actor)
 
     -- Calculate resist rate.
-    local bonusAcc = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC)
-    local resist   = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.MARKSMANSHIP, 0,  data.element, xi.mod.AGI, 0, bonusAcc)
+    local params =
+    {
+        skillType      = xi.skill.MARKSMANSHIP,
+        magicalElement = data.element,
+        actorStat      = xi.mod.AGI,
+        bonusAcc       = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC),
+    }
+    local resist   = xi.combat.magicHitRate.calculateResistRate(actor, target, params)
 
     -- Handle damage.
     local damage = 0

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -387,14 +387,23 @@ xi.job_utils.dancer.useDesperateFlourishAbility = function(player, target, abili
         (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target))
     then
         infoValue = actionInfo[ability:getID()][2]
-        local resistRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.WIND, xi.mod.INT, xi.effect.WEIGHT, 0)
+
+        local maccParams =
+        {
+            effectId       = xi.effect.WEIGHT,
+            magicalElement = xi.element.WIND,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
 
         if
-            not xi.data.statusEffect.isTargetImmune(target, xi.effect.WEIGHT, xi.element.WIND) and -- Check immunity.
-            not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.WEIGHT) and       -- Check resistance trigger.
-            not xi.data.statusEffect.isEffectNullified(target, xi.effect.WEIGHT, 0) and               -- Check conflicting effect.
-            resistRate > 0.25 and                                                                  -- Check actual resistance.
-            target:addStatusEffect(xi.effect.WEIGHT, { power = 50, duration = 60 * resistRate, origin = player })                       -- Check effect power.
+            not xi.data.statusEffect.isTargetImmune(target, xi.effect.WEIGHT, xi.element.WIND) and                -- Check immunity.
+            not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.WEIGHT) and                      -- Check resistance trigger.
+            not xi.data.statusEffect.isEffectNullified(target, xi.effect.WEIGHT, 0) and                           -- Check conflicting effect.
+            resistRate > 0.25 and                                                                                 -- Check actual resistance.
+            target:addStatusEffect(xi.effect.WEIGHT, { power = 50, duration = 60 * resistRate, origin = player }) -- Check effect power.
         then
             ability:setMsg(xi.msg.basic.JA_ENFEEB_IS)
         else
@@ -444,8 +453,16 @@ xi.job_utils.dancer.useViolentFlourishAbility = function(player, target, ability
         action:recordDamage(target, xi.attackType.PHYSICAL, dmg)
 
         -- Effect
-        local bonusMacc  = player:getMod(xi.mod.VFLOURISH_MACC)
-        local resistRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, bonusMacc)
+        local maccParams =
+        {
+            effectId       = xi.effect.STUN,
+            magicalElement = xi.element.THUNDER,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+            bonusMacc      = player:getMod(xi.mod.VFLOURISH_MACC),
+        }
+
+        local resistRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
 
         if
             not xi.data.statusEffect.isTargetImmune(target, xi.effect.STUN, xi.element.THUNDER) and -- Check immunity.

--- a/scripts/globals/job_utils/dark_knight.lua
+++ b/scripts/globals/job_utils/dark_knight.lua
@@ -148,7 +148,15 @@ xi.job_utils.dark_knight.useWeaponBash = function(player, target, ability, actio
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.STUN) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.STUN, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
+        local maccParams =
+        {
+            effectId       = xi.effect.STUN,
+            magicalElement = xi.element.THUNDER,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
             target:addStatusEffect(xi.effect.STUN, { power = 1, duration = math.randomInt(2, 8) * resistanceRate, origin = player })
         end

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -692,12 +692,18 @@ xi.job_utils.dragoon.useDamageBreath = function(wyvern, target, skill, action, d
         wyvern:addTP(strafeMeritPower * 5) -- add 50 TP per merit with augmented AF2 legs
     end
 
-    local bonusMacc       = strafeMeritPower + master:getMod(xi.mod.WYVERN_BREATH_MACC)
     local element         = damageType - xi.damageType.ELEMENTAL
     local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, element)
 
     -- Breath accuracy is directly affected by a wyvern's current HP, but no data exists.
-    local resist              = xi.combat.magicHitRate.calculateResistRate(wyvern, target, 0, 0, 0, element, 0, 0, bonusMacc)
+    local maccParams =
+    {
+        magicalElement = damageType - xi.damageType.ELEMENTAL,
+        magicBurstTier = skillchainCount,
+        bonusMacc      = strafeMeritPower + master:getMod(xi.mod.WYVERN_BREATH_MACC),
+    }
+
+    local resist              = xi.combat.magicHitRate.calculateResistRate(wyvern, target, maccParams)
     local sdt                 = xi.combat.damage.magicalElementSDT(target, element)
     local absorb              = xi.spells.damage.calculateAbsorption(target, element, false, true, false, true)
     local nullify             = xi.spells.damage.calculateNullification(target, element, false, true, false, true)

--- a/scripts/globals/job_utils/ninja.lua
+++ b/scripts/globals/job_utils/ninja.lua
@@ -46,7 +46,7 @@ end
 
 xi.job_utils.ninja.useMijinGakure = function(player, target, ability, action)
     local dmg        = math.floor(player:getHP() * 0.8)
-    local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
+    local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, { actorStat = xi.mod.INT })
     local tmdaFactor = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
     local jpFactor   = 1 + player:getJobPointLevel(xi.jp.MIJIN_GAKURE_EFFECT) * 0.03
 

--- a/scripts/globals/job_utils/paladin.lua
+++ b/scripts/globals/job_utils/paladin.lua
@@ -214,7 +214,15 @@ xi.job_utils.paladin.useShieldBash = function(player, target, ability)
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.STUN) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.STUN, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
+        local maccParams =
+        {
+            effectId       = xi.effect.STUN,
+            magicalElement = xi.element.THUNDER,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
             target:addStatusEffect(xi.effect.STUN, { power = 1, duration = math.randomInt(2, 8) * resistanceRate, origin = player })
         end

--- a/scripts/globals/job_utils/rune_fencer.lua
+++ b/scripts/globals/job_utils/rune_fencer.lua
@@ -514,12 +514,13 @@ xi.job_utils.rune_fencer.onBattutaEffectLose = function(target, effect)
 end
 
 local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc) -- get these multipliers once and store them
-    local multipliers = {}
+    local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, element)
+    local multipliers     = {}
 
     multipliers.eleStaffBonus       = xi.spells.damage.calculateElementalStaffBonus(player, element)
     multipliers.eleAffinityBonus    = xi.spells.damage.calculateElementalAffinityBonus(player, element)
     multipliers.SDT                 = xi.combat.damage.magicalElementSDT(target, element)
-    multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, element, 0, 0, bonusMacc)
+    multipliers.resist              = xi.combat.magicHitRate.calculateResistRate(player, target, { magicalElement = element, magicBurstTier = skillchainCount, bonusMacc = bonusMacc })
     multipliers.dayAndWeather       = xi.spells.damage.calculateDayAndWeather(player, element, false)
     multipliers.magicBonusDiff      = xi.spells.damage.calculateMagicBonusDiff(player, target, 0, 0, element, 0)
     multipliers.TMDA                = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
@@ -527,8 +528,6 @@ local function getSwipeLungeDamageMultipliers(player, target, element, bonusMacc
     multipliers.nullify             = xi.spells.damage.calculateNullification(target, element, false, true, false, false)
     multipliers.magicBurst          = 1
     multipliers.magicBurstBonus     = 1
-
-    local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, element)
 
     if skillchainCount > 0 then
         multipliers.magicBurst      = xi.spells.damage.calculateIfMagicBurst(player, target, element, skillchainCount)

--- a/scripts/globals/job_utils/samurai.lua
+++ b/scripts/globals/job_utils/samurai.lua
@@ -215,9 +215,17 @@ xi.job_utils.samurai.useBladeBash = function(player, target, ability, action)
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.STUN) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.STUN, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
-        if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
-            target:addStatusEffect(xi.effect.STUN, { power = 1, duration = 6 * resistanceRate, origin = player })
+        local stunMaccParams =
+        {
+            effectId       = xi.effect.STUN,
+            magicalElement = xi.element.THUNDER,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local stunResistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, stunMaccParams)
+        if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, stunResistanceRate, 0) then
+            target:addStatusEffect(xi.effect.STUN, { power = 1, duration = 6 * stunResistanceRate, origin = player })
         end
     end
 
@@ -227,9 +235,17 @@ xi.job_utils.samurai.useBladeBash = function(player, target, ability, action)
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.PLAGUE) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.PLAGUE, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.FIRE, xi.mod.INT, xi.effect.PLAGUE, 0)
-        if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.PLAGUE, resistanceRate, 0) then
-            local duration = (15 + player:getMerit(xi.merit.BLADE_BASH)) * resistanceRate
+        local plagueMaccParams =
+        {
+            effectId       = xi.effect.PLAGUE,
+            magicalElement = xi.element.FIRE,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local plagueResistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, plagueMaccParams)
+        if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.PLAGUE, plagueResistanceRate, 0) then
+            local duration = (15 + player:getMerit(xi.merit.BLADE_BASH)) * plagueResistanceRate
             target:addStatusEffect(xi.effect.PLAGUE, { power = 5, duration = duration, origin = player })
         end
     end

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -456,7 +456,7 @@ xi.job_utils.thief.useSteal = function(player, target, ability, action)
     -- Attempt Aura steal
     -- local effect = xi.effect.NONE
     if player:hasTrait(xi.trait.AURA_STEAL) then
-        local resist = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
+        local resist = xi.combat.magicHitRate.calculateResistRate(player, target, { actorStat = xi.mod.INT })
         -- local effectStealSuccess = false
         if resist >= 0.25 then
             local auraStealChance = math.min(player:getMerit(xi.merit.AURA_STEAL), 95)

--- a/scripts/globals/magic.lua
+++ b/scripts/globals/magic.lua
@@ -77,7 +77,7 @@ end
 
 -- Applies resistance for additional effects
 function applyResistanceAddEffect(actor, target, element, bonusMacc)
-    return xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.NONE, 0, element, 0, 0, bonusMacc)
+    return xi.combat.magicHitRate.calculateResistRate(actor, target, { magicalElement = element, bonusMacc = bonusMacc })
 end
 
 function addBonusesAbility(caster, ele, target, dmg, params)

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -1005,15 +1005,15 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
     local shadowsToRemove      = utils.defaultIfNil(skillParams.shadowBehavior, xi.mobskills.shadowBehavior.NUMSHADOWS_1)
     local mATTBonusfTP         = utils.defaultIfNil(skillParams.mATTBonus, { 0, 0, 0 })
     local mACCBonusfTP         = utils.defaultIfNil(skillParams.mACCBonus, { 0, 0, 0 })
-    local skipDamageAdjustment = utils.defaultIfNil(skillParams.skipDamageAdjustment and true, false)
-    local skipMagicBonusDiff   = utils.defaultIfNil(skillParams.skipMagicBonusDiff and true, false)
-    local skipStoneskin        = utils.defaultIfNil(skillParams.skipStoneSkin and true, false)
+    local skipDamageAdjustment = utils.defaultIfNil(skillParams.skipDamageAdjustment, false)
+    local skipMagicBonusDiff   = utils.defaultIfNil(skillParams.skipMagicBonusDiff, false)
+    local skipStoneskin        = utils.defaultIfNil(skillParams.skipStoneSkin, false)
     -- TODO: handle different types of Stoneskin(Magical, Physical, Agnostic)
     local resistTierOverride   = utils.defaultIfNil(skillParams.resistTierOverride, 0)
     local dStatMultiplier      = utils.defaultIfNil(skillParams.dStatMultiplier, 0)
     local dStatAttackerMod     = utils.defaultIfNil(skillParams.dStatAttackerMod, xi.mod.INT)
-    local dStatDefenderMod     = utils.defaultIfNil(skillParams.dStatDefenderMod, xi.mod.INT)
-    local canMagicBurst        = utils.defaultIfNil(skillParams.canMagicBurst and true, false)
+    local dStatDefenderMod     = utils.defaultIfNil(skillParams.dStatDefenderMod, dStatAttackerMod)
+    local canMagicBurst        = utils.defaultIfNil(skillParams.canMagicBurst, false)
     local primaryMessage       = utils.defaultIfNil(skillParams.primaryMessage, xi.msg.basic.DAMAGE)
 
     -- If a stat_wSC is not specified in skill script, it will default to 0. (Sanitized in xi.combat.physical.calculateWSC)
@@ -1026,10 +1026,10 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
     local chrWSC = skillParams.chr_wSC
 
     -- Initialize returnInfo params
-    returnInfo.damage              = 0
-    returnInfo.hitsLanded          = 0
-    returnInfo.attackType          = attackType
-    returnInfo.damageType          = damageType
+    returnInfo.damage     = 0
+    returnInfo.hitsLanded = 0
+    returnInfo.attackType = attackType
+    returnInfo.damageType = damageType
 
     -- Set skill's default message.
     skill:setMsg(primaryMessage)
@@ -1096,15 +1096,7 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
     end
 
     -- Calculate if skill will be absorbed or nullified.
-    local absorbDamage  = 1
-    local nullifyDamage = 1
-
-    if attackType == xi.attackType.BREATH then
-        nullifyDamage  = xi.spells.damage.calculateNullification(target, actionElement, false, false, false, true)
-    else
-        nullifyDamage  = xi.spells.damage.calculateNullification(target, actionElement, false, true, false, false)
-    end
-
+    local nullifyDamage = xi.spells.damage.calculateNullification(target, actionElement, false, attackType ~= xi.attackType.BREATH, false, attackType == xi.attackType.BREATH)
     if nullifyDamage == 0 then
         -- Note: Nullification takes precedence over elemental absorption.
         -- Note: We still count nullifies as a "hit" since additional status effects tied to the skill itself will still apply.
@@ -1114,11 +1106,7 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
         return returnInfo
     end
 
-    if attackType == xi.attackType.BREATH then
-        absorbDamage  = xi.spells.damage.calculateAbsorption(target, actionElement, false, false, false, true)
-    else
-        absorbDamage  = xi.spells.damage.calculateAbsorption(target, actionElement, false, true, false, false)
-    end
+    local absorbDamage = xi.spells.damage.calculateAbsorption(target, actionElement, false, attackType ~= xi.attackType.BREATH, false, attackType == xi.attackType.BREATH)
 
     ----------------------------------
     -- Calculate MACC/Resists/Damage Adjustments
@@ -1152,35 +1140,35 @@ xi.mobskills.mobMagicalMove = function(mob, target, skill, action, skillParams)
     -- If skill was not absorbed, calculate resist and damage adjustments.
     -- Note: Elemental absorb mechanics such as Liement are calculated BEFORE resist/damage adjustments (such as shell/magic bursts).
     if absorbDamage > 0 then
-        resistTier = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, actionElement, dStatAttackerMod, 0, mAccuracyBonus)
+        local skillchainCount = canMagicBurst and xi.combat.magicBurst.getMagicBurstTier(target, actionElement) or 0
+
+        local maccParams =
+        {
+            magicalElement = actionElement,
+            magicBurstTier = skillchainCount,
+            actorStat      = dStatAttackerMod,
+            targetStat     = dStatDefenderMod,
+            bonusMacc      = mAccuracyBonus,
+        }
+
+        resistTier = xi.combat.magicHitRate.calculateResistRate(mob, target, maccParams)
 
         if mob:isAvatar() then
             bloodPactMultiplier = 1 + mob:getMod(xi.mod.BP_DAMAGE) / 100
         end
 
-        if
-            not skipDamageAdjustment and
-            attackType == xi.attackType.BREATH
-        then
-            -- Damage Adjustment for breath damage
-            magicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true)
-        elseif not skipDamageAdjustment then
-            -- Damage Adjustment for Magical damage.
-            magicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
+        if not skipDamageAdjustment then
+            magicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, attackType ~= xi.attackType.BREATH, false, attackType == xi.attackType.BREATH)
         end
 
-        if canMagicBurst then
-            local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, actionElement)
+        if skillchainCount > 0 then
+            -- TODO: Glyphic Bracers magic burst modifiers. https://www.bg-wiki.com/ffxi/Glyphic_Bracers
+            magicBurst      = xi.spells.damage.calculateIfMagicBurst(mob, target, actionElement, skillchainCount)
+            magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(mob, target, 0, 0, actionElement)
 
-            if skillchainCount > 0 then
-                -- TODO: Glyphic Bracers magic burst modifiers. https://www.bg-wiki.com/ffxi/Glyphic_Bracers
-                magicBurst      = xi.spells.damage.calculateIfMagicBurst(mob, target, actionElement, skillchainCount)
-                magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(mob, target, 0, 0, actionElement)
-
-                -- TODO: petskills currently seem to be searching for a mobskillID rather than the petskill ID which causes the magic burst to display the wrong message. Use JA_MAGIC_BURST for now.
-                -- skill:setMsg(xi.msg.basic.PET_MAGIC_BURST)
-                skill:setMsg(xi.msg.basic.JA_MAGIC_BURST)
-            end
+            -- TODO: petskills currently seem to be searching for a mobskillID rather than the petskill ID which causes the magic burst to display the wrong message. Use JA_MAGIC_BURST for now.
+            -- skill:setMsg(xi.msg.basic.PET_MAGIC_BURST)
+            skill:setMsg(xi.msg.basic.JA_MAGIC_BURST)
         end
     end
 
@@ -1356,23 +1344,30 @@ xi.mobskills.mobBreathMove = function(mob, target, skill, action, skillParams)
     -- If skill was not absorbed, calculate resist and damage adjustments.
     -- Note: Elemental absorb mechanics such as Liement are calculated BEFORE resist/damage adjustments (such as shell/magic bursts).
     if absorbDamage > 0 then
-        if canMagicBurst then
-            local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, actionElement)
+        local skillchainCount = canMagicBurst and xi.combat.magicBurst.getMagicBurstTier(target, actionElement) or 0
 
-            if skillchainCount > 0 then
-                if mob:isPet() and mob:getMaster() ~= nil then
-                    mAccuracyBonus = mAccuracyBonus + 25 -- TODO: This is based off a previous function. Would eventually like to get a capture for this.
+        if skillchainCount > 0 then
+            if mob:isPet() and mob:getMaster() ~= nil then
+                mAccuracyBonus = mAccuracyBonus + 25 -- TODO: This is based off a previous function. Would eventually like to get a capture for this.
 
-                    -- TODO: Do jug pet breaths gain damage or only an accuracy bonus?
-                    -- magicBurst      = xi.spells.damage.calculateIfMagicBurst(mob, target, actionElement, skillchainCount)
-                    -- magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(mob, target, 0, 0, actionElement)
+                -- TODO: Do jug pet breaths gain damage or only an accuracy bonus?
+                -- magicBurst      = xi.spells.damage.calculateIfMagicBurst(mob, target, actionElement, skillchainCount)
+                -- magicBurstBonus = xi.spells.damage.calculateIfMagicBurstBonus(mob, target, 0, 0, actionElement)
 
-                    skill:setMsg(xi.msg.basic.PET_MAGIC_BURST)
-                end
+                skill:setMsg(xi.msg.basic.PET_MAGIC_BURST)
             end
         end
 
-        resistRate             = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, xi.skillRank.A_PLUS, actionElement, resistStat, 0, mAccuracyBonus)
+        local maccParams =
+        {
+            magicalElement = actionElement,
+            magicBurstTier = skillchainCount,
+            actorStat      = resistStat,
+            skillRank      = xi.skillRank.A_PLUS,
+            bonusMacc      = mAccuracyBonus,
+        }
+
+        resistRate             = xi.combat.magicHitRate.calculateResistRate(mob, target, maccParams)
         breathDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, false, false, true)
     end
 
@@ -1583,7 +1578,15 @@ xi.mobskills.mobStatusEffectMove = function(mob, target, typeEffect, power, tick
         end
 
         local element    = mob:getStatusEffectElement(typeEffect) -- TODO: Do something.
-        local resistRate = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, element, xi.mod.INT, typeEffect, 0)
+
+        local maccParams =
+        {
+            effectId       = typeEffect,
+            magicalElement = element,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistRate = xi.combat.magicHitRate.calculateResistRate(mob, target, maccParams)
         if resistRate >= 0.25 then
             local totalDuration = math.floor(duration * resistRate)
             target:addStatusEffect(typeEffect, { power = power, duration = totalDuration, origin = mob, tick = tick, subType = subType, subPower = subPower, tier = tier })
@@ -1722,28 +1725,23 @@ xi.mobskills.handleShadowConsumption = function(target, skill, params, shadowsTo
 end
 
 xi.mobskills.calculatePetMagicAccuracyBonus = function(mob, target, actionElement)
-    local petAccBonus = 0
-
-    if mob:isPet() and mob:getMaster() ~= nil then
-        local master = mob:getMaster()
-
-        if mob:isAvatar() then
-            local masterSkillLevel    = master:getSkillLevel(xi.skill.SUMMONING_MAGIC)
-            local masterMaxSkillLevel = master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC)
-
-            petAccBonus = utils.clamp(masterSkillLevel - masterMaxSkillLevel, 0, 200)
-        end
-
-        local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, actionElement)
-        if
-            mob:getPetID() > 0 and
-            skillchainCount > 0
-        then
-            petAccBonus = petAccBonus + 25
-        end
+    if not mob:isPet() then
+        return 0
     end
 
-    return petAccBonus
+    if not mob:isAvatar() then
+        return 0
+    end
+
+    local master = mob:getMaster()
+    if not mob:getMaster() then
+        return 0
+    end
+
+    local masterSkillLevel    = master:getSkillLevel(xi.skill.SUMMONING_MAGIC)
+    local masterMaxSkillLevel = master:getMaxSkillLevel(mob:getMainLvl(), xi.job.SMN, xi.skill.SUMMONING_MAGIC)
+
+    return utils.clamp(masterSkillLevel - masterMaxSkillLevel, 0, 200)
 end
 
 xi.mobskills.handleHybridDamage = function(mob, target, physicalDamage, element)
@@ -1761,8 +1759,15 @@ xi.mobskills.handleHybridDamage = function(mob, target, physicalDamage, element)
     -- Note: Elemental absorb mechanics such as Liement are calculated BEFORE resist/damage adjustments (such as shell/magic bursts).
 
     if absorbDamage > 0 then
+        local maccParams =
+        {
+            magicalElement = element,
+            actorStat      = xi.mod.INT,
+            bonusMacc      = petAccBonus,
+        }
+
+        resist                = xi.combat.magicHitRate.calculateResistRate(mob, target, maccParams)
         sdt                   = xi.combat.damage.magicalElementSDT(target, element)
-        resist                = xi.combat.magicHitRate.calculateResistRate(mob, target, 0, 0, 0, element, xi.mod.INT, 0, petAccBonus)
         magicDamageAdjustment = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
     end
 

--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -28,7 +28,16 @@ xi.spells.absorb.doAbsorbStatSpell = function(caster, target, spell)
     local enfeeblingEffect = xi.spells.absorb.absorbStatData[spellId].downEffect
 
     -- Calculate resistance (2 state effects: Either No resist, half resist or full resist)
-    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, enfeeblingEffect, 0)
+    local maccParams =
+    {
+        effectId       = enfeeblingEffect,
+        magicalElement = xi.element.DARK,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.DARK_MAGIC,
+        spellGroup     = xi.magic.spellGroup.BLACK,
+    }
+
+    local resist = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     if resist < 0.5 then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return 0
@@ -123,8 +132,16 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
     local minDamagePotential = math.floor(maxDamagePotential * xi.spells.absorb.absorbPointsData[spellId][4])
     local baseDamage         = math.randomInt(minDamagePotential, maxDamagePotential)
 
+    local maccParams =
+    {
+        magicalElement = xi.element.DARK,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.DARK_MAGIC,
+        spellGroup     = xi.magic.spellGroup.BLACK,
+    }
+
     -- Multipliers.
-    local resistTier             = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, 0, 0)
+    local resistTier             = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     local additionalResistTier   = xi.spells.damage.calculateAdditionalResistTier(caster, target, xi.element.DARK)
     local sdt                    = xi.combat.damage.magicalElementSDT(target, xi.element.DARK)
     local elementalStaffBonus    = xi.spells.damage.calculateElementalStaffBonus(caster, xi.element.DARK)
@@ -235,8 +252,16 @@ xi.spells.absorb.doAbsorbTPSpell = function(caster, target, spell)
     -- Base damage.
     local baseDamage = targetTP * 30 / 100
 
+    local maccParams =
+    {
+        magicalElement = xi.element.DARK,
+        actorStat      = xi.mod.INT,
+        skillType      = xi.skill.DARK_MAGIC,
+        spellGroup     = xi.magic.spellGroup.BLACK,
+    }
+
     -- Multipliers.
-    local resistTier           = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.BLACK, xi.skill.DARK_MAGIC, 0, xi.element.DARK, xi.mod.INT, 0, 0)
+    local resistTier           = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     local additionalResistTier = xi.spells.damage.calculateAdditionalResistTier(caster, target, xi.element.DARK)
     local sdt                  = xi.combat.damage.magicalElementSDT(target, xi.element.DARK)
     local elementalStaffBonus  = xi.spells.damage.calculateElementalStaffBonus(caster, xi.element.DARK)

--- a/scripts/globals/spells/damage_spell.lua
+++ b/scripts/globals/spells/damage_spell.lua
@@ -1109,15 +1109,24 @@ xi.spells.damage.useDamageSpell = function(caster, target, spell)
     local skillType       = spell:getSkillType()
     local spellGroup      = spell:getSpellGroup()
     local statUsed        = xi.spells.damage.pTable[spellId][column.STAT_USED]
-    local bonusMacc       = xi.spells.damage.pTable[spellId][column.BONUS_MACC] + cardinalChantBonus(caster, target, xi.direction.SOUTH, spellId, skillType)
     local forceDayWeather = xi.spells.damage.pTable[spellId][column.FORCE_DAY_WEATHER]
+
+    local maccParams =
+    {
+        magicBurstTier = canMBurst and magicBurstTier or 0,
+        magicalElement = spellElement,
+        actorStat      = statUsed,
+        skillType      = skillType,
+        spellGroup     = spellGroup,
+        bonusMacc      = xi.spells.damage.pTable[spellId][column.BONUS_MACC] + cardinalChantBonus(caster, target, xi.direction.SOUTH, spellId, skillType),
+    }
 
     -- Calculate base damage and the rest of damage multipliers.
     local spellDamage                 = xi.spells.damage.calculateBaseDamage(caster, target, spellId, spellGroup, skillType, statUsed)
     local multipleTargetReduction     = xi.spells.damage.calculateMTDR(caster, spell)
     local elementalStaffBonus         = xi.spells.damage.calculateElementalStaffBonus(caster, spellElement)
     local elementalAffinityBonus      = xi.spells.damage.calculateElementalAffinityBonus(caster, spellElement)
-    local resistTier                  = not absorb and xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, statUsed, 0, bonusMacc) or 1
+    local resistTier                  = not absorb and xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams) or 1
     local additionalResistTier        = not absorb and xi.spells.damage.calculateAdditionalResistTier(caster, target, spellElement) or 1
     local magicBurst                  = canMBurst and xi.spells.damage.calculateIfMagicBurst(caster, target, spellElement, magicBurstTier) or 1
     local magicBurstBonus             = canMBurst and xi.spells.damage.calculateIfMagicBurstBonus(caster, target, spellId, skillType, spellElement) or 1

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -176,12 +176,24 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     local gearBoost = caster:getMod(pTable[spellId][column.SONG_MODIFIER]) + caster:getMod(xi.mod.ALL_SONGS_EFFECT)
 
     -- Finale has innate +175 to magic accuracy.
+    local magicBurstTier = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
     local bonusMagicAcc = 0
     if spellEffect == xi.effect.NONE then
         bonusMagicAcc = 175 + gearBoost * 5
     end
 
-    local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, xi.magic.spellGroup.SONG, xi.skill.SINGING, 0, spellElement, xi.mod.CHR, spellEffect, bonusMagicAcc)
+    local maccParams =
+    {
+        effectId       = spellEffect,
+        magicalElement = spellElement,
+        magicBurstTier = magicBurstTier,
+        actorStat      = xi.mod.CHR,
+        skillType      = xi.skill.SINGING,
+        spellGroup     = xi.magic.spellGroup.SONG,
+        bonusMacc      = bonusMagicAcc,
+    }
+
+    local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
     if not xi.data.statusEffect.isResistRateSuccessfull(spellEffect, resistRate, 0) then
         spell:setMsg(xi.msg.basic.MAGIC_RESIST)
         return spellEffect
@@ -242,7 +254,6 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     -- STEP 5: Attempt to apply the status effect. Check for magic burst.
     ------------------------------
     if target:addStatusEffect(spellEffect, { power = power, duration = duration, origin = caster, tick = tick, subPower = subEffect, tier = spellTier }) then
-        local magicBurstTier = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
         if magicBurstTier > 0 then
             spell:setMsg(xi.msg.basic.MAGIC_BURST_ENFEEB)
             caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)

--- a/scripts/globals/spells/enfeebling_spell.lua
+++ b/scripts/globals/spells/enfeebling_spell.lua
@@ -413,11 +413,24 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     ------------------------------
     -- STEP 2: Calculate resist tiers.
     ------------------------------
-    local spellGroup = spell:getSpellGroup()
-    local statUsed   = pTable[spellId][column.STAT_USED]
-    local message    = pTable[spellId][column.MESSAGE_OFFSET]
-    local bonusMacc  = pTable[spellId][column.BONUS_MACC]
-    local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, spellGroup, skillType, 0, spellElement, statUsed, spellEffect, bonusMacc)
+    local spellGroup     = spell:getSpellGroup()
+    local statUsed       = pTable[spellId][column.STAT_USED]
+    local message        = pTable[spellId][column.MESSAGE_OFFSET]
+    local bonusMacc      = pTable[spellId][column.BONUS_MACC]
+    local magicBurstTier = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
+
+    local maccParams =
+    {
+        effectId       = spellEffect,
+        magicalElement = spellElement,
+        magicBurstTier = magicBurstTier,
+        actorStat      = statUsed,
+        skillType      = skillType,
+        spellGroup     = spellGroup,
+        bonusMacc      = bonusMacc,
+    }
+
+    local resistRate = xi.combat.magicHitRate.calculateResistRate(caster, target, maccParams)
 
     if spellEffect ~= xi.effect.NONE then
         -- Stymie
@@ -492,8 +505,6 @@ xi.spells.enfeebling.useEnfeeblingSpell = function(caster, target, spell)
     ------------------------------
     if target:addStatusEffect(spellEffect, { power = potency, duration = duration, origin = caster, tick = tick, subPower = subpotency, tier = tier }) then
         -- Add "Magic Burst!" message
-        local magicBurstTier = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
-
         if magicBurstTier > 0 then
             spell:setMsg(xi.msg.basic.MAGIC_BURST_ENFEEB_IS - message * 3)
             caster:triggerRoeEvent(xi.roeTrigger.MAGIC_BURST)

--- a/scripts/globals/weaponskills.lua
+++ b/scripts/globals/weaponskills.lua
@@ -243,10 +243,17 @@ local function calculateHybridMagicDamage(tp, physicaldmg, attacker, target, wsP
         wsd = wsd + attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)
     end
 
+    local maccParams =
+    {
+        magicalElement = wsParams.ele,
+        skillType      = wsParams.skill,
+        bonusMacc      = calcParams.bonusAcc,
+    }
+
     magicdmg = math.floor(magicdmg * (100 + wsd) / 100)
     magicdmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, magicdmg, wsParams))
     magicdmg = math.floor(magicdmg + calcParams.bonusfTP * physicaldmg)
-    magicdmg = math.floor(magicdmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, calcParams.bonusAcc))
+    magicdmg = math.floor(magicdmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, maccParams))
     magicdmg = math.floor(magicdmg * xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false))
     magicdmg = math.floor(target:handleSevereDamage(magicdmg, false))
 
@@ -877,13 +884,20 @@ xi.weaponskills.doMagicWeaponskill = function(attacker, target, wsID, wsParams, 
             bonusdmg = bonusdmg + attacker:getMod(xi.mod.WEAPONSKILL_DAMAGE_BASE + wsID)
         end
 
+        local maccParams =
+        {
+            magicalElement = wsParams.ele,
+            skillType      = wsParams.skill,
+            bonusMacc      = gearAcc,
+        }
+
         -- Add in bonusdmg
         dmg = dmg * (100 + bonusdmg) / 100 -- Apply our "all hits" WS dmg bonuses
         dmg = dmg + dmg * attacker:getMod(xi.mod.ALL_WSDMG_FIRST_HIT) / 100 -- Add in our "first hit" WS dmg bonus
 
         -- Calculate magical bonuses and reductions
         dmg = math.floor(addBonusesAbility(attacker, wsParams.ele, target, dmg, wsParams))
-        dmg = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, 0, wsParams.skill, 0, wsParams.ele, 0, 0, gearAcc))
+        dmg = math.floor(dmg * xi.combat.magicHitRate.calculateResistRate(attacker, target, maccParams))
         dmg = math.floor(dmg * xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false))
         dmg = math.floor(target:handleSevereDamage(dmg, false))
 

--- a/scripts/items/balmung.lua
+++ b/scripts/items/balmung.lua
@@ -9,8 +9,8 @@ local itemObject = {}
 itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, item)
     local pTable =
     {
-        chance  = 10,
-        element = xi.element.DARK,
+        chance         = 10,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(actor, target, pTable)

--- a/scripts/items/bloodsword.lua
+++ b/scripts/items/bloodsword.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/bloody_blade.lua
+++ b/scripts/items/bloody_blade.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/bloody_lance.lua
+++ b/scripts/items/bloody_lance.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/bloody_rapier.lua
+++ b/scripts/items/bloody_rapier.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/bloody_sword.lua
+++ b/scripts/items/bloody_sword.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/carnage_blade.lua
+++ b/scripts/items/carnage_blade.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/carnage_lance.lua
+++ b/scripts/items/carnage_lance.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/carnage_rapier.lua
+++ b/scripts/items/carnage_rapier.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/carnage_sword.lua
+++ b/scripts/items/carnage_sword.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/dainslaif.lua
+++ b/scripts/items/dainslaif.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/deae_gratia.lua
+++ b/scripts/items/deae_gratia.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/muketsu.lua
+++ b/scripts/items/muketsu.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/muketsu_+1.lua
+++ b/scripts/items/muketsu_+1.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/items/vampiric_claws.lua
+++ b/scripts/items/vampiric_claws.lua
@@ -21,7 +21,6 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
         limitUndead     = true,
         drainHP         = true,
         overDrain       = true,
-        animation       = xi.subEffect.DARKNESS_DAMAGE,
     }
 
     return xi.combat.action.executeAddEffectDamage(actor, target, pTable)

--- a/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
+++ b/scripts/zones/AlTaieu/mobs/Jailer_of_Hope.lua
@@ -102,10 +102,10 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance   = 65,
-        effectId = xi.effect.STUN,
-        element  = xi.element.THUNDER,
-        duration = math.randomInt(4, 8),
+        chance         = 65,
+        effectId       = xi.effect.STUN,
+        magicalElement = xi.element.THUNDER,
+        duration       = math.randomInt(4, 8),
     }
 
     return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)

--- a/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
+++ b/scripts/zones/Arrapago_Reef/mobs/Velionis.lua
@@ -48,7 +48,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
+++ b/scripts/zones/Attohwa_Chasm/mobs/Sargas.lua
@@ -32,7 +32,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Gilagoge_Tlugvi.lua
@@ -46,8 +46,8 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance  = 25,
-        element = xi.element.DARK,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
+++ b/scripts/zones/Balgas_Dais/mobs/King_of_Coins.lua
@@ -36,8 +36,8 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance  = 25,
-        element = xi.element.DARK,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
+++ b/scripts/zones/Beaucedine_Glacier/mobs/Humbaba.lua
@@ -38,7 +38,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
+++ b/scripts/zones/Crawlers_Nest/mobs/Aqrabuamelu.lua
@@ -77,7 +77,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Halvung/mobs/Copper_Borer.lua
+++ b/scripts/zones/Halvung/mobs/Copper_Borer.lua
@@ -37,7 +37,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga.lua
@@ -13,10 +13,11 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance       = 25,
-        absorbEffect = true,
-        animation    = xi.subEffect.STATUS_DRAIN,
-        message      = xi.msg.basic.NONE,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
+        absorbEffect   = true,
+        animation      = xi.subEffect.STATUS_DRAIN,
+        message        = xi.msg.basic.NONE,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga_Hildesvini.lua
+++ b/scripts/zones/Hazhalm_Testing_Grounds/mobs/Djigga_Hildesvini.lua
@@ -19,10 +19,11 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance       = 25,
-        absorbEffect = true,
-        animation    = xi.subEffect.STATUS_DRAIN,
-        message      = xi.msg.basic.NONE,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
+        absorbEffect   = true,
+        animation      = xi.subEffect.STATUS_DRAIN,
+        message        = xi.msg.basic.NONE,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Bombast.lua
@@ -23,7 +23,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/mobs/Eight_of_Cups.lua
@@ -12,10 +12,10 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance   = 10,
-        effectId = xi.effect.MUTE,
-        element  = xi.element.WIND,
-        duration = 3600,
+        chance         = 10,
+        effectId       = xi.effect.MUTE,
+        magicalElement = xi.element.WIND,
+        duration       = 3600,
     }
 
     return xi.combat.action.executeAddEffectEnfeeblement(mob, target, pTable)

--- a/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Unstable_Cluster.lua
@@ -100,7 +100,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 return entity

--- a/scripts/zones/RoMaeve/mobs/Martinet.lua
+++ b/scripts/zones/RoMaeve/mobs/Martinet.lua
@@ -47,7 +47,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Grande.lua
@@ -46,8 +46,8 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance  = 25,
-        element = xi.element.DARK,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Media.lua
@@ -53,8 +53,8 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance  = 25,
-        element = xi.element.DARK,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
+++ b/scripts/zones/The_Shrine_of_RuAvitau/mobs/Olla_Pequena.lua
@@ -58,8 +58,8 @@ end
 entity.onAdditionalEffect = function(mob, target, damage)
     local pTable =
     {
-        chance  = 25,
-        element = xi.element.DARK,
+        chance         = 25,
+        magicalElement = xi.element.DARK,
     }
 
     return xi.combat.action.executeAddEffectDispel(mob, target, pTable)

--- a/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
+++ b/scripts/zones/Toraimarai_Canal/mobs/Brazen_Bones.lua
@@ -32,7 +32,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Uleguerand_Range/mobs/Father_Frost.lua
+++ b/scripts/zones/Uleguerand_Range/mobs/Father_Frost.lua
@@ -25,7 +25,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
+++ b/scripts/zones/Upper_Delkfutts_Tower/mobs/Autarch.lua
@@ -30,7 +30,7 @@ entity.onSpikesDamage = function(mob, target, damage)
         canResistExtra  = true,
     }
 
-    return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
+    return xi.combat.action.executeSpikesDamage(mob, target, pTable)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Makes `xi.combat.magicHitRate.calculateResistRate` function use a single table of parameters as oposed to the infinite and ever increasing number f paramters it uses now.
- Allows to feed different stats to check against for actor and target.
- Renames all parameter tables to use the same parameter names, for consistency and OCD
- Some cleanup.
- A few additional fixes.

## Steps to test these changes

No changes should be observed. Except for the cases where a fix happened, that is.
