### PR TITLE
[data, lua] Allow Threnody to overwrite other threnodies by tier

### DIFF
--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -2096,8 +2096,7 @@ status_effects:
       - no_loss_message
       - song
       - no_cancel
-    overwrite: higher
-    sort_key:  2000
+    sort_key: 2000
 
   hymnus:
     id: 218

--- a/scripts/globals/spells/enfeebling_song.lua
+++ b/scripts/globals/spells/enfeebling_song.lua
@@ -164,7 +164,14 @@ xi.spells.enfeebling.useEnfeeblingSong = function(caster, target, spell)
     end
 
     -- Target already has an status effect that nullifies current.
-    if xi.data.statusEffect.isEffectNullified(target, spellEffect, spellTier) then
+    -- Threnody uses one effect ID for all eight elements, so the generic same-tier
+    -- nullifier wrongly rejects a different element at the same tier. Its tier rule
+    -- (equal or higher tier overwrites, lower tier is blocked, regardless of element)
+    -- is instead enforced by the effect's default overwrite when it is applied below.
+    if
+        spellEffect ~= xi.effect.THRENODY and
+        xi.data.statusEffect.isEffectNullified(target, spellEffect, spellTier)
+    then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)
         return spellEffect
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows Threnody of the same tier to override the other.

screenshot from retail provided by @CriticalXI . ty critical
<img width="468" height="102" alt="image" src="https://github.com/user-attachments/assets/6dfb09d1-977c-4e4c-acc1-e8d1535bae12" />

just a note this is by tier. playing a tier II threnody and switching to a tier 1 threnody even by element will give a no effect. I tested this and have a screenshot:
<img width="617" height="182" alt="image" src="https://github.com/user-attachments/assets/e3de9556-0932-4fdb-9c08-fabf28bff2ef" />



## Steps to test these changes

casted threnody. casted a different threnody of a different element.
