### PR TITLE
[lua] Ranged mobskill fixes

### DIFF
--- a/scripts/actions/mobskills/aerial_wheel.lua
+++ b/scripts/actions/mobskills/aerial_wheel.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/apex_arrow.lua
+++ b/scripts/actions/mobskills/apex_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.0, 3.0, 3.0 }
     -- params.agi_wSC     = 0.85 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/arching_arrow.lua
+++ b/scripts/actions/mobskills/arching_arrow.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.5, 3.5, 3.5 }
     -- params.str_wSC     = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/arcuballista.lua
+++ b/scripts/actions/mobskills/arcuballista.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 2.5, 3.0, 4.0 }
     params.accuracyModifier = { 100, 100, 100 }

--- a/scripts/actions/mobskills/arrow_deluge.lua
+++ b/scripts/actions/mobskills/arrow_deluge.lua
@@ -17,7 +17,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/axe_throw.lua
+++ b/scripts/actions/mobskills/axe_throw.lua
@@ -19,7 +19,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/blast_arrow.lua
+++ b/scripts/actions/mobskills/blast_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 2.0, 2.0, 2.0 }
     -- params.str_wSC       = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/blast_shot.lua
+++ b/scripts/actions/mobskills/blast_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage      = mob:getWeaponDmg()
+    params.baseDamage      = mob:getRangedDmg()
     params.numHits         = 1
     params.fTP             = { 2.0, 2.0, 2.0 }
     -- params.agi_wSC         = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/calcifying_deluge.lua
+++ b/scripts/actions/mobskills/calcifying_deluge.lua
@@ -14,7 +14,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 6.0, 6.0, 6.0 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/catapult.lua
+++ b/scripts/actions/mobskills/catapult.lua
@@ -19,7 +19,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.0, 3.0, 3.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/coronach.lua
+++ b/scripts/actions/mobskills/coronach.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage      = mob:getWeaponDmg()
+    params.baseDamage      = mob:getRangedDmg()
     params.numHits         = 1
     params.fTP             = { 3.0, 3.0, 3.0 }
     -- params.dex_wSC         = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/daze.lua
+++ b/scripts/actions/mobskills/daze.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 5.0, 5.5, 6.0 }
     params.accuracyModifier = { 150, 150, 150 }

--- a/scripts/actions/mobskills/detonator.lua
+++ b/scripts/actions/mobskills/detonator.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 1.5, 2.0, 2.5 }
     params.attackMultiplier = { 2.0, 2.0, 2.0 }

--- a/scripts/actions/mobskills/dulling_arrow.lua
+++ b/scripts/actions/mobskills/dulling_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     -- params.str_wSC     = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/eagle_eye_shot.lua
+++ b/scripts/actions/mobskills/eagle_eye_shot.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 9.0, 9.0, 9.0 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/eagle_eye_shot_maat.lua
+++ b/scripts/actions/mobskills/eagle_eye_shot_maat.lua
@@ -11,7 +11,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 6.0, 6.0, 6.0 } -- Maat's Eagle Eye Shot does far less damage than the standard version
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/empyreal_arrow.lua
+++ b/scripts/actions/mobskills/empyreal_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 2.0, 2.75, 3.0 }
     params.attackMultiplier = { 2.0, 2.0, 2.0 }

--- a/scripts/actions/mobskills/flaming_arrow.lua
+++ b/scripts/actions/mobskills/flaming_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage         = mob:getWeaponDmg()
+    params.baseDamage         = mob:getRangedDmg()
     params.numHits            = 1
     params.fTP                = { 1.0, 1.0, 1.0 }
     -- params.str_wSC         = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/heavy_shot.lua
+++ b/scripts/actions/mobskills/heavy_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.5, 3.5, 3.5 }
     -- params.agi_wSC        = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/hot_shot.lua
+++ b/scripts/actions/mobskills/hot_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage         = mob:getWeaponDmg()
+    params.baseDamage         = mob:getRangedDmg()
     params.numHits            = 1
     params.fTP                = { 0.5, 0.75, 1.0 }
     -- params.agi_wSC            = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/javelin_throw.lua
+++ b/scripts/actions/mobskills/javelin_throw.lua
@@ -19,7 +19,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/jishnus_radiance.lua
+++ b/scripts/actions/mobskills/jishnus_radiance.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 3
     params.fTP            = { 1.75, 1.75, 1.75 }
     -- params.dex_wSC     = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/last_stand.lua
+++ b/scripts/actions/mobskills/last_stand.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage         = mob:getWeaponDmg()
+    params.baseDamage         = mob:getRangedDmg()
     params.numHits            = 2
     params.fTP                = { 2.0, 2.125, 2.25 }
     params.fTPSubsequentHits  = { 2.0, 2.125, 2.25 }

--- a/scripts/actions/mobskills/leaf_dagger.lua
+++ b/scripts/actions/mobskills/leaf_dagger.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.0, 2.0, 2.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/light_blade.lua
+++ b/scripts/actions/mobskills/light_blade.lua
@@ -14,7 +14,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 6.0, 6.0, 6.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/luminous_lance.lua
+++ b/scripts/actions/mobskills/luminous_lance.lua
@@ -12,7 +12,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.0, 3.0, 3.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/megalith_throw.lua
+++ b/scripts/actions/mobskills/megalith_throw.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.5, 2.5, 2.5 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/namas_arrow.lua
+++ b/scripts/actions/mobskills/namas_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 2.75, 2.75, 2.75 }
     -- params.str_wSC       = 0.4 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/needleshot.lua
