### PR TITLE
[lua] Some NM Bug/Respawn Fixes

### DIFF
--- a/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
+++ b/scripts/zones/FeiYin/mobs/Capricious_Cassie.lua
@@ -63,7 +63,7 @@ entity.spawnPoints =
 
 entity.onMobInitialize = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400))
+    mob:setRespawnTime(math.randomInt(5400, 7200))
 
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
@@ -125,7 +125,7 @@ end
 
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400)) -- 21-24 hours
+    mob:setRespawnTime(math.randomInt(5400, 7200)) -- 90 to 120 minutes
 end
 
 return entity

--- a/scripts/zones/FeiYin/mobs/Specter.lua
+++ b/scripts/zones/FeiYin/mobs/Specter.lua
@@ -17,10 +17,10 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.NORTHERN_SHADOW, 5, 57600) -- 16 hours
-    xi.mob.phOnDespawn(mob, ID.mob.EASTERN_SHADOW, 5, 36000) -- 10 hours
-    xi.mob.phOnDespawn(mob, ID.mob.WESTERN_SHADOW, 5, 36000) -- 10 hours
-    xi.mob.phOnDespawn(mob, ID.mob.SOUTHERN_SHADOW, 5, 57600) -- 16 hours
+    xi.mob.phOnDespawn(mob, ID.mob.NORTHERN_SHADOW, 10, math.randomInt(3600, 7200)) -- 1 to 2 hours
+    xi.mob.phOnDespawn(mob, ID.mob.EASTERN_SHADOW, 10, math.randomInt(3600, 7200)) -- 1 to 2 hours
+    xi.mob.phOnDespawn(mob, ID.mob.WESTERN_SHADOW, 10, math.randomInt(3600, 7200)) -- 1 to 2 hours
+    xi.mob.phOnDespawn(mob, ID.mob.SOUTHERN_SHADOW, 10, math.randomInt(3600, 7200)) -- 1 to 2 hours
 end
 
 return entity

--- a/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
+++ b/scripts/zones/Grand_Palace_of_HuXzoi/mobs/Jailer_of_Temperance.lua
@@ -2,6 +2,7 @@
 -- Area: Grand Palace of Hu'Xzoi
 --   NM: Jailer of Temperance
 -----------------------------------
+local ID           = zones[xi.zone.GRAND_PALACE_OF_HUXZOI]
 local huxzoiGlobal = require('scripts/zones/Grand_Palace_of_HuXzoi/globals')
 mixins = { require('scripts/mixins/job_special') }
 -----------------------------------
@@ -128,10 +129,23 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
 end
 
 entity.onMobDespawn = function(mob)
-    local ph = mob:getLocalVar('ph')
-    DisallowRespawn(mob:getID(), true)
-    DisallowRespawn(ph, false)
-    GetMobByID(ph):setRespawnTime(GetMobRespawnTime(ph))
+    local phId = mob:getLocalVar('ph')
+
+    -- Temperance can spawn outside of the zdei system with no placeholder set, so pick one at random.
+    if phId == 0 then
+        local phTable = ID.mob.JAILER_OF_TEMPERANCE_PH
+        phId = phTable[math.randomInt(1, #phTable)]
+    end
+
+    local ph = GetMobByID(phId)
+
+    -- allow the placeholder to respawn
+    if ph then
+        DisallowRespawn(mob:getID(), true)
+        DisallowRespawn(phId, false)
+        ph:setRespawnTime(GetMobRespawnTime(phId))
+    end
+
     mob:setLocalVar('pop', GetSystemTime() + 900) -- 15 mins
     huxzoiGlobal.pickTemperancePH()
 end

--- a/scripts/zones/Kuftal_Tunnel/mobs/Greater_Cockatrice.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Greater_Cockatrice.lua
@@ -66,9 +66,7 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    local params = {}
-    params.SpawnPoints = pelicanSpawnPoints
-    xi.mob.phOnDespawn(mob, ID.mob.PELICAN, 5, 10800, params) -- 4 hours
+    xi.mob.phOnDespawn(mob, ID.mob.PELICAN, 10, 14400, { spawnPoints = pelicanSpawnPoints }) -- 4 hours
 end
 
 return entity

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Mercenary.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Mercenary.lua
@@ -1,9 +1,6 @@
 -----------------------------------
 -- Area: Labyrinth of Onzozo
 --  Mob: Goblin Mercenary
--- Note: Place holder Soulstealer Skullnix
------------------------------------
-local ID = zones[xi.zone.LABYRINTH_OF_ONZOZO]
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -12,10 +9,6 @@ entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 771, 2, xi.regime.type.GROUNDS)
     xi.regime.checkRegime(player, mob, 772, 2, xi.regime.type.GROUNDS)
     xi.regime.checkRegime(player, mob, 774, 2, xi.regime.type.GROUNDS)
-end
-
-entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.SOULSTEALER_SKULLNIX, 5, math.randomInt(7200, 10800)) -- 2 to 3 hours
 end
 
 return entity

--- a/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Shepherd.lua
+++ b/scripts/zones/Labyrinth_of_Onzozo/mobs/Goblin_Shepherd.lua
@@ -1,9 +1,6 @@
 -----------------------------------
 -- Area: Labyrinth of Onzozo
 --  Mob: Goblin Shepherd
--- Note: Place holder Soulstealer Skullnix
------------------------------------
-local ID = zones[xi.zone.LABYRINTH_OF_ONZOZO]
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -16,10 +13,6 @@ entity.onMobDeath = function(mob, player, optParams)
     xi.regime.checkRegime(player, mob, 771, 2, xi.regime.type.GROUNDS)
     xi.regime.checkRegime(player, mob, 772, 2, xi.regime.type.GROUNDS)
     xi.regime.checkRegime(player, mob, 774, 2, xi.regime.type.GROUNDS)
-end
-
-entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.SOULSTEALER_SKULLNIX, 5, math.randomInt(7200, 10800)) -- 2 to 3 hours
 end
 
 return entity

--- a/scripts/zones/Lufaise_Meadows/mobs/Defoliate_Leshy.lua
+++ b/scripts/zones/Lufaise_Meadows/mobs/Defoliate_Leshy.lua
@@ -2,6 +2,8 @@
 -- Area: Lufaise Meadows
 --  Mob: Defoliate Leshy
 -----------------------------------
+local ID = zones[xi.zone.LUFAISE_MEADOWS]
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 
@@ -13,10 +15,23 @@ end
 
 entity.onMobDespawn = function(mob)
     local phIndex = mob:getLocalVar('phIndex')
-    mob:setLocalVar('phIndex', 0)
-    DisallowRespawn(mob:getID(), true)
-    DisallowRespawn(phIndex, false)
-    GetMobByID(phIndex):setRespawnTime(GetMobRespawnTime(phIndex))
+
+    -- Defoliate Leshy can spawn outside of the grow system with no placeholder index, so pick one at random.
+    if
+        phIndex < ID.mob.LESHY_OFFSET or
+        phIndex > ID.mob.LESHY_OFFSET + 7
+    then
+        phIndex = ID.mob.LESHY_OFFSET + math.randomInt(0, 7)
+    end
+
+    local ph = GetMobByID(phIndex)
+
+    -- allow the placeholder to respawn
+    if ph then
+        DisallowRespawn(mob:getID(), true)
+        DisallowRespawn(phIndex, false)
+        ph:setRespawnTime(GetMobRespawnTime(phIndex))
+    end
 end
 
 return entity

--- a/scripts/zones/Silver_Sea_route_to_Al_Zahbi/mobs/Almighty_Apkallu.lua
+++ b/scripts/zones/Silver_Sea_route_to_Al_Zahbi/mobs/Almighty_Apkallu.lua
@@ -35,6 +35,10 @@ entity.onMobSpawn = function(mob)
         mobArg:hideName(false)
         mobArg:setUntargetable(false)
     end)
+
+    -- The zone script's setRespawnTime leaves him allowed to respawn on a short timer, which
+    -- would pop him again every few minutes. Only a successful roll may bring Almighty Apkallu back.
+    DisallowRespawn(mob:getID(), true)
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/Silver_Sea_route_to_Nashmau/mobs/Proteus.lua
+++ b/scripts/zones/Silver_Sea_route_to_Nashmau/mobs/Proteus.lua
@@ -16,6 +16,10 @@ end
 entity.onMobSpawn = function(mob)
     mob:setMod(xi.mod.TRIPLE_ATTACK, 100)
     mob:setMod(xi.mod.ACC, 250)
+
+    -- The zone script's setRespawnTime leaves him allowed to respawn on a short timer, which
+    -- would pop him again every few minutes. Only a successful roll may bring Proteus back.
+    DisallowRespawn(mob:getID(), true)
 end
 
 entity.onMobDespawn = function(mob)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request fixes various NM related bugs and adjusts NM respawn timers that were lowered on retail [in this patch](https://forum.square-enix.com/ffxi/threads/38100) but have not yet been adjusted on LSB. This PR does the following:

- Fixes a bug with Almighty Apkallu and Proteus to properly gate the repop timer. This is the same issue fixed in this PR with different NMs. https://github.com/LandSandBoat/server/pull/10755
- Lowers Capricious Cassie's respawn from 21-24 hours to [90-120 minutes](https://wiki.ffo.jp/html/980.html). 
- Lowers the four Fei'Yin Shadows' lottery cooldowns from 10/16 hours to a [1 to 2 hour window ](https://wiki.ffo.jp/html/18132.html)and raises the pop chance from 5% to 10%
- Corrects Pelican's lottery timer to actually be 4 hours. The code had 3, even though the comment said 4.
- Fixes Pelican's spawn points never being used. Now it does.
- Removes dead Soulstealer Skullnix placeholder code from Goblin Shepherd and Goblin Mercenary in the Labyrinth of Onzozo. I should have done this when I submitted [this PR previously](https://github.com/LandSandBoat/server/pull/10897), but I forgot to - so I am correcting it now.
- Corrects Defoliate Leshy's onMobDespawn against a missing placeholder index. Same fix added for Taisaijin [in a recent PR](https://github.com/LandSandBoat/server/pull/10897).
- Corrects Jailer of Temperance's onMobDespawn the same way. Same fix added for Taisaijin [in a recent PR](https://github.com/LandSandBoat/server/pull/10897).

## Steps to test these changes

!spawnmob any of the above and witness the changes. For the lottery mobs, you will need to set the PH rate to 100% and kill them naturally.