### PR TITLE
[core] Rename EntityId fields, deprecate GetBattleTargetID()

### DIFF
--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -191,7 +191,7 @@ auto CAutomatonController::DoCombatTick(timer::time_point tick) -> Task<void>
         co_return;
     }
 
-    setTarget(static_cast<CBattleEntity*>(PAutomaton->GetEntity(PAutomaton->GetBattleTargetID())));
+    setTarget(PAutomaton->battleTarget().resolve<CBattleEntity>());
 
     if (TryDeaggro())
     {

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1169,7 +1169,7 @@ auto CMobController::DoCombatTick(timer::time_point tick) -> Task<void>
 
     if (PMob->m_OwnerID.ActIndex != 0)
     {
-        auto* POwner = dynamic_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.ActIndex));
+        auto* POwner = PMob->m_OwnerID.resolve<CCharEntity>();
         if (POwner && POwner->PClaimedMob != static_cast<CBattleEntity*>(PMob))
         {
             if (m_Tick >= m_DeclaimTime + 3s)
@@ -1181,7 +1181,7 @@ auto CMobController::DoCombatTick(timer::time_point tick) -> Task<void>
     }
 
     HandleEnmity();
-    setTarget(static_cast<CBattleEntity*>(PMob->GetEntity(PMob->GetBattleTargetID())));
+    setTarget(PMob->battleTarget().resolve<CBattleEntity>());
 
     if (TryDeaggro())
     {
@@ -1382,7 +1382,7 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
     else if (PMob->m_OwnerID.UniqueNo != 0 && (PMob->m_roamFlags & xi::RoamFlag::Ignore) == xi::RoamFlag::None)
     {
         // i'm claimed by someone and want to be fighting them
-        setTarget(static_cast<CBattleEntity*>(PMob->GetEntity(PMob->m_OwnerID.ActIndex, TYPE_PC | TYPE_MOB | TYPE_PET | TYPE_TRUST)));
+        setTarget(PMob->m_OwnerID.resolve<CBattleEntity>());
         auto* PTarget = target().resolve<CBattleEntity>();
 
         if (PTarget != nullptr)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1167,9 +1167,9 @@ auto CMobController::DoCombatTick(timer::time_point tick) -> Task<void>
 {
     TracyZoneScopedC(0xFF0000);
 
-    if (PMob->m_OwnerID.targid != 0)
+    if (PMob->m_OwnerID.ActIndex != 0)
     {
-        auto* POwner = dynamic_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid));
+        auto* POwner = dynamic_cast<CCharEntity*>(PMob->GetEntity(PMob->m_OwnerID.ActIndex));
         if (POwner && POwner->PClaimedMob != static_cast<CBattleEntity*>(PMob))
         {
             if (m_Tick >= m_DeclaimTime + 3s)
@@ -1382,7 +1382,7 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
     else if (PMob->m_OwnerID.UniqueNo != 0 && (PMob->m_roamFlags & xi::RoamFlag::Ignore) == xi::RoamFlag::None)
     {
         // i'm claimed by someone and want to be fighting them
-        setTarget(static_cast<CBattleEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid, TYPE_PC | TYPE_MOB | TYPE_PET | TYPE_TRUST)));
+        setTarget(static_cast<CBattleEntity*>(PMob->GetEntity(PMob->m_OwnerID.ActIndex, TYPE_PC | TYPE_MOB | TYPE_PET | TYPE_TRUST)));
         auto* PTarget = target().resolve<CBattleEntity>();
 
         if (PTarget != nullptr)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -643,7 +643,7 @@ void CMobController::TryLink()
     // Handle pets that act as bodyguards for their master. Will defend the master if they are being attacked.
     // Will not switch targets if they are already engaged.
     // Atomos, Alexander, and Odin are exempt from this behavior.
-    if (PTarget->PPet != nullptr && PTarget->PPet->GetBattleTargetID() == 0)
+    if (PTarget->PPet != nullptr && !PTarget->PPet->battleTarget().isSet())
     {
         bool isBodyguard = false;
 
@@ -777,7 +777,7 @@ auto CMobController::CanDetectTarget(CBattleEntity* PTarget, const bool forceSig
         }
     }
 
-    const bool isTargetAndInRange = PMob->GetBattleTargetID() == PTarget->targid && currentDistance <= PMob->GetMeleeRange(PTarget);
+    const bool isTargetAndInRange = PMob->battleTarget() == PTarget && currentDistance <= PMob->GetMeleeRange(PTarget);
 
     if (detectSight && !hasInvisible && currentDistance < PMob->getMobMod(xi::MobMod::SightRange) && facing(PMob->loc.p, PTarget->loc.p, 64))
     {
@@ -1304,7 +1304,7 @@ void CMobController::HandleEnmity()
     {
         ChangeTarget(static_cast<CMobEntity*>(PMob->GetEntity(PMob->getMobMod(xi::MobMod::ShareTarget), TYPE_MOB))->battleTarget());
 
-        if (!PMob->GetBattleTargetID())
+        if (!PMob->battleTarget().isSet())
         {
             if (PHighestEnmityTarget)
             {

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1379,7 +1379,7 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
         Engage(PMob->PEnmityContainer->GetHighestEnmity()->entityId());
         co_return;
     }
-    else if (PMob->m_OwnerID.id != 0 && (PMob->m_roamFlags & xi::RoamFlag::Ignore) == xi::RoamFlag::None)
+    else if (PMob->m_OwnerID.UniqueNo != 0 && (PMob->m_roamFlags & xi::RoamFlag::Ignore) == xi::RoamFlag::None)
     {
         // i'm claimed by someone and want to be fighting them
         setTarget(static_cast<CBattleEntity*>(PMob->GetEntity(PMob->m_OwnerID.targid, TYPE_PC | TYPE_MOB | TYPE_PET | TYPE_TRUST)));

--- a/src/map/ai/controllers/player_charm_controller.cpp
+++ b/src/map/ai/controllers/player_charm_controller.cpp
@@ -69,7 +69,7 @@ void CPlayerCharmController::DoCombatTick(timer::time_point tick) const
     {
         POwner->PAI->Internal_Disengage();
     }
-    if (POwner->PMaster->GetBattleTargetID() != POwner->GetBattleTargetID())
+    if (POwner->PMaster->battleTarget() != POwner->battleTarget())
     {
         POwner->PAI->Internal_ChangeTarget(POwner->PMaster->battleTarget());
     }

--- a/src/map/ai/controllers/trust_controller.cpp
+++ b/src/map/ai/controllers/trust_controller.cpp
@@ -138,7 +138,7 @@ auto CTrustController::DoCombatTick(timer::time_point tick) -> Task<void>
         m_CombatEndTime = m_Tick;
     }
 
-    if (PMaster && PMob && PTrust->GetBattleTargetID() != PMaster->GetBattleTargetID())
+    if (PMaster && PMob && PTrust->battleTarget() != PMaster->battleTarget())
     {
         auto  masterID   = PMaster->id;
         auto* enmityList = PMob->PEnmityContainer->GetEnmityList();

--- a/src/map/ai/helpers/gambits_container.cpp
+++ b/src/map/ai/helpers/gambits_container.cpp
@@ -1454,7 +1454,7 @@ auto CGambitsContainer::CheckTrigger(const CBattleEntity* triggerTarget, const G
                                 continue;
                             }
 
-                            const bool targetingMaster        = (PZoneMob->GetBattleTargetID() == PMaster->targid);
+                            const bool targetingMaster        = (PZoneMob->battleTarget() == PMaster);
                             const bool isMastersCurrentTarget = (PZoneMob->id == PMob->id);
                             const bool hostile                = (PZoneMob->allegiance != PMaster->allegiance);
 

--- a/src/map/ai/helpers/targetfind.cpp
+++ b/src/map/ai/helpers/targetfind.cpp
@@ -448,7 +448,7 @@ bool CTargetFind::isMobOwner(CBattleEntity* PTarget)
         return true;
     }
 
-    if (PTarget->m_OwnerID.id == 0 || PTarget->m_OwnerID.id == findMaster(m_PBattleEntity)->id)
+    if (PTarget->m_OwnerID.UniqueNo == 0 || PTarget->m_OwnerID.UniqueNo == findMaster(m_PBattleEntity)->id)
     {
         return true;
     }
@@ -466,7 +466,7 @@ bool CTargetFind::isMobOwner(CBattleEntity* PTarget)
     // clang-format off
     findMaster(m_PBattleEntity)->ForAlliance([&found, &PTarget](CBattleEntity* PMember)
     {
-        if (PMember->id == PTarget->m_OwnerID.id)
+        if (PMember->id == PTarget->m_OwnerID.UniqueNo)
         {
             found = true;
         }

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -72,7 +72,7 @@ auto CAttackState::Update(timer::time_point tick) -> bool
         if (CanAttack(PTarget))
         {
             // CanAttack may have set target id to 0 (disengage from out of range)
-            if (m_PEntity->GetBattleTargetID() == 0)
+            if (!m_PEntity->battleTarget().isSet())
             {
                 return true;
             }
@@ -93,7 +93,7 @@ auto CAttackState::Update(timer::time_point tick) -> bool
         {
             m_PEntity->HandleErrorMessage(m_errorMsg);
         }
-        if (m_PEntity->GetBattleTargetID() == 0)
+        if (!m_PEntity->battleTarget().isSet())
         {
             return true;
         }

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -89,7 +89,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, c
         // For self-centered AoE damaging moves, show battle target in readies message
         // For true self-target buffs (TARGET_SELF), show self
         const bool isSelfBuff    = skill->getValidTargets() == TARGET_SELF;
-        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : m_PEntity->GetEntity(target.ActIndex));
+        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : target.resolve());
         if (!PActionTarget)
         {
             PActionTarget = m_PEntity;

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -55,7 +55,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, c
     // Self-centered AoE: validate mob can target itself, but keep original targid for allegiance
     const bool   isSelfCenteredAoE = skill->getAoe() == static_cast<uint8>(AOE_RADIUS::ATTACKER);
     const uint16 validTargets      = isSelfCenteredAoE ? static_cast<uint16>(TARGET_SELF) : skill->getValidTargets();
-    const uint16 validateTargid    = isSelfCenteredAoE ? m_PEntity->targid : target.targid;
+    const uint16 validateTargid    = isSelfCenteredAoE ? m_PEntity->targid : target.ActIndex;
     auto*        PTarget           = m_PEntity->IsValidTarget(validateTargid, validTargets, m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
@@ -89,7 +89,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, c
         // For self-centered AoE damaging moves, show battle target in readies message
         // For true self-target buffs (TARGET_SELF), show self
         const bool isSelfBuff    = skill->getValidTargets() == TARGET_SELF;
-        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : m_PEntity->GetEntity(target.targid));
+        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : m_PEntity->GetEntity(target.ActIndex));
         if (!PActionTarget)
         {
             PActionTarget = m_PEntity;

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -884,7 +884,7 @@ bool CBattlefield::CheckInProgress()
     ForEachEnemy([&](const CMobEntity* PMob)
                  {
                      // Any entry in enmity list or currently chasing someone
-                     if (!PMob->PEnmityContainer->GetEnmityList()->empty() || PMob->GetBattleTargetID())
+                     if (!PMob->PEnmityContainer->GetEnmityList()->empty() || PMob->battleTarget().isSet())
                      {
                          if (m_Status == BATTLEFIELD_STATUS_OPEN)
                          {

--- a/src/map/enmity_container.cpp
+++ b/src/map/enmity_container.cpp
@@ -484,9 +484,9 @@ CBattleEntity* CEnmityContainer::GetHighestEnmity()
             {
                 // Deal with ties by preferring current battle target
                 // Check if there is a tie, the current highest entity is valid, the mob has a battle target,
-                if (Enmity == HighestEnmity && highest != m_EnmityList.end() && m_EnmityHolder->GetBattleTargetID() != 0 &&
+                if (Enmity == HighestEnmity && highest != m_EnmityList.end() && m_EnmityHolder->battleTarget().isSet() &&
                     // the current highest entity is the current battle target
-                    highest->second.PEnmityOwner && highest->second.PEnmityOwner->targid == m_EnmityHolder->GetBattleTargetID())
+                    highest->second.PEnmityOwner && m_EnmityHolder->battleTarget() == highest->second.PEnmityOwner)
                 {
                     continue;
                 }

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -2351,7 +2351,7 @@ void CBattleEntity::Die()
 {
     TracyZoneScoped;
 
-    if (CBaseEntity* PKiller = GetEntity(m_OwnerID.targid))
+    if (CBaseEntity* PKiller = GetEntity(m_OwnerID.ActIndex))
     {
         static_cast<CBattleEntity*>(PKiller)->ForAlliance(
             [this](CBattleEntity* PMember)
@@ -4094,7 +4094,7 @@ void CBattleEntity::PostTick()
 
 uint16 CBattleEntity::GetBattleTargetID() const
 {
-    return battleTarget_.targid;
+    return battleTarget_.ActIndex;
 }
 
 bool CBattleEntity::hasEnmityEXPENSIVE() const

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -4092,11 +4092,6 @@ void CBattleEntity::PostTick()
     }
 }
 
-uint16 CBattleEntity::GetBattleTargetID() const
-{
-    return battleTarget_.ActIndex;
-}
-
 bool CBattleEntity::hasEnmityEXPENSIVE() const
 {
     // TODO: This check seems to always fail for pets?
@@ -4117,7 +4112,7 @@ bool CBattleEntity::hasEnmityEXPENSIVE() const
                                      return;
                                  }
                                  // Account for charmed mobs attacking normal mobs, etc
-                                 if (PMob->GetBattleTargetID() == targid && PMob->allegiance != allegiance)
+                                 if (PMob->battleTarget().ActIndex == targid && PMob->allegiance != allegiance)
                                  {
                                      isTargeted = true;
                                      return;

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -2351,7 +2351,7 @@ void CBattleEntity::Die()
 {
     TracyZoneScoped;
 
-    if (CBaseEntity* PKiller = GetEntity(m_OwnerID.ActIndex))
+    if (CBaseEntity* PKiller = m_OwnerID.resolve())
     {
         static_cast<CBattleEntity*>(PKiller)->ForAlliance(
             [this](CBattleEntity* PMember)

--- a/src/map/entities/battle_entity.h
+++ b/src/map/entities/battle_entity.h
@@ -322,7 +322,6 @@ public:
 
     virtual void Spawn() override;
     virtual void Die();
-    uint16       GetBattleTargetID() const;
 
     auto battleTarget() const -> EntityId;
     void setBattleTarget(const Maybe<EntityId>& target);

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2096,7 +2096,7 @@ bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
         return false;
     }
 
-    if (PBattleTarget->m_OwnerID.id == 0 || PBattleTarget->m_OwnerID.id == this->id || PBattleTarget->objtype == TYPE_PC)
+    if (PBattleTarget->m_OwnerID.UniqueNo == 0 || PBattleTarget->m_OwnerID.UniqueNo == this->id || PBattleTarget->objtype == TYPE_PC)
     {
         return true;
     }
@@ -2114,7 +2114,7 @@ bool CCharEntity::IsMobOwner(CBattleEntity* PBattleTarget)
     // clang-format off
     ForAlliance([&PBattleTarget, &found](CBattleEntity* PEntity)
     {
-        if (PEntity->id == PBattleTarget->m_OwnerID.id)
+        if (PEntity->id == PBattleTarget->m_OwnerID.UniqueNo)
         {
             found = true;
         }

--- a/src/map/entities/entity_id.cpp
+++ b/src/map/entities/entity_id.cpp
@@ -33,7 +33,7 @@ EntityId::EntityId(const CBaseEntity* PEntity)
         return;
     }
 
-    id            = PEntity->id;
+    UniqueNo            = PEntity->id;
     targid        = PEntity->targid;
     zoneId        = PEntity->loc.zone ? static_cast<uint16>(PEntity->loc.zone->GetID()) : uint16{ 0 };
     instanceRunId = PEntity->PInstance ? PEntity->PInstance->runId() : uint32{ 0 };
@@ -58,7 +58,7 @@ auto EntityId::isDynamic() const -> bool
 
 auto EntityId::operator==(const EntityId& other) const -> bool
 {
-    return isDynamic() ? serial == other.serial : id == other.id;
+    return isDynamic() ? serial == other.serial : UniqueNo == other.UniqueNo;
 }
 
 auto EntityId::operator==(const CBaseEntity* PEntity) const -> bool
@@ -68,7 +68,7 @@ auto EntityId::operator==(const CBaseEntity* PEntity) const -> bool
         return !isSet();
     }
 
-    return PEntity->IsDynamicEntity() ? serial == PEntity->serial() : id == PEntity->id;
+    return PEntity->IsDynamicEntity() ? serial == PEntity->serial() : UniqueNo == PEntity->id;
 }
 
 auto EntityId::resolveEntity() const -> CBaseEntity*

--- a/src/map/entities/entity_id.cpp
+++ b/src/map/entities/entity_id.cpp
@@ -33,8 +33,8 @@ EntityId::EntityId(const CBaseEntity* PEntity)
         return;
     }
 
-    UniqueNo            = PEntity->id;
-    targid        = PEntity->targid;
+    UniqueNo      = PEntity->id;
+    ActIndex      = PEntity->targid;
     zoneId        = PEntity->loc.zone ? static_cast<uint16>(PEntity->loc.zone->GetID()) : uint16{ 0 };
     instanceRunId = PEntity->PInstance ? PEntity->PInstance->runId() : uint32{ 0 };
     serial        = PEntity->serial();
@@ -48,12 +48,12 @@ void EntityId::clean()
 
 auto EntityId::isSet() const -> bool
 {
-    return targid != 0;
+    return ActIndex != 0;
 }
 
 auto EntityId::isDynamic() const -> bool
 {
-    return targid >= 0x700;
+    return ActIndex >= 0x700;
 }
 
 auto EntityId::operator==(const EntityId& other) const -> bool
@@ -73,7 +73,7 @@ auto EntityId::operator==(const CBaseEntity* PEntity) const -> bool
 
 auto EntityId::resolveEntity() const -> CBaseEntity*
 {
-    if (targid == 0 || serial == 0)
+    if (ActIndex == 0 || serial == 0)
     {
         return nullptr;
     }
@@ -93,11 +93,11 @@ auto EntityId::resolveEntity() const -> CBaseEntity*
             return nullptr;
         }
 
-        PEntity = PInstance->GetEntity(targid, objtype);
+        PEntity = PInstance->GetEntity(ActIndex, objtype);
     }
     else
     {
-        PEntity = PZone->GetEntity(targid, objtype);
+        PEntity = PZone->GetEntity(ActIndex, objtype);
     }
 
     // Verify that we retrieved the exact same entity (dynamic entities).

--- a/src/map/entities/entity_id.cpp
+++ b/src/map/entities/entity_id.cpp
@@ -36,7 +36,7 @@ EntityId::EntityId(const CBaseEntity* PEntity)
     UniqueNo      = PEntity->id;
     ActIndex      = PEntity->targid;
     zoneId        = PEntity->loc.zone ? static_cast<uint16>(PEntity->loc.zone->GetID()) : uint16{ 0 };
-    instanceRunId = PEntity->PInstance ? PEntity->PInstance->runId() : uint32{ 0 };
+    instanceRunId = PEntity->PInstance ? Maybe<uint32>(PEntity->PInstance->runId()) : std::nullopt;
     serial        = PEntity->serial();
     objtype       = PEntity->objtype;
 }
@@ -85,9 +85,9 @@ auto EntityId::resolveEntity() const -> CBaseEntity*
     }
 
     CBaseEntity* PEntity = nullptr;
-    if (instanceRunId != 0)
+    if (instanceRunId)
     {
-        auto* PInstance = zoneutils::GetInstanceByRunId(zoneId, instanceRunId);
+        auto* PInstance = zoneutils::GetInstanceByRunId(zoneId, *instanceRunId);
         if (PInstance == nullptr)
         {
             return nullptr;

--- a/src/map/entities/entity_id.h
+++ b/src/map/entities/entity_id.h
@@ -25,6 +25,7 @@
 
 #include <type_traits>
 
+enum ENTITYTYPE : uint8;
 class CBaseEntity;
 
 // A resolvable reference to an entity.
@@ -42,14 +43,12 @@ struct EntityId
     auto operator==(const EntityId& other) const -> bool;
     auto operator==(const CBaseEntity* PEntity) const -> bool;
 
-    // TODO: Globally rename targid to index, zoneIndex, etc.
-    uint32 UniqueNo{ 0 };      // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
-    uint16 targid{ 0 };        // The "index" of the entity in the current zone. Used for local targeting and referencing.
-    uint16 zoneId{ 0 };        // Zone the entity was in when this reference was taken.
-    uint32 instanceRunId{ 0 }; // Live instance the entity was in, 0 if it was not instanced.
-    uint64 serial{ 0 };        // Never-reused per-process counter, telling a rebuilt entity from the
-                               // one that held the slot before it. Only dynamic entities need it.
-    uint8 objtype{ 0 };        // What kind of entity this is.
+    uint32     UniqueNo{ 0 };      // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | ActIndex. Formerly known as "id"
+    uint16     ActIndex{ 0 };      // The "index" of the entity in the current zone. Used for local targeting and referencing. Formerly known as "targid".
+    uint16     zoneId{ 0 };        // Zone the entity was in when this reference was taken.
+    uint32     instanceRunId{ 0 }; // Live instance the entity was in, 0 if it was not instanced.
+    uint64     serial{ 0 };        // Never-reused per-process counter, telling a rebuilt entity from the one that held the slot before it. Only dynamic entities need it.
+    ENTITYTYPE objtype{ 0 };       // What kind of entity this is.
 
     // Look the entity up again, or nullptr if it is gone
     //

--- a/src/map/entities/entity_id.h
+++ b/src/map/entities/entity_id.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common/cbasetypes.h"
+#include "common/types/maybe.h"
 
 #include <type_traits>
 
@@ -43,12 +44,12 @@ struct EntityId
     auto operator==(const EntityId& other) const -> bool;
     auto operator==(const CBaseEntity* PEntity) const -> bool;
 
-    uint32     UniqueNo{ 0 };      // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | ActIndex. Formerly known as "id"
-    uint16     ActIndex{ 0 };      // The "index" of the entity in the current zone. Used for local targeting and referencing. Formerly known as "targid".
-    uint16     zoneId{ 0 };        // Zone the entity was in when this reference was taken.
-    uint32     instanceRunId{ 0 }; // Live instance the entity was in, 0 if it was not instanced.
-    uint64     serial{ 0 };        // Never-reused per-process counter, telling a rebuilt entity from the one that held the slot before it. Only dynamic entities need it.
-    ENTITYTYPE objtype{ 0 };       // What kind of entity this is.
+    uint32        UniqueNo{ 0 }; // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | ActIndex. Formerly known as "id"
+    uint16        ActIndex{ 0 }; // The "index" of the entity in the current zone. Used for local targeting and referencing. Formerly known as "targid".
+    uint16        zoneId{ 0 };   // Zone the entity was in when this reference was taken.
+    Maybe<uint32> instanceRunId; // Live instance the entity was in, nullopt if it was not instanced.
+    uint64        serial{ 0 };   // Never-reused per-process counter, telling a rebuilt entity from the one that held the slot before it. Only dynamic entities need it.
+    ENTITYTYPE    objtype{ 0 };  // What kind of entity this is.
 
     // Look the entity up again, or nullptr if it is gone
     //

--- a/src/map/entities/entity_id.h
+++ b/src/map/entities/entity_id.h
@@ -43,7 +43,7 @@ struct EntityId
     auto operator==(const CBaseEntity* PEntity) const -> bool;
 
     // TODO: Globally rename targid to index, zoneIndex, etc.
-    uint32 id{ 0 };            // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
+    uint32 UniqueNo{ 0 };      // "Long" global ID of the entity. Built from 0x10000000 | (zoneId << 16) | targid.
     uint16 targid{ 0 };        // The "index" of the entity in the current zone. Used for local targeting and referencing.
     uint16 zoneId{ 0 };        // Zone the entity was in when this reference was taken.
     uint32 instanceRunId{ 0 }; // Live instance the entity was in, 0 if it was not instanced.

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -766,7 +766,7 @@ void CMobEntity::DistributeRewards()
 {
     TracyZoneScoped;
 
-    CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.ActIndex, TYPE_PC);
+    CCharEntity* PChar = m_OwnerID.resolve<CCharEntity>();
 
     if (PChar != nullptr && PChar->id == m_OwnerID.UniqueNo)
     {

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -766,7 +766,7 @@ void CMobEntity::DistributeRewards()
 {
     TracyZoneScoped;
 
-    CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.targid, TYPE_PC);
+    CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.ActIndex, TYPE_PC);
 
     if (PChar != nullptr && PChar->id == m_OwnerID.UniqueNo)
     {

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -768,7 +768,7 @@ void CMobEntity::DistributeRewards()
 
     CCharEntity* PChar = (CCharEntity*)GetEntity(m_OwnerID.targid, TYPE_PC);
 
-    if (PChar != nullptr && PChar->id == m_OwnerID.id)
+    if (PChar != nullptr && PChar->id == m_OwnerID.UniqueNo)
     {
         StatusEffectContainer->KillAllStatusEffect();
         PChar->m_charHistory.enemiesDefeated++;

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -488,7 +488,7 @@ void IPCClient::handleMessage_PartyInvite(const IPP& ipp, const ipc::PartyInvite
             return;
         }
 
-        PInvitee->InvitePending.UniqueNo     = message.inviterId;
+        PInvitee->InvitePending.UniqueNo = message.inviterId;
         PInvitee->InvitePending.ActIndex = message.inviterTargId;
 
         PInvitee->pushPacket(std::make_unique<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(message.inviterId, message.inviterTargId, message.inviterName, message.inviteType));

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -489,7 +489,7 @@ void IPCClient::handleMessage_PartyInvite(const IPP& ipp, const ipc::PartyInvite
         }
 
         PInvitee->InvitePending.UniqueNo     = message.inviterId;
-        PInvitee->InvitePending.targid = message.inviterTargId;
+        PInvitee->InvitePending.ActIndex = message.inviterTargId;
 
         PInvitee->pushPacket(std::make_unique<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(message.inviterId, message.inviterTargId, message.inviterName, message.inviteType));
     }

--- a/src/map/ipc_client.cpp
+++ b/src/map/ipc_client.cpp
@@ -446,7 +446,7 @@ void IPCClient::handleMessage_PartyInvite(const IPP& ipp, const ipc::PartyInvite
         // make sure invitee isn't dead or in jail, they aren't a party member and don't already have an invite pending, and your party is not full
         if (PInvitee->isDead() ||
             jailutils::InPrison(PInvitee) ||
-            PInvitee->InvitePending.id != 0 ||
+            PInvitee->InvitePending.UniqueNo != 0 ||
             (PInvitee->PParty && message.inviteType == PartyKind::Party) ||
             (message.inviteType == PartyKind::Alliance && (!PInvitee->PParty || PInvitee->PParty->GetLeader() != PInvitee || (PInvitee->PParty && PInvitee->PParty->m_PAlliance))))
         {
@@ -488,7 +488,7 @@ void IPCClient::handleMessage_PartyInvite(const IPP& ipp, const ipc::PartyInvite
             return;
         }
 
-        PInvitee->InvitePending.id     = message.inviterId;
+        PInvitee->InvitePending.UniqueNo     = message.inviterId;
         PInvitee->InvitePending.targid = message.inviterTargId;
 
         PInvitee->pushPacket(std::make_unique<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(message.inviterId, message.inviterTargId, message.inviterName, message.inviteType));

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2819,8 +2819,7 @@ auto CLuaBaseEntity::openGuildShop(CLuaBaseEntity* PNpc, uint8 open, uint8 close
 
     const auto* PNpcEntity = PNpc->GetBaseEntity();
 
-    PChar->guildShopNpc_.UniqueNo = PNpcEntity->id;
-    PChar->guildShopNpc_.ActIndex = PNpcEntity->targid;
+    PChar->guildShopNpc_ = EntityId(PNpcEntity);
     PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(status, open, close, holiday.value_or(0));
 
     return isOpen;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2819,7 +2819,7 @@ auto CLuaBaseEntity::openGuildShop(CLuaBaseEntity* PNpc, uint8 open, uint8 close
 
     const auto* PNpcEntity = PNpc->GetBaseEntity();
 
-    PChar->guildShopNpc_.id     = PNpcEntity->id;
+    PChar->guildShopNpc_.UniqueNo     = PNpcEntity->id;
     PChar->guildShopNpc_.targid = PNpcEntity->targid;
     PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(status, open, close, holiday.value_or(0));
 

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2820,7 +2820,7 @@ auto CLuaBaseEntity::openGuildShop(CLuaBaseEntity* PNpc, uint8 open, uint8 close
     const auto* PNpcEntity = PNpc->GetBaseEntity();
 
     PChar->guildShopNpc_.UniqueNo     = PNpcEntity->id;
-    PChar->guildShopNpc_.targid = PNpcEntity->targid;
+    PChar->guildShopNpc_.ActIndex = PNpcEntity->targid;
     PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(status, open, close, holiday.value_or(0));
 
     return isOpen;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2819,7 +2819,7 @@ auto CLuaBaseEntity::openGuildShop(CLuaBaseEntity* PNpc, uint8 open, uint8 close
 
     const auto* PNpcEntity = PNpc->GetBaseEntity();
 
-    PChar->guildShopNpc_.UniqueNo     = PNpcEntity->id;
+    PChar->guildShopNpc_.UniqueNo = PNpcEntity->id;
     PChar->guildShopNpc_.ActIndex = PNpcEntity->targid;
     PChar->pushPacket<GP_SERV_COMMAND_GUILD_OPEN>(status, open, close, holiday.value_or(0));
 
@@ -13930,7 +13930,7 @@ auto CLuaBaseEntity::getMasterThreatMob(const sol::object& rangeOverride) -> CBa
     }
 
     const auto maxDistance = rangeOverride.is<float>() ? rangeOverride.as<float>() : 22.0f;
-    auto*      PMastersTarget{ PMaster->GetEntity(PMaster->GetBattleTargetID()) };
+    auto*      PMastersTarget{ PMaster->battleTarget().resolve() };
 
     auto isMasterTopEnmityOnMob = [PMaster](CMobEntity* PMob) -> bool
     {
@@ -13976,7 +13976,7 @@ auto CLuaBaseEntity::getMasterThreatMob(const sol::object& rangeOverride) -> CBa
             continue;
         }
 
-        auto* PTarget            = PMob->GetEntity(PMob->GetBattleTargetID());
+        auto* PTarget            = PMob->battleTarget().resolve();
         bool  isTargetingMaster  = PTarget && PTarget->id == PMaster->id;
         bool  masterHasTopEnmity = isMasterTopEnmityOnMob(PMob);
 

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -18818,7 +18818,7 @@ auto CLuaBaseEntity::getTarget() -> CBaseEntity*
         return nullptr;
     }
 
-    auto* PBattleTarget{ m_PBaseEntity->GetEntity(static_cast<CBattleEntity*>(m_PBaseEntity)->GetBattleTargetID()) };
+    auto* PBattleTarget{ static_cast<CBattleEntity*>(m_PBaseEntity)->battleTarget().resolve() };
 
     if (PBattleTarget)
     {

--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -96,7 +96,7 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
         PChar->WideScanTarget,
         [&](const auto& wideScanTarget)
         {
-            if (const auto* PWideScanEntity = PChar->GetEntity(wideScanTarget.targid, TYPE_MOB | TYPE_NPC))
+            if (const auto* PWideScanEntity = PChar->GetEntity(wideScanTarget.ActIndex, TYPE_MOB | TYPE_NPC))
             {
                 PChar->pushPacket<GP_SERV_COMMAND_TRACKING_POS>(PWideScanEntity);
 

--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -96,7 +96,7 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
         PChar->WideScanTarget,
         [&](const auto& wideScanTarget)
         {
-            if (const auto* PWideScanEntity = PChar->GetEntity(wideScanTarget.ActIndex, TYPE_MOB | TYPE_NPC))
+            if (const auto* PWideScanEntity = wideScanTarget.resolve())
             {
                 PChar->pushPacket<GP_SERV_COMMAND_TRACKING_POS>(PWideScanEntity);
 

--- a/src/map/packets/c2s/0x032_trade_req.cpp
+++ b/src/map/packets/c2s/0x032_trade_req.cpp
@@ -77,7 +77,7 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
         return;
     }
 
-    if (PTarget->TradePending.id == PChar->id)
+    if (PTarget->TradePending.UniqueNo == PChar->id)
     {
         ShowDebug("%s has already sent a trade request to %s", PChar->getName(), PTarget->getName());
         return;
@@ -102,11 +102,11 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
     // This block usually doesn't trigger,
     // The client is generally forced to send a trade cancel packet via a cancel yes/no menu,
     // resulting in an outgoing 0x033 with 0x04 set to 0x01 for their old trade target, but sometimes the menu does not happen and a cancel is sent instead.
-    if (PChar->TradePending.id != 0)
+    if (PChar->TradePending.UniqueNo != 0)
     {
         // Tell previous trader we don't want their business
-        auto* POldTradeTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.id, TYPE_PC));
-        if (POldTradeTarget && POldTradeTarget->id == PChar->TradePending.id)
+        auto* POldTradeTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.UniqueNo, TYPE_PC));
+        if (POldTradeTarget && POldTradeTarget->id == PChar->TradePending.UniqueNo)
         {
             POldTradeTarget->TradePending.clean();
             PChar->TradePending.clean();
@@ -118,11 +118,11 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
     }
 
     PChar->lastTradeInvite     = currentTime;
-    PChar->TradePending.id     = this->UniqueNo;
+    PChar->TradePending.UniqueNo     = this->UniqueNo;
     PChar->TradePending.targid = this->ActIndex;
 
     PTarget->lastTradeInvite     = currentTime;
-    PTarget->TradePending.id     = PChar->id;
+    PTarget->TradePending.UniqueNo     = PChar->id;
     PTarget->TradePending.targid = PChar->targid;
     PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_REQ>(PChar);
 }

--- a/src/map/packets/c2s/0x032_trade_req.cpp
+++ b/src/map/packets/c2s/0x032_trade_req.cpp
@@ -92,7 +92,7 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
 
     const timer::time_point currentTime     = timer::now();
     const auto              lastTargetTrade = currentTime - PTarget->lastTradeInvite;
-    if ((PTarget->TradePending.targid != 0 && lastTargetTrade < 60s) || PTarget->UContainer->GetType() == UCONTAINER_TRADE)
+    if ((PTarget->TradePending.ActIndex != 0 && lastTargetTrade < 60s) || PTarget->UContainer->GetType() == UCONTAINER_TRADE)
     {
         // Can't trade with someone who's already got a pending trade before timeout
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
@@ -119,10 +119,10 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
 
     PChar->lastTradeInvite     = currentTime;
     PChar->TradePending.UniqueNo     = this->UniqueNo;
-    PChar->TradePending.targid = this->ActIndex;
+    PChar->TradePending.ActIndex = this->ActIndex;
 
     PTarget->lastTradeInvite     = currentTime;
     PTarget->TradePending.UniqueNo     = PChar->id;
-    PTarget->TradePending.targid = PChar->targid;
+    PTarget->TradePending.ActIndex = PChar->targid;
     PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_REQ>(PChar);
 }

--- a/src/map/packets/c2s/0x032_trade_req.cpp
+++ b/src/map/packets/c2s/0x032_trade_req.cpp
@@ -117,12 +117,10 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
         }
     }
 
-    PChar->lastTradeInvite       = currentTime;
-    PChar->TradePending.UniqueNo = this->UniqueNo;
-    PChar->TradePending.ActIndex = this->ActIndex;
+    PChar->lastTradeInvite = currentTime;
+    PChar->TradePending    = EntityId(PTarget);
 
-    PTarget->lastTradeInvite       = currentTime;
-    PTarget->TradePending.UniqueNo = PChar->id;
-    PTarget->TradePending.ActIndex = PChar->targid;
+    PTarget->lastTradeInvite = currentTime;
+    PTarget->TradePending    = EntityId(PChar);
     PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_REQ>(PChar);
 }

--- a/src/map/packets/c2s/0x032_trade_req.cpp
+++ b/src/map/packets/c2s/0x032_trade_req.cpp
@@ -117,12 +117,12 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
         }
     }
 
-    PChar->lastTradeInvite     = currentTime;
-    PChar->TradePending.UniqueNo     = this->UniqueNo;
+    PChar->lastTradeInvite       = currentTime;
+    PChar->TradePending.UniqueNo = this->UniqueNo;
     PChar->TradePending.ActIndex = this->ActIndex;
 
-    PTarget->lastTradeInvite     = currentTime;
-    PTarget->TradePending.UniqueNo     = PChar->id;
+    PTarget->lastTradeInvite       = currentTime;
+    PTarget->TradePending.UniqueNo = PChar->id;
     PTarget->TradePending.ActIndex = PChar->targid;
     PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_REQ>(PChar);
 }

--- a/src/map/packets/c2s/0x033_trade_res.cpp
+++ b/src/map/packets/c2s/0x033_trade_res.cpp
@@ -47,7 +47,7 @@ auto GP_CLI_COMMAND_TRADE_RES::validate(MapSession* PSession, const CCharEntity*
 
 void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
+    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     if (!PTarget ||
         PChar->TradePending.UniqueNo != PTarget->id ||

--- a/src/map/packets/c2s/0x033_trade_res.cpp
+++ b/src/map/packets/c2s/0x033_trade_res.cpp
@@ -50,8 +50,8 @@ void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar)
     auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
 
     if (!PTarget ||
-        PChar->TradePending.id != PTarget->id ||
-        PTarget->TradePending.id != PChar->id)
+        PChar->TradePending.UniqueNo != PTarget->id ||
+        PTarget->TradePending.UniqueNo != PChar->id)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_RES: Could not find trade targets.");
         return;

--- a/src/map/packets/c2s/0x033_trade_res.cpp
+++ b/src/map/packets/c2s/0x033_trade_res.cpp
@@ -42,12 +42,12 @@ auto GP_CLI_COMMAND_TRADE_RES::validate(MapSession* PSession, const CCharEntity*
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent, BlockedState::Monstrosity })
         .oneOf<GP_CLI_COMMAND_TRADE_RES_KIND>(this->Kind)
-        .mustNotEqual(PChar->TradePending.targid, 0, "No pending trade target");
+        .mustNotEqual(PChar->TradePending.ActIndex, 0, "No pending trade target");
 }
 
 void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
+    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
 
     if (!PTarget ||
         PChar->TradePending.UniqueNo != PTarget->id ||

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -59,7 +59,7 @@ auto GP_CLI_COMMAND_TRADE_LIST::validate(MapSession* PSession, const CCharEntity
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent, BlockedState::Monstrosity })
-        .mustNotEqual(PChar->TradePending.id, 0, "No trade target")
+        .mustNotEqual(PChar->TradePending.UniqueNo, 0, "No trade target")
         .range("TradeIndex", this->TradeIndex, 0, 8);
 }
 
@@ -68,8 +68,8 @@ void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar
     auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
 
     if (!PTarget ||
-        PTarget->id != PChar->TradePending.id ||
-        PChar->id != PTarget->TradePending.id)
+        PTarget->id != PChar->TradePending.UniqueNo ||
+        PChar->id != PTarget->TradePending.UniqueNo)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_LIST: Could not find trade targets.");
         return;

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -65,7 +65,7 @@ auto GP_CLI_COMMAND_TRADE_LIST::validate(MapSession* PSession, const CCharEntity
 
 void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
+    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
 
     if (!PTarget ||
         PTarget->id != PChar->TradePending.UniqueNo ||

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -65,7 +65,7 @@ auto GP_CLI_COMMAND_TRADE_LIST::validate(MapSession* PSession, const CCharEntity
 
 void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
+    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     if (!PTarget ||
         PTarget->id != PChar->TradePending.UniqueNo ||

--- a/src/map/packets/c2s/0x06e_group_solicit_req.cpp
+++ b/src/map/packets/c2s/0x06e_group_solicit_req.cpp
@@ -118,7 +118,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     }
 
                     PInvitee->InvitePending.UniqueNo     = PInviter->id;
-                    PInvitee->InvitePending.targid = PInviter->targid;
+                    PInvitee->InvitePending.ActIndex = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Party);
 
@@ -204,7 +204,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     }
 
                     PInvitee->InvitePending.UniqueNo     = PInviter->id;
-                    PInvitee->InvitePending.targid = PInviter->targid;
+                    PInvitee->InvitePending.ActIndex = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Alliance);
 

--- a/src/map/packets/c2s/0x06e_group_solicit_req.cpp
+++ b/src/map/packets/c2s/0x06e_group_solicit_req.cpp
@@ -117,7 +117,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                         break;
                     }
 
-                    PInvitee->InvitePending.UniqueNo     = PInviter->id;
+                    PInvitee->InvitePending.UniqueNo = PInviter->id;
                     PInvitee->InvitePending.ActIndex = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Party);
@@ -203,7 +203,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                         break;
                     }
 
-                    PInvitee->InvitePending.UniqueNo     = PInviter->id;
+                    PInvitee->InvitePending.UniqueNo = PInviter->id;
                     PInvitee->InvitePending.ActIndex = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Alliance);

--- a/src/map/packets/c2s/0x06e_group_solicit_req.cpp
+++ b/src/map/packets/c2s/0x06e_group_solicit_req.cpp
@@ -90,7 +90,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     ShowDebug("%s sent party invite to %s", PInviter->getName(), PInvitee->getName());
 
                     // make sure invitee isn't dead or in jail, they aren't a party member and don't already have an invite pending, and your party is not full
-                    if (PInvitee->isDead() || jailutils::InPrison(PInvitee) || PInvitee->InvitePending.id != 0 || PInvitee->PParty != nullptr)
+                    if (PInvitee->isDead() || jailutils::InPrison(PInvitee) || PInvitee->InvitePending.UniqueNo != 0 || PInvitee->PParty != nullptr)
                     {
                         ShowDebug("%s is dead, in jail, has a pending invite, or is already in a party", PInvitee->getName());
                         PInviter->pushPacket<GP_SERV_COMMAND_MESSAGE>(PInviter, 0, 0, MsgStd::CannotInvite);
@@ -117,7 +117,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                         break;
                     }
 
-                    PInvitee->InvitePending.id     = PInviter->id;
+                    PInvitee->InvitePending.UniqueNo     = PInviter->id;
                     PInvitee->InvitePending.targid = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Party);
@@ -188,7 +188,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                     }
 
                     // make sure intvitee isn't dead or in jail, they are an unallied party leader and don't already have an invite pending
-                    if (PInvitee->isDead() || jailutils::InPrison(PInvitee) || PInvitee->InvitePending.id != 0 || PInvitee->PParty == nullptr ||
+                    if (PInvitee->isDead() || jailutils::InPrison(PInvitee) || PInvitee->InvitePending.UniqueNo != 0 || PInvitee->PParty == nullptr ||
                         PInvitee->PParty->GetLeader() != PInvitee || PInvitee->PParty->m_PAlliance)
                     {
                         ShowDebug("%s is dead, in jail, has a pending invite, or is already in a party/alliance", PInvitee->getName());
@@ -203,7 +203,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_REQ::process(MapSession* PSession, CCharEntity
                         break;
                     }
 
-                    PInvitee->InvitePending.id     = PInviter->id;
+                    PInvitee->InvitePending.UniqueNo     = PInviter->id;
                     PInvitee->InvitePending.targid = PInviter->targid;
 
                     PInvitee->pushPacket<GP_SERV_COMMAND_GROUP_SOLICIT_REQ>(inviteeCharId, inviteeTargId, PInviter->getName(), PartyKind::Alliance);

--- a/src/map/packets/c2s/0x074_group_solicit_res.cpp
+++ b/src/map/packets/c2s/0x074_group_solicit_res.cpp
@@ -39,7 +39,7 @@ auto GP_CLI_COMMAND_GROUP_SOLICIT_RES::validate(MapSession* PSession, const CCha
 
 void GP_CLI_COMMAND_GROUP_SOLICIT_RES::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    if (CCharEntity* PInviter = zoneutils::GetCharFromWorld(PChar->InvitePending.id, PChar->InvitePending.targid); PInviter != nullptr)
+    if (CCharEntity* PInviter = zoneutils::GetCharFromWorld(PChar->InvitePending.UniqueNo, PChar->InvitePending.targid); PInviter != nullptr)
     {
         // This switch statement only occurs when both the invitee and inviter are on the same process
         switch (static_cast<GP_CLI_COMMAND_GROUP_SOLICIT_RES_RES>(this->Res))
@@ -135,7 +135,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_RES::process(MapSession* PSession, CCharEntity
         message::send(ipc::PartyInviteResponse{
             .inviteeId     = PChar->id,
             .inviteeTargId = PChar->targid,
-            .inviterId     = PChar->InvitePending.id,
+            .inviterId     = PChar->InvitePending.UniqueNo,
             .inviterTargId = PChar->InvitePending.targid,
             .inviteAnswer  = this->Res,
         });

--- a/src/map/packets/c2s/0x074_group_solicit_res.cpp
+++ b/src/map/packets/c2s/0x074_group_solicit_res.cpp
@@ -39,7 +39,7 @@ auto GP_CLI_COMMAND_GROUP_SOLICIT_RES::validate(MapSession* PSession, const CCha
 
 void GP_CLI_COMMAND_GROUP_SOLICIT_RES::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    if (CCharEntity* PInviter = zoneutils::GetCharFromWorld(PChar->InvitePending.UniqueNo, PChar->InvitePending.targid); PInviter != nullptr)
+    if (CCharEntity* PInviter = zoneutils::GetCharFromWorld(PChar->InvitePending.UniqueNo, PChar->InvitePending.ActIndex); PInviter != nullptr)
     {
         // This switch statement only occurs when both the invitee and inviter are on the same process
         switch (static_cast<GP_CLI_COMMAND_GROUP_SOLICIT_RES_RES>(this->Res))
@@ -136,7 +136,7 @@ void GP_CLI_COMMAND_GROUP_SOLICIT_RES::process(MapSession* PSession, CCharEntity
             .inviteeId     = PChar->id,
             .inviteeTargId = PChar->targid,
             .inviterId     = PChar->InvitePending.UniqueNo,
-            .inviterTargId = PChar->InvitePending.targid,
+            .inviterTargId = PChar->InvitePending.ActIndex,
             .inviteAnswer  = this->Res,
         });
     }

--- a/src/map/packets/c2s/0x096_combine_ask.cpp
+++ b/src/map/packets/c2s/0x096_combine_ask.cpp
@@ -93,7 +93,7 @@ void GP_CLI_COMMAND_COMBINE_ASK::process(MapSession* PSession, CCharEntity* PCha
 
     // NOTE: This section is intended to be temporary to ensure that duping shenanigans aren't possible.
     // It should be replaced by something more robust or more stateful as soon as is reasonable
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
+    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
 
     // Clear pending trades on synthesis start
     if (PTarget && PChar->TradePending.UniqueNo == PTarget->id)

--- a/src/map/packets/c2s/0x096_combine_ask.cpp
+++ b/src/map/packets/c2s/0x096_combine_ask.cpp
@@ -93,7 +93,7 @@ void GP_CLI_COMMAND_COMBINE_ASK::process(MapSession* PSession, CCharEntity* PCha
 
     // NOTE: This section is intended to be temporary to ensure that duping shenanigans aren't possible.
     // It should be replaced by something more robust or more stateful as soon as is reasonable
-    auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.ActIndex, TYPE_PC));
+    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     // Clear pending trades on synthesis start
     if (PTarget && PChar->TradePending.UniqueNo == PTarget->id)

--- a/src/map/packets/c2s/0x096_combine_ask.cpp
+++ b/src/map/packets/c2s/0x096_combine_ask.cpp
@@ -96,7 +96,7 @@ void GP_CLI_COMMAND_COMBINE_ASK::process(MapSession* PSession, CCharEntity* PCha
     auto* PTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.targid, TYPE_PC));
 
     // Clear pending trades on synthesis start
-    if (PTarget && PChar->TradePending.id == PTarget->id)
+    if (PTarget && PChar->TradePending.UniqueNo == PTarget->id)
     {
         PChar->TradePending.clean();
         PTarget->TradePending.clean();

--- a/src/map/packets/c2s/0x0aa_guild_buy.cpp
+++ b/src/map/packets/c2s/0x0aa_guild_buy.cpp
@@ -32,7 +32,7 @@ auto GP_CLI_COMMAND_GUILD_BUY::validate(MapSession* PSession, const CCharEntity*
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent })
-        .mustNotEqual(PChar->guildShopNpc_.id, 0, "Character does not have a guild shop")
+        .mustNotEqual(PChar->guildShopNpc_.UniqueNo, 0, "Character does not have a guild shop")
         .range("ItemNum", this->ItemNum, 1, 99)
         .mustEqual(this->PropertyItemIndex, 0, "PropertyItemIndex not 0");
 }
@@ -54,7 +54,7 @@ void GP_CLI_COMMAND_GUILD_BUY::process(MapSession* PSession, CCharEntity* PChar)
         return;
     }
 
-    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.id, TYPE_NPC))
+    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
     {
         // onPlayerBuy returns { itemNo, count, trade }; serialize it into the 0x082 result
         // (a rejection is { 0, 0, -1 }).

--- a/src/map/packets/c2s/0x0ab_guild_buylist.cpp
+++ b/src/map/packets/c2s/0x0ab_guild_buylist.cpp
@@ -30,12 +30,12 @@ auto GP_CLI_COMMAND_GUILD_BUYLIST::validate(MapSession* PSession, const CCharEnt
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent })
-        .mustNotEqual(PChar->guildShopNpc_.id, 0, "Character does not have a guild shop");
+        .mustNotEqual(PChar->guildShopNpc_.UniqueNo, 0, "Character does not have a guild shop");
 }
 
 void GP_CLI_COMMAND_GUILD_BUYLIST::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.id, TYPE_NPC))