+++ b/scripts/actions/mobskills/needleshot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.0, 2.0, 2.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/numbing_shot.lua
+++ b/scripts/actions/mobskills/numbing_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.0, 3.0, 3.0 }
     -- params.agi_wSC        = 0.6 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/oisoya.lua
+++ b/scripts/actions/mobskills/oisoya.lua
@@ -21,7 +21,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 5.5, 5.5, 5.5 }
     params.attackType       = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/ore_toss.lua
+++ b/scripts/actions/mobskills/ore_toss.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.0, 2.0, 2.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/ore_toss_ranged.lua
+++ b/scripts/actions/mobskills/ore_toss_ranged.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/panzerschreck.lua
+++ b/scripts/actions/mobskills/panzerschreck.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.0, 2.0, 2.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/piercing_arrow.lua
+++ b/scripts/actions/mobskills/piercing_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 1.0, 1.0, 1.0 }
     -- params.str_wSC       = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/pinecone_bomb.lua
+++ b/scripts/actions/mobskills/pinecone_bomb.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/pinecone_bomb_nm.lua
+++ b/scripts/actions/mobskills/pinecone_bomb_nm.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.0, 3.0, 3.0 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/ranged_attack.lua
+++ b/scripts/actions/mobskills/ranged_attack.lua
@@ -16,7 +16,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/refulgent_arrow.lua
+++ b/scripts/actions/mobskills/refulgent_arrow.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 2
     params.fTP            = { 3.0, 4.25, 5.0 }
     -- params.str_wSC     = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/rock_throw.lua
+++ b/scripts/actions/mobskills/rock_throw.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 3.5, 3.5, 3.5 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/sarv.lua
+++ b/scripts/actions/mobskills/sarv.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.75, 5.5, 8.25 }
     -- params.str_wSC     = 0.65 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/sharp_sting.lua
+++ b/scripts/actions/mobskills/sharp_sting.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/sidewinder.lua
+++ b/scripts/actions/mobskills/sidewinder.lua
@@ -15,7 +15,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 5.0, 5.0, 5.0 }
     -- params.str_wSC       = 0.16 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/slug_shot.lua
+++ b/scripts/actions/mobskills/slug_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 5.0, 5.0, 5.0 }
     -- params.agi_wSC     = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/sniper_shot.lua
+++ b/scripts/actions/mobskills/sniper_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.0, 1.0, 1.0 }
     -- params.agi_wSC        = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/split_shot.lua
+++ b/scripts/actions/mobskills/split_shot.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage       = mob:getWeaponDmg()
+    params.baseDamage       = mob:getRangedDmg()
     params.numHits          = 1
     params.fTP              = { 1.0, 1.0, 1.0 }
     -- params.agi_wSC          = 0.3 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/stone_throw.lua
+++ b/scripts/actions/mobskills/stone_throw.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 }
     params.attackType     = xi.attackType.PHYSICAL

--- a/scripts/actions/mobskills/tenzen_ranged_high.lua
+++ b/scripts/actions/mobskills/tenzen_ranged_high.lua
@@ -14,7 +14,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/tenzen_ranged_low.lua
+++ b/scripts/actions/mobskills/tenzen_ranged_low.lua
@@ -14,7 +14,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.5, 1.5, 1.5 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.RANGED

--- a/scripts/actions/mobskills/terminus.lua
+++ b/scripts/actions/mobskills/terminus.lua
@@ -13,7 +13,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 2.5, 5.0, 7.5 }
     -- params.dex_wSC        = 0.7 -- TODO: Capture if mobskill weaponskills have wSC.

--- a/scripts/actions/mobskills/trebuchet.lua
+++ b/scripts/actions/mobskills/trebuchet.lua
@@ -14,7 +14,7 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage     = mob:getWeaponDmg()
+    params.baseDamage     = mob:getRangedDmg()
     params.numHits        = 1
     params.fTP            = { 1.6, 1.6, 1.6 } -- TODO: Capture fTPs
     params.attackType     = xi.attackType.RANGED

--- a/scripts/globals/mobskills.lua
+++ b/scripts/globals/mobskills.lua
@@ -506,7 +506,7 @@ xi.mobskills.mobRangedMove = function(mob, target, skill, action, skillParams)
     -- Sanitizes skillParams and sets defaults for any params not explicitly set in mob skill scripts.
     local params = normalizePhysicalSkillParams(skillParams)
 
-    local damage = params.baseDamage or mob:getWeaponDmg()
+    local damage = params.baseDamage or mob:getRangedDmg()
 
     -- Initialize return structure
     returnInfo.damage           = 0


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adjust multiple ranged mobskills to use `params.baseDamage = mob:getRangedDmg()` instead of `params.baseDamage = mob:getWeaponDmg()`. Discovered when looking at ranged_attack.lua and discussed with @WinterSolstice8 and @UmeboshiXI.

## Steps to test these changes

Encounter the mob skills listed.
