### PR TITLE
Core: Don't use exceptions in AI state regular usage

### DIFF
--- a/src/common/types/error_or.h
+++ b/src/common/types/error_or.h
@@ -31,9 +31,9 @@
 //
 // ErrorOr<T, E = std::string>
 //
-//   An alias for std::expected (C++23): either a T (the success value) or an E
+//   An alias for std::expected: either a T (the success value) or an E
 //   describing why it couldn't be produced. Prefer this over out-params,
-//   sentinel values, or Maybe<T> when the caller needs to know *why* something
+//   sentinel values, or Maybe<T> when the caller needs to know why something
 //   failed, not just that it did.
 //
 //   Return a success value directly, and an error via Error():
@@ -44,26 +44,57 @@
 //           {
 //               return Error("empty position string");
 //           }
+//
 //           return position_t{ ... };
 //       }
-//
-//   Callers can branch (`if (result) { result->x; }` / `result.error()`), or use
-//   the monadic ops (and_then/transform/or_else) to chain without branching.
 //
 
 template <typename T, typename E = std::string>
 using ErrorOr = std::expected<T, E>;
 
-// Construct the error side of an ErrorOr: `return Error("reason");`
+//
+// Error<E>
+//
+//   The error side of an ErrorOr. Return one to fail:
+//
+//       return Error("could not open the file");
+//
+//   E comes from the argument, then converts to the function's error type. A
+//   std::unique_ptr<Derived> can therefore satisfy an error type of std::unique_ptr<Base>.
+//
 template <typename E = std::string>
-auto Error(E error) -> std::unexpected<E>
-{
-    return std::unexpected<E>{ std::move(error) };
-}
+using Error = std::unexpected<E>;
 
-inline auto Error(const char* message) -> std::unexpected<std::string>
+//
+// Success()
+//
+//   The success side of an ErrorOr<void, E>, for functions that report a failure reason
+//   but have nothing to return when they work:
+//
+//       auto init() -> ErrorOr<void>
+//       {
+//           if (somethingWrong)
+//           {
+//               return Error("...");
+//           }
+//
+//           return Success();
+//       }
+//
+//   It reads better than `return {};`, which says nothing about which side you mean.
+//
+struct SuccessType
 {
-    return std::unexpected<std::string>{ message };
+    template <typename E>
+    constexpr operator ErrorOr<void, E>() const // NOLINT(google-explicit-constructor)
+    {
+        return ErrorOr<void, E>{};
+    }
+};
+
+constexpr auto Success() -> SuccessType
+{
+    return {};
 }
 
 // } // namespace xi

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -371,14 +371,24 @@ auto CAIContainer::GetCurrentState() const -> CState*
     return m_currentState.get();
 }
 
-void CAIContainer::enterState(std::unique_ptr<CState> next)
+auto CAIContainer::enterState(std::unique_ptr<CState> next) -> bool
 {
+    // init() decides whether the entity may enter the state. If it refuses, drop the new
+    // state and keep the current one.
+    if (auto result = next->init(); !result)
+    {
+        PEntity->HandleErrorMessage(result.error());
+        return false;
+    }
+
     // Suspend the state we're leaving beneath the new one, which becomes current.
     if (m_currentState)
     {
         m_stateStack.push(std::move(m_currentState));
     }
     m_currentState = std::move(next);
+
+    return true;
 }
 
 void CAIContainer::resumeNextState()

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -146,8 +146,9 @@ protected:
     auto ForceChangeState(Args&&... args) -> bool;
 
 private:
-    // Suspend the current state (if any) beneath `next`, then make `next` current.
-    void enterState(std::unique_ptr<CState> next);
+    // Initialize `next`. If it accepts, suspend the current state beneath it and make
+    // `next` current. Returns true if the entity entered the state.
+    auto enterState(std::unique_ptr<CState> next) -> bool;
 
     // Finish with the current state and resume the one suspended beneath it (or go idle).
     void resumeNextState();
@@ -196,18 +197,8 @@ auto CAIContainer::ChangeState(Args&&... args) -> bool
 
     if (CanChangeState())
     {
-        try
-        {
-            CheckCompletedStates();
-
-            // Construct first: if it throws, the current state is left untouched.
-            enterState(std::make_unique<T>(std::forward<Args>(args)...));
-            return true;
-        }
-        catch (CStateInitException& e)
-        {
-            PEntity->HandleErrorMessage(e.packet);
-        }
+        CheckCompletedStates();
+        return enterState(CState::make<T>(std::forward<Args>(args)...));
     }
 
     return false;
@@ -222,18 +213,6 @@ auto CAIContainer::ForceChangeState(Args&&... args) -> bool
         return false;
     }
 
-    try
-    {
-        CheckCompletedStates();
-
-        // Construct first: if it throws, the current state is left untouched.
-        enterState(std::make_unique<T>(std::forward<Args>(args)...));
-        return true;
-    }
-    catch (CStateInitException& e)
-    {
-        PEntity->HandleErrorMessage(e.packet);
-    }
-
-    return false;
+    CheckCompletedStates();
+    return enterState(CState::make<T>(std::forward<Args>(args)...));
 }

--- a/src/map/ai/states/ability_state.cpp
+++ b/src/map/ai/states/ability_state.cpp
@@ -98,37 +98,35 @@ auto PetSkillDistanceCheck(CCharEntity* PChar, CBaseEntity* PTarget, const CAbil
 
 } // namespace
 
-CAbilityState::CAbilityState(CBattleEntity* PEntity, const EntityId& target, const uint16 abilityid)
+CAbilityState::CAbilityState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, const uint16 abilityid)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
+, m_abilityId(abilityid)
 {
-    CAbility* PAbility = ability::GetAbility(abilityid);
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CAbilityState::init() -> StateErrorOr<void>
+{
+    CAbility* PAbility = ability::GetAbility(m_abilityId);
 
     if (!PAbility)
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, 0, 0, MsgBasic::UnableToUseJobAbility));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, 0, 0, MsgBasic::UnableToUseJobAbility) };
     }