+    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
     {
         const auto items = luautils::callGlobal<sol::table>("xi.guildShops.onBuyList", PChar, PNpc);
 

--- a/src/map/packets/c2s/0x0ac_guild_sell.cpp
+++ b/src/map/packets/c2s/0x0ac_guild_sell.cpp
@@ -60,7 +60,7 @@ auto GP_CLI_COMMAND_GUILD_SELL::validate(MapSession* PSession, const CCharEntity
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent, BlockedState::Crafting })
-        .mustNotEqual(PChar->guildShopNpc_.id, 0, "Character does not have a guild shop")
+        .mustNotEqual(PChar->guildShopNpc_.UniqueNo, 0, "Character does not have a guild shop")
         .range("ItemNum", this->ItemNum, 1, 99);
 }
 
@@ -80,7 +80,7 @@ void GP_CLI_COMMAND_GUILD_SELL::process(MapSession* PSession, CCharEntity* PChar
         return;
     }
 
-    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.id, TYPE_NPC))
+    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
     {
         const auto result = luautils::callGlobal<sol::table>("xi.guildShops.onPlayerSell", PChar, PNpc, this->ItemNo, this->ItemNum);
         if (result.valid())

--- a/src/map/packets/c2s/0x0ad_guild_selllist.cpp
+++ b/src/map/packets/c2s/0x0ad_guild_selllist.cpp
@@ -30,12 +30,12 @@ auto GP_CLI_COMMAND_GUILD_SELLLIST::validate(MapSession* PSession, const CCharEn
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent })
-        .mustNotEqual(PChar->guildShopNpc_.id, 0, "Character does not have a guild shop");
+        .mustNotEqual(PChar->guildShopNpc_.UniqueNo, 0, "Character does not have a guild shop");
 }
 
 void GP_CLI_COMMAND_GUILD_SELLLIST::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.id, TYPE_NPC))
