### PR TITLE
[lua, sql] Fomor Species detection fixes

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -4066,6 +4066,9 @@ ecosystems:
                 agi: d
                 int: d
                 mnd: d
+              detects:
+                - hearing
+                - lowhp
               mob_mods:
                 roam_cool:  50
                 roam_turns: 2

--- a/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Bard.lua
@@ -1,12 +1,11 @@
 -----------------------------------
--- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+-- Area: Bhaflau Thickets
+--  Mob: Fomor Bard
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 

--- a/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Beastmaster.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Beastmaster.lua
@@ -7,6 +7,7 @@ local entity = {}
 
 entity.onMobInitialize = function(mob)
     xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
+    mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 
 return entity

--- a/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Paladin.lua
@@ -1,12 +1,11 @@
 -----------------------------------
--- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+-- Area: Bhaflau Thickets
+--  Mob: Fomor Paladin
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 

--- a/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Bhaflau_Thickets/mobs/Fomor_Thief.lua
@@ -1,12 +1,11 @@
 -----------------------------------
--- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+-- Area: Bhaflau Thickets
+--  Mob: Fomor Thief
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Bard.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Bard.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+--  Mob: Fomor Bard
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Paladin.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Paladin.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+--  Mob: Fomor Paladin
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 

--- a/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Thief.lua
+++ b/scripts/zones/Wajaom_Woodlands/mobs/Fomor_Thief.lua
@@ -1,12 +1,11 @@
 -----------------------------------
 -- Area: Wajaom Woodlands
---  Mob: Fomor Beastmaster
+--  Mob: Fomor Thief
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    xi.pet.setMobPet(mob, 1, 'Fomors_Bats')
     mob:setMobMod(xi.mobMod.DETECTION, bit.bor(xi.detects.HEARING, xi.detects.LOWHP, xi.detects.ABILITY))
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes detection behaviour for Species Fomor [Jobs]. 
COP Fomor [Jobs] only detect Low HP and Sound.
ToAU Fomor [Jobs] detect Low HP, Sound, Weaponskills and Job Abilities

- Removes Job Ability and Weaponskill detection from Fomor Species
- Adds detection back in for Bhaflau and Wajaom Fomors onMobInit in their luas

Retail testing: https://www.youtube.com/live/6pB00GYE-28

Bhaflau example: https://www.youtube.com/live/6pB00GYE-28?si=6u1THnZ89Zyb91Dk&t=359
Aquaducts example: https://www.youtube.com/live/6pB00GYE-28?si=FmLZEhYHo_Gta582&t=1996
Sacrarium example: https://www.youtube.com/live/6pB00GYE-28?si=oFvWcXlXqfwLKwSD&t=1294
Lufaise example: https://www.youtube.com/live/6pB00GYE-28?si=Af3VA7uOpwWfSBQk&t=4082

Arrapago Fallen Subspecies: https://www.youtube.com/live/6pB00GYE-28?si=MCXb7ldbz4bR6Akb&t=3015
Caedarva Ephradamian Subspecies: https://www.youtube.com/live/6pB00GYE-28?si=8fO_qWZcrMMd-0fh&t=4545
Arrapago Ephradamian Subspecies: https://www.youtube.com/live/6pB00GYE-28?si=8Dl78ZlHRMkgVYPl&t=4853

## Steps to test these changes

!changejob THF 60

**COP Fomors**
!zone Sacrarium
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should not aggro.
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should not aggro.

!zone Phomiuna
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should not aggro.
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should not aggro.

!zone Misareaux
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should not aggro.
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should not aggro.

!zone Lufaise
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should not aggro.
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should not aggro.

**ToAU Fomors**
!zone Bhaflau
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should aggro.
!goto <me>
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should aggro.

!zone Wajaom
!gotoname Fomor_Bard 1
Perform the Sneak Attack ability. Fomor Bard should aggro.
!goto <me>
!tp 1000
Perform a Weaponskill on a nearby enemy. Fomor Bard should aggro.

NOTE: Ephramadian and Fallen species (which are other Fomor families in ToAU) are unaffected and still have blanket detection for Low HP, Sound, Weaponskills and Job Abilities in mob_species_system.sql