### PR TITLE
[C++] Fix Ranged Attack Free Phase Ordering / Prevent Rapid Shot on Throwing Attacks

### DIFF
--- a/scripts/tests/systems/combat/ranged_free_phase.lua
+++ b/scripts/tests/systems/combat/ranged_free_phase.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- TEST: Ensures the player cannot ranged attack again inside of phase 3 ranged attack delay
+-----------------------------------
+describe('Ranged Attack Free Phase Delay', function()
+    ---@type CClientEntityPair
+    local player
+
+    ---@type CTestEntity
+    local target
+
+    local function bulletCount()
+        local ammo = player:getEquippedItem(xi.slot.AMMO)
+        if ammo == nil then
+            return 0
+        end
+
+        return ammo:getQuantity()
+    end
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE, job = xi.job.THF, level = 99 })
+        target = player.entities:moveTo('Wild_Rabbit')
+        target:respawn()
+        target:setUnkillable(true)
+        target:setBaseSpeed(0)
+
+        local pos = target:getPos()
+        player:setPos(pos.x - 5, pos.y, pos.z, 0)
+        player:lookAt(target:getPos())
+
+        player:addItem(xi.item.PLATOON_GUN)
+        player:addItem(xi.item.BULLET, 99)
+        player:equipItem(xi.item.PLATOON_GUN)
+        player:equipItem(xi.item.BULLET)
+    end)
+
+    -- skipTime() places a 400ms tick on top of each call, this is 6.2s, need to do this because the timing of this test is very specific.
+    it('cannot perform another ranged attack inside of free phase window', function()
+        player.actions:rangedAttack(target)
+        xi.test.world:skipTime(3)
+        xi.test.world:skipTime(1)
+        xi.test.world:skipTime(1)
+        assert(bulletCount() == 98, 'the first shot should fire and consume a bullet')
+
+        player.actions:rangedAttack(target)
+        xi.test.world:skipTime(6)
+        assert(bulletCount() == 98, 'a shot attempted inside the free phase should not fire')
+
+        player.actions:rangedAttack(target)
+        xi.test.world:skipTime(6)
+        assert(bulletCount() == 97, 'a shot attempted after the free phase should fire')
+    end)
+end)

--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -53,6 +53,9 @@ auto CRangeState::init() -> StateErrorOr<void>
         return refuseWithErrorMsg();
     }
 
+    // Configured in main : Default is 500ms
+    m_freePhaseTimePlayer = std::chrono::milliseconds(settings::get<uint32>("main.RANGED_ATTACK_FREE_PHASE_DELAY"));
+
     if (!CanUseRangedAttack(PTarget, false))
     {
         return refuseWithErrorMsg();
@@ -64,9 +67,6 @@ auto CRangeState::init() -> StateErrorOr<void>
         return refuseWithErrorMsg();
     }
 
-    // Configured in main. default : 500ms
-    m_freePhaseTimePlayer = std::chrono::milliseconds(settings::get<uint32>("main.RANGED_ATTACK_FREE_PHASE_DELAY"));
-
     // https://www.bg-wiki.com/ffxi/Delay#Ranged_Delay
     // GetRangedDelayReduction is 2 of the 3 steps of `Ranged Weapon Delay x (1 - Snapshot) x (1 - Velocity Shot) x (1 - Rapid Shot)`
     // If Rapid Shot fires it will do the third multiplicative step
@@ -77,8 +77,9 @@ auto CRangeState::init() -> StateErrorOr<void>
     if (m_PEntity->objtype == TYPE_PC || m_PEntity->objtype == TYPE_TRUST)
     {
         const CItemWeapon* weapon     = dynamic_cast<CItemWeapon*>(m_PEntity->m_Weapons[SLOT_RANGED]);
-        const bool         isThrowing = weapon && weapon->isThrowing();
-        // Don't apply Rapid Shot to throwing weapons
+        const CItemWeapon* ammo       = dynamic_cast<CItemWeapon*>(m_PEntity->m_Weapons[SLOT_AMMO]);
+        const bool         isThrowing = (weapon && weapon->isThrowing()) || (ammo && ammo->isThrowing());
+        // Do not apply Rapid Shot to throwing weapons (Covers both Chakrams and Shurikens)
         if (!isThrowing)
         {
             auto chance{ m_PEntity->getMod(xi::Mod::RAPID_SHOT) };

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -3366,13 +3366,18 @@ void CBattleEntity::OnRangedAttack(CRangeState& state, action_t& action)
             StatusEffectContainer->DelStatusEffect(xi::StatusEffect::FlashyShot);
             StatusEffectContainer->DelStatusEffect(xi::StatusEffect::StealthShot);
 
-            if (PAmmo != nullptr && xirand::GetRandomNumber(100) > recycleChance)
+            if (PAmmo != nullptr)
             {
-                ++ammoConsumed;
-                charutils::TrackArrowUsageForScavenge(PChar, PAmmo);
-                if (PAmmo->getQuantity() == i)
+                const bool recycleProc = xirand::GetRandomNumber(100) < recycleChance;
+
+                if (!recycleProc)
                 {
-                    hitCount = i;
+                    ++ammoConsumed;
+                    charutils::TrackArrowUsageForScavenge(PChar, PAmmo);
+                    if (PAmmo->getQuantity() == i)
+                    {
+                        hitCount = i;
+                    }
                 }
             }
         }

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3675,10 +3675,15 @@ bool HasNinjaTool(CBattleEntity* PEntity, CSpell* PSpell, bool ConsumeTool)
 
             uint16 chance = (PChar->getMod(xi::Mod::NINJA_TOOL) + meritBonus);
 
-            if (ConsumeTool && xirand::GetRandomNumber(100) > chance)
+            if (ConsumeTool)
             {
-                charutils::UpdateItem(PChar, LOC_INVENTORY, SlotID, -1);
-                PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);
+                const bool expertiseProc = xirand::GetRandomNumber(100) < chance;
+
+                if (!expertiseProc)
+                {
+                    charutils::UpdateItem(PChar, LOC_INVENTORY, SlotID, -1);
+                    PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);
+                }
             }
         }
     }


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes ranged attack free phase delay - due to an error I made with ordering it was defaulting to 0ms because it wasn't defined early enough - moved it up so it is properly used. Retail free phase delay is so short now I didn't notice it in my testing (I was using a Platoon Gun), in hindsight I should have used a thrown weapon, as it would have been obvious.

* Adds a test to ensure this does not regress again in the future.

* Also fixes a bug I found where thrown attacks could benefit from Rapid Shot.

EDIT: Also fixes another bug with Recycle / Ninja Tool Expertise, confirmed with @zach2good - that was causing my test to fail (Recycle could activate with 0 Recycle) when it activated. Rewrote them to be easier to reason/understand keeping the same roll < chance pattern used elsewhere in the code base and fixed the bug.

## Steps to test these changes

Try ranged attacks, see that you have to wait for the animation to finish to start another one. 