+    if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
     {
         const auto items = luautils::callGlobal<sol::table>("xi.guildShops.onSellList", PChar, PNpc);
 

--- a/src/map/packets/c2s/0x104_bazaar_exit.cpp
+++ b/src/map/packets/c2s/0x104_bazaar_exit.cpp
@@ -39,11 +39,11 @@ void GP_CLI_COMMAND_BAZAAR_EXIT::process(MapSession* PSession, CCharEntity* PCha
         return;
     }
 
-    if (auto* PTarget = static_cast<CCharEntity*>(PEntity); PTarget->id == PChar->BazaarID.id)
+    if (auto* PTarget = static_cast<CCharEntity*>(PEntity); PTarget->id == PChar->BazaarID.UniqueNo)
     {
         for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
         {
-            if (PTarget->BazaarCustomers[i].id == PChar->id)
+            if (PTarget->BazaarCustomers[i].UniqueNo == PChar->id)
             {
                 PTarget->BazaarCustomers.erase(PTarget->BazaarCustomers.begin() + i--);
             }

--- a/src/map/packets/c2s/0x104_bazaar_exit.cpp
+++ b/src/map/packets/c2s/0x104_bazaar_exit.cpp
@@ -33,7 +33,7 @@ auto GP_CLI_COMMAND_BAZAAR_EXIT::validate(MapSession* PSession, const CCharEntit
 
 void GP_CLI_COMMAND_BAZAAR_EXIT::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PEntity = PChar->GetEntity(PChar->BazaarID.ActIndex, TYPE_PC);
+    auto* PEntity = PChar->BazaarID.resolve<CCharEntity>();
     if (!PEntity)
     {
         return;

--- a/src/map/packets/c2s/0x104_bazaar_exit.cpp
+++ b/src/map/packets/c2s/0x104_bazaar_exit.cpp
@@ -33,7 +33,7 @@ auto GP_CLI_COMMAND_BAZAAR_EXIT::validate(MapSession* PSession, const CCharEntit
 
 void GP_CLI_COMMAND_BAZAAR_EXIT::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PEntity = PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
+    auto* PEntity = PChar->GetEntity(PChar->BazaarID.ActIndex, TYPE_PC);
     if (!PEntity)
     {
         return;

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -30,7 +30,7 @@ auto GP_CLI_COMMAND_BAZAAR_LIST::validate(MapSession* PSession, const CCharEntit
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent })
         .mustEqual(PChar->BazaarID.UniqueNo, 0, "Character already has a Bazaar ID")
-        .mustEqual(PChar->BazaarID.targid, 0, "Character already has a Bazaar Target ID");
+        .mustEqual(PChar->BazaarID.ActIndex, 0, "Character already has a Bazaar Target ID");
 }
 
 void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PChar) const
@@ -40,7 +40,7 @@ void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PCha
     if (PTarget != nullptr && PTarget->id == this->UniqueNo && PTarget->hasBazaar())
     {
         PChar->BazaarID.UniqueNo     = PTarget->id;
-        PChar->BazaarID.targid = PTarget->targid;
+        PChar->BazaarID.ActIndex = PTarget->targid;
 
         auto EntityID = PChar->entityId();
 

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -29,7 +29,7 @@ auto GP_CLI_COMMAND_BAZAAR_LIST::validate(MapSession* PSession, const CCharEntit
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent })
-        .mustEqual(PChar->BazaarID.id, 0, "Character already has a Bazaar ID")
+        .mustEqual(PChar->BazaarID.UniqueNo, 0, "Character already has a Bazaar ID")
         .mustEqual(PChar->BazaarID.targid, 0, "Character already has a Bazaar Target ID");
 }
 
@@ -39,7 +39,7 @@ void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PCha
 
     if (PTarget != nullptr && PTarget->id == this->UniqueNo && PTarget->hasBazaar())
     {
-        PChar->BazaarID.id     = PTarget->id;
+        PChar->BazaarID.UniqueNo     = PTarget->id;
         PChar->BazaarID.targid = PTarget->targid;
 
         auto EntityID = PChar->entityId();

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -39,8 +39,7 @@ void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PCha
 
     if (PTarget != nullptr && PTarget->id == this->UniqueNo && PTarget->hasBazaar())
     {
-        PChar->BazaarID.UniqueNo = PTarget->id;
-        PChar->BazaarID.ActIndex = PTarget->targid;
+        PChar->BazaarID = EntityId(PTarget);
 
         auto EntityID = PChar->entityId();
 

--- a/src/map/packets/c2s/0x105_bazaar_list.cpp
+++ b/src/map/packets/c2s/0x105_bazaar_list.cpp
@@ -39,7 +39,7 @@ void GP_CLI_COMMAND_BAZAAR_LIST::process(MapSession* PSession, CCharEntity* PCha
 
     if (PTarget != nullptr && PTarget->id == this->UniqueNo && PTarget->hasBazaar())
     {
-        PChar->BazaarID.UniqueNo     = PTarget->id;
+        PChar->BazaarID.UniqueNo = PTarget->id;
         PChar->BazaarID.ActIndex = PTarget->targid;
 
         auto EntityID = PChar->entityId();

--- a/src/map/packets/c2s/0x106_bazaar_buy.cpp
+++ b/src/map/packets/c2s/0x106_bazaar_buy.cpp
@@ -51,7 +51,7 @@ void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar
     }
 
     auto* PTarget = static_cast<CCharEntity*>(PEntity);
-    if (PTarget->id != PChar->BazaarID.id)
+    if (PTarget->id != PChar->BazaarID.UniqueNo)
     {
         return;
     }
@@ -190,7 +190,7 @@ void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar
                 continue;
             }
 
-            if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PTarget->BazaarCustomers[i].id)
+            if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PTarget->BazaarCustomers[i].UniqueNo)
             {
                 if (PCustomer->id != PChar->id)
                 {

--- a/src/map/packets/c2s/0x106_bazaar_buy.cpp
+++ b/src/map/packets/c2s/0x106_bazaar_buy.cpp
@@ -44,7 +44,7 @@ auto GP_CLI_COMMAND_BAZAAR_BUY::validate(MapSession* PSession, const CCharEntity
 
 void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PEntity = PChar->GetEntity(PChar->BazaarID.targid, TYPE_PC);
+    auto* PEntity = PChar->GetEntity(PChar->BazaarID.ActIndex, TYPE_PC);
     if (!PEntity)
     {
         return;
@@ -184,7 +184,7 @@ void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar
         }
         for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
         {
-            PEntity = PTarget->GetEntity(PTarget->BazaarCustomers[i].targid, TYPE_PC);
+            PEntity = PTarget->GetEntity(PTarget->BazaarCustomers[i].ActIndex, TYPE_PC);
             if (!PEntity)
             {
                 continue;

--- a/src/map/packets/c2s/0x106_bazaar_buy.cpp
+++ b/src/map/packets/c2s/0x106_bazaar_buy.cpp
@@ -44,7 +44,7 @@ auto GP_CLI_COMMAND_BAZAAR_BUY::validate(MapSession* PSession, const CCharEntity
 
 void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PEntity = PChar->GetEntity(PChar->BazaarID.ActIndex, TYPE_PC);
+    auto* PEntity = PChar->BazaarID.resolve<CCharEntity>();
     if (!PEntity)
     {
         return;
@@ -184,7 +184,7 @@ void GP_CLI_COMMAND_BAZAAR_BUY::process(MapSession* PSession, CCharEntity* PChar
         }
         for (std::size_t i = 0; i < PTarget->BazaarCustomers.size(); ++i)
         {
-            PEntity = PTarget->GetEntity(PTarget->BazaarCustomers[i].ActIndex, TYPE_PC);
+            PEntity = PTarget->BazaarCustomers[i].resolve<CCharEntity>();
             if (!PEntity)
             {
                 continue;

--- a/src/map/packets/c2s/0x10b_bazaar_close.cpp
+++ b/src/map/packets/c2s/0x10b_bazaar_close.cpp
@@ -35,7 +35,7 @@ void GP_CLI_COMMAND_BAZAAR_CLOSE::process(MapSession* PSession, CCharEntity* PCh
 {
     for (std::size_t i = 0; i < PChar->BazaarCustomers.size(); ++i)
     {
-        auto* PEntity = PChar->GetEntity(PChar->BazaarCustomers[i].ActIndex, TYPE_PC);
+        auto* PEntity = PChar->BazaarCustomers[i].resolve<CCharEntity>();
         if (!PEntity)
         {
             continue;

--- a/src/map/packets/c2s/0x10b_bazaar_close.cpp
+++ b/src/map/packets/c2s/0x10b_bazaar_close.cpp
@@ -35,7 +35,7 @@ void GP_CLI_COMMAND_BAZAAR_CLOSE::process(MapSession* PSession, CCharEntity* PCh
 {
     for (std::size_t i = 0; i < PChar->BazaarCustomers.size(); ++i)
     {
-        auto* PEntity = PChar->GetEntity(PChar->BazaarCustomers[i].targid, TYPE_PC);
+        auto* PEntity = PChar->GetEntity(PChar->BazaarCustomers[i].ActIndex, TYPE_PC);
         if (!PEntity)
         {
             continue;

--- a/src/map/packets/c2s/0x10b_bazaar_close.cpp
+++ b/src/map/packets/c2s/0x10b_bazaar_close.cpp
@@ -41,7 +41,7 @@ void GP_CLI_COMMAND_BAZAAR_CLOSE::process(MapSession* PSession, CCharEntity* PCh
             continue;
         }
 
-        if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PChar->BazaarCustomers[i].id)
+        if (auto* PCustomer = static_cast<CCharEntity*>(PEntity); PCustomer->id == PChar->BazaarCustomers[i].UniqueNo)
         {
             PCustomer->pushPacket<GP_SERV_COMMAND_BAZAAR_CLOSE>(PChar);
 

--- a/src/map/packets/entity_update.cpp
+++ b/src/map/packets/entity_update.cpp
@@ -413,7 +413,7 @@ void CEntityUpdatePacket::updateWith(CBaseEntity* PEntity, ENTITYUPDATE type, ui
 
             if (updatemask & UPDATE_STATUS)
             {
-                ref<uint32>(0x2C) = PMob->m_OwnerID.id;
+                ref<uint32>(0x2C) = PMob->m_OwnerID.UniqueNo;
             }
 
             if (updatemask & UPDATE_NAME)

--- a/src/map/time_server.cpp
+++ b/src/map/time_server.cpp
@@ -124,9 +124,9 @@ auto time_server(Scheduler& scheduler, MapConfig config) -> Task<void>
                         PChar->PLatentEffectContainer->CheckLatentsHours();
                         PChar->PLatentEffectContainer->CheckLatentsMoonPhase();
 
-                        if (PChar->guildShopNpc_.id != 0)
+                        if (PChar->guildShopNpc_.UniqueNo != 0)
                         {
-                            if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.id, TYPE_NPC))
+                            if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
                             {
                                 luautils::callGlobal<void>("xi.guildShops.onGameHour", PChar, PNpc);
                             }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4222,7 +4222,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
             if (!battleTarget || battleTarget == PDefender || battleTarget != attacker->PClaimedMob || PDefender->isDead())
             {
                 if (PDefender->isAlive() && attacker->PClaimedMob && attacker->PClaimedMob != PDefender && attacker->PClaimedMob->isAlive() &&
-                    attacker->PClaimedMob->m_OwnerID.id == attacker->id)
+                    attacker->PClaimedMob->m_OwnerID.UniqueNo == attacker->id)
                 { // unclaim any other living mobs owned by attacker
                     static_cast<CMobController*>(attacker->PClaimedMob->PAI->GetController())->TapDeclaimTime();
                     attacker->PClaimedMob = nullptr;
@@ -4231,7 +4231,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                 {
                     if (battleutils::HasClaim(PAttacker, PDefender))
                     { // mob is currently claimed by your alliance, update ownership
-                        mob->m_OwnerID.id     = PAttacker->id;
+                        mob->m_OwnerID.UniqueNo     = PAttacker->id;
                         mob->m_OwnerID.targid = PAttacker->targid;
                         if (PDefender->isAlive())
                         { // ignore killing blow
@@ -4243,7 +4243,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                     { // mob is unclaimed
                         if (PDefender->isDead())
                         { // always give rewards on the killing blow
-                            mob->m_OwnerID.id     = PAttacker->id;
+                            mob->m_OwnerID.UniqueNo     = PAttacker->id;
                             mob->m_OwnerID.targid = PAttacker->targid;
                             return;
                         }
@@ -4257,7 +4257,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                             {
                                 if (!highestClaim || highestClaim == PMember || highestClaim == PMember->PPet)
                                 { // someone in your alliance is top of hate list, claim for your alliance
-                                    mob->m_OwnerID.id     = PAttacker->id;
+                                    mob->m_OwnerID.UniqueNo     = PAttacker->id;
                                     mob->m_OwnerID.targid = PAttacker->targid;
                                     if (PDefender->isAlive())
                                     { // ignore killing blow
@@ -4313,7 +4313,7 @@ void DirtyExp(CBattleEntity* PDefender, CBattleEntity* PAttacker)
 void RelinquishClaim(CCharEntity* PChar)
 {
     CBattleEntity* mob = PChar->PClaimedMob;
-    if (mob && mob->isAlive() && mob->m_OwnerID.id == PChar->id)
+    if (mob && mob->isAlive() && mob->m_OwnerID.UniqueNo == PChar->id)
     { // if we currently own a mob
         bool found = false;
         // clang-format off
@@ -5377,7 +5377,7 @@ bool HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget)
         PMaster = PEntity->PMaster;
     }
 
-    if (PTarget->m_OwnerID.id == PMaster->id)
+    if (PTarget->m_OwnerID.UniqueNo == PMaster->id)
     {
         return true;
     }
@@ -5387,7 +5387,7 @@ bool HasClaim(CBattleEntity* PEntity, CBattleEntity* PTarget)
     // clang-format off
         PMaster->ForAlliance([&PTarget, &found](CBattleEntity* PChar)
         {
-            if (PChar->id == PTarget->m_OwnerID.id)
+            if (PChar->id == PTarget->m_OwnerID.UniqueNo)
             {
                 found = true;
             }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4232,7 +4232,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                     if (battleutils::HasClaim(PAttacker, PDefender))
                     { // mob is currently claimed by your alliance, update ownership
                         mob->m_OwnerID.UniqueNo     = PAttacker->id;
-                        mob->m_OwnerID.targid = PAttacker->targid;
+                        mob->m_OwnerID.ActIndex = PAttacker->targid;
                         if (PDefender->isAlive())
                         { // ignore killing blow
                             mob->updatemask |= UPDATE_STATUS;
@@ -4244,7 +4244,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                         if (PDefender->isDead())
                         { // always give rewards on the killing blow
                             mob->m_OwnerID.UniqueNo     = PAttacker->id;
-                            mob->m_OwnerID.targid = PAttacker->targid;
+                            mob->m_OwnerID.ActIndex = PAttacker->targid;
                             return;
                         }
                         CBattleEntity* highestClaim = mob->PEnmityContainer->GetHighestEnmity();
@@ -4258,7 +4258,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                                 if (!highestClaim || highestClaim == PMember || highestClaim == PMember->PPet)
                                 { // someone in your alliance is top of hate list, claim for your alliance
                                     mob->m_OwnerID.UniqueNo     = PAttacker->id;
-                                    mob->m_OwnerID.targid = PAttacker->targid;
+                                    mob->m_OwnerID.ActIndex = PAttacker->targid;
                                     if (PDefender->isAlive())
                                     { // ignore killing blow
                                         mob->updatemask |= UPDATE_STATUS;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4231,8 +4231,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                 {
                     if (battleutils::HasClaim(PAttacker, PDefender))
                     { // mob is currently claimed by your alliance, update ownership
-                        mob->m_OwnerID.UniqueNo = PAttacker->id;
-                        mob->m_OwnerID.ActIndex = PAttacker->targid;
+                        mob->m_OwnerID = EntityId(PAttacker);
                         if (PDefender->isAlive())
                         { // ignore killing blow
                             mob->updatemask |= UPDATE_STATUS;
@@ -4243,8 +4242,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                     { // mob is unclaimed
                         if (PDefender->isDead())
                         { // always give rewards on the killing blow
-                            mob->m_OwnerID.UniqueNo = PAttacker->id;
-                            mob->m_OwnerID.ActIndex = PAttacker->targid;
+                            mob->m_OwnerID = EntityId(PAttacker);
                             return;
                         }
                         CBattleEntity* highestClaim = mob->PEnmityContainer->GetHighestEnmity();
@@ -4257,8 +4255,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                             {
                                 if (!highestClaim || highestClaim == PMember || highestClaim == PMember->PPet)
                                 { // someone in your alliance is top of hate list, claim for your alliance
-                                    mob->m_OwnerID.UniqueNo     = PAttacker->id;
-                                    mob->m_OwnerID.ActIndex = PAttacker->targid;
+                                    mob->m_OwnerID = EntityId(PAttacker);
                                     if (PDefender->isAlive())
                                     { // ignore killing blow
                                         mob->updatemask |= UPDATE_STATUS;

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -4231,7 +4231,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                 {
                     if (battleutils::HasClaim(PAttacker, PDefender))
                     { // mob is currently claimed by your alliance, update ownership
-                        mob->m_OwnerID.UniqueNo     = PAttacker->id;
+                        mob->m_OwnerID.UniqueNo = PAttacker->id;
                         mob->m_OwnerID.ActIndex = PAttacker->targid;
                         if (PDefender->isAlive())
                         { // ignore killing blow
@@ -4243,7 +4243,7 @@ void ClaimMob(CBattleEntity* PDefender, CBattleEntity* PAttacker, bool passing)
                     { // mob is unclaimed
                         if (PDefender->isDead())
                         { // always give rewards on the killing blow
-                            mob->m_OwnerID.UniqueNo     = PAttacker->id;
+                            mob->m_OwnerID.UniqueNo = PAttacker->id;
                             mob->m_OwnerID.ActIndex = PAttacker->targid;
                             return;
                         }
@@ -4763,7 +4763,7 @@ void assistTarget(CCharEntity* PChar, uint16 TargID)
     CBattleEntity* EntityToAssist = (CBattleEntity*)PChar->GetEntity(TargID, TYPE_MOB | TYPE_PC);
     if (EntityToAssist != nullptr)
     {
-        if (EntityToAssist->objtype == TYPE_PC && EntityToAssist->GetBattleTargetID() != 0)
+        if (EntityToAssist->objtype == TYPE_PC && EntityToAssist->battleTarget().isSet())
         {
             // get that players engaged target
             CBattleEntity* EntityToLockon = EntityToAssist->GetBattleTarget();
@@ -4773,7 +4773,7 @@ void assistTarget(CCharEntity* PChar, uint16 TargID)
                 PChar->pushPacket<GP_SERV_COMMAND_ASSIST>(PChar, EntityToLockon);
             }
         }
-        else if (EntityToAssist->GetBattleTargetID() != 0)
+        else if (EntityToAssist->battleTarget().isSet())
         {
             // lock on to the new target!
             PChar->pushPacket<GP_SERV_COMMAND_ASSIST>(PChar, EntityToAssist->GetBattleTarget());

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -2033,7 +2033,7 @@ bool IsTandemActive(CBattleEntity* PAttacker)
     if (
         tandemPartner->PAI->IsEngaged() &&
         tandemPartner->GetBattleTarget() != nullptr &&
-        tandemPartner->GetBattleTargetID() == PAttacker->GetBattleTargetID())
+        tandemPartner->battleTarget() == PAttacker->battleTarget())
     {
         return true;
     }

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -364,7 +364,7 @@ auto LoadTrust(CCharEntity* PMaster, uint32 TrustID) -> CTrustEntity*
 
     PTrust->loc              = PMaster->loc;
     PTrust->m_OwnerID.UniqueNo     = PMaster->id;
-    PTrust->m_OwnerID.targid = PMaster->targid;
+    PTrust->m_OwnerID.ActIndex = PMaster->targid;
 
     // spawn me randomly around master
     PTrust->loc.p = nearPosition(PMaster->loc.p, CTrustController::SpawnDistance + (PMaster->PTrusts.size() * CTrustController::SpawnDistance), (float)M_PI);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -362,9 +362,8 @@ auto LoadTrust(CCharEntity* PMaster, uint32 TrustID) -> CTrustEntity*
 
     auto* PTrust = new CTrustEntity(PMaster, trustData->trustID, IsPassiveTrust{ trustData->isPassiveTrust });
 
-    PTrust->loc                = PMaster->loc;
-    PTrust->m_OwnerID.UniqueNo = PMaster->id;
-    PTrust->m_OwnerID.ActIndex = PMaster->targid;
+    PTrust->loc       = PMaster->loc;
+    PTrust->m_OwnerID = EntityId(PMaster);
 
     // spawn me randomly around master
     PTrust->loc.p = nearPosition(PMaster->loc.p, CTrustController::SpawnDistance + (PMaster->PTrusts.size() * CTrustController::SpawnDistance), (float)M_PI);

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -362,8 +362,8 @@ auto LoadTrust(CCharEntity* PMaster, uint32 TrustID) -> CTrustEntity*
 
     auto* PTrust = new CTrustEntity(PMaster, trustData->trustID, IsPassiveTrust{ trustData->isPassiveTrust });
 
-    PTrust->loc              = PMaster->loc;
-    PTrust->m_OwnerID.UniqueNo     = PMaster->id;
+    PTrust->loc                = PMaster->loc;
+    PTrust->m_OwnerID.UniqueNo = PMaster->id;
     PTrust->m_OwnerID.ActIndex = PMaster->targid;
 
     // spawn me randomly around master

--- a/src/map/utils/trustutils.cpp
+++ b/src/map/utils/trustutils.cpp
@@ -363,7 +363,7 @@ auto LoadTrust(CCharEntity* PMaster, uint32 TrustID) -> CTrustEntity*
     auto* PTrust = new CTrustEntity(PMaster, trustData->trustID, IsPassiveTrust{ trustData->isPassiveTrust });
 
     PTrust->loc              = PMaster->loc;
-    PTrust->m_OwnerID.id     = PMaster->id;
+    PTrust->m_OwnerID.UniqueNo     = PMaster->id;
     PTrust->m_OwnerID.targid = PMaster->targid;
 
     // spawn me randomly around master

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -569,7 +569,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
             PCurrentMob->m_OwnerID.clean();
             PCurrentMob->updatemask |= UPDATE_STATUS;
         }
-        if (PCurrentMob->GetBattleTargetID() == PChar->targid)
+        if (PCurrentMob->battleTarget() == PChar)
         {
             PCurrentMob->setBattleTarget(std::nullopt);
         }

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -564,7 +564,7 @@ void CZoneEntities::DecreaseZoneCounter(CCharEntity* PChar)
     FOR_EACH_PAIR_CAST_SECOND(CMobEntity*, PCurrentMob, m_mobList)
     {
         PCurrentMob->PEnmityContainer->LogoutReset(PChar->id);
-        if (PCurrentMob->m_OwnerID.id == PChar->id)
+        if (PCurrentMob->m_OwnerID.UniqueNo == PChar->id)
         {
             PCurrentMob->m_OwnerID.clean();
             PCurrentMob->updatemask |= UPDATE_STATUS;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Rename EntityId.id to EntityId.UniqueNo
- Rename EntityId.targid to EntityId.ActIndex
- Change the way entities are resolved in a few spot to account for new methods
- Get rid of GetBattleTargetID() to leverage battleTarget() instead

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
