### PR TITLE
[login] Clear justCreatedNewChar after character select

### DIFF
--- a/src/login/data_session.cpp
+++ b/src/login/data_session.cpp
@@ -559,8 +559,9 @@ void data_session::read_func()
                 viewSession->socket_.lowest_layer().close(closeEc);
                 session.view_session = nullptr;
 
-                session.incrementKeyValue = 0;     // Reset incremented key after inserting into db
-                generatedCharInfo         = false; // Reset this so next time we log out it regenerates the char info
+                session.incrementKeyValue  = 0;     // Reset incremented key after inserting into db
+                session.justCreatedNewChar = false; // The client only advances its key for character creation once
+                generatedCharInfo          = false; // Reset this so next time we log out it regenerates the char info
 
                 const auto payload = ipc::toBytesWithHeader(ipc::CharZone{
                     .charId            = charid,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

When you make a character, log out and try to log back in with a different character it FFXI-3001 errors after a minute of black screen. If you try to log in another character after that it keeps giving the same black screen for a minute and resulting in 3001 until you close the client and restart. This patch fixes it cleanly without touching other log in methods.