### PR TITLE
[lua] Fix Module Status Effects

### DIFF
--- a/modules/era/lua/actions/weaponskills/archery.lua
+++ b/modules/era/lua/actions/weaponskills/archery.lua
@@ -63,10 +63,20 @@ m:addOverride('xi.actions.weaponskills.dulling_arrow.onUseWeaponSkill', function
     local effectId      = xi.effect.INT_DOWN
     local actionElement = xi.element.FIRE
     local power         = 10
-    local skillType     = xi.skill.ARCHERY
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(140 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.ARCHERY,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(140 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/axe.lua
+++ b/modules/era/lua/actions/weaponskills/axe.lua
@@ -37,13 +37,21 @@ m:addOverride('xi.actions.weaponskills.smash_axe.onUseWeaponSkill', function(pla
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.AXE
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.AXE,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -63,13 +71,21 @@ m:addOverride('xi.actions.weaponskills.gale_axe.onUseWeaponSkill', function(play
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.CHOKE
-        local actionElement = xi.element.WIND
-        local power         = 5
-        local skillType     = xi.skill.AXE
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(90 * resist)
+    local effectId      = xi.effect.CHOKE
+    local actionElement = xi.element.WIND
+    local power         = 5
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.AXE,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(90 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -175,10 +191,20 @@ m:addOverride('xi.actions.weaponskills.onslaught.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.ACCURACY_DOWN
     local actionElement = xi.element.EARTH
     local power         = 30
-    local skillType     = xi.skill.AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(120 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.AXE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(120 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/club.lua
+++ b/modules/era/lua/actions/weaponskills/club.lua
@@ -56,13 +56,21 @@ m:addOverride('xi.actions.weaponskills.brainshaker.onUseWeaponSkill', function(p
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.CLUB
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.CLUB,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -106,13 +114,21 @@ m:addOverride('xi.actions.weaponskills.skullbreaker.onUseWeaponSkill', function(
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.INT_DOWN
-        local actionElement = xi.element.FIRE
-        local power         = 10
-        local skillType     = xi.skill.CLUB
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(140 * resist)
+    local effectId      = xi.effect.INT_DOWN
+    local actionElement = xi.element.FIRE
+    local power         = 10
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.CLUB,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(140 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -198,10 +214,20 @@ m:addOverride('xi.actions.weaponskills.randgrith.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.EVASION_DOWN
     local actionElement = xi.element.ICE
     local power         = 32
-    local skillType     = xi.skill.CLUB
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(120 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.CLUB,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(120 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/dagger.lua
+++ b/modules/era/lua/actions/weaponskills/dagger.lua
@@ -26,10 +26,20 @@ m:addOverride('xi.actions.weaponskills.wasp_sting.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.POISON
     local actionElement = xi.element.WATER
     local power         = 1
-    local skillType     = xi.skill.DAGGER
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((75 + 15 * tp / 1000) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.DAGGER,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((75 + 15 * tp / 1000) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -63,13 +73,21 @@ m:addOverride('xi.actions.weaponskills.shadowstitch.onUseWeaponSkill', function(
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.BIND
-        local actionElement = xi.element.ICE
-        local power         = 1
-        local skillType     = xi.skill.DAGGER
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor((5 + tp / 200) * resist)
+    local effectId      = xi.effect.BIND
+    local actionElement = xi.element.ICE
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.DAGGER,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((5 + tp / 200) * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -92,10 +110,20 @@ m:addOverride('xi.actions.weaponskills.viper_bite.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.POISON
     local actionElement = xi.element.WATER
     local power         = 3
-    local skillType     = xi.skill.DAGGER
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((30 + 6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.DAGGER,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((30 + 6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -270,13 +298,21 @@ m:addOverride('xi.actions.weaponskills.mordant_rime.onUseWeaponSkill', function(
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.WEIGHT
-        local actionElement = xi.element.WIND
-        local power         = 25
-        local skillType     = xi.skill.DAGGER
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(60 * resist)
+    local effectId      = xi.effect.WEIGHT
+    local actionElement = xi.element.WIND
+    local power         = 25
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.DAGGER,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end

--- a/modules/era/lua/actions/weaponskills/great_axe.lua
+++ b/modules/era/lua/actions/weaponskills/great_axe.lua
@@ -26,10 +26,20 @@ m:addOverride('xi.actions.weaponskills.shield_break.onUseWeaponSkill', function(
     local effectId      = xi.effect.EVASION_DOWN
     local actionElement = xi.element.ICE
     local power         = 40
-    local skillType     = xi.skill.GREAT_AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((120 + 6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_AXE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((120 + 6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -72,10 +82,20 @@ m:addOverride('xi.actions.weaponskills.armor_break.onUseWeaponSkill', function(p
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 25
-    local skillType     = xi.skill.GREAT_AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((120 + 6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_AXE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((120 + 6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -106,10 +126,20 @@ m:addOverride('xi.actions.weaponskills.weapon_break.onUseWeaponSkill', function(
     local effectId      = xi.effect.ATTACK_DOWN
     local actionElement = xi.element.WATER
     local power         = 25
-    local skillType     = xi.skill.GREAT_AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((120 + 6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_AXE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((120 + 6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -137,7 +167,6 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effects.
-    local skillType     = xi.skill.GREAT_AXE
     local effects =
     {
         [1] = { xi.effect.ATTACK_DOWN,   xi.element.WATER, 12.5 },
@@ -149,9 +178,20 @@ m:addOverride('xi.actions.weaponskills.full_break.onUseWeaponSkill', function(pl
         local effectId      = effects[index][1]
         local actionElement = effects[index][2]
         local power         = effects[index][3]
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor((120 + 6 * tp / 100) * resist)
-        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+        local maccParams    =
+        {
+            effectId       = effectId,
+            magicalElement = actionElement,
+            skillType      = xi.skill.GREAT_AXE,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+        if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+            local duration = math.floor((120 + 6 * tp / 100) * resistanceRate)
+
+            xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+        end
     end
 
     return tpHits, extraHits, criticalHit, damage
@@ -185,10 +225,20 @@ m:addOverride('xi.actions.weaponskills.metatron_torment.onUseWeaponSkill', funct
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 19
-    local skillType     = xi.skill.GREAT_AXE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(120 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_AXE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(120 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/great_katana.lua
+++ b/modules/era/lua/actions/weaponskills/great_katana.lua
@@ -37,13 +37,21 @@ m:addOverride('xi.actions.weaponskills.tachi_hobaku.onUseWeaponSkill', function(
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.GREAT_KATANA
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_KATANA,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -136,10 +144,20 @@ m:addOverride('xi.actions.weaponskills.tachi_yukikaze.onUseWeaponSkill', functio
     local effectId      = xi.effect.BLINDNESS
     local actionElement = xi.element.DARK
     local power         = 25
-    local skillType     = xi.skill.GREAT_KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -160,10 +178,20 @@ m:addOverride('xi.actions.weaponskills.tachi_gekko.onUseWeaponSkill', function(p
     local effectId      = xi.effect.SILENCE
     local actionElement = xi.element.WIND
     local power         = 1
-    local skillType     = xi.skill.GREAT_KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -184,10 +212,20 @@ m:addOverride('xi.actions.weaponskills.tachi_kasha.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = 25
-    local skillType     = xi.skill.GREAT_KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/great_sword.lua
+++ b/modules/era/lua/actions/weaponskills/great_sword.lua
@@ -90,10 +90,20 @@ m:addOverride('xi.actions.weaponskills.shockwave.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.SLEEP_I
     local actionElement = xi.element.DARK
     local power         = 1
-    local skillType     = xi.skill.GREAT_SWORD
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((math.randomInt(0, 30) + tp * 0.01) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.GREAT_SWORD,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((math.randomInt(0, 30) + tp * 0.01) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/hand_to_hand.lua
+++ b/modules/era/lua/actions/weaponskills/hand_to_hand.lua
@@ -37,13 +37,21 @@ m:addOverride('xi.actions.weaponskills.shoulder_tackle.onUseWeaponSkill', functi
 
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.HAND_TO_HAND
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.HAND_TO_HAND,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end

--- a/modules/era/lua/actions/weaponskills/katana.lua
+++ b/modules/era/lua/actions/weaponskills/katana.lua
@@ -43,10 +43,20 @@ m:addOverride('xi.actions.weaponskills.blade_retsu.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = utils.clamp(30 + 3 * (player:getMainLvl() - target:getMainLvl()), 5, 35)
-    local skillType     = xi.skill.KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(xi.weaponskills.fTP(tp, { 30, 60, 120 }) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -184,10 +194,20 @@ m:addOverride('xi.actions.weaponskills.blade_metsu.onUseWeaponSkill', function(p
     local effectId      = xi.effect.PARALYSIS
     local actionElement = xi.element.ICE
     local power         = 10
-    local skillType     = xi.skill.KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(60 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -212,10 +232,20 @@ m:addOverride('xi.actions.weaponskills.blade_kamu.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.ACCURACY_DOWN
     local actionElement = xi.element.EARTH
     local power         = 10
-    local skillType     = xi.skill.KATANA
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(6 * tp / 100 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.KATANA,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(6 * tp / 100 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/marksmanship.lua
+++ b/modules/era/lua/actions/weaponskills/marksmanship.lua
@@ -60,10 +60,20 @@ m:addOverride('xi.actions.weaponskills.sniper_shot.onUseWeaponSkill', function(p
     local effectId      = xi.effect.INT_DOWN
     local actionElement = xi.element.FIRE
     local power         = 10
-    local skillType     = xi.skill.MARKSMANSHIP
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(140 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.MARKSMANSHIP,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(140 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/polearm.lua
+++ b/modules/era/lua/actions/weaponskills/polearm.lua
@@ -69,13 +69,21 @@ m:addOverride('xi.actions.weaponskills.leg_sweep.onUseWeaponSkill', function(pla
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 33, 66, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.POLEARM
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.POLEARM,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end

--- a/modules/era/lua/actions/weaponskills/scythe.lua
+++ b/modules/era/lua/actions/weaponskills/scythe.lua
@@ -75,10 +75,20 @@ m:addOverride('xi.actions.weaponskills.nightmare_scythe.onUseWeaponSkill', funct
     local effectId      = xi.effect.BLINDNESS
     local actionElement = xi.element.DARK
     local power         = 20
-    local skillType     = xi.skill.SCYTHE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.SCYTHE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -128,10 +138,20 @@ m:addOverride('xi.actions.weaponskills.guillotine.onUseWeaponSkill', function(pl
     local effectId      = xi.effect.SILENCE
     local actionElement = xi.element.WIND
     local power         = 1
-    local skillType     = xi.skill.SCYTHE
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((30 + 3 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.SCYTHE,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((30 + 3 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/staff.lua
+++ b/modules/era/lua/actions/weaponskills/staff.lua
@@ -112,10 +112,20 @@ m:addOverride('xi.actions.weaponskills.shell_crusher.onUseWeaponSkill', function
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 25
-    local skillType     = xi.skill.STAFF
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((120 + 6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.STAFF,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((120 + 6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -183,10 +193,20 @@ m:addOverride('xi.actions.weaponskills.gate_of_tartarus.onUseWeaponSkill', funct
     local effectId      = xi.effect.ATTACK_DOWN
     local actionElement = xi.element.WATER
     local power         = 18.75
-    local skillType     = xi.skill.STAFF
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(120 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.STAFF,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(120 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -212,10 +232,20 @@ m:addOverride('xi.actions.weaponskills.vidohunir.onUseWeaponSkill', function(pla
     local effectId      = xi.effect.MAGIC_DEF_DOWN
     local actionElement = xi.element.THUNDER
     local power         = 10
-    local skillType     = xi.skill.STAFF
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor(6 * tp / 100 * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.STAFF,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(6 * tp / 100 * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)
@@ -242,10 +272,20 @@ m:addOverride('xi.actions.weaponskills.garland_of_bliss.onUseWeaponSkill', funct
     local effectId      = xi.effect.DEFENSE_DOWN
     local actionElement = xi.element.WIND
     local power         = 12.5
-    local skillType     = xi.skill.STAFF
-    local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-    local duration      = math.floor((6 * tp / 100) * resist)
-    xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.STAFF,
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor((6 * tp / 100) * resistanceRate)
+
+        xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
+    end
 
     return tpHits, extraHits, criticalHit, damage
 end)

--- a/modules/era/lua/actions/weaponskills/sword.lua
+++ b/modules/era/lua/actions/weaponskills/sword.lua
@@ -72,13 +72,21 @@ m:addOverride('xi.actions.weaponskills.flat_blade.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.STUN
-        local actionElement = xi.element.THUNDER
-        local power         = 1
-        local skillType     = xi.skill.SWORD
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(4 * resist)
+    local effectId      = xi.effect.STUN
+    local actionElement = xi.element.THUNDER
+    local power         = 1
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.SWORD,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(4 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end
@@ -352,13 +360,21 @@ m:addOverride('xi.actions.weaponskills.death_blossom.onUseWeaponSkill', function
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
 
     -- Handle status effect
-    if math.randomInt(1, 100) <= xi.weaponskills.fTP(tp, { 50, 75, 100 }) then
-        local effectId      = xi.effect.MAGIC_EVASION_DOWN
-        local actionElement = xi.element.THUNDER
-        local power         = 10
-        local skillType     = xi.skill.SWORD
-        local resist        = xi.combat.magicHitRate.calculateResistRate(player, target, 0, skillType, 0, actionElement, 0, effectId, 0)
-        local duration      = math.floor(60 * resist)
+    local effectId      = xi.effect.MAGIC_EVASION_DOWN
+    local actionElement = xi.element.THUNDER
+    local power         = 10
+    local maccParams    =
+    {
+        effectId       = effectId,
+        magicalElement = actionElement,
+        skillType      = xi.skill.SWORD,
+        bonusMacc      = xi.weaponskills.fTP(tp, { 25, 50, 100 }),
+    }
+
+    local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+    if xi.data.statusEffect.isResistRateSuccessfull(effectId, resistanceRate, 0) then
+        local duration = math.floor(60 * resistanceRate)
 
         xi.weaponskills.handleWeaponskillEffect(player, target, effectId, actionElement, damage, power, duration)
     end

--- a/modules/era/lua/combat/skillchain.lua
+++ b/modules/era/lua/combat/skillchain.lua
@@ -88,7 +88,7 @@ m:addOverride('xi.combat.skillchain.calculateSkillchainDamage', function(actor, 
     local dayWeatherMultiplier = xi.spells.damage.calculateDayAndWeather(actor, skillchainElement, false)
     local staffMultiplier      = xi.spells.damage.calculateElementalStaffBonus(actor, skillchainElement)
     local affinityMultiplier   = xi.spells.damage.calculateElementalAffinityBonus(actor, skillchainElement)
-    local resistRate           = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, 0, xi.skillRank.A_PLUS, skillchainElement, 0, 0, 0)
+    local resistRate           = xi.combat.magicHitRate.calculateResistRate(actor, target, { magicalElement = skillchainElement, skillRank = xi.skillRank.A_PLUS })
     local magicTakenMultiplier = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
 
     -- Unconfirmed order.

--- a/modules/era/lua/globals/job_utils/beastmaster.lua
+++ b/modules/era/lua/globals/job_utils/beastmaster.lua
@@ -29,7 +29,15 @@ if not xi.module.isContentEnabled('ABYSSEA') then
             not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.TERROR) and
             not xi.data.statusEffect.isEffectNullified(target, xi.effect.TERROR, 0)
         then
-            local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.B_MINUS, xi.element.DARK, xi.mod.CHR, xi.effect.TERROR)
+            local maccParams =
+            {
+                effectId       = xi.effect.TERROR,
+                magicalElement = xi.element.DARK,
+                skillRank      = xi.skillRank.B_MINUS,
+                actorStat      = xi.mod.CHR,
+            }
+
+            local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
 
             if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.TERROR, resistanceRate, 0) then
                 target:addStatusEffect(xi.effect.TERROR, { power = 1, duration = 10 * resistanceRate, origin = player })

--- a/modules/era/lua/globals/job_utils/corsair.lua
+++ b/modules/era/lua/globals/job_utils/corsair.lua
@@ -324,8 +324,17 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         target:updateClaim(actor)
 
         -- Calculate resist rate.
-        local bonusAcc = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC)
-        local resist   = xi.combat.magicHitRate.calculateResistRate(actor, target, 0, xi.skill.MARKSMANSHIP, 0,  data.element, xi.mod.AGI, 0, bonusAcc)
+        local bonusAcc   = actor:getMerit(xi.merit.QUICK_DRAW_ACCURACY) + actor:getMod(xi.mod.QUICK_DRAW_MACC)
+        local maccParams =
+        {
+            effectId       = data.applyEffectId or 0,
+            magicalElement = data.element,
+            skillType      = xi.skill.MARKSMANSHIP,
+            actorStat      = xi.mod.AGI,
+            bonusMacc      = bonusAcc,
+        }
+
+        local resist = xi.combat.magicHitRate.calculateResistRate(actor, target, maccParams)
 
         -- Handle damage.
         local damage = 0

--- a/modules/era/lua/globals/job_utils/ninja.lua
+++ b/modules/era/lua/globals/job_utils/ninja.lua
@@ -48,7 +48,7 @@ if not xi.module.isContentEnabled('WOTG') then
     -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(07/20/2009)
     m:addOverride('xi.job_utils.ninja.useMijinGakure', function(player, target, ability, action)
         local dmg        = math.floor(player:getHP() * 0.8)
-        local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, 0, xi.element.NONE, xi.mod.INT, 0, 0)
+        local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, { magicalElement = xi.element.NONE, actorStat = xi.mod.INT })
         local tmdaFactor = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
         local jpFactor   = 1 + player:getJobPointLevel(xi.jp.MIJIN_GAKURE_EFFECT) * 0.03
 

--- a/modules/era/lua/globals/job_utils/paladin.lua
+++ b/modules/era/lua/globals/job_utils/paladin.lua
@@ -95,7 +95,15 @@ if not xi.module.isContentEnabled('ABYSSEA') then
             not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.STUN) and
             not xi.data.statusEffect.isEffectNullified(target, xi.effect.STUN, 0)
         then
-            local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
+            local maccParams =
+            {
+                effectId       = xi.effect.STUN,
+                magicalElement = xi.element.THUNDER,
+                skillRank      = xi.skillRank.A_PLUS,
+                actorStat      = xi.mod.INT,
+            }
+
+            local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
             if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
                 target:addStatusEffect(xi.effect.STUN, { power = 1, duration = math.randomInt(2, 8) * resistanceRate, origin = player })
             end

--- a/modules/era/lua/globals/job_utils/samurai.lua
+++ b/modules/era/lua/globals/job_utils/samurai.lua
@@ -48,7 +48,15 @@ m:addOverride('xi.job_utils.samurai.useBladeBash', function(player, target, abil
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.STUN) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.STUN, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.THUNDER, xi.mod.INT, xi.effect.STUN, 0)
+        local maccParams =
+        {
+            effectId       = xi.effect.STUN,
+            magicalElement = xi.element.THUNDER,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.STUN, resistanceRate, 0) then
             target:addStatusEffect(xi.effect.STUN, { power = 1, duration = 6 * resistanceRate, origin = player })
         end
@@ -60,7 +68,15 @@ m:addOverride('xi.job_utils.samurai.useBladeBash', function(player, target, abil
         not xi.data.statusEffect.isTargetResistant(player, target, xi.effect.PLAGUE) and
         not xi.data.statusEffect.isEffectNullified(target, xi.effect.PLAGUE, 0)
     then
-        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, 0, 0, xi.skillRank.A_PLUS, xi.element.FIRE, xi.mod.INT, xi.effect.PLAGUE, 0)
+        local maccParams =
+        {
+            effectId       = xi.effect.PLAGUE,
+            magicalElement = xi.element.FIRE,
+            skillRank      = xi.skillRank.A_PLUS,
+            actorStat      = xi.mod.INT,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
         if xi.data.statusEffect.isResistRateSuccessfull(xi.effect.PLAGUE, resistanceRate, 0) then
             target:addStatusEffect(xi.effect.PLAGUE, { power = 5, duration = 15 * resistanceRate, origin = player })
         end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Switches over status effects in various modules to be fed tables.
* Switches weaponskill status effects to follow allowed resist states (no bonus MACC for now outside of the weaponskills that state they get bonus macc for TP, more research needed)

## Steps to test these changes
Enable the modules, see no errors.
