### PR TITLE
[lua] Can Cardians Cry Title Fix

### DIFF
--- a/scripts/zones/Windurst_Woods/npcs/Apururu.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Apururu.lua
@@ -114,7 +114,10 @@ entity.onEventFinish = function(player, csid, option, npc)
         player:addQuest(xi.questLog.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY)
     elseif
         csid == 325 and
-        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY, { gil = 5000 })
+        npcUtil.completeQuest(player, xi.questLog.WINDURST, xi.quest.id.windurst.CAN_CARDIANS_CRY, {
+            gil   = 5000,
+            title = xi.title.DELIVERER_OF_TEARFUL_NEWS
+        })
     then
         player:confirmTrade()
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the quest Can Cardians Cry so the completion of the quest grants the proper title.

https://youtu.be/YSQiWNRZ_9A?t=952

## Steps to test these changes

!addquest 2 47
!additem BRUISED_STARFRUIT
!zone <windurst woods>
!gotoname Apururu
Trade fruit profit