### PR TITLE
[lua][sql] Fixes fame system rank values and fame calcs

### DIFF
--- a/modules/era/lua/data/fame_rank_points.lua
+++ b/modules/era/lua/data/fame_rank_points.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Era fame rank thresholds
+-- Points required per fame rank before the February 18th 2014 relaxation, at the 10x retail scale used by this server (fame cap 2500).
+-- https://wiki.ffo.jp/html/2683.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'old_fame_rank_points'
+
+if xi.module.isContentEnabled('ROV') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.data.fame.rankPoints =
+    {
+        [1] = 0,
+        [2] = 200,
+        [3] = 500,
+        [4] = 900,
+        [5] = 1300,
+        [6] = 1700,
+        [7] = 1950,
+        [8] = 2200,
+        [9] = 2450,
+    }
+end)
+
+return m

--- a/modules/era/lua/quests/jeuno/Northward.lua
+++ b/modules/era/lua/quests/jeuno/Northward.lua
@@ -19,8 +19,6 @@ m:addOverride('xi.server.onServerStart', function()
 
     xi.module.modifyInteractionEntry('scripts/quests/jeuno/Northward', function(quest)
         quest.reward = {
-            fame     = 30,
-            fameArea = xi.fameArea.JEUNO,
             keyItem  = xi.ki.MAP_OF_CASTLE_ZVAHL,
             title    = xi.title.ENVOY_TO_THE_NORTH,
         }

--- a/scripts/commands/getfame.lua
+++ b/scripts/commands/getfame.lua
@@ -59,7 +59,7 @@ commandObj.onTrigger = function(player, target, famezone)
         return
     end
 
-    local fameBaseValues = { 0, 50, 125, 225, 325, 425, 488, 550, 613 }
+    local fameBaseValues = xi.data.fame.rankPoints
     local fame = player:getFame(famezone)
     local level = player:getFameLevel(famezone)
 

--- a/scripts/commands/setfamelevel.lua
+++ b/scripts/commands/setfamelevel.lua
@@ -54,15 +54,22 @@ commandObj.onTrigger = function(player, famezone, level, target)
         return
     end
 
-    local fameBaseValues = { 0, 50, 125, 225, 325, 425, 488, 550, 613 }
-    local fameMultiplier = xi.settings.map.FAME_MULTIPLIER
+    if famezone == xi.fameArea.JEUNO then
+        error(player, 'Jeuno fame is derived from the three nations; set San d\'Oria, Bastok and Windurst fame instead.')
+        return
+    elseif famezone == xi.fameArea.SELBINA_RABAO then
+        error(player, 'Selbina/Rabao fame is derived from San d\'Oria and Bastok; set those instead.')
+        return
+    end
+
+    local fameBaseValues = xi.data.fame.rankPoints
 
     if level > 6 and (famezone >= 6 and famezone <= 14) then -- Abyssea fame caps at level 6
         level = 6
         error(player, 'Abyssea fame capped at level 6. Setting to level 6.')
     end
 
-    targ:setFame(famezone, fameBaseValues[level] / fameMultiplier)
+    targ:setFame(famezone, fameBaseValues[level])
     player:printToPlayer(string.format('Set %s\'s fame for fame area %i (%s) to %i (Level %i).', targ:getName(), famezone, fameZoneNames[famezone], fameBaseValues[level], level))
 end
 

--- a/scripts/data/fame.lua
+++ b/scripts/data/fame.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- Rank thresholds for fame calculations
+-- Fame is stored at 10x the retail 0-250 scale to account for decimal precision (2500 cap)
+-- https://wiki.ffo.jp/html/2683.html
+-----------------------------------
+xi = xi or {}
+xi.data = xi.data or {}
+xi.data.fame = xi.data.fame or {}
+-----------------------------------
+
+-- Points required for each fame rank
+-- These are the retail values after the February 18th 2014 "relaxation" as called by JP wiki (see link above)
+xi.data.fame.rankPoints =
+{
+    [1] = 0,
+    [2] = 50,
+    [3] = 125,
+    [4] = 225,
+    [5] = 325,
+    [6] = 425,
+    [7] = 488,
+    [8] = 550,
+    [9] = 613,
+}
+
+-- Fame rank (1-9) for a raw fame point value
+-- Called by CLuaBaseEntity::getFameLevel
+xi.data.fame.getRankFromPoints = function(famePoints)
+    local rank = 1
+
+    for level, points in ipairs(xi.data.fame.rankPoints) do
+        if famePoints >= points then
+            rank = level
+        end
+    end
+
+    return rank
+end

--- a/scripts/globals/player.lua
+++ b/scripts/globals/player.lua
@@ -21,9 +21,9 @@ local startingRaceInfo =
 
 local startingNationInfo =
 {
-    [xi.nation.SANDORIA] = { ring = xi.item.SAN_DORIAN_RING,  map = xi.ki.MAP_OF_THE_SAN_DORIA_AREA },
-    [xi.nation.BASTOK  ] = { ring = xi.item.BASTOKAN_RING,    map = xi.ki.MAP_OF_THE_BASTOK_AREA    },
-    [xi.nation.WINDURST] = { ring = xi.item.WINDURSTIAN_RING, map = xi.ki.MAP_OF_THE_WINDURST_AREA  },
+    [xi.nation.SANDORIA] = { ring = xi.item.SAN_DORIAN_RING,  map = xi.ki.MAP_OF_THE_SAN_DORIA_AREA, fameArea = xi.fameArea.SANDORIA },
+    [xi.nation.BASTOK  ] = { ring = xi.item.BASTOKAN_RING,    map = xi.ki.MAP_OF_THE_BASTOK_AREA,    fameArea = xi.fameArea.BASTOK   },
+    [xi.nation.WINDURST] = { ring = xi.item.WINDURSTIAN_RING, map = xi.ki.MAP_OF_THE_WINDURST_AREA,  fameArea = xi.fameArea.WINDURST },
 }
 
 local startingJobGear =
@@ -77,6 +77,13 @@ xi.player.charCreate = function(player)
     -- add nation- and race-specific ring
     if nation == raceInfo.homeNation and not player:hasItem(nationInfo.ring) then
         player:addItem(nationInfo.ring)
+    end
+
+    -- Add starting fame: 7 for the nation the player starts in
+    -- Add 3 for the races home nation
+    if player:getFame(nationInfo.fameArea) == 0 then
+        player:addFame(nationInfo.fameArea, 70)
+        player:addFame(startingNationInfo[raceInfo.homeNation].fameArea, 30)
     end
 
     -- unlock advanced jobs

--- a/scripts/quests/outlands/Open_Sesame.lua
+++ b/scripts/quests/outlands/Open_Sesame.lua
@@ -9,9 +9,7 @@ local quest = Quest:new(xi.questLog.OUTLANDS, xi.quest.id.outlands.OPEN_SESAME)
 
 quest.reward =
 {
-    fameArea = xi.fameArea.SELBINA_RABAO,
-    fame     = 30,
-    keyItem  = xi.ki.LOADSTONE,
+    keyItem = xi.ki.LOADSTONE,
 }
 
 local tradeOptions =
@@ -74,6 +72,8 @@ quest.sections =
             {
                 [22] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:addFame(xi.fameArea.SANDORIA, 15)
+                        player:addFame(xi.fameArea.BASTOK, 15)
                         player:tradeComplete()
                     end
                 end,

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -78,9 +78,6 @@ xi.settings.map =
     -- Capacity Point Settings
     CAPACITY_RATE = 1.0,
 
-    -- For old fame calculation use .25
-    FAME_MULTIPLIER = 1.00,
-
     -- Percentage of experience normally lost to keep upon death. 0 means full loss, where 1 means no loss.
     EXP_RETAIN = 0,
 

--- a/sql/char_profile.sql
+++ b/sql/char_profile.sql
@@ -20,7 +20,6 @@ CREATE TABLE IF NOT EXISTS `char_profile` (
   `fame_bastok` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_windurst` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_norg` smallint(5) unsigned NOT NULL DEFAULT '0',
-  `fame_jeuno` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_aby_konschtat` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_aby_tahrongi` smallint(5) unsigned NOT NULL DEFAULT '0',
   `fame_aby_latheine` smallint(5) unsigned NOT NULL DEFAULT '0',

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -94,8 +94,8 @@ struct profile_t
     uint16 mhflag;
 
     uint16     title;
-    uint16     fame[15];
-    uint8      rank[3]; // RANK in three kingdoms
+    uint16     fame[14]; // 0-2 nations, 3 Norg, 4-12 Abyssea, 13 Adoulin (Jeuno and Selbina/Rabao fame are derived)
+    uint8      rank[3];  // RANK in three kingdoms
     uint16     rankpoints;
     location_t home_point;
     uint8      campaign_allegiance;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -7810,24 +7810,23 @@ uint16 CLuaBaseEntity::getFame(const sol::object& areaObj)
 
     if (fameArea <= 15)
     {
-        float fameMultiplier = settings::get<float>("map.FAME_MULTIPLIER");
-        auto* PChar          = static_cast<CCharEntity*>(m_PBaseEntity);
+        auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
         switch (fameArea)
         {
             case 0: // San d'Oria
             case 1: // Bastok
             case 2: // Windurst
-                fame = static_cast<uint16>(PChar->profile.fame[fameArea] * fameMultiplier);
+                fame = PChar->profile.fame[fameArea];
                 break;
-            case 3: // Jeuno
-                fame = static_cast<uint16>(PChar->profile.fame[4] + ((PChar->profile.fame[0] + PChar->profile.fame[1] + PChar->profile.fame[2]) * fameMultiplier / 3));
+            case 3: // Jeuno - derived: all three nations / 2
+                fame = (PChar->profile.fame[0] + PChar->profile.fame[1] + PChar->profile.fame[2]) / 2;
                 break;
-            case 4: // Selbina / Rabao
-                fame = static_cast<uint16>((PChar->profile.fame[0] + PChar->profile.fame[1]) * fameMultiplier / 2);
+            case 4: // Selbina / Rabao - derived: San d'Oria + Bastok * 2/3
+                fame = (PChar->profile.fame[0] + PChar->profile.fame[1]) * 2 / 3;
                 break;
             case 5: // Norg
-                fame = static_cast<uint16>(PChar->profile.fame[3] * fameMultiplier);
+                fame = PChar->profile.fame[3];
                 break;
             // Abyssea
             case 6:  // Konschtat
@@ -7839,10 +7838,10 @@ uint16 CLuaBaseEntity::getFame(const sol::object& areaObj)
             case 12: // Altepa
             case 13: // Grauberg
             case 14: // Uleguerand
-                fame = static_cast<uint16>(PChar->profile.fame[fameArea - 1] * fameMultiplier);
+                fame = PChar->profile.fame[fameArea - 2];
                 break;
             case 15: // Adoulin
-                fame = static_cast<uint16>(PChar->profile.fame[14] * fameMultiplier);
+                fame = PChar->profile.fame[13];
                 break;
         }
     }
@@ -7851,7 +7850,7 @@ uint16 CLuaBaseEntity::getFame(const sol::object& areaObj)
         ShowError("Lua::getFame: fameArea %i is invalid", fameArea);
     }
 
-    return fame;
+    return std::min<uint16>(fame, 2500); // Fame cap is 2500
 }
 
 /************************************************************************
@@ -7883,12 +7882,11 @@ void CLuaBaseEntity::addFame(const sol::object& areaObj, uint16 fame)
                 PChar->profile.fame[fameArea] += fame;
                 break;
             case 3: // Jeuno
-                PChar->profile.fame[4] += fame;
-                break;
+                ShowWarning("Lua::addFame: Jeuno fame is derived from nation fame and cannot be awarded directly");
+                return;
             case 4: // Selbina / Rabao
-                PChar->profile.fame[0] += fame;
-                PChar->profile.fame[1] += fame;
-                break;
+                ShowWarning("Lua::addFame: Selbina/Rabao fame is derived from nation fame and cannot be awarded directly");
+                return;
             case 5: // Norg
                 PChar->profile.fame[3] += fame;
                 break;
@@ -7902,12 +7900,19 @@ void CLuaBaseEntity::addFame(const sol::object& areaObj, uint16 fame)
             case 12: // Altepa
             case 13: // Grauberg
             case 14: // Uleguerand
-                PChar->profile.fame[fameArea - 1] += fame;
+                PChar->profile.fame[fameArea - 2] += fame;
                 break;
             case 15: // Adoulin
-                PChar->profile.fame[14] += fame;
+                PChar->profile.fame[13] += fame;
                 break;
         }
+
+        // Enforce fame cap
+        for (auto& storedFame : PChar->profile.fame)
+        {
+            storedFame = std::min<uint16>(storedFame, 2500); // Fame cap is 2500
+        }
+
         charutils::SaveFame(PChar);
     }
     else
@@ -7937,6 +7942,9 @@ void CLuaBaseEntity::setFame(const sol::object& areaObj, uint16 fame)
     {
         auto* PChar = static_cast<CCharEntity*>(m_PBaseEntity);
 
+        // Stop the user from adding more than 2500 fame
+        fame = std::min<uint16>(fame, 2500); // Fame cap is 2500
+
         switch (fameArea)
         {
             case 0: // San d'Oria
@@ -7944,13 +7952,12 @@ void CLuaBaseEntity::setFame(const sol::object& areaObj, uint16 fame)
             case 2: // Windurst
                 PChar->profile.fame[fameArea] = fame;
                 break;
-            case 3: // Jeuno
-                PChar->profile.fame[4] = fame;
-                break;
-            case 4: // Selbina / Rabao
-                PChar->profile.fame[0] = fame;
-                PChar->profile.fame[1] = fame;
-                break;
+            case 3: // Jeuno - derived from the three nations
+                ShowWarning("Lua::setFame: Jeuno fame is derived from nation fame and cannot be set directly");
+                return;
+            case 4: // Selbina / Rabao - derived from San d'Oria and Bastok
+                ShowWarning("Lua::setFame: Selbina/Rabao fame is derived from nation fame and cannot be set directly");
+                return;
             case 5: // Norg
                 PChar->profile.fame[3] = fame;
                 break;
@@ -7964,10 +7971,10 @@ void CLuaBaseEntity::setFame(const sol::object& areaObj, uint16 fame)
             case 12: // Altepa
             case 13: // Grauberg
             case 14: // Uleguerand
-                PChar->profile.fame[fameArea - 1] = fame;
+                PChar->profile.fame[fameArea - 2] = fame;
                 break;
             case 15: // Adoulin
-                PChar->profile.fame[14] = fame;
+                PChar->profile.fame[13] = fame;
                 break;
         }
 
@@ -8001,37 +8008,11 @@ uint8 CLuaBaseEntity::getFameLevel(const sol::object& areaObj)
     {
         uint16 fame = this->getFame(areaObj);
 
-        if (fame >= 613)
+        // Rank thresholds live in xi.data.fame.rankPoints
+        fameLevel = luautils::callGlobal<uint8>("xi.data.fame.getRankFromPoints", fame);
+        if (fameLevel == 0)
         {
-            fameLevel = 9;
-        }
-        else if (fame >= 550)
-        {
-            fameLevel = 8;
-        }
-        else if (fame >= 488)
-        {
-            fameLevel = 7;
-        }
-        else if (fame >= 425)
-        {
-            fameLevel = 6;
-        }
-        else if (fame >= 325)
-        {
-            fameLevel = 5;
-        }
-        else if (fame >= 225)
-        {
-            fameLevel = 4;
-        }
-        else if (fame >= 125)
-        {
-            fameLevel = 3;
-        }
-        else if (fame >= 50)
-        {
-            fameLevel = 2;
+            fameLevel = 1; // Lua error fallback
         }
 
         if ((fameArea >= 6) && (fameArea <= 14) && (fameLevel >= 6))

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -547,7 +547,6 @@ auto LoadChar(Scheduler& scheduler, MapConfig config, const uint32 charId) -> st
                "fame_bastok,"
                "fame_windurst,"
                "fame_norg, "
-               "fame_jeuno, "
                "fame_aby_konschtat, "
                "fame_aby_tahrongi, "
                "fame_aby_latheine, "
@@ -575,17 +574,16 @@ auto LoadChar(Scheduler& scheduler, MapConfig config, const uint32 charId) -> st
         PChar->profile.fame[1]      = rset->get<uint16>("fame_bastok");
         PChar->profile.fame[2]      = rset->get<uint16>("fame_windurst");
         PChar->profile.fame[3]      = rset->get<uint16>("fame_norg");
-        PChar->profile.fame[4]      = rset->get<uint16>("fame_jeuno");
-        PChar->profile.fame[5]      = rset->get<uint16>("fame_aby_konschtat");
-        PChar->profile.fame[6]      = rset->get<uint16>("fame_aby_tahrongi");
-        PChar->profile.fame[7]      = rset->get<uint16>("fame_aby_latheine");
-        PChar->profile.fame[8]      = rset->get<uint16>("fame_aby_misareaux");
-        PChar->profile.fame[9]      = rset->get<uint16>("fame_aby_vunkerl");
-        PChar->profile.fame[10]     = rset->get<uint16>("fame_aby_attohwa");
-        PChar->profile.fame[11]     = rset->get<uint16>("fame_aby_altepa");
-        PChar->profile.fame[12]     = rset->get<uint16>("fame_aby_grauberg");
-        PChar->profile.fame[13]     = rset->get<uint16>("fame_aby_uleguerand");
-        PChar->profile.fame[14]     = rset->get<uint16>("fame_adoulin");
+        PChar->profile.fame[4]      = rset->get<uint16>("fame_aby_konschtat");
+        PChar->profile.fame[5]      = rset->get<uint16>("fame_aby_tahrongi");
+        PChar->profile.fame[6]      = rset->get<uint16>("fame_aby_latheine");
+        PChar->profile.fame[7]      = rset->get<uint16>("fame_aby_misareaux");
+        PChar->profile.fame[8]      = rset->get<uint16>("fame_aby_vunkerl");
+        PChar->profile.fame[9]      = rset->get<uint16>("fame_aby_attohwa");
+        PChar->profile.fame[10]     = rset->get<uint16>("fame_aby_altepa");
+        PChar->profile.fame[11]     = rset->get<uint16>("fame_aby_grauberg");
+        PChar->profile.fame[12]     = rset->get<uint16>("fame_aby_uleguerand");
+        PChar->profile.fame[13]     = rset->get<uint16>("fame_adoulin");
         PChar->profile.unity_leader = rset->get<uint8>("unity_leader");
     }
 
@@ -5963,7 +5961,6 @@ void SaveFame(CCharEntity* PChar)
                      "fame_bastok = ?,"
                      "fame_windurst = ?,"
                      "fame_norg = ?,"
-                     "fame_jeuno = ?,"
                      "fame_aby_konschtat = ?,"
                      "fame_aby_tahrongi = ?,"
                      "fame_aby_latheine = ?,"
@@ -5989,7 +5986,6 @@ void SaveFame(CCharEntity* PChar)
                      PChar->profile.fame[11],
                      PChar->profile.fame[12],
                      PChar->profile.fame[13],
-                     PChar->profile.fame[14],
                      PChar->id);
 }
 

--- a/tools/migrations/058_drop_fame_jeuno.py
+++ b/tools/migrations/058_drop_fame_jeuno.py
@@ -1,0 +1,24 @@
+import mariadb
+
+
+def migration_name():
+    return "Dropping fame_jeuno column from char_profile (Jeuno fame is derived from nation fame)"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    cur.execute("SHOW COLUMNS FROM char_profile LIKE 'fame_jeuno'")
+    if cur.fetchone():
+        return True
+    return False
+
+
+def migrate(cur, db):
+    try:
+        cur.execute("ALTER TABLE `char_profile` DROP COLUMN `fame_jeuno`;")
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Corrects the entire fame system to follow retail values. Some of the changes in here are further explained in https://github.com/LandSandBoat/server/pull/10930 but I will do my best to outline the main changed that this PR introduces. See other PR for capture data | [video](https://www.youtube.com/watch?v=AkG5smrnr_k)

[JP Wiki](https://wiki.ffo.jp/html/2683.html) has all of this information and proven on retail.
<img width="397" height="456" alt="image" src="https://github.com/user-attachments/assets/8c96d635-7d1d-41cb-b620-2dbab0c626a6" />

**Jeuno:**
> ジュノ大公国編
> ジュノの名声ランクは「3国の名声合計÷2」に基づいて決まっている。そのため、初めてジュノを訪れたとき既にそれなりの名声ランクになっていることも少なくない。
> 
> また、ジュノのクエストをこなすと3国の名声が上昇する*6。

> The Grand Duchy of Jeuno Chapter
> Jeuno’s reputation rank is determined based on “the total reputation of the three nations divided by 2.” As a result, it’s not uncommon for players to already have a decent reputation rank when they first visit Jeuno.
> 
> Additionally, completing quests in Jeuno increases your reputation with the three nations

Selbina/Rabao

> セルビナ・ラバオ編
> セルビナ・ラバオの名声ランクは共通となっており、「サンドリア・バストゥークの名声合計×2/3」に基づいて決まっている。
> 
> また、セルビナ・ラバオのクエストをこなすと、サンドリア・バストゥークの名声が上昇する*7。

> Selbina Rabao Section
> Selbina Rabao’s reputation rank is shared, and is determined based on “Total Reputation in San d’Oria and Bastok × 2/3.”
> 
> Additionally, completing Selbina Rabao’s quests increases your reputation in San d’Oria and Bastok*7.

Those are the two changes in this PR, the rest were ok.

**General change**
- Fame is stored at 10x the retail 0-250 scale to keep decimal precision (cap 2500)

**Derived fame areas**
- Jeuno fame no longer exists as a stored value, t is strictly derived: `(San d'Oria + Bastok + Windurst) / 2`. The `fame_jeuno` column is dropped via migration and the fame array is remapped (nations 0-2, Norg 3, Abyssea 4-12, Adoulin 13)
- Selbina/Rabao fame is corrected from `(San d'Oria + Bastok) / 2` to  `(San d'Oria + Bastok) * 2/3`.
- `addFame`/`setFame` against either derived area now warn and quests award the source cities directly (converted in [#10930](https://github.com/LandSandBoat/server/pull/10930)).

**Fame cap**
- Stored fame is capped at 2500 (retail 250)
- Every `addFame` clamps all slots before saving, `setFame` clamps its input, and `getFame` clamps at the return
- The `FAME_MULTIPLIER` setting is removed and replaced with fame module for the appropriate table for rank 1-9 fame values through rank thresholds (below), not by scaling fame values. This has been proven in both retail which agrees with JP wiki.

**Rank thresholds**
- Each threshold for how much fame you need per rank are now in  `xi.data.fame.rankPoints` (`scripts/data/fame.lua`)
- New era module `modules/era/lua/data/fame_rank_points.lua` restores the pre-relaxation thresholds (200/500/900/1300/1700/1950/2200/2450)

**Starting fame**
- New characters receive 70 fame in their creation nation and 30 in their races home nation (Hume/Galka -> Bastok, Elvaan -> San d'Oria,  Tarutaru/Mithra -> Windurst), stacking to 100

<img width="673" height="930" alt="image" src="https://github.com/user-attachments/assets/a1f6e504-4ca3-43bf-b391-2554e459c3a0" />

Testing fame caps:
<img width="715" height="689" alt="image" src="https://github.com/user-attachments/assets/ecde413d-a445-410b-850c-bf0f17fe65e5" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
1. Build and run `dbtool` so migration runs
2. Create a new character -> `!getfame` shows 70 in the creation nation and 30 in the racial nation (100 if they match).
3. `!setfamelevel` a character's three nation fames and check `!getfame`. Jeuno reads exactly `(sandoria + bastok + windurst) / 2`, Selbina/Rabao reads `(sandoria + bastok) * 2/3`.
4. Repeatedly `addFame` a nation past 2500 and check `!getfame` or db entries to see it cap at 2500
5. `!setfamelevel` against Jeuno or Selbina/Rabao prints the derived fame notice instead of setting anything.
6. Rank checks against `xi.data.fame.rankPoints`: 49 fame = rank 1, 50 = rank 2, 613+ = rank 9

<!-- Clear and detailed steps to test your changes here -->