-    auto* PTarget = m_PEntity->IsValidTarget(target, PAbility->getValidTarget(), m_errorMsg);
+    auto* PTarget = m_PEntity->IsValidTarget(target(), PAbility->getValidTarget(), m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
-    SetTarget(target);
     m_PAbility = std::make_unique<CAbility>(*PAbility);
     m_castTime = PAbility->getCastTime();
 
     if (m_castTime > 0s && CanUseAbility())
     {
         action_t action{
-            .actorId    = PEntity->id,
+            .actorId    = m_PEntity->id,
             .actiontype = ActionCategory::AbilityStart,
             .targets    = {
                 {
@@ -144,7 +142,7 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, const EntityId& target, con
             }
         };
 
-        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
         m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", m_PEntity, PAbility);
 
         // face toward target
@@ -154,6 +152,8 @@ CAbilityState::CAbilityState(CBattleEntity* PEntity, const EntityId& target, con
     {
         m_PEntity->PAI->EventHandler.triggerListener("ABILITY_START", m_PEntity, PAbility);
     }
+
+    return Success();
 }
 
 auto CAbilityState::GetAbility() const -> CAbility*

--- a/src/map/ai/states/ability_state.h
+++ b/src/map/ai/states/ability_state.h
@@ -27,7 +27,9 @@
 class CAbilityState : public CState
 {
 public:
-    CAbilityState(CBattleEntity* PEntity, const EntityId& target, uint16 abilityid);
+    CAbilityState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, uint16 abilityid);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto GetAbility() const -> CAbility*;
     void ApplyEnmity() const;
@@ -41,7 +43,10 @@ protected:
     auto CanUseAbility() const -> bool;
 
 private:
+    // Shadows CState::m_PEntity
+    CBattleEntity* const m_PEntity;
+
     timer::duration           m_castTime{ 0s };
-    CBattleEntity* const      m_PEntity;
+    const uint16              m_abilityId;
     std::unique_ptr<CAbility> m_PAbility;
 };

--- a/src/map/ai/states/attack_state.cpp
+++ b/src/map/ai/states/attack_state.cpp
@@ -29,31 +29,31 @@
 #include "packets/s2c/0x058_assist.h"
 #include "utils/battleutils.h"
 
-CAttackState::CAttackState(CBattleEntity* PEntity, const EntityId& target)
+CAttackState::CAttackState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
 {
-    PEntity->setBattleTarget(target);
-    PEntity->SetBattleStartTime(timer::now());
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CAttackState::init() -> StateErrorOr<void>
+{
+    m_PEntity->setBattleTarget(target());
+    m_PEntity->SetBattleStartTime(timer::now());
     CAttackState::UpdateTarget();
 
     if (!m_PEntity->GetBattleTarget() || m_errorMsg)
     {
-        PEntity->setBattleTarget(std::nullopt);
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        m_PEntity->setBattleTarget(std::nullopt);
+        return refuseWithErrorMsg();
     }
 
-    if (PEntity->PAI->PathFind)
+    if (m_PEntity->PAI->PathFind)
     {
-        PEntity->PAI->PathFind->Clear();
+        m_PEntity->PAI->PathFind->Clear();
     }
+
+    return Success();
 }
 
 auto CAttackState::Update(timer::time_point tick) -> bool

--- a/src/map/ai/states/attack_state.h
+++ b/src/map/ai/states/attack_state.h
@@ -26,7 +26,9 @@
 class CAttackState : public CState
 {
 public:
-    CAttackState(CBattleEntity* PEntity, const EntityId& target);
+    CAttackState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
@@ -41,6 +43,8 @@ protected:
     auto AttackReady() const -> bool;
 
 private:
+    // Shadows CState::m_PEntity
     CBattleEntity* const m_PEntity;
-    timer::duration      m_attackTime{ 2s };
+
+    timer::duration m_attackTime{ 2s };
 };

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -35,11 +35,16 @@ static constexpr timer::duration TIME_TO_SEND_RERAISE_MENU = 8s;
 
 }
 
-CDeathState::CDeathState(CBattleEntity* PEntity, timer::duration death_time)
+CDeathState::CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time)
 : CState(PEntity, PEntity->entityId())
 , m_PEntity(PEntity)
 , m_deathTime(death_time)
 , m_raiseTime(GetEntryTime() + TIME_TO_SEND_RERAISE_MENU)
+{
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CDeathState::init() -> StateErrorOr<void>
 {
     m_PEntity->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Death, EffectNotice::Silent);
 
@@ -49,6 +54,8 @@ CDeathState::CDeathState(CBattleEntity* PEntity, timer::duration death_time)
     {
         m_PEntity->PAI->PathFind->Clear();
     }
+
+    return Success();
 }
 
 auto CDeathState::Update(const timer::time_point tick) -> bool

--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -26,7 +26,9 @@
 class CDeathState : public CState
 {
 public:
-    CDeathState(CBattleEntity* PEntity, timer::duration death_time);
+    CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
@@ -37,10 +39,12 @@ public:
     void acceptRaise();
 
 private:
+    // Shadows CState::m_PEntity
     CBattleEntity* const m_PEntity;
-    timer::duration      m_deathTime;
-    bool                 m_raiseSent{ false };
-    bool                 m_raiseAccepted{ false };
-    timer::time_point    m_raiseTime;
-    timer::time_point    m_raiseAcceptedTime;
+
+    timer::duration   m_deathTime;
+    bool              m_raiseSent{ false };
+    bool              m_raiseAccepted{ false };
+    timer::time_point m_raiseTime;
+    timer::time_point m_raiseAcceptedTime;
 };

--- a/src/map/ai/states/despawn_state.cpp
+++ b/src/map/ai/states/despawn_state.cpp
@@ -27,19 +27,28 @@
 #include "spawn_handler.h"
 #include "zone.h"
 
-CDespawnState::CDespawnState(CBaseEntity* PEntity, const bool instantDespawn)
+CDespawnState::CDespawnState(xi::Badge<CState>, CBaseEntity* PEntity, const bool instantDespawn)
 : CState(PEntity, PEntity->entityId())
-, despawnTime_(timer::now() + (instantDespawn ? 0s : 3s))
+, instantDespawn_(instantDespawn)
 {
-    if (!instantDespawn && (PEntity->status != xi::Status::Disappear && !((static_cast<CMobEntity*>(PEntity)->m_Behavior & xi::Behavior::NoDespawn) != xi::Behavior::None)))
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CDespawnState::init() -> StateErrorOr<void>
+{
+    despawnTime_ = timer::now() + (instantDespawn_ ? 0s : 3s);
+
+    if (!instantDespawn_ && (m_PEntity->status != xi::Status::Disappear && !((static_cast<CMobEntity*>(m_PEntity)->m_Behavior & xi::Behavior::NoDespawn) != xi::Behavior::None)))
     {
-        PEntity->loc.zone->PushPacket(PEntity, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_SCHEDULOR>(PEntity, PEntity, FourCC::FadeOut));
+        m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE, std::make_unique<GP_SERV_COMMAND_SCHEDULOR>(m_PEntity, m_PEntity, FourCC::FadeOut));
     }
 
-    if (auto* PMob = dynamic_cast<CMobEntity*>(PEntity); PMob && PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
+    if (auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity); PMob && PMob->m_AllowRespawn && PMob->loc.zone != nullptr)
     {
         PMob->loc.zone->spawnHandler().registerForRespawn(PMob);
     }
+
+    return Success();
 }
 
 auto CDespawnState::Update(const timer::time_point tick) -> bool

--- a/src/map/ai/states/despawn_state.h
+++ b/src/map/ai/states/despawn_state.h
@@ -26,7 +26,10 @@
 class CDespawnState : public CState
 {
 public:
-    CDespawnState(CBaseEntity* PEntity, bool instantDespawn);
+    CDespawnState(xi::Badge<CState>, CBaseEntity* PEntity, bool instantDespawn);
+
+    auto init() -> StateErrorOr<void> override;
+
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
     auto CanChangeState() -> bool override;
@@ -34,5 +37,6 @@ public:
     auto CanInterrupt() -> bool override;
 
 private:
+    const bool        instantDespawn_;
     timer::time_point despawnTime_;
 };

--- a/src/map/ai/states/inactive_state.cpp
+++ b/src/map/ai/states/inactive_state.cpp
@@ -24,16 +24,23 @@
 #include "entities/battle_entity.h"
 #include "status_effect_container.h"
 
-CInactiveState::CInactiveState(CBaseEntity* PEntity, const timer::duration _duration, const bool canChangeState, const bool untargetable)
+CInactiveState::CInactiveState(xi::Badge<CState>, CBaseEntity* PEntity, const timer::duration _duration, const bool canChangeState, const bool untargetable)
 : CState(PEntity, PEntity->entityId())
 , m_duration(_duration)
 , m_canChangeState(canChangeState)
 , m_untargetable(untargetable)
 {
-    if (!canChangeState)
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CInactiveState::init() -> StateErrorOr<void>
+{
+    if (!m_canChangeState)
     {
-        PEntity->PAI->InterruptStates();
+        m_PEntity->PAI->InterruptStates();
     }
+
+    return Success();
 }
 
 auto CInactiveState::Update(const timer::time_point tick) -> bool

--- a/src/map/ai/states/inactive_state.h
+++ b/src/map/ai/states/inactive_state.h
@@ -26,7 +26,9 @@
 class CInactiveState : public CState
 {
 public:
-    CInactiveState(CBaseEntity* PEntity, timer::duration _duration, bool canChangeState, bool untargetable);
+    CInactiveState(xi::Badge<CState>, CBaseEntity* PEntity, timer::duration _duration, bool canChangeState, bool untargetable);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto GetUntargetable() const -> bool;
 

--- a/src/map/ai/states/item_state.cpp
+++ b/src/map/ai/states/item_state.cpp
@@ -44,14 +44,19 @@
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
 
-CItemState::CItemState(CCharEntity* PEntity, const EntityId& target, const uint8 loc, const uint8 slotid)
+CItemState::CItemState(xi::Badge<CState>, CCharEntity* PEntity, const EntityId& target, const uint8 loc, const uint8 slotid)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
 , m_PItem(nullptr)
 , m_location(loc)
 , m_slot(slotid)
 {
-    auto* PItem = dynamic_cast<CItemUsable*>(m_PEntity->getStorage(loc)->GetItem(slotid));
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CItemState::init() -> StateErrorOr<void>
+{
+    auto* PItem = dynamic_cast<CItemUsable*>(m_PEntity->getStorage(m_location)->GetItem(m_slot));
     m_PItem     = PItem;
 
     if (m_PItem && m_PItem->isType(ITEM_USABLE))
@@ -83,21 +88,14 @@ CItemState::CItemState(CCharEntity* PEntity, const EntityId& target, const uint8
 
     if (!m_PItem)
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, 0, 0, MsgBasic::UnableToUseItem));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, 0, 0, MsgBasic::UnableToUseItem) };
     }
 
     auto* PTarget = validatedTarget();
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     auto [error, param, value] = luautils::OnItemCheck(PTarget, m_PItem, m_PEntity);
@@ -105,7 +103,7 @@ CItemState::CItemState(CCharEntity* PEntity, const EntityId& target, const uint8
     {
         if (error == -1)
         {
-            throw CStateInitException(nullptr);
+            return RefuseSilently();
         }
         else
         {
@@ -113,7 +111,7 @@ CItemState::CItemState(CCharEntity* PEntity, const EntityId& target, const uint8
             {
                 param = m_PItem->hasFlag(ItemFlag::Scroll) ? m_PItem->getSubID() : m_PItem->getID();
             }
-            throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget ? PTarget : m_PEntity, param, value, static_cast<MsgBasic>(error)));
+            return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget ? PTarget : m_PEntity, param, value, static_cast<MsgBasic>(error)) };
         }
     }
 
