### PR TITLE
[lua] Refresh drink buff effects on re-use instead of No effect

### DIFF
--- a/scripts/items/bottle_of_apple_juice.lua
+++ b/scripts/items/bottle_of_apple_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 135, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 135, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_grape_juice.lua
+++ b/scripts/items/bottle_of_grape_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 90, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 90, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_kitron_juice.lua
+++ b/scripts/items/bottle_of_kitron_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 3, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 3, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_melon_juice.lua
+++ b/scripts/items/bottle_of_melon_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 135, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 135, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_orange_juice.lua
+++ b/scripts/items/bottle_of_orange_juice.lua
@@ -17,9 +17,7 @@ itemObject.onItemUse = function(target, user)
         power = power + 1
     end
 
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = power, duration = 90, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = power, duration = 90, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_pineapple_juice.lua
+++ b/scripts/items/bottle_of_pineapple_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 240, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 240, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_tomato_juice.lua
+++ b/scripts/items/bottle_of_tomato_juice.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bottle_of_yagudo_drink.lua
+++ b/scripts/items/bottle_of_yagudo_drink.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/bowl_of_yogurt.lua
+++ b/scripts/items/bowl_of_yogurt.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_apple_au_lait.lua
+++ b/scripts/items/flask_of_apple_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_ayran.lua
+++ b/scripts/items/flask_of_ayran.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_dragon_fruit_au_lait.lua
+++ b/scripts/items/flask_of_dragon_fruit_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 6, duration = 300, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 6, duration = 300, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_orange_au_lait.lua
+++ b/scripts/items/flask_of_orange_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 300, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 300, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_pamama_au_lait.lua
+++ b/scripts/items/flask_of_pamama_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 600, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 600, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_pear_au_lait.lua
+++ b/scripts/items/flask_of_pear_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 3, duration = 300, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 3, duration = 300, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/flask_of_persikos_au_lait.lua
+++ b/scripts/items/flask_of_persikos_au_lait.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 4, duration = 600, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 4, duration = 600, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/jug_of_selbina_milk.lua
+++ b/scripts/items/jug_of_selbina_milk.lua
@@ -11,13 +11,9 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        if target:getEquipID(xi.slot.BODY) == 14520 then -- Dream Robe +1
-            target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 150, origin = user, tick = 3 })
-        else
-            target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 120, origin = user, tick = 3 })
-        end
-    else
+    local duration = target:getEquipID(xi.slot.BODY) == xi.item.DREAM_ROBE_P1 and 150 or 120
+
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = duration, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/jug_of_soy_milk.lua
+++ b/scripts/items/jug_of_soy_milk.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 120, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 120, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end

--- a/scripts/items/jug_of_uleguerand_milk.lua
+++ b/scripts/items/jug_of_uleguerand_milk.lua
@@ -11,9 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 120, origin = user, tick = 3 })
-    else
+    if not target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 120, origin = user, tick = 3 }) then
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the "No effect on <player>" issue  when a player  uses the same drink or one of equal or higher potency before the effect wears off.

retail screenshot here
<img width="1493" height="177" alt="image" src="https://github.com/user-attachments/assets/214d0d27-01b1-4a1d-b390-506b0fcb7809" />

quick note that i only changed the ones i tested on retail that you could craft or buy from a vendor. any drink from/for a quest or from a special event i did not test so, i did not change those.

## Steps to test these changes

drink a yagudo drink for example and then drink another one right after or before the original drink effect wears off.