### PR TITLE
[codegen] Support multiple enums per data file; Validate files in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,7 +224,7 @@ if(NOT CODEGEN_DEPS_EXIT_CODE EQUAL 0)
 endif()
 
 add_custom_target(data_codegen
-    COMMAND ${Python_EXECUTABLE} -m tools.codegen ${CMAKE_BINARY_DIR}
+    COMMAND ${Python_EXECUTABLE} -m tools.codegen ${CMAKE_BINARY_DIR} --validate
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     BYPRODUCTS
         ${CMAKE_BINARY_DIR}/generated/.codegen.stamp
@@ -236,7 +236,7 @@ add_custom_target(data_codegen
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/generated/.codegen.stamp)
     message(STATUS "Bootstrapping data codegen")
     execute_process(
-        COMMAND ${Python_EXECUTABLE} -m tools.codegen ${CMAKE_BINARY_DIR}
+        COMMAND ${Python_EXECUTABLE} -m tools.codegen ${CMAKE_BINARY_DIR} --validate
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         RESULT_VARIABLE CODEGEN_EXIT_CODE
     )

--- a/data/schemas/_meta.schema.json
+++ b/data/schemas/_meta.schema.json
@@ -7,35 +7,58 @@
   "unevaluatedProperties": false,
   "properties": {
     "enum": {
-      "type": "object",
-      "unevaluatedProperties": false,
-      "required": ["cpp"],
-      "description": "Emit a typed enum derived from a top-level section of the data file.",
-      "properties": {
-        "cpp": {
-          "type": "object",
-          "unevaluatedProperties": false,
-          "required": ["underlying", "class"],
-          "properties": {
-            "underlying": { "type": "string" },
-            "class": { "type": "string", "pattern": "^[A-Z][A-Za-z0-9]*$" },
-            "case": { "type": "string", "enum": ["pascal", "screaming"], "default": "pascal" }
+      "type": "array",
+      "minItems": 1,
+      "description": "Enums to emit from this file, one per entry.",
+      "items": {
+        "type": "object",
+        "unevaluatedProperties": false,
+        "required": ["cpp"],
+        "properties": {
+          "cpp": {
+            "type": "object",
+            "description": "The C++ enum to be generated.",
+            "unevaluatedProperties": false,
+            "required": ["underlying", "class"],
+            "properties": {
+              "underlying": {
+                "type": "string",
+                "description": "Underlying integer type of the C++ enum."
+              },
+              "class": {
+                "type": "string",
+                "pattern": "^[A-Z][A-Za-z0-9]*$",
+                "description": "Name of the C++ enum class."
+              },
+              "case": {
+                "type": "string",
+                "enum": ["pascal", "screaming"],
+                "default": "pascal",
+                "description": "Casing of the C++ member names."
+              }
+            }
+          },
+          "lua": {
+            "type": "object",
+            "description": "Emit the enum as a Lua table.",
+            "unevaluatedProperties": false,
+            "properties": {
+              "table": {
+                "type": "string",
+                "pattern": "^xi\\.[A-Za-z][A-Za-z0-9_]*$",
+                "description": "The fully qualified global Lua table name to be created for the enum."
+              }
+            }
+          },
+          "section": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_]*([.](\\*|[a-z][a-z0-9_]*))*$",
+            "description": "Dotted path to the section holding the entries; `*` matches every entry at that level (`ecosystems.*.families` = the families of every ecosystem). Defaults to the filename."
+          },
+          "name_from": {
+            "type": "string",
+            "description": "Dot-path to a string inside each entry, slugged into the member name (e.g. `name.en`). When set, the YAML key is the integer id."
           }
-        },
-        "lua": {
-          "type": "object",
-          "unevaluatedProperties": false,
-          "properties": {
-            "table": { "type": "string", "pattern": "^xi\\.[A-Za-z][A-Za-z0-9_]*$" }
-          }
-        },
-        "section": {
-          "type": "string",
-          "description": "Which top-level YAML section to walk. Defaults to the filename."
-        },
-        "name_from": {
-          "type": "string",
-          "description": "Dot-path inside each entry to a string that gets slugged into the enum value name (e.g., `name.en`). When set, the YAML key is treated as the integer id."
         }
       }
     }

--- a/data/status_effects.yaml
+++ b/data/status_effects.yaml
@@ -2,11 +2,11 @@
 
 meta:
   enum:
-    cpp:
-      underlying: uint16_t
-      class:      StatusEffect
-    lua:
-      table: xi.effect
+    - cpp:
+        underlying: uint16_t
+        class:      StatusEffect
+      lua:
+        table: xi.effect
 
 status_effects:
   ko:

--- a/tools/codegen/cli.py
+++ b/tools/codegen/cli.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from .common import ENUMS_DIR, ROOT, TEMPLATES_DIR, write_if_changed
 from .data_codegen import SchemaWalker
-from .enum_codegen import emit_pure_enum, emit_table_enum
+from .enum_codegen import emit_pure_enum, emit_table_enums
 from .validate import validate_data_yamls
 
 
@@ -54,10 +54,8 @@ def main():
     for p in sorted((ROOT / "data").rglob("*.yaml")):
         if p.is_relative_to(ENUMS_DIR):
             continue
-        print(f"scanning {p.relative_to(ROOT).as_posix()} for embedded enum ...", flush=True)
-        result = emit_table_enum(p)
-        if result is not None:
-            enums.append(result)
+        print(f"scanning {p.relative_to(ROOT).as_posix()} for embedded enums ...", flush=True)
+        enums.extend(emit_table_enums(p))
 
     for e in enums:
         write_if_changed(out_dir / (e["name"] + ".h"), e["header"])
@@ -77,6 +75,9 @@ def main():
     walker = SchemaWalker()
     data_names: list[str] = []
     for schema_path in sorted(schemas_dir.glob("*.schema.json")):
+        # _meta describes the `meta:` block; its $defs are fragments, not records.
+        if schema_path.name == "_meta.schema.json":
+            continue
         print(f"rendering {schema_path.relative_to(ROOT).as_posix()} ...", flush=True)
         result = walker.emit(schema_path)
         if result is None:

--- a/tools/codegen/enum_codegen.py
+++ b/tools/codegen/enum_codegen.py
@@ -83,41 +83,77 @@ def emit_pure_enum(yaml_path: Path) -> dict[str, Any]:
     }
 
 
-def emit_table_enum(yaml_path: Path) -> dict[str, Any] | None:
-    """Same return shape as `emit_pure_enum`. Returns None when the file has no `meta.enum:` block."""
+def resolve_sections(doc: dict[str, Any], path: str) -> list[dict[str, Any]]:
+    """Every section the path names; `*` steps through all entries at that level (`ecosystems.*.families`)."""
+    nodes: list[dict[str, Any]] = [doc]
+    for part in path.split("."):
+        nxt: list[dict[str, Any]] = []
+        for node in nodes:
+            if part == "*":
+                nxt.extend(v for v in node.values() if isinstance(v, dict))
+            else:
+                child = node.get(part)
+                if isinstance(child, dict):
+                    nxt.append(child)
+        nodes = nxt
+    return nodes
+
+
+def emit_table_enums(yaml_path: Path) -> list[dict[str, Any]]:
+    """One entry per `meta.enum:` block. Members emit in id order."""
     with yaml_path.open(encoding="utf-8") as f:
         doc = yaml.load(f, Loader=FastLoader)
 
     if not isinstance(doc, dict):
-        return None
+        return []
     meta_enum = (doc.get("meta") or {}).get("enum")
     if not meta_enum:
-        return None
+        return []
 
-    section_name = meta_enum.get("section") or yaml_path.stem
-    section = doc.get(section_name) or {}
-    if not section:
-        raise ValueError(f"{yaml_path}: no '{section_name}' section to derive enum from")
-
-    values = derive_values(yaml_path, section, meta_enum.get("name_from"))
-
-    cpp = meta_enum.get("cpp") or {}
-    cls_name = cpp["class"]
     source_name = str(yaml_path.relative_to(ENUMS_DIR.parents[1])).replace("\\", "/")
-    return {
-        "name": pascal_to_snake(cls_name),
-        "values": values,
-        "source_name": source_name,
-        "header": render_header(
-            source_name=source_name,
-            cls_name=cls_name,
-            underlying=cpp.get("underlying", "uint32_t"),
-            is_flags=False,
-            case=cpp.get("case", "pascal"),
-            values=values,
-        ),
-        "lua": lua_block(meta_enum.get("lua"), source_name, False, values),
-    }
+    out: list[dict[str, Any]] = []
+    for block in meta_enum:
+        path = block.get("section") or yaml_path.stem
+        sections = resolve_sections(doc, path)
+        if not sections:
+            raise ValueError(f"{yaml_path}: section path '{path}' matched nothing")
+
+        values: dict[str, int] = {}
+        for section in sections:
+            for key, value in derive_values(yaml_path, section, block.get("name_from")).items():
+                if key in values:
+                    raise ValueError(f"{yaml_path}: '{path}' yields duplicate key '{key}' "
+                                     f"(ids {values[key]} and {value}); keys must be unique across the tree")
+                values[key] = value
+
+        # Disallow duplicate IDs
+        by_id: dict[int, list[str]] = {}
+        for key, value in values.items():
+            by_id.setdefault(value, []).append(key)
+        collisions = {v: ks for v, ks in by_id.items() if len(ks) > 1}
+        if collisions:
+            raise ValueError(f"{yaml_path}: '{path}' reuses ids across entries: "
+                             + "; ".join(f"{v} -> {ks}" for v, ks in sorted(collisions.items())))
+
+        values = dict(sorted(values.items(), key=lambda kv: kv[1]))
+
+        cpp = block.get("cpp") or {}
+        cls_name = cpp["class"]
+        out.append({
+            "name": pascal_to_snake(cls_name),
+            "values": values,
+            "source_name": source_name,
+            "header": render_header(
+                source_name=source_name,
+                cls_name=cls_name,
+                underlying=cpp.get("underlying", "uint32_t"),
+                is_flags=False,
+                case=cpp.get("case", "pascal"),
+                values=values,
+            ),
+            "lua": lua_block(block.get("lua"), source_name, False, values),
+        })
+    return out
 
 
 def derive_values(yaml_path: Path, section: dict[str, Any], name_from: str | None) -> dict[str, int]:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
While I'm battling with preparing a massive PR for ecosystems, I can at least push this forward:
- Turn `meta.enum` into an array, supporting multiple enum tables/classes to be created from nested entries
  - This will be used to auto-create and maintain nested `ecosystems.*.families` and `ecosystems.*.families.*.species` entries.
- Add descriptions to all fields in `meta.enum` so that they show in VSCode
- Pass --validate flag to the codegen script in CMake so that bad (duplicate) enums fail loudly

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
