### PR TITLE
[lua] Fomor Party Fixes

### DIFF
--- a/scripts/mixins/fomor_party.lua
+++ b/scripts/mixins/fomor_party.lua
@@ -208,7 +208,7 @@ xi.mix.fomorParty.onPartySpawn = function(mob)
             local follower = GetMobByID(followerID)
 
             if follower then
-                local respawnTime = follower:getRespawnTime()
+                local respawnTime = GetMobRespawnTime(followerID)
 
                 if respawnTime ~= 0 then
                     DisallowRespawn(followerID, false)
@@ -321,7 +321,7 @@ xi.mix.fomorParty.onPartyDeath = function(mob)
 
         -- Last member of the party died - sync all members to this mob's respawn time
         if allDead then
-            local respawnTime = mob:getRespawnTime()
+            local respawnTime = GetMobRespawnTime(mob:getID())
             for _, memberID in ipairs(party.members) do
                 local member = GetMobByID(memberID)
                 if member then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request fixes a current bug in the fomor party mixin where any fomor in a party respawns instantly upon death.

## Steps to test these changes

Kill partied fomors. See they now respawn according to their appropriate respawn times in the DB instead of instantly.