@@ -156,6 +154,8 @@ CItemState::CItemState(CCharEntity* PEntity, const EntityId& target, const uint8
 
     m_PEntity->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(m_PItem, ItemLockFlg::NoSelect);
     m_PEntity->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(m_PEntity);
+
+    return Success();
 }
 
 CItemState::~CItemState() = default;

--- a/src/map/ai/states/item_state.h
+++ b/src/map/ai/states/item_state.h
@@ -33,8 +33,10 @@ struct action_t;
 class CItemState : public CState
 {
 public:
-    CItemState(CCharEntity* PEntity, const EntityId& target, uint8 loc, uint8 slotid);
+    CItemState(xi::Badge<CState>, CCharEntity* PEntity, const EntityId& target, uint8 loc, uint8 slotid);
     ~CItemState() override;
+
+    auto init() -> StateErrorOr<void> override;
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
@@ -50,7 +52,9 @@ protected:
     auto HasMoved() const -> bool;
     auto validatedTarget() -> CBaseEntity*;
 
-    CCharEntity*        m_PEntity;
+    // Shadows CState::m_PEntity
+    CCharEntity* const m_PEntity;
+
     CItemUsable*        m_PItem;
     uint8               m_location;
     uint8               m_slot;

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -40,11 +40,17 @@
 #include "utils/battleutils.h"
 #include "utils/zoneutils.h"
 
-CMagicState::CMagicState(CBattleEntity* PEntity, const EntityId& target, SpellID spellid, uint8 flags)
+CMagicState::CMagicState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, SpellID spellid, uint8 flags)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
+, m_spellId(spellid)
 , m_PSpell(nullptr)
 , m_flags(flags)
+{
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CMagicState::init() -> StateErrorOr<void>
 {
     if (const auto* PMob = dynamic_cast<CMobEntity*>(m_PEntity))
     {
@@ -54,43 +60,29 @@ CMagicState::CMagicState(CBattleEntity* PEntity, const EntityId& target, SpellID
         }
     }
 
-    auto* PSpell = spell::GetSpell(spellid);
+    auto* PSpell = spell::GetSpell(m_spellId);
     if (PSpell == nullptr)
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, static_cast<uint16>(spellid), 0, MsgBasic::CannotCastSpell));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, static_cast<uint16>(m_spellId), 0, MsgBasic::CannotCastSpell) };
     }
 
     m_PSpell = PSpell->clone();
 
-    auto* PTarget = m_PEntity->IsValidTarget(target, m_PSpell->getValidTarget(), m_errorMsg);
+    auto* PTarget = m_PEntity->IsValidTarget(target(), m_PSpell->getValidTarget(), m_errorMsg);
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     if (!CanCastSpell(PTarget, false))
     {
-        if (HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     auto errorMsg = luautils::OnMagicCastingCheck(m_PEntity, PTarget, GetSpell());
     if (errorMsg)
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, static_cast<uint16>(m_PSpell->getID()), 0, errorMsg == 1 ? MsgBasic::CannotCastSpell : static_cast<MsgBasic>(errorMsg)));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, static_cast<uint16>(m_PSpell->getID()), 0, errorMsg == 1 ? MsgBasic::CannotCastSpell : static_cast<MsgBasic>(errorMsg)) };
     }
 
     m_castTime = battleutils::CalculateSpellCastTime(m_PEntity, this);
@@ -114,7 +106,7 @@ CMagicState::CMagicState(CBattleEntity* PEntity, const EntityId& target, SpellID
                 .results = {
                     {
                         .param     = static_cast<int32_t>(m_PSpell->getID()),
-                        .messageID = PEntity->objtype != TYPE_PC ? MsgBasic::StartsCastingSelf : MsgBasic::StartsCastingTarget,
+                        .messageID = m_PEntity->objtype != TYPE_PC ? MsgBasic::StartsCastingSelf : MsgBasic::StartsCastingTarget,
                     },
                 },
             },
@@ -136,6 +128,8 @@ CMagicState::CMagicState(CBattleEntity* PEntity, const EntityId& target, SpellID
     }
 
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
+
+    return Success();
 }
 
 auto CMagicState::Update(timer::time_point tick) -> bool

--- a/src/map/ai/states/magic_state.h
+++ b/src/map/ai/states/magic_state.h
@@ -36,7 +36,9 @@ enum MAGICFLAGS
 class CMagicState : public CState
 {
 public:
-    CMagicState(CBattleEntity* PEntity, const EntityId& target, SpellID spellid, uint8 flags = 0);
+    CMagicState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, SpellID spellid, uint8 flags = 0);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
@@ -57,7 +59,10 @@ protected:
     auto HasCost() -> bool;
     auto HasMoved() const -> bool;
 
-    CBattleEntity* const    m_PEntity;
+    // Shadows CState::m_PEntity
+    CBattleEntity* const m_PEntity;
+
+    const SpellID           m_spellId;
     std::unique_ptr<CSpell> m_PSpell;
     timer::duration         m_castTime{};
     position_t              m_startPos;

--- a/src/map/ai/states/mobskill_state.cpp
+++ b/src/map/ai/states/mobskill_state.cpp
@@ -36,48 +36,47 @@
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
 
-CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, const uint16 wsid, const Maybe<timer::duration> castTimeOverride)
+CMobSkillState::CMobSkillState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, const uint16 wsid, const Maybe<timer::duration> castTimeOverride)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
+, m_wsid(wsid)
+, m_castTimeOverride(castTimeOverride)
 , m_spentTP(0)
 {
-    auto* skill = battleutils::GetMobSkill(wsid);
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CMobSkillState::init() -> StateErrorOr<void>
+{
+    auto* skill = battleutils::GetMobSkill(m_wsid);
     if (!skill)
     {
-        throw CStateInitException(nullptr);
+        return RefuseSilently();
     }
 
     if (m_PEntity->StatusEffectContainer->HasStatusEffect({ xi::StatusEffect::Amnesia, xi::StatusEffect::Impairment }))
     {
-        throw CStateInitException(nullptr);
+        return RefuseSilently();
     }
 
     // Self-centered AoE: validate mob can target itself, but keep original targid for allegiance
     const bool   isSelfCenteredAoE = skill->getAoe() == static_cast<uint8>(AOE_RADIUS::ATTACKER);
     const uint16 validTargets      = isSelfCenteredAoE ? static_cast<uint16>(TARGET_SELF) : skill->getValidTargets();
-    const uint16 validateTargid    = isSelfCenteredAoE ? m_PEntity->targid : target.ActIndex;
+    const uint16 validateTargid    = isSelfCenteredAoE ? m_PEntity->targid : target().ActIndex;
     auto*        PTarget           = m_PEntity->IsValidTarget(validateTargid, validTargets, m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
-    // Store original targid - for self-centered AoE this preserves battle target for allegiance checks
-    SetTarget(target);
-
+    // target() still holds the original targid, not validateTargid. For self-centered AoE
+    // that preserves the battle target for allegiance checks.
     m_PSkill = std::make_unique<CMobSkill>(*skill);
 
-    if (castTimeOverride.has_value())
+    if (m_castTimeOverride.has_value())
     {
-        m_castTime = castTimeOverride.value();
+        m_castTime = m_castTimeOverride.value();
     }
     else
     {
@@ -89,7 +88,7 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, c
         // For self-centered AoE damaging moves, show battle target in readies message
         // For true self-target buffs (TARGET_SELF), show self
         const bool isSelfBuff    = skill->getValidTargets() == TARGET_SELF;
-        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : target.resolve());
+        auto*      PActionTarget = isSelfBuff ? m_PEntity : (isSelfCenteredAoE ? m_PEntity->GetBattleTarget() : target().resolve());
         if (!PActionTarget)
         {
             PActionTarget = m_PEntity;
@@ -133,6 +132,8 @@ CMobSkillState::CMobSkillState(CBattleEntity* PEntity, const EntityId& target, c
     {
         DoUpdate(GetEntryTime());
     }
+
+    return Success();
 }
 
 auto CMobSkillState::GetSkill() const -> CMobSkill*

--- a/src/map/ai/states/mobskill_state.h
+++ b/src/map/ai/states/mobskill_state.h
@@ -29,7 +29,9 @@ class CBattleEntity;
 class CMobSkillState : public CState
 {
 public:
-    CMobSkillState(CBattleEntity* PEntity, const EntityId& target, uint16 wsid, Maybe<timer::duration> castTimeOverride);
+    CMobSkillState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, uint16 wsid, Maybe<timer::duration> castTimeOverride);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto GetSkill() const -> CMobSkill*;
     auto GetSpentTP() const -> int16;
@@ -44,12 +46,16 @@ protected:
     void SpendCost();
 
 private:
-    CBattleEntity* const       m_PEntity;
-    std::unique_ptr<CMobSkill> m_PSkill;
-    timer::time_point          m_finishTime;
-    timer::duration            m_castTime{};
-    int16                      m_spentTP;
-    bool                       m_skillSuccess{ false };
+    // Shadows CState::m_PEntity
+    CBattleEntity* const m_PEntity;
+
+    const uint16                 m_wsid;
+    const Maybe<timer::duration> m_castTimeOverride;
+    std::unique_ptr<CMobSkill>   m_PSkill;
+    timer::time_point            m_finishTime;
+    timer::duration              m_castTime{};
+    int16                        m_spentTP;
+    bool                         m_skillSuccess{ false };
 
     void reduceTpOnInterrupt() const;
 };

--- a/src/map/ai/states/petskill_state.cpp
+++ b/src/map/ai/states/petskill_state.cpp
@@ -33,34 +33,33 @@
 #include "utils/battleutils.h"
 #include "utils/petutils.h"
 
-CPetSkillState::CPetSkillState(CPetEntity* PEntity, const EntityId& target, uint16 wsid)
+CPetSkillState::CPetSkillState(xi::Badge<CState>, CPetEntity* PEntity, const EntityId& target, uint16 wsid)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
+, m_wsid(wsid)
 , m_spentTP(0)
 {
-    auto* skill = battleutils::GetPetSkill(wsid);
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CPetSkillState::init() -> StateErrorOr<void>
+{
+    auto* skill = battleutils::GetPetSkill(m_wsid);
     if (!skill)
     {
-        throw CStateInitException(nullptr);
+        return RefuseSilently();
     }
 
     if (m_PEntity->StatusEffectContainer->HasStatusEffect({ xi::StatusEffect::Amnesia, xi::StatusEffect::Impairment }))
     {
-        throw CStateInitException(nullptr);
+        return RefuseSilently();
     }
 
-    const auto* PTarget = m_PEntity->IsValidTarget(target, skill->getValidTargets(), m_errorMsg);
+    const auto* PTarget = m_PEntity->IsValidTarget(target(), skill->getValidTargets(), m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     m_PSkill = std::make_unique<CPetSkill>(*skill);
@@ -97,13 +96,15 @@ CPetSkillState::CPetSkillState(CPetEntity* PEntity, const EntityId& target, uint
 
         // Wyverns immediately emit a skill interrupt packet.
         // This looks like a hack but is retail accurate.
-        if (PEntity->petID() == PETID_WYVERN && PEntity->getMod(xi::Mod::WYVERN_SHOW_READYING) == 0)
+        if (m_PEntity->petID() == PETID_WYVERN && m_PEntity->getMod(xi::Mod::WYVERN_SHOW_READYING) == 0)
         {
-            ActionInterrupts::WyvernSkillReady(PEntity);
+            ActionInterrupts::WyvernSkillReady(m_PEntity);
         }
     }
     m_PEntity->PAI->EventHandler.triggerListener("WEAPONSKILL_STATE_ENTER", m_PEntity, m_PSkill->getID());
     SpendCost();
+
+    return Success();
 }
 
 auto CPetSkillState::GetPetSkill() const -> CPetSkill*

--- a/src/map/ai/states/petskill_state.h
+++ b/src/map/ai/states/petskill_state.h
@@ -29,7 +29,9 @@ class CPetEntity;
 class CPetSkillState : public CState
 {
 public:
-    CPetSkillState(CPetEntity* PEntity, const EntityId& target, uint16 wsid);
+    CPetSkillState(xi::Badge<CState>, CPetEntity* PEntity, const EntityId& target, uint16 wsid);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto GetPetSkill() const -> CPetSkill*;
     auto GetSpentTP() const -> int16;
@@ -43,7 +45,10 @@ protected:
     void SpendCost();
 
 private:
-    CPetEntity* const          m_PEntity;
+    // Shadows CState::m_PEntity
+    CPetEntity* const m_PEntity;
+
+    const uint16               m_wsid;
     std::unique_ptr<CPetSkill> m_PSkill;
     timer::time_point          m_finishTime;
     timer::duration            m_castTime{};

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -37,40 +37,31 @@
 #include "utils/battleutils.h"
 #include "utils/charutils.h"
 
-CRangeState::CRangeState(CBattleEntity* PEntity, const EntityId& target)
+CRangeState::CRangeState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
 {
-    auto* PTarget = m_PEntity->IsValidTarget(target, TARGET_ENEMY, m_errorMsg);
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CRangeState::init() -> StateErrorOr<void>
+{
+    auto* PTarget = m_PEntity->IsValidTarget(target(), TARGET_ENEMY, m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     if (!CanUseRangedAttack(PTarget, false))
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     if (distance(m_PEntity->loc.p, PTarget->loc.p) > m_PEntity->GetRangedAttackRange())
     {
         m_errorMsg = std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, 0, 0, MsgBasic::TooFarAway);
-        throw CStateInitException(m_errorMsg->copy());
+        return refuseWithErrorMsg();
     }
 
     // Configured in main. default : 500ms
@@ -144,6 +135,8 @@ CRangeState::CRangeState(CBattleEntity* PEntity, const EntityId& target)
 
     m_PEntity->PAI->EventHandler.triggerListener("RANGE_START", m_PEntity, &action);
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
+
+    return Success();
 }
 
 void CRangeState::SpendCost() const

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -26,7 +26,9 @@
 class CRangeState : public CState
 {
 public:
-    CRangeState(CBattleEntity* PEntity, const EntityId& target);
+    CRangeState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target);
+
+    auto init() -> StateErrorOr<void> override;
 
     void SpendCost() const;
     auto IsRapidShot() const -> bool;
@@ -43,12 +45,14 @@ protected:
 
     // This will likely need to be re-adjusted when states tick more precisely. Changed in 2012. https://wiki.ffo.jp/html/1734.html
 private:
+    // Shadows CState::m_PEntity
     CBattleEntity* const m_PEntity;
-    timer::duration      m_aimTime{};                  // Phase 1: Delay based on weapon and job trait reductions. 120 delay = 1000 milliseconds.
-    timer::duration      m_returnWeaponDelay = 800ms;  // Phase 2: Time to be locked in place while putting your weapon away after a shot.
-    timer::duration      m_freePhaseTimeMob  = 1100ms; // Phase 3 (mobs/trusts): Cooldown before a ranged attack can fire again.
-    timer::duration      m_freePhaseTimePlayer{};      // Phase 3 (players): Cooldown before a ranged attack can fire again, set from RANGED_ATTACK_FREE_PHASE_DELAY (Default 500ms)
-    bool                 m_rapidShot{ false };
-    position_t           m_startPos;
-    bool                 m_isOutOfRange{ false }; // True if target moved out of range during aim time
+
+    timer::duration m_aimTime{};                  // Phase 1: Delay based on weapon and job trait reductions. 120 delay = 1000 milliseconds.
+    timer::duration m_returnWeaponDelay = 800ms;  // Phase 2: Time to be locked in place while putting your weapon away after a shot.
+    timer::duration m_freePhaseTimeMob  = 1100ms; // Phase 3 (mobs/trusts): Cooldown before a ranged attack can fire again.
+    timer::duration m_freePhaseTimePlayer{};      // Phase 3 (players): Cooldown before a ranged attack can fire again, set from RANGED_ATTACK_FREE_PHASE_DELAY (Default 500ms)
+    bool            m_rapidShot{ false };
+    position_t      m_startPos;
+    bool            m_isOutOfRange{ false }; // True if target moved out of range during aim time
 };

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -22,12 +22,6 @@
 #include "state.h"
 #include "entities/base_entity.h"
 
-CStateInitException::CStateInitException(std::unique_ptr<CBasicPacket> _msg)
-: std::exception()
-, packet(std::move(_msg))
-{
-}
-
 void CState::TryInterrupt(CBattleEntity* PAttacker)
 {
 }
@@ -69,6 +63,17 @@ void CState::SetTarget(const EntityId& target)
         target_ = target;
         UpdateTarget(target);
     }
+}
+
+auto CState::refuseWithErrorMsg() const -> Error<std::unique_ptr<CBasicPacket>>
+{
+    if (m_errorMsg)
+    {
+        return Error{ m_errorMsg->copy() };
+    }
+
+    // The check failed but left no reason behind.
+    return RefuseSilently();
 }
 
 auto CState::HasErrorMsg() const -> bool

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -23,24 +23,59 @@
 #pragma once
 
 #include "common/timer.h"
+#include "common/types/badge.h"
+#include "common/types/error_or.h"
 #include "entities/base_entity.h"
 #include "packets/basic.h"
+
+#include <concepts>
 #include <memory>
 
 class CBattleEntity;
 
-class CStateInitException : public std::exception
-{
-public:
-    explicit CStateInitException(std::unique_ptr<CBasicPacket> _msg);
+//
+// StateErrorOr<T>
+//
+//   The result of entering a state.
+//
+//       return Success();
+//       return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(...) };
+//       return RefuseSilently();
+//
+template <typename T>
+using StateErrorOr = ErrorOr<T, std::unique_ptr<CBasicPacket>>;
 
-    std::unique_ptr<CBasicPacket> packet;
-};
+//
+// RefuseSilently()
+//
+//   Refuse to enter a state without telling the entity why.
+//
+inline auto RefuseSilently() -> Error<std::unique_ptr<CBasicPacket>>
+{
+    // Despite being a whole lot of words, this is essentially just nullptr.
+    return Error{ std::unique_ptr<CBasicPacket>{ nullptr } };
+}
 
 class CState
 {
 public:
-    CState(CBaseEntity* PEntity, const EntityId& target);
+    //
+    // The only way to create a state.
+    //
+    //   Every state constructor takes a Badge<CState>, and only this function can make
+    //   one.
+    //
+    template <typename T, typename... Args>
+        requires std::derived_from<T, CState>
+    static auto make(Args&&... args) -> std::unique_ptr<T>
+    {
+        return std::unique_ptr<T>(new T(xi::Badge<CState>{}, std::forward<Args>(args)...));
+    }
+
+    virtual auto init() -> StateErrorOr<void>
+    {
+        return Success();
+    }
 
     virtual ~CState() = default;
 
@@ -66,6 +101,10 @@ public:
     void         SetTarget(const EntityId& target);
 
 protected:
+    CState(CBaseEntity* PEntity, const EntityId& target);
+
+    auto refuseWithErrorMsg() const -> Error<std::unique_ptr<CBasicPacket>>;
+
     // state logic done per tick - returns whether to exit the state or not
     virtual auto Update(timer::time_point tick) -> bool = 0;
     virtual void UpdateTarget(const EntityId& target);

--- a/src/map/ai/states/synth_state.cpp
+++ b/src/map/ai/states/synth_state.cpp
@@ -26,39 +26,47 @@
 #include "ai/ai_container.h"
 #include "utils/synthutils.h"
 
-CSynthState::CSynthState(CCharEntity* PChar, const xi::SkillType skill)
+CSynthState::CSynthState(xi::Badge<CState>, CCharEntity* PChar, const xi::SkillType skill)
 : CState(PChar, PChar->entityId())
 , m_PEntity(PChar)
+, m_skill(skill)
 {
-    switch (skill)
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CSynthState::init() -> StateErrorOr<void>
+{
+    switch (m_skill)
     {
         case xi::SkillType::Woodworking:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_WOODWORKING));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_WOODWORKING));
             break;
         case xi::SkillType::Smithing:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_SMITHING));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_SMITHING));
             break;
         case xi::SkillType::Goldsmithing:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_GOLDSMITHING));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_GOLDSMITHING));
             break;
         case xi::SkillType::Clothcraft:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_CLOTHCRAFT));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_CLOTHCRAFT));
             break;
         case xi::SkillType::Leathercraft:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_LEATHERCRAFT));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_LEATHERCRAFT));
             break;
         case xi::SkillType::Bonecraft:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_BONECRAFT));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_BONECRAFT));
             break;
         case xi::SkillType::Alchemy:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_ALCHEMY));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_ALCHEMY));
             break;
         case xi::SkillType::Cooking:
-            m_synthFinishTime -= std::chrono::milliseconds(PChar->getMod(xi::Mod::SYNTH_SPEED_COOKING));
+            m_synthFinishTime -= std::chrono::milliseconds(m_PEntity->getMod(xi::Mod::SYNTH_SPEED_COOKING));
             break;
         default:
             break;
     }
+
+    return Success();
 }
 
 auto CSynthState::Update(timer::time_point tick) -> bool

--- a/src/map/ai/states/synth_state.h
+++ b/src/map/ai/states/synth_state.h
@@ -27,7 +27,9 @@
 class CSynthState : public CState
 {
 public:
-    CSynthState(CCharEntity* PChar, xi::SkillType skill);
+    CSynthState(xi::Badge<CState>, CCharEntity* PChar, xi::SkillType skill);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
@@ -39,6 +41,9 @@ protected:
     auto SynthReady() const -> bool;
 
 private:
+    // Shadows CState::m_PEntity
     CCharEntity* const m_PEntity;
-    timer::duration    m_synthFinishTime{ 16s };
+
+    const xi::SkillType m_skill;
+    timer::duration     m_synthFinishTime{ 16s };
 };

--- a/src/map/ai/states/trigger_state.cpp
+++ b/src/map/ai/states/trigger_state.cpp
@@ -23,10 +23,11 @@
 
 #include "entities/char_entity.h"
 
-CTriggerState::CTriggerState(CBaseEntity* PEntity, const EntityId& target, const bool door)
+CTriggerState::CTriggerState(xi::Badge<CState>, CBaseEntity* PEntity, const EntityId& target, const bool door)
 : CState(PEntity, target)
 , door(door)
 {
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
 }
 
 auto CTriggerState::Update(const timer::time_point tick) -> bool

--- a/src/map/ai/states/trigger_state.h
+++ b/src/map/ai/states/trigger_state.h
@@ -26,7 +26,7 @@
 class CTriggerState : public CState
 {
 public:
-    CTriggerState(CBaseEntity* PEntity, const EntityId& target, bool door);
+    CTriggerState(xi::Badge<CState>, CBaseEntity* PEntity, const EntityId& target, bool door);
 
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;

--- a/src/map/ai/states/weaponskill_state.cpp
+++ b/src/map/ai/states/weaponskill_state.cpp
@@ -34,34 +34,33 @@
 #include "utils/zoneutils.h"
 #include "weapon_skill.h"
 
-CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, const EntityId& target, const uint16 wsid)
+CWeaponSkillState::CWeaponSkillState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, const uint16 wsid)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
+, m_wsid(wsid)
 {
-    auto* skill = battleutils::GetWeaponSkill(wsid);
+    // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CWeaponSkillState::init() -> StateErrorOr<void>
+{
+    auto* skill = battleutils::GetWeaponSkill(m_wsid);
     if (!skill)
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(PEntity, PEntity, 0, 0, MsgBasic::CannotUseWeaponskill));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, m_PEntity, 0, 0, MsgBasic::CannotUseWeaponskill) };
     }
 
-    const auto targetFlags = battleutils::isValidSelfTargetWeaponskill(wsid) ? TARGET_SELF : TARGET_ENEMY;
-    auto*      PTarget     = m_PEntity->IsValidTarget(target, targetFlags, m_errorMsg);
+    const auto targetFlags = battleutils::isValidSelfTargetWeaponskill(m_wsid) ? TARGET_SELF : TARGET_ENEMY;
+    auto*      PTarget     = m_PEntity->IsValidTarget(target(), targetFlags, m_errorMsg);
 
     if (!PTarget || this->HasErrorMsg())
     {
-        if (this->HasErrorMsg())
-        {
-            throw CStateInitException(m_errorMsg->copy());
-        }
-        else
-        {
-            throw CStateInitException(std::make_unique<CBasicPacket>());
-        }
+        return refuseWithErrorMsg();
     }
 
     if (!m_PEntity->CanSeeTarget(PTarget))
     {
-        throw CStateInitException(std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, 0, 0, MsgBasic::CannotPerformAction));
+        return Error{ std::make_unique<GP_SERV_COMMAND_BATTLE_MESSAGE>(m_PEntity, PTarget, 0, 0, MsgBasic::CannotPerformAction) };
     }
 
     m_PSkill = std::make_unique<CWeaponSkill>(*skill);
@@ -84,6 +83,8 @@ CWeaponSkillState::CWeaponSkillState(CBattleEntity* PEntity, const EntityId& tar
     };
 
     m_PEntity->loc.zone->PushPacket(m_PEntity, CHAR_INRANGE_SELF, std::make_unique<GP_SERV_COMMAND_BATTLE2>(action));
+
+    return Success();
 }
 
 auto CWeaponSkillState::GetSkill() const -> CWeaponSkill*

--- a/src/map/ai/states/weaponskill_state.h
+++ b/src/map/ai/states/weaponskill_state.h
@@ -27,7 +27,9 @@
 class CWeaponSkillState : public CState
 {
 public:
-    CWeaponSkillState(CBattleEntity* PEntity, const EntityId& target, uint16 wsid);
+    CWeaponSkillState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, uint16 wsid);
+
+    auto init() -> StateErrorOr<void> override;
 
     auto GetSkill() const -> CWeaponSkill*;
     auto GetSpentTP() const -> int16;
@@ -41,7 +43,10 @@ protected:
     void SpendCost();
 
 private:
-    CBattleEntity* const          m_PEntity;
+    // Shadows CState::m_PEntity
+    CBattleEntity* const m_PEntity;
+
+    const uint16                  m_wsid;
     std::unique_ptr<CWeaponSkill> m_PSkill;
     timer::time_point             m_finishTime;
     int16                         m_spent{ 0 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Since time immemorial, we've used exceptions to denote when something has gone wrong with a state and that we should bail out. I subscribe to "exceptions should be exceptional", and the previous usage was woven into regular usage. They were however a useful mechanism for being able to report if something had gone wrong in the constructor of something.

I've made an `xi::Badge`'d factory method, that constructs each state, and each of these constructors is stripped down to only store things in that state's member vars. We then move the old setup logic into `init()` in each state, which can report `StateErrorOr<void>`, bringing the error packet with it, if there was one.

There are some other tidbits tidied up along the way:
- If there was an error before, we'd emit a fully constructed error packet, which would eventually hit the network system. Instead, we now construct `std::unique_ptr<CBasicPacket>{ nullptr }` so it appeases the type ErrorOr wants, but is a `nullptr` at the end of the day and won't allocate or make it to the network system.
- Marked a bunch of sneaky casting we were doing inside each state. I had no idea we were doing that. It's technically shadowwing, but I don't hate it.