### PR TITLE
[core] xi_search cleanup

### DIFF
--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ${PACKET_SOURCES}
     data_loader.cpp
     data_loader.h
+    enums/search_type.h
     search_listener.h
     search_application.h
     search_application.cpp

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -45,9 +45,9 @@ CDataLoader::~CDataLoader()
  *                                                                       *
  ************************************************************************/
 
-auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory*>
+auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory>
 {
-    std::vector<AuctionHouseHistory*> HistoryList;
+    std::vector<AuctionHouseHistory> HistoryList;
 
     const auto rset = db::preparedStmt("SELECT sale, sell_date, seller_name, buyer_name "
                                        "FROM auction_house "
@@ -61,15 +61,15 @@ auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vect
     {
         while (rset->next())
         {
-            AuctionHouseHistory* PAHHistory = new AuctionHouseHistory;
+            AuctionHouseHistory history{};
 
-            PAHHistory->Price = rset->get<uint32>("sale");
-            PAHHistory->Data  = rset->get<uint32>("sell_date");
+            history.Price = rset->get<uint32>("sale");
+            history.Data  = rset->get<uint32>("sell_date");
 
-            PAHHistory->Name1 = rset->get<std::string>("seller_name");
-            PAHHistory->Name2 = rset->get<std::string>("buyer_name");
+            history.Name1 = rset->get<std::string>("seller_name");
+            history.Name2 = rset->get<std::string>("buyer_name");
 
-            HistoryList.emplace_back(PAHHistory);
+            HistoryList.emplace_back(std::move(history));
         }
         std::reverse(HistoryList.begin(), HistoryList.end());
     }
@@ -82,11 +82,11 @@ auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vect
  *                                                                       *
  ************************************************************************/
 
-auto CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem*>
+auto CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem>
 {
     ShowDebugFmt("Try find category: {}", ahCategoryID);
 
-    std::vector<AuctionHouseItem*> ItemList;
+    std::vector<AuctionHouseItem> ItemList;
 
     const auto rset = [&]()
     {
@@ -118,20 +118,20 @@ auto CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& or
 
     FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        AuctionHouseItem* PAHItem = new AuctionHouseItem;
+        AuctionHouseItem item{};
 
-        PAHItem->ItemID = rset->get<uint16>("itemid");
+        item.ItemID = rset->get<uint16>("itemid");
 
-        PAHItem->SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
-        PAHItem->StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
-        PAHItem->Category     = ahCategoryID;
+        item.SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
+        item.StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
+        item.Category     = ahCategoryID;
 
         if (rset->get<uint32>("stackSize") == 1)
         {
-            PAHItem->StackAmount = -1;
+            item.StackAmount = -1;
         }
 
-        ItemList.emplace_back(PAHItem);
+        ItemList.emplace_back(item);
     }
 
     return ItemList;
@@ -197,10 +197,10 @@ auto CDataLoader::GetPlayersCount(const SearchRequest& sr) const -> uint32
  *          Job ID is 0 for none specified.                              *
  ************************************************************************/
 
-auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::list<SearchEntity*>
+auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::vector<SearchEntity>
 {
-    std::list<SearchEntity*> PlayersList;
-    std::string              filterQry;
+    std::vector<SearchEntity> PlayersList;
+    std::string               filterQry;
 
     if (sr.jobid > 0 && sr.jobid < 21)
     {
@@ -256,35 +256,35 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
         int visibleResults = 0; // capped at first 20
         while (rset->next())
         {
-            SearchEntity* PPlayer = new SearchEntity();
+            SearchEntity player{};
 
-            PPlayer->name = rset->get<std::string>("charname");
+            player.name = rset->get<std::string>("charname");
 
-            PPlayer->id       = rset->get<uint32>("charid");
-            PPlayer->zone     = rset->get<uint16>("pos_zone");
-            PPlayer->prevzone = rset->get<uint16>("pos_prevzone");
-            PPlayer->nation   = rset->get<uint8>("nation");
-            PPlayer->mjob     = rset->get<uint8>("mjob");
-            PPlayer->sjob     = rset->get<uint8>("sjob");
-            PPlayer->mlvl     = rset->get<uint8>("mlvl");
-            PPlayer->slvl     = rset->get<uint8>("slvl");
-            PPlayer->race     = rset->get<uint8>("race");
+            player.id       = rset->get<uint32>("charid");
+            player.zone     = rset->get<uint16>("pos_zone");
+            player.prevzone = rset->get<uint16>("pos_prevzone");
+            player.nation   = rset->get<uint8>("nation");
+            player.mjob     = rset->get<uint8>("mjob");
+            player.sjob     = rset->get<uint8>("sjob");
+            player.mlvl     = rset->get<uint8>("mlvl");
+            player.slvl     = rset->get<uint8>("slvl");
+            player.race     = rset->get<uint8>("race");
 
             // TODO: Use a nation enum?
-            switch (PPlayer->nation)
+            switch (player.nation)
             {
                 case 0:
-                    PPlayer->rank = rset->get<uint8>("rank_sandoria");
+                    player.rank = rset->get<uint8>("rank_sandoria");
                     break;
                 case 1:
-                    PPlayer->rank = rset->get<uint8>("rank_bastok");
+                    player.rank = rset->get<uint8>("rank_bastok");
                     break;
                 case 2:
-                    PPlayer->rank = rset->get<uint8>("rank_windurst");
+                    player.rank = rset->get<uint8>("rank_windurst");
                     break;
                 default:
-                    ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
-                    PPlayer->rank = static_cast<uint8>(0U);
+                    ShowWarningFmt("Inconsistent player nation allegiance : {}", player.nation);
+                    player.rank = static_cast<uint8>(0U);
                     break;
             }
 
@@ -292,69 +292,69 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             SAVE_CONF playerSettings = {};
             std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
 
-            PPlayer->zone          = (PPlayer->zone == 0 ? PPlayer->prevzone : PPlayer->zone);
-            PPlayer->languages     = rset->get<uint8>("languages");
-            PPlayer->mentor        = playerSettings.MentorFlg;
-            PPlayer->linkshellid1  = rset->get<uint32>("linkshellid1");
-            PPlayer->linkshellid2  = rset->get<uint32>("linkshellid2");
-            PPlayer->seacom_type   = rset->get<uint8>("seacom_type");
-            PPlayer->disconnecting = rset->get<bool>("disconnecting");
-            PPlayer->gmHidden      = rset->get<bool>("gmHiddenEnabled");
-            PPlayer->muted         = rset->get<bool>("muted");
-            PPlayer->unityLeader   = rset->get<uint8>("unity_leader");
-            const auto partyid     = rset->getOrDefault<uint32>("partyid", 0);
+            player.zone          = (player.zone == 0 ? player.prevzone : player.zone);
+            player.languages     = rset->get<uint8>("languages");
+            player.mentor        = playerSettings.MentorFlg;
+            player.linkshellid1  = rset->get<uint32>("linkshellid1");
+            player.linkshellid2  = rset->get<uint32>("linkshellid2");
+            player.seacom_type   = rset->get<uint8>("seacom_type");
+            player.disconnecting = rset->get<bool>("disconnecting");
+            player.gmHidden      = rset->get<bool>("gmHiddenEnabled");
+            player.muted         = rset->get<bool>("muted");
+            player.unityLeader   = rset->get<uint8>("unity_leader");
+            const auto partyid   = rset->getOrDefault<uint32>("partyid", 0);
 
-            if (PPlayer->mentor)
+            if (player.mentor)
             {
-                PPlayer->flags1 |= 0x0001;
+                player.flags1 |= 0x0001;
             }
 
-            if (partyid == PPlayer->id)
+            if (partyid == player.id)
             {
-                PPlayer->flags1 |= 0x0008;
+                player.flags1 |= 0x0008;
             }
 
-            if (PPlayer->seacom_type)
+            if (player.seacom_type)
             {
-                PPlayer->flags1 |= 0x0010;
+                player.flags1 |= 0x0010;
             }
 
             if (playerSettings.AwayFlg)
             {
-                PPlayer->flags1 |= 0x0100;
+                player.flags1 |= 0x0100;
             }
 
-            if (PPlayer->disconnecting)
+            if (player.disconnecting)
             {
-                PPlayer->flags1 |= 0x0800;
+                player.flags1 |= 0x0800;
             }
 
             if (partyid != 0)
             {
-                PPlayer->flags1 |= 0x2000;
+                player.flags1 |= 0x2000;
             }
 
             if (playerSettings.AnonymityFlg)
             {
-                PPlayer->flags1 |= 0x4000;
+                player.flags1 |= 0x4000;
             }
 
             if (playerSettings.InviteFlg)
             {
-                PPlayer->flags1 |= 0x8000;
+                player.flags1 |= 0x8000;
             }
 
-            if (PPlayer->muted)
+            if (player.muted)
             {
-                PPlayer->flags1 |= 0x20000000;
+                player.flags1 |= 0x20000000;
             }
 
-            PPlayer->flags2 = PPlayer->flags1;
+            player.flags2 = player.flags1;
 
-            if (PPlayer->mjob == static_cast<uint8>(xi::Job::MON) || PPlayer->sjob == static_cast<uint8>(xi::Job::MON))
+            if (player.mjob == static_cast<uint8>(xi::Job::MON) || player.sjob == static_cast<uint8>(xi::Job::MON))
             {
-                PPlayer->mjob = 0;
-                PPlayer->sjob = 0;
+                player.mjob = 0;
+                player.sjob = 0;
             }
 
             // filter by linkshell ID
@@ -367,7 +367,7 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
                     continue;
                 }
 
-                if (PPlayer->linkshellid1 != searchedLsId && PPlayer->linkshellid2 != searchedLsId)
+                if (player.linkshellid1 != searchedLsId && player.linkshellid2 != searchedLsId)
                 {
                     // Current player does not match the given LS ID
                     continue;
@@ -375,20 +375,20 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             }
 
             // filter anon players if job/nation/race/rank/level search
-            if ((PPlayer->flags1 & 0x4000) &&
+            if ((player.flags1 & 0x4000) &&
                 (sr.jobid > 0 || sr.nation != 255 || sr.race != 255 || sr.minRank > 0 || sr.maxRank > 0 || sr.minlvl > 0 || sr.maxlvl > 0))
             {
                 continue;
             }
 
             // filter by job
-            if (sr.jobid > 0 && sr.jobid != PPlayer->mjob)
+            if (sr.jobid > 0 && sr.jobid != player.mjob)
             {
                 continue;
             }
 
             // filter by nation
-            if (sr.nation != 255 && sr.nation != PPlayer->nation)
+            if (sr.nation != 255 && sr.nation != player.nation)
             {
                 continue;
             }
@@ -397,27 +397,27 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             if (sr.race != 255)
             {
                 // hume (male/female)
-                if (sr.race == 0 && (PPlayer->race != 1 && PPlayer->race != 2))
+                if (sr.race == 0 && (player.race != 1 && player.race != 2))
                 {
                     continue;
                     // elvaan (male/female)
                 }
-                if (sr.race == 1 && (PPlayer->race != 3 && PPlayer->race != 4))
+                if (sr.race == 1 && (player.race != 3 && player.race != 4))
                 {
                     continue;
                     // tarutaru (male/female)
                 }
-                if (sr.race == 2 && (PPlayer->race != 5 && PPlayer->race != 6))
+                if (sr.race == 2 && (player.race != 5 && player.race != 6))
                 {
                     continue;
                     // mithra (female only)
                 }
-                else if (sr.race == 3 && PPlayer->race != 7)
+                else if (sr.race == 3 && player.race != 7)
                 {
                     continue;
                     // galka (male only)
                 }
-                else if (sr.race == 4 && PPlayer->race != 8)
+                else if (sr.race == 4 && player.race != 8)
                 {
                     continue;
                 }
@@ -426,7 +426,7 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             // filter by rank
             if (sr.minRank > 0 && sr.maxRank >= sr.minRank)
             {
-                if (PPlayer->rank < sr.minRank || PPlayer->rank > sr.maxRank)
+                if (player.rank < sr.minRank || player.rank > sr.maxRank)
                 {
                     continue;
                 }
@@ -438,12 +438,12 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
                 // Check if unity ID is set (bits 22+)
                 if (uint32_t searchUnityId = sr.flags >> 22; searchUnityId != 0)
                 {
-                    if (PPlayer->unityLeader != searchUnityId)
+                    if (player.unityLeader != searchUnityId)
                     {
                         continue;
                     }
                 }
-                else if (!(PPlayer->flags2 & sr.flags))
+                else if (!(player.flags2 & sr.flags))
                 {
                     // Normal bitwise check for other flags (bits 0-21)
                     continue;
@@ -453,7 +453,7 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             // filter by level
             if (sr.minlvl > 0 && sr.maxlvl >= sr.minlvl)
             {
-                if (PPlayer->mlvl < sr.minlvl || PPlayer->mlvl > sr.maxlvl)
+                if (player.mlvl < sr.minlvl || player.mlvl > sr.maxlvl)
                 {
                     continue;
                 }
@@ -463,7 +463,7 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
             if (sr.nameLen > 0)
             {
                 std::string dbname;
-                dbname.insert(0, PPlayer->name);
+                dbname.insert(0, player.name);
 
                 // can't be this name, too long
                 if (sr.nameLen > dbname.length())
@@ -474,7 +474,7 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
                 for (int i = 0; i < sr.nameLen; i++)
                 {
                     // convert to lowercase for both
-                    if (tolower(sr.name[i]) != tolower(PPlayer->name[i]))
+                    if (tolower(sr.name[i]) != tolower(player.name[i]))
                     {
                         validName = false;
                         break;
@@ -486,14 +486,14 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
                 }
             }
 
-            if (PPlayer->gmHidden)
+            if (player.gmHidden)
             {
                 continue;
             }
 
             if (visibleResults < 40)
             {
-                PlayersList.emplace_back(PPlayer);
+                PlayersList.emplace_back(std::move(player));
                 visibleResults++;
             }
             totalResults++;
@@ -514,9 +514,9 @@ auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::lis
  *                                                                       *
  ************************************************************************/
 
-auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::list<SearchEntity*>
+auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::vector<SearchEntity>
 {
-    std::list<SearchEntity*> PartyList;
+    std::vector<SearchEntity> PartyList;
 
     auto rset = db::preparedStmt("SELECT charid, partyid, charname, pos_zone, nation, rank_sandoria, rank_bastok, rank_windurst, race, settings, mjob, sjob, mlvl, slvl, languages, seacom_type, disconnecting "
                                  "FROM accounts_sessions "
@@ -533,33 +533,33 @@ auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::
                                  (!PartyID ? AllianceID : PartyID));
     FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        SearchEntity* PPlayer = new SearchEntity();
+        SearchEntity player{};
 
-        PPlayer->name   = rset->get<std::string>("charname");
-        PPlayer->id     = rset->get<uint32>("charid");
-        PPlayer->zone   = rset->get<uint16>("pos_zone");
-        PPlayer->nation = rset->get<uint8>("nation");
-        PPlayer->mjob   = rset->get<uint8>("mjob");
-        PPlayer->sjob   = rset->get<uint8>("sjob");
-        PPlayer->mlvl   = rset->get<uint8>("mlvl");
-        PPlayer->slvl   = rset->get<uint8>("slvl");
-        PPlayer->race   = rset->get<uint8>("race");
+        player.name   = rset->get<std::string>("charname");
+        player.id     = rset->get<uint32>("charid");
+        player.zone   = rset->get<uint16>("pos_zone");
+        player.nation = rset->get<uint8>("nation");
+        player.mjob   = rset->get<uint8>("mjob");
+        player.sjob   = rset->get<uint8>("sjob");
+        player.mlvl   = rset->get<uint8>("mlvl");
+        player.slvl   = rset->get<uint8>("slvl");
+        player.race   = rset->get<uint8>("race");
 
         // TODO: Use a nation enum?
-        switch (PPlayer->nation)
+        switch (player.nation)
         {
             case 0:
-                PPlayer->rank = rset->get<uint8>("rank_sandoria");
+                player.rank = rset->get<uint8>("rank_sandoria");
                 break;
             case 1:
-                PPlayer->rank = rset->get<uint8>("rank_bastok");
+                player.rank = rset->get<uint8>("rank_bastok");
                 break;
             case 2:
-                PPlayer->rank = rset->get<uint8>("rank_windurst");
+                player.rank = rset->get<uint8>("rank_windurst");
                 break;
             default:
-                ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
-                PPlayer->rank = static_cast<uint8>(0U);
+                ShowWarningFmt("Inconsistent player nation allegiance : {}", player.nation);
+                player.rank = static_cast<uint8>(0U);
                 break;
         }
 
@@ -567,47 +567,47 @@ auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::
         SAVE_CONF playerSettings = {};
         std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
 
-        PPlayer->languages     = rset->get<uint8>("languages");
-        PPlayer->mentor        = playerSettings.MentorFlg;
-        PPlayer->seacom_type   = rset->get<uint8>("seacom_type");
-        PPlayer->disconnecting = rset->get<bool>("disconnecting");
+        player.languages     = rset->get<uint8>("languages");
+        player.mentor        = playerSettings.MentorFlg;
+        player.seacom_type   = rset->get<uint8>("seacom_type");
+        player.disconnecting = rset->get<bool>("disconnecting");
 
-        if (PPlayer->mentor)
+        if (player.mentor)
         {
-            PPlayer->flags1 |= 0x0001;
+            player.flags1 |= 0x0001;
         }
-        if (PartyID == PPlayer->id)
+        if (PartyID == player.id)
         {
-            PPlayer->flags1 |= 0x0008;
+            player.flags1 |= 0x0008;
         }
-        if (PPlayer->seacom_type)
+        if (player.seacom_type)
         {
-            PPlayer->flags1 |= 0x0010;
+            player.flags1 |= 0x0010;
         }
         if (playerSettings.AwayFlg)
         {
-            PPlayer->flags1 |= 0x0100;
+            player.flags1 |= 0x0100;
         }
-        if (PPlayer->disconnecting)
+        if (player.disconnecting)
         {
-            PPlayer->flags1 |= 0x0800;
+            player.flags1 |= 0x0800;
         }
         if (PartyID != 0)
         {
-            PPlayer->flags1 |= 0x2000;
+            player.flags1 |= 0x2000;
         }
         if (playerSettings.AnonymityFlg)
         {
-            PPlayer->flags1 |= 0x4000;
+            player.flags1 |= 0x4000;
         }
         if (playerSettings.InviteFlg)
         {
-            PPlayer->flags1 |= 0x8000;
+            player.flags1 |= 0x8000;
         }
 
-        PPlayer->flags2 = PPlayer->flags1;
+        player.flags2 = player.flags1;
 
-        PartyList.emplace_back(PPlayer);
+        PartyList.emplace_back(std::move(player));
     }
     return PartyList;
 }
@@ -618,9 +618,9 @@ auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::
  *                                                                       *
  ************************************************************************/
 
-auto CDataLoader::GetLinkshellList(uint32 LinkshellID) const -> std::list<SearchEntity*>
+auto CDataLoader::GetLinkshellList(uint32 LinkshellID) const -> std::vector<SearchEntity>
 {
-    std::list<SearchEntity*> LinkshellList;
+    std::vector<SearchEntity> LinkshellList;
 
     auto rset = db::preparedStmt("SELECT charid, partyid, charname, pos_zone, nation, rank_sandoria, rank_bastok, rank_windurst, race, settings, mjob, sjob, "
                                  "mlvl, slvl, linkshellid1, linkshellid2, "
@@ -639,41 +639,41 @@ auto CDataLoader::GetLinkshellList(uint32 LinkshellID) const -> std::list<Search
                                  LinkshellID);
     FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        SearchEntity* PPlayer = new SearchEntity();
+        SearchEntity player{};
 
-        PPlayer->name   = rset->get<std::string>("charname");
-        PPlayer->id     = rset->get<uint32>("charid");
-        PPlayer->zone   = rset->get<uint16>("pos_zone");
-        PPlayer->nation = rset->get<uint8>("nation");
-        PPlayer->mjob   = rset->get<uint8>("mjob");
-        PPlayer->sjob   = rset->get<uint8>("sjob");
-        PPlayer->mlvl   = rset->get<uint8>("mlvl");
-        PPlayer->slvl   = rset->get<uint8>("slvl");
-        PPlayer->race   = rset->get<uint8>("race");
+        player.name   = rset->get<std::string>("charname");
+        player.id     = rset->get<uint32>("charid");
+        player.zone   = rset->get<uint16>("pos_zone");
+        player.nation = rset->get<uint8>("nation");
+        player.mjob   = rset->get<uint8>("mjob");
+        player.sjob   = rset->get<uint8>("sjob");
+        player.mlvl   = rset->get<uint8>("mlvl");
+        player.slvl   = rset->get<uint8>("slvl");
+        player.race   = rset->get<uint8>("race");
 
         // TODO: Use a nation enum?
-        switch (PPlayer->nation)
+        switch (player.nation)
         {
             case 0:
-                PPlayer->rank = rset->get<uint8>("rank_sandoria");
+                player.rank = rset->get<uint8>("rank_sandoria");
                 break;
             case 1:
-                PPlayer->rank = rset->get<uint8>("rank_bastok");
+                player.rank = rset->get<uint8>("rank_bastok");
                 break;
             case 2:
-                PPlayer->rank = rset->get<uint8>("rank_windurst");
+                player.rank = rset->get<uint8>("rank_windurst");
                 break;
             default:
-                ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
-                PPlayer->rank = static_cast<uint8>(0U);
+                ShowWarningFmt("Inconsistent player nation allegiance : {}", player.nation);
+                player.rank = static_cast<uint8>(0U);
                 break;
         }
 
-        PPlayer->linkshellid1   = rset->get<uint32>("linkshellid1");
-        PPlayer->linkshellid2   = rset->get<uint32>("linkshellid2");
-        PPlayer->linkshellrank1 = rset->get<uint8>("linkshellrank1");
-        PPlayer->linkshellrank2 = rset->get<uint8>("linkshellrank2");
-        PPlayer->disconnecting  = rset->get<bool>("disconnecting");
+        player.linkshellid1   = rset->get<uint32>("linkshellid1");
+        player.linkshellid2   = rset->get<uint32>("linkshellid2");
+        player.linkshellrank1 = rset->get<uint8>("linkshellrank1");
+        player.linkshellrank2 = rset->get<uint8>("linkshellrank2");
+        player.disconnecting  = rset->get<bool>("disconnecting");
 
         const auto partyid = rset->getOrDefault<uint32>("partyid", 0);
 
@@ -681,36 +681,36 @@ auto CDataLoader::GetLinkshellList(uint32 LinkshellID) const -> std::list<Search
         SAVE_CONF playerSettings = {};
         std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
 
-        if (partyid == PPlayer->id)
+        if (partyid == player.id)
         {
-            PPlayer->flags1 |= 0x0008;
+            player.flags1 |= 0x0008;
         }
         if (playerSettings.AwayFlg)
         {
-            PPlayer->flags1 |= 0x0100;
+            player.flags1 |= 0x0100;
         }
 
-        if (PPlayer->disconnecting)
+        if (player.disconnecting)
         {
-            PPlayer->flags1 |= 0x0800;
+            player.flags1 |= 0x0800;
         }
 
         if (partyid != 0)
         {
-            PPlayer->flags1 |= 0x2000;
+            player.flags1 |= 0x2000;
         }
         if (playerSettings.AnonymityFlg)
         {
-            PPlayer->flags1 |= 0x4000;
+            player.flags1 |= 0x4000;
         }
         if (playerSettings.InviteFlg)
         {
-            PPlayer->flags1 |= 0x8000;
+            player.flags1 |= 0x8000;
         }
 
-        PPlayer->flags2 = PPlayer->flags1;
+        player.flags2 = player.flags1;
 
-        LinkshellList.emplace_back(PPlayer);
+        LinkshellList.emplace_back(std::move(player));
     }
 
     return LinkshellList;

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -27,6 +27,7 @@
 #include "data/enums/job.h"
 
 #include <algorithm>
+#include <cstring>
 
 #include "data_loader.h"
 #include "search.h"
@@ -745,9 +746,15 @@ void CDataLoader::ExpireAHItems(uint16 expireAgeInDays) const
                                          "T0.itemid = T1.itemid WHERE T0.buyer_name IS NULL AND T0.date <= ?",
                                          cutoff);
 
+    if (!rset0)
+    {
+        ShowErrorFmt("Failed to query expired auction house listings");
+        return;
+    }
+
     const auto expiredAuctions = rset0->rowsCount();
 
-    if (rset0 && expiredAuctions > 0)
+    if (expiredAuctions > 0)
     {
         std::vector<ListingToExpire> listingsToExpire;
         while (rset0->next())

--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -18,7 +18,6 @@
 
 ===========================================================================
 */
-#include <cstring>
 
 #include "common/database.h"
 #include "common/earth_time.h"
@@ -46,23 +45,23 @@ CDataLoader::~CDataLoader()
  *                                                                       *
  ************************************************************************/
 
-std::vector<ahHistory*> CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack)
+auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory*>
 {
-    std::vector<ahHistory*> HistoryList;
+    std::vector<AuctionHouseHistory*> HistoryList;
 
-    auto rset = db::preparedStmt("SELECT sale, sell_date, seller_name, buyer_name "
-                                 "FROM auction_house "
-                                 "WHERE itemid = ? AND stack = ? AND buyer_name IS NOT NULL "
-                                 "ORDER BY sell_date DESC "
-                                 "LIMIT 10",
-                                 ItemID,
-                                 stack);
+    const auto rset = db::preparedStmt("SELECT sale, sell_date, seller_name, buyer_name "
+                                       "FROM auction_house "
+                                       "WHERE itemid = ? AND stack = ? AND buyer_name IS NOT NULL "
+                                       "ORDER BY sell_date DESC "
+                                       "LIMIT 10",
+                                       ItemID,
+                                       stack);
 
     if (rset && rset->rowsCount())
     {
         while (rset->next())
         {
-            ahHistory* PAHHistory = new ahHistory;
+            AuctionHouseHistory* PAHHistory = new AuctionHouseHistory;
 
             PAHHistory->Price = rset->get<uint32>("sale");
             PAHHistory->Data  = rset->get<uint32>("sell_date");
@@ -83,11 +82,11 @@ std::vector<ahHistory*> CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack)
  *                                                                       *
  ************************************************************************/
 
-std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString)
+auto CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem*>
 {
     ShowDebugFmt("Try find category: {}", ahCategoryID);
 
-    std::vector<ahItem*> ItemList;
+    std::vector<AuctionHouseItem*> ItemList;
 
     const auto rset = [&]()
     {
@@ -117,46 +116,43 @@ std::vector<ahItem*> CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const
         return db::preparedStmt(queryStr, ahCategoryID);
     }();
 
-    if (rset && rset->rowsCount())
+    FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        while (rset->next())
+        AuctionHouseItem* PAHItem = new AuctionHouseItem;
+
+        PAHItem->ItemID = rset->get<uint16>("itemid");
+
+        PAHItem->SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
+        PAHItem->StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
+        PAHItem->Category     = ahCategoryID;
+
+        if (rset->get<uint32>("stackSize") == 1)
         {
-            ahItem* PAHItem = new ahItem;
-
-            PAHItem->ItemID = rset->get<uint16>("itemid");
-
-            PAHItem->SingleAmount = rset->getOrDefault<uint32>("COUNT(*)-SUM(stack)", 0);
-            PAHItem->StackAmount  = rset->getOrDefault<uint32>("SUM(stack)", 0);
-            PAHItem->Category     = ahCategoryID;
-
-            if (rset->get<uint32>("stackSize") == 1)
-            {
-                PAHItem->StackAmount = -1;
-            }
-
-            ItemList.emplace_back(PAHItem);
+            PAHItem->StackAmount = -1;
         }
+
+        ItemList.emplace_back(PAHItem);
     }
 
     return ItemList;
 }
 
 // Return single item including category and how many are listed
-ahItem CDataLoader::GetAHItemFromItemID(uint16 ItemID)
+auto CDataLoader::GetAHItemFromItemID(uint16 ItemID) const -> AuctionHouseItem
 {
-    ahItem CAHItem       = {};
-    CAHItem.ItemID       = ItemID;
-    CAHItem.Category     = 0;
-    CAHItem.SingleAmount = 0;
-    CAHItem.StackAmount  = 0;
+    AuctionHouseItem CAHItem = {};
+    CAHItem.ItemID           = ItemID;
+    CAHItem.Category         = 0;
+    CAHItem.SingleAmount     = 0;
+    CAHItem.StackAmount      = 0;
 
-    auto rset = db::preparedStmt("SELECT aH, COUNT(*)-SUM(stack), SUM(stack) "
-                                 "FROM item_basic "
-                                 "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
-                                 "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
-                                 "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
-                                 "WHERE item_basic.itemid = ?",
-                                 ItemID);
+    const auto rset = db::preparedStmt("SELECT aH, COUNT(*)-SUM(stack), SUM(stack) "
+                                       "FROM item_basic "
+                                       "LEFT JOIN auction_house ON item_basic.itemId = auction_house.itemid AND auction_house.buyer_name IS NULL "
+                                       "LEFT JOIN item_equipment ON item_basic.itemid = item_equipment.itemid "
+                                       "LEFT JOIN item_weapon ON item_basic.itemid = item_weapon.itemid "
+                                       "WHERE item_basic.itemid = ?",
+                                       ItemID);
     FOR_DB_SINGLE_RESULT(rset)
     {
         CAHItem.Category     = rset->get<uint16>("aH");
@@ -172,13 +168,13 @@ ahItem CDataLoader::GetAHItemFromItemID(uint16 ItemID)
  *                                                                       *
  ************************************************************************/
 
-uint32 CDataLoader::GetPlayersCount(const search_req& sr)
+auto CDataLoader::GetPlayersCount(const SearchRequest& sr) const -> uint32
 {
     uint8 jobid = sr.jobid;
     if (jobid > 0 && jobid < 21)
     {
         auto rset = db::preparedStmt("SELECT COUNT(*) FROM accounts_sessions LEFT JOIN char_stats USING (charid) WHERE mjob = ?", jobid);
-        if (rset && rset->rowsCount() && rset->next())
+        FOR_DB_SINGLE_RESULT(rset)
         {
             return rset->get<uint32>("COUNT(*)");
         }
@@ -186,7 +182,7 @@ uint32 CDataLoader::GetPlayersCount(const search_req& sr)
     else
     {
         auto rset = db::preparedStmt("SELECT COUNT(*) FROM accounts_sessions");
-        if (rset && rset->rowsCount() && rset->next())
+        FOR_DB_SINGLE_RESULT(rset)
         {
             return rset->get<uint32>("COUNT(*)");
         }
@@ -201,7 +197,7 @@ uint32 CDataLoader::GetPlayersCount(const search_req& sr)
  *          Job ID is 0 for none specified.                              *
  ************************************************************************/
 
-std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
+auto CDataLoader::GetPlayersList(SearchRequest sr, int* count) const -> std::list<SearchEntity*>
 {
     std::list<SearchEntity*> PlayersList;
     std::string              filterQry;
@@ -518,7 +514,7 @@ std::list<SearchEntity*> CDataLoader::GetPlayersList(search_req sr, int* count)
  *                                                                       *
  ************************************************************************/
 
-std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID)
+auto CDataLoader::GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::list<SearchEntity*>
 {
     std::list<SearchEntity*> PartyList;
 
@@ -535,86 +531,83 @@ std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 Allian
                                  "LIMIT 64",
                                  (!AllianceID ? PartyID : AllianceID),
                                  (!PartyID ? AllianceID : PartyID));
-    if (rset && rset->rowsCount())
+    FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        while (rset->next())
+        SearchEntity* PPlayer = new SearchEntity();
+
+        PPlayer->name   = rset->get<std::string>("charname");
+        PPlayer->id     = rset->get<uint32>("charid");
+        PPlayer->zone   = rset->get<uint16>("pos_zone");
+        PPlayer->nation = rset->get<uint8>("nation");
+        PPlayer->mjob   = rset->get<uint8>("mjob");
+        PPlayer->sjob   = rset->get<uint8>("sjob");
+        PPlayer->mlvl   = rset->get<uint8>("mlvl");
+        PPlayer->slvl   = rset->get<uint8>("slvl");
+        PPlayer->race   = rset->get<uint8>("race");
+
+        // TODO: Use a nation enum?
+        switch (PPlayer->nation)
         {
-            SearchEntity* PPlayer = new SearchEntity();
-
-            PPlayer->name   = rset->get<std::string>("charname");
-            PPlayer->id     = rset->get<uint32>("charid");
-            PPlayer->zone   = rset->get<uint16>("pos_zone");
-            PPlayer->nation = rset->get<uint8>("nation");
-            PPlayer->mjob   = rset->get<uint8>("mjob");
-            PPlayer->sjob   = rset->get<uint8>("sjob");
-            PPlayer->mlvl   = rset->get<uint8>("mlvl");
-            PPlayer->slvl   = rset->get<uint8>("slvl");
-            PPlayer->race   = rset->get<uint8>("race");
-
-            // TODO: Use a nation enum?
-            switch (PPlayer->nation)
-            {
-                case 0:
-                    PPlayer->rank = rset->get<uint8>("rank_sandoria");
-                    break;
-                case 1:
-                    PPlayer->rank = rset->get<uint8>("rank_bastok");
-                    break;
-                case 2:
-                    PPlayer->rank = rset->get<uint8>("rank_windurst");
-                    break;
-                default:
-                    ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
-                    PPlayer->rank = static_cast<uint8>(0U);
-                    break;
-            }
-
-            uint32    settingsInt    = rset->get<uint32>("settings");
-            SAVE_CONF playerSettings = {};
-            std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
-
-            PPlayer->languages     = rset->get<uint8>("languages");
-            PPlayer->mentor        = playerSettings.MentorFlg;
-            PPlayer->seacom_type   = rset->get<uint8>("seacom_type");
-            PPlayer->disconnecting = rset->get<bool>("disconnecting");
-
-            if (PPlayer->mentor)
-            {
-                PPlayer->flags1 |= 0x0001;
-            }
-            if (PartyID == PPlayer->id)
-            {
-                PPlayer->flags1 |= 0x0008;
-            }
-            if (PPlayer->seacom_type)
-            {
-                PPlayer->flags1 |= 0x0010;
-            }
-            if (playerSettings.AwayFlg)
-            {
-                PPlayer->flags1 |= 0x0100;
-            }
-            if (PPlayer->disconnecting)
-            {
-                PPlayer->flags1 |= 0x0800;
-            }
-            if (PartyID != 0)
-            {
-                PPlayer->flags1 |= 0x2000;
-            }
-            if (playerSettings.AnonymityFlg)
-            {
-                PPlayer->flags1 |= 0x4000;
-            }
-            if (playerSettings.InviteFlg)
-            {
-                PPlayer->flags1 |= 0x8000;
-            }
-
-            PPlayer->flags2 = PPlayer->flags1;
-
-            PartyList.emplace_back(PPlayer);
+            case 0:
+                PPlayer->rank = rset->get<uint8>("rank_sandoria");
+                break;
+            case 1:
+                PPlayer->rank = rset->get<uint8>("rank_bastok");
+                break;
+            case 2:
+                PPlayer->rank = rset->get<uint8>("rank_windurst");
+                break;
+            default:
+                ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
+                PPlayer->rank = static_cast<uint8>(0U);
+                break;
         }
+
+        uint32    settingsInt    = rset->get<uint32>("settings");
+        SAVE_CONF playerSettings = {};
+        std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
+
+        PPlayer->languages     = rset->get<uint8>("languages");
+        PPlayer->mentor        = playerSettings.MentorFlg;
+        PPlayer->seacom_type   = rset->get<uint8>("seacom_type");
+        PPlayer->disconnecting = rset->get<bool>("disconnecting");
+
+        if (PPlayer->mentor)
+        {
+            PPlayer->flags1 |= 0x0001;
+        }
+        if (PartyID == PPlayer->id)
+        {
+            PPlayer->flags1 |= 0x0008;
+        }
+        if (PPlayer->seacom_type)
+        {
+            PPlayer->flags1 |= 0x0010;
+        }
+        if (playerSettings.AwayFlg)
+        {
+            PPlayer->flags1 |= 0x0100;
+        }
+        if (PPlayer->disconnecting)
+        {
+            PPlayer->flags1 |= 0x0800;
+        }
+        if (PartyID != 0)
+        {
+            PPlayer->flags1 |= 0x2000;
+        }
+        if (playerSettings.AnonymityFlg)
+        {
+            PPlayer->flags1 |= 0x4000;
+        }
+        if (playerSettings.InviteFlg)
+        {
+            PPlayer->flags1 |= 0x8000;
+        }
+
+        PPlayer->flags2 = PPlayer->flags1;
+
+        PartyList.emplace_back(PPlayer);
     }
     return PartyList;
 }
@@ -625,7 +618,7 @@ std::list<SearchEntity*> CDataLoader::GetPartyList(uint32 PartyID, uint32 Allian
  *                                                                       *
  ************************************************************************/
 
-std::list<SearchEntity*> CDataLoader::GetLinkshellList(uint32 LinkshellID)
+auto CDataLoader::GetLinkshellList(uint32 LinkshellID) const -> std::list<SearchEntity*>
 {
     std::list<SearchEntity*> LinkshellList;
 
@@ -644,92 +637,89 @@ std::list<SearchEntity*> CDataLoader::GetLinkshellList(uint32 LinkshellID)
                                  "LIMIT 64",
                                  LinkshellID,
                                  LinkshellID);
-    if (rset && rset->rowsCount())
+    FOR_DB_MULTIPLE_RESULTS(rset)
     {
-        while (rset->next())
+        SearchEntity* PPlayer = new SearchEntity();
+
+        PPlayer->name   = rset->get<std::string>("charname");
+        PPlayer->id     = rset->get<uint32>("charid");
+        PPlayer->zone   = rset->get<uint16>("pos_zone");
+        PPlayer->nation = rset->get<uint8>("nation");
+        PPlayer->mjob   = rset->get<uint8>("mjob");
+        PPlayer->sjob   = rset->get<uint8>("sjob");
+        PPlayer->mlvl   = rset->get<uint8>("mlvl");
+        PPlayer->slvl   = rset->get<uint8>("slvl");
+        PPlayer->race   = rset->get<uint8>("race");
+
+        // TODO: Use a nation enum?
+        switch (PPlayer->nation)
         {
-            SearchEntity* PPlayer = new SearchEntity();
-
-            PPlayer->name   = rset->get<std::string>("charname");
-            PPlayer->id     = rset->get<uint32>("charid");
-            PPlayer->zone   = rset->get<uint16>("pos_zone");
-            PPlayer->nation = rset->get<uint8>("nation");
-            PPlayer->mjob   = rset->get<uint8>("mjob");
-            PPlayer->sjob   = rset->get<uint8>("sjob");
-            PPlayer->mlvl   = rset->get<uint8>("mlvl");
-            PPlayer->slvl   = rset->get<uint8>("slvl");
-            PPlayer->race   = rset->get<uint8>("race");
-
-            // TODO: Use a nation enum?
-            switch (PPlayer->nation)
-            {
-                case 0:
-                    PPlayer->rank = rset->get<uint8>("rank_sandoria");
-                    break;
-                case 1:
-                    PPlayer->rank = rset->get<uint8>("rank_bastok");
-                    break;
-                case 2:
-                    PPlayer->rank = rset->get<uint8>("rank_windurst");
-                    break;
-                default:
-                    ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
-                    PPlayer->rank = (uint8)0;
-                    break;
-            }
-
-            PPlayer->linkshellid1   = rset->get<uint32>("linkshellid1");
-            PPlayer->linkshellid2   = rset->get<uint32>("linkshellid2");
-            PPlayer->linkshellrank1 = rset->get<uint8>("linkshellrank1");
-            PPlayer->linkshellrank2 = rset->get<uint8>("linkshellrank2");
-            PPlayer->disconnecting  = rset->get<bool>("disconnecting");
-
-            const auto partyid = rset->getOrDefault<uint32>("partyid", 0);
-
-            uint32    settingsInt    = rset->get<uint32>("settings");
-            SAVE_CONF playerSettings = {};
-            std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
-
-            if (partyid == PPlayer->id)
-            {
-                PPlayer->flags1 |= 0x0008;
-            }
-            if (playerSettings.AwayFlg)
-            {
-                PPlayer->flags1 |= 0x0100;
-            }
-
-            if (PPlayer->disconnecting)
-            {
-                PPlayer->flags1 |= 0x0800;
-            }
-
-            if (partyid != 0)
-            {
-                PPlayer->flags1 |= 0x2000;
-            }
-            if (playerSettings.AnonymityFlg)
-            {
-                PPlayer->flags1 |= 0x4000;
-            }
-            if (playerSettings.InviteFlg)
-            {
-                PPlayer->flags1 |= 0x8000;
-            }
-
-            PPlayer->flags2 = PPlayer->flags1;
-
-            LinkshellList.emplace_back(PPlayer);
+            case 0:
+                PPlayer->rank = rset->get<uint8>("rank_sandoria");
+                break;
+            case 1:
+                PPlayer->rank = rset->get<uint8>("rank_bastok");
+                break;
+            case 2:
+                PPlayer->rank = rset->get<uint8>("rank_windurst");
+                break;
+            default:
+                ShowWarningFmt("Inconsistent player nation allegiance : {}", PPlayer->nation);
+                PPlayer->rank = static_cast<uint8>(0U);
+                break;
         }
+
+        PPlayer->linkshellid1   = rset->get<uint32>("linkshellid1");
+        PPlayer->linkshellid2   = rset->get<uint32>("linkshellid2");
+        PPlayer->linkshellrank1 = rset->get<uint8>("linkshellrank1");
+        PPlayer->linkshellrank2 = rset->get<uint8>("linkshellrank2");
+        PPlayer->disconnecting  = rset->get<bool>("disconnecting");
+
+        const auto partyid = rset->getOrDefault<uint32>("partyid", 0);
+
+        uint32    settingsInt    = rset->get<uint32>("settings");
+        SAVE_CONF playerSettings = {};
+        std::memcpy(&playerSettings, &settingsInt, sizeof(uint32));
+
+        if (partyid == PPlayer->id)
+        {
+            PPlayer->flags1 |= 0x0008;
+        }
+        if (playerSettings.AwayFlg)
+        {
+            PPlayer->flags1 |= 0x0100;
+        }
+
+        if (PPlayer->disconnecting)
+        {
+            PPlayer->flags1 |= 0x0800;
+        }
+
+        if (partyid != 0)
+        {
+            PPlayer->flags1 |= 0x2000;
+        }
+        if (playerSettings.AnonymityFlg)
+        {
+            PPlayer->flags1 |= 0x4000;
+        }
+        if (playerSettings.InviteFlg)
+        {
+            PPlayer->flags1 |= 0x8000;
+        }
+
+        PPlayer->flags2 = PPlayer->flags1;
+
+        LinkshellList.emplace_back(PPlayer);
     }
 
     return LinkshellList;
 }
 
-std::string CDataLoader::GetSearchComment(uint32 playerId)
+auto CDataLoader::GetSearchComment(uint32 playerId) const -> std::string
 {
     auto rset = db::preparedStmt("SELECT seacom_message FROM accounts_sessions WHERE charid = ?", playerId);
-    if (rset && rset->rowsCount() && rset->next())
+    FOR_DB_SINGLE_RESULT(rset)
     {
         return rset->get<std::string>("seacom_message");
     }
@@ -746,11 +736,9 @@ struct ListingToExpire
     std::string sellerName = "?";
 };
 
-void CDataLoader::ExpireAHItems(uint16 expireAgeInDays)
+void CDataLoader::ExpireAHItems(uint16 expireAgeInDays) const
 {
     ShowInfoFmt("Expiring auction house listings over {} days old", expireAgeInDays);
-
-    std::vector<ListingToExpire> listingsToExpire;
 
     const auto cutoff = earth_time::timestamp() - static_cast<uint32>(expireAgeInDays) * 86400u;
     const auto rset0  = db::preparedStmt("SELECT T0.id,T0.itemid,T1.stacksize, T0.stack, T0.seller FROM auction_house T0 INNER JOIN item_basic T1 ON "
@@ -761,14 +749,15 @@ void CDataLoader::ExpireAHItems(uint16 expireAgeInDays)
 
     if (rset0 && expiredAuctions > 0)
     {
+        std::vector<ListingToExpire> listingsToExpire;
         while (rset0->next())
         {
             // Collect the items we're going to expire
-            uint32 saleID    = rset0->get<uint32>("id");
-            uint32 itemID    = rset0->get<uint32>("itemid");
-            uint8  itemStack = rset0->get<uint8>("stacksize");
-            uint8  ahStack   = rset0->get<uint8>("stack");
-            uint32 sellerID  = rset0->get<uint32>("seller");
+            const uint32 saleID    = rset0->get<uint32>("id");
+            const uint32 itemID    = rset0->get<uint32>("itemid");
+            const uint8  itemStack = rset0->get<uint8>("stacksize");
+            const uint8  ahStack   = rset0->get<uint8>("stack");
+            const uint32 sellerID  = rset0->get<uint32>("seller");
             // NOTE: seller name left out for now, we'll populate this later
 
             listingsToExpire.emplace_back(ListingToExpire{ saleID, itemID, itemStack, ahStack, sellerID, "?" });
@@ -778,7 +767,7 @@ void CDataLoader::ExpireAHItems(uint16 expireAgeInDays)
         {
             // Populate name now
             const auto rset1 = db::preparedStmt("SELECT charname FROM chars WHERE charid = ?", listing.sellerID);
-            if (rset1 && rset1->rowsCount() && rset1->next())
+            FOR_DB_SINGLE_RESULT(rset1)
             {
                 listing.sellerName = rset1->get<std::string>("charname");
             }

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -19,16 +19,15 @@
 ===========================================================================
 */
 
-#ifndef _CDATALOADER_H_
-#define _CDATALOADER_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
 #include <list>
 
-struct search_req;
+struct SearchRequest;
 
-struct ahItem
+struct AuctionHouseItem
 {
     uint16 ItemID;
     uint32 SingleAmount;
@@ -36,7 +35,7 @@ struct ahItem
     uint16 Category;
 };
 
-struct ahHistory
+struct AuctionHouseHistory
 {
     uint32      Price;
     uint32      Data;
@@ -84,16 +83,13 @@ public:
     CDataLoader();
     ~CDataLoader();
 
-    uint32 GetPlayersCount(const search_req& sr);
-
-    std::vector<ahHistory*>  GetAHItemHistory(uint16 ItemID, bool stack);
-    std::list<SearchEntity*> GetPartyList(uint32 PartyID, uint32 AllianceID);
-    std::list<SearchEntity*> GetLinkshellList(uint32 LinkshellID);
-    std::list<SearchEntity*> GetPlayersList(search_req sr, int* count);
-    std::string              GetSearchComment(uint32 playerId);
-    std::vector<ahItem*>     GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString);
-    ahItem                   GetAHItemFromItemID(uint16 ItemID);
-    void                     ExpireAHItems(uint16 expireAgeInDays);
+    auto GetPlayersCount(const SearchRequest& sr) const -> uint32;
+    auto GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory*>;
+    auto GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::list<SearchEntity*>;
+    auto GetLinkshellList(uint32 LinkshellID) const -> std::list<SearchEntity*>;
+    auto GetPlayersList(SearchRequest sr, int* count) const -> std::list<SearchEntity*>;
+    auto GetSearchComment(uint32 playerId) const -> std::string;
+    auto GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem*>;
+    auto GetAHItemFromItemID(uint16 ItemID) const -> AuctionHouseItem;
+    void ExpireAHItems(uint16 expireAgeInDays) const;
 };
-
-#endif

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -23,7 +23,7 @@
 
 #include "common/cbasetypes.h"
 
-#include <list>
+#include <vector>
 
 struct SearchRequest;
 
@@ -84,12 +84,12 @@ public:
     ~CDataLoader();
 
     auto GetPlayersCount(const SearchRequest& sr) const -> uint32;
-    auto GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory*>;
-    auto GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::list<SearchEntity*>;
-    auto GetLinkshellList(uint32 LinkshellID) const -> std::list<SearchEntity*>;
-    auto GetPlayersList(SearchRequest sr, int* count) const -> std::list<SearchEntity*>;
+    auto GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vector<AuctionHouseHistory>;
+    auto GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::vector<SearchEntity>;
+    auto GetLinkshellList(uint32 LinkshellID) const -> std::vector<SearchEntity>;
+    auto GetPlayersList(SearchRequest sr, int* count) const -> std::vector<SearchEntity>;
     auto GetSearchComment(uint32 playerId) const -> std::string;
-    auto GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem*>;
+    auto GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem>;
     auto GetAHItemFromItemID(uint16 ItemID) const -> AuctionHouseItem;
     void ExpireAHItems(uint16 expireAgeInDays) const;
 };

--- a/src/search/enums/search_type.h
+++ b/src/search/enums/search_type.h
@@ -1,7 +1,7 @@
 ﻿/*
 ===========================================================================
 
-  Copyright (c) 2025 LandSandBoat Dev Teams
+  Copyright (c) 2026 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/search/enums/search_type.h
+++ b/src/search/enums/search_type.h
@@ -1,7 +1,7 @@
 ﻿/*
 ===========================================================================
 
-  Copyright (c) 2010-2015 Darkstar Dev Teams
+  Copyright (c) 2025 LandSandBoat Dev Teams
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -21,20 +21,26 @@
 
 #pragma once
 
-#include "common/cbasetypes.h"
+#include <cstdint>
 
-class CSearchListPacket
+enum class SearchType : uint8_t
 {
-public:
-    CSearchListPacket(uint32 Total);
-
-    auto AddPlayer(SearchEntity* PPlayer) -> bool;
-    void SetFinal();
-
-    auto GetData() -> uint8*;
-    auto GetSize() const -> uint16;
-
-private:
-    uint32 m_offset{};
-    uint8  m_data[1024]{};
+    Name          = 0x00, // 00000
+    Area          = 0x01, // 00001
+    Nation        = 0x02, // 00010
+    Job           = 0x03, // 00011
+    Level         = 0x04, // 00100
+    Race          = 0x05, // 00101
+    Flags1        = 0x06, // 00110
+    Id            = 0x08, // 01000
+    Party         = 0x0A, // 01010
+    Linkshell     = 0x0B, // 01011
+    Friend        = 0x0C, // 01100
+    LinkshellRank = 0x0D, // 01101
+    Unknown0E     = 0x0E, // 01110
+    Rank          = 0x10, // 10000
+    Comment       = 0x11, // 10001
+    Linkshell2    = 0x13, // 10011
+    Flags2        = 0x16, // 10110
+    Language      = 0x17, // 10111
 };

--- a/src/search/packets/auction_history.cpp
+++ b/src/search/packets/auction_history.cpp
@@ -26,7 +26,7 @@
 
 #include "auction_history.h"
 
-CAHHistoryPacket::CAHHistoryPacket(ahItem item, uint8 stack)
+CAHHistoryPacket::CAHHistoryPacket(const AuctionHouseItem item, const uint8 stack)
 {
     // Comments and RE by atom0s
     ref<uint8>(m_PData, 0x0A)  = 0x80;        // flags, may be int8 as it's checked against negative.
@@ -41,7 +41,7 @@ CAHHistoryPacket::CAHHistoryPacket(ahItem item, uint8 stack)
     ref<uint16>(m_PData, 0x1E) = item.Category;
 }
 
-void CAHHistoryPacket::AddItem(ahHistory* item)
+void CAHHistoryPacket::AddItem(AuctionHouseHistory* item)
 {
     if (m_count < 10)
     {
@@ -63,7 +63,7 @@ void CAHHistoryPacket::AddItem(ahHistory* item)
  *                                                                       *
  ************************************************************************/
 
-uint8* CAHHistoryPacket::GetData()
+auto CAHHistoryPacket::GetData() -> uint8*
 {
     return m_PData;
 }
@@ -74,7 +74,7 @@ uint8* CAHHistoryPacket::GetData()
  *                                                                       *
  ************************************************************************/
 
-uint16 CAHHistoryPacket::GetSize() const
+auto CAHHistoryPacket::GetSize() const -> uint16
 {
     return 0x20 + 40 * m_count + 28;
 }

--- a/src/search/packets/auction_history.cpp
+++ b/src/search/packets/auction_history.cpp
@@ -18,13 +18,14 @@
 
 ===========================================================================
 */
-#include <cstring>
-
 #include "common/utils.h"
 
 #include "data_loader.h"
 
 #include "auction_history.h"
+
+#include <algorithm>
+#include <cstring>
 
 CAHHistoryPacket::CAHHistoryPacket(const AuctionHouseItem item, const uint8 stack)
 {
@@ -48,8 +49,8 @@ void CAHHistoryPacket::AddItem(const AuctionHouseHistory& item)
         ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x00) = item.Price;
         ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x04) = item.Data;
 
-        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x08, item.Name1.c_str(), 15);
-        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x18, item.Name2.c_str(), 15);
+        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x08, item.Name1.c_str(), std::min(item.Name1.size(), size_t(15)));
+        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x18, item.Name2.c_str(), std::min(item.Name2.size(), size_t(15)));
 
         ref<uint16>(m_PData, (0x08)) = 0x20 + 40 * ++m_count;
     }

--- a/src/search/packets/auction_history.cpp
+++ b/src/search/packets/auction_history.cpp
@@ -41,20 +41,18 @@ CAHHistoryPacket::CAHHistoryPacket(const AuctionHouseItem item, const uint8 stac
     ref<uint16>(m_PData, 0x1E) = item.Category;
 }
 
-void CAHHistoryPacket::AddItem(AuctionHouseHistory* item)
+void CAHHistoryPacket::AddItem(const AuctionHouseHistory& item)
 {
     if (m_count < 10)
     {
-        ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x00) = item->Price;
-        ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x04) = item->Data;
+        ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x00) = item.Price;
+        ref<uint32>(m_PData, (0x20 + 40 * m_count) + 0x04) = item.Data;
 
-        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x08, item->Name1.c_str(), 15);
-        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x18, item->Name2.c_str(), 15);
+        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x08, item.Name1.c_str(), 15);
+        std::memcpy(m_PData + 0x20 + 40 * m_count + 0x18, item.Name2.c_str(), 15);
 
         ref<uint16>(m_PData, (0x08)) = 0x20 + 40 * ++m_count;
     }
-
-    destroy(item);
 }
 
 /************************************************************************

--- a/src/search/packets/auction_history.h
+++ b/src/search/packets/auction_history.h
@@ -28,7 +28,7 @@ class CAHHistoryPacket
 public:
     CAHHistoryPacket(AuctionHouseItem item, uint8 stack);
 
-    void AddItem(AuctionHouseHistory* item);
+    void AddItem(const AuctionHouseHistory& item);
 
     auto GetData() -> uint8*;
     auto GetSize() const -> uint16;

--- a/src/search/packets/auction_history.h
+++ b/src/search/packets/auction_history.h
@@ -19,24 +19,21 @@
 ===========================================================================
 */
 
-#ifndef _CAHHISTORYPACKET_H_
-#define _CAHHISTORYPACKET_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
 class CAHHistoryPacket
 {
 public:
-    CAHHistoryPacket(ahItem item, uint8 stack);
+    CAHHistoryPacket(AuctionHouseItem item, uint8 stack);
 
-    void AddItem(ahHistory* item);
+    void AddItem(AuctionHouseHistory* item);
 
-    uint8* GetData();
-    uint16 GetSize() const;
+    auto GetData() -> uint8*;
+    auto GetSize() const -> uint16;
 
 private:
     uint8 m_count{};
     uint8 m_PData[475]{};
 };
-
-#endif

--- a/src/search/packets/auction_list.cpp
+++ b/src/search/packets/auction_list.cpp
@@ -46,15 +46,13 @@ CAHItemsListPacket::CAHItemsListPacket(const uint16 offset)
  *                                                                       *
  ************************************************************************/
 
-void CAHItemsListPacket::AddItem(AuctionHouseItem* item)
+void CAHItemsListPacket::AddItem(const AuctionHouseItem& item)
 {
-    ref<uint16>(m_PData, (0x18 + 0x0A * m_count) + 0) = item->ItemID;
-    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 2) = item->SingleAmount;
-    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 6) = item->StackAmount;
+    ref<uint16>(m_PData, (0x18 + 0x0A * m_count) + 0) = item.ItemID;
+    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 2) = item.SingleAmount;
+    ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 6) = item.StackAmount;
 
     m_count++;
-
-    destroy(item);
 }
 
 /************************************************************************

--- a/src/search/packets/auction_list.cpp
+++ b/src/search/packets/auction_list.cpp
@@ -34,7 +34,7 @@
  *                                                                       *
  ************************************************************************/
 
-CAHItemsListPacket::CAHItemsListPacket(uint16 offset)
+CAHItemsListPacket::CAHItemsListPacket(const uint16 offset)
 : m_offset(offset)
 {
     ref<uint8>(m_PData, (0x0B)) = 0x95; // packet type
@@ -46,7 +46,7 @@ CAHItemsListPacket::CAHItemsListPacket(uint16 offset)
  *                                                                       *
  ************************************************************************/
 
-void CAHItemsListPacket::AddItem(ahItem* item)
+void CAHItemsListPacket::AddItem(AuctionHouseItem* item)
 {
     ref<uint16>(m_PData, (0x18 + 0x0A * m_count) + 0) = item->ItemID;
     ref<uint32>(m_PData, (0x18 + 0x0A * m_count) + 2) = item->SingleAmount;
@@ -63,7 +63,7 @@ void CAHItemsListPacket::AddItem(ahItem* item)
  *                                                                       *
  ************************************************************************/
 
-void CAHItemsListPacket::SetItemCount(uint16 count)
+void CAHItemsListPacket::SetItemCount(const uint16 count)
 {
     ref<uint16>(m_PData, (0x0E)) = count;
 
@@ -84,7 +84,7 @@ void CAHItemsListPacket::SetItemCount(uint16 count)
  *                                                                       *
  ************************************************************************/
 
-uint8* CAHItemsListPacket::GetData()
+auto CAHItemsListPacket::GetData() -> uint8*
 {
     return m_PData;
 }
@@ -95,7 +95,7 @@ uint8* CAHItemsListPacket::GetData()
  *                                                                       *
  ************************************************************************/
 
-uint16 CAHItemsListPacket::GetSize() const
+auto CAHItemsListPacket::GetSize() const -> uint16
 {
     return 0x18 + 0x0A * m_count + 28;
 }

--- a/src/search/packets/auction_list.h
+++ b/src/search/packets/auction_list.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CAHITEMSLISTPACKET_H_
-#define _CAHITEMSLISTPACKET_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
@@ -29,11 +28,11 @@ class CAHItemsListPacket
 public:
     CAHItemsListPacket(uint16 offset);
 
-    void AddItem(ahItem* item);
+    void AddItem(AuctionHouseItem* item);
     void SetItemCount(uint16 count);
 
-    uint8* GetData();
-    uint16 GetSize() const;
+    auto GetData() -> uint8*;
+    auto GetSize() const -> uint16;
 
 private:
     uint8  m_count{};
@@ -41,5 +40,3 @@ private:
 
     uint8 m_PData[256]{};
 };
-
-#endif

--- a/src/search/packets/auction_list.h
+++ b/src/search/packets/auction_list.h
@@ -28,7 +28,7 @@ class CAHItemsListPacket
 public:
     CAHItemsListPacket(uint16 offset);
 
-    void AddItem(AuctionHouseItem* item);
+    void AddItem(const AuctionHouseItem& item);
     void SetItemCount(uint16 count);
 
     auto GetData() -> uint8*;

--- a/src/search/packets/linkshell_list.cpp
+++ b/src/search/packets/linkshell_list.cpp
@@ -40,7 +40,7 @@ CLinkshellListPacket::CLinkshellListPacket(const uint32 linkshellid, const uint3
  *                                                                       *
  ************************************************************************/
 
-auto CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
+auto CLinkshellListPacket::AddPlayer(const SearchEntity& player) -> bool
 {
     const uint32 size_offset = m_offset / 8;
     if ((sizeof(m_data) - size_offset) < (20 + 67))
@@ -52,65 +52,65 @@ auto CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
 
-    const auto length = std::min(PPlayer->name.size(), size_t(15));
+    const auto length = std::min(player.name.size(), size_t(15));
     m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
-        m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
+        m_offset = packBitsLE(m_data, player.name[c], m_offset, 7);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
+    m_offset = packBitsLE(m_data, player.zone, m_offset, 10);
 
-    if (!(PPlayer->flags1 & 0x4000))
+    if (!(player.flags1 & 0x4000))
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
+        m_offset = packBitsLE(m_data, player.nation, m_offset, 2);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.mjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.sjob, m_offset, 5);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
-        m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.mlvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.slvl, m_offset, 8);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
+        m_offset = packBitsLE(m_data, player.race, m_offset, 4);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.rank, m_offset, 8);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.flags1, m_offset, 16);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
+    m_offset = packBitsLE(m_data, player.id, m_offset, 20);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->linkshellrank1, m_offset, 8); // 2=sack, 1=holder, 3=pearl
-    m_offset = packBitsLE(m_data, PPlayer->linkshellrank2, m_offset, 8);
+    m_offset = packBitsLE(m_data, player.linkshellrank1, m_offset, 8); // 2=sack, 1=holder, 3=pearl
+    m_offset = packBitsLE(m_data, player.linkshellrank2, m_offset, 8);
     m_offset = packBitsLE(m_data, 0, m_offset, 8); // linkshellrank3
-    m_offset = packBitsLE(m_data, PPlayer->linkshellid1, m_offset, 32);
-    m_offset = packBitsLE(m_data, PPlayer->linkshellid2, m_offset, 32);
+    m_offset = packBitsLE(m_data, player.linkshellid1, m_offset, 32);
+    m_offset = packBitsLE(m_data, player.linkshellid2, m_offset, 32);
     m_offset = packBitsLE(m_data, 0, m_offset, 32); // linkshellid3
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
-    if (PPlayer->seacom_type != 0)
+    if (player.seacom_type != 0)
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
+        m_offset = packBitsLE(m_data, player.seacom_type, m_offset, 32);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
+    m_offset = packBitsLE(m_data, player.flags2, m_offset, 32);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
     {
@@ -119,8 +119,6 @@ auto CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
-
-    destroy(PPlayer);
 
     return true;
 }

--- a/src/search/packets/linkshell_list.cpp
+++ b/src/search/packets/linkshell_list.cpp
@@ -22,13 +22,10 @@
 #include "common/utils.h"
 
 #include "data_loader.h"
-#include "search_list.h"
-
-#include <cstring>
-
+#include "enums/search_type.h"
 #include "linkshell_list.h"
 
-CLinkshellListPacket::CLinkshellListPacket(uint32 linkshellid, uint32 Total)
+CLinkshellListPacket::CLinkshellListPacket(const uint32 linkshellid, const uint32 Total)
 : m_offset(192)
 {
     ref<uint8>(m_data, (0x0A)) = 0x00; // is final packet
@@ -43,9 +40,9 @@ CLinkshellListPacket::CLinkshellListPacket(uint32 linkshellid, uint32 Total)
  *                                                                       *
  ************************************************************************/
 
-bool CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer)
+auto CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 {
-    uint32 size_offset = m_offset / 8;
+    const uint32 size_offset = m_offset / 8;
     if ((sizeof(m_data) - size_offset) < (20 + 67))
     {
         return false; // not enough space available, worst case.
@@ -53,46 +50,46 @@ bool CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer)
 
     m_offset += 8;
 
-    m_offset = packBitsLE(m_data, SEARCH_NAME, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
 
-    auto length = std::min(PPlayer->name.size(), size_t(15));
-    m_offset    = packBitsLE(m_data, length, m_offset, 4);
+    const auto length = std::min(PPlayer->name.size(), size_t(15));
+    m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
         m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
     }
 
-    m_offset = packBitsLE(m_data, 1, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
 
     if (!(PPlayer->flags1 & 0x4000))
     {
-        m_offset = packBitsLE(m_data, SEARCH_NATION, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
 
-        m_offset = packBitsLE(m_data, SEARCH_JOB, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
 
-        m_offset = packBitsLE(m_data, SEARCH_LEVEL, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
         m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
 
-        m_offset = packBitsLE(m_data, SEARCH_RACE, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
 
-        m_offset = packBitsLE(m_data, SEARCH_RANK, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS1, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
 
-    m_offset = packBitsLE(m_data, SEARCH_ID, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
 
-    m_offset = packBitsLE(m_data, SEARCH_LINKSHELLRANK, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->linkshellrank1, m_offset, 8); // 2=sack, 1=holder, 3=pearl
     m_offset = packBitsLE(m_data, PPlayer->linkshellrank2, m_offset, 8);
     m_offset = packBitsLE(m_data, 0, m_offset, 8); // linkshellrank3
@@ -100,19 +97,19 @@ bool CLinkshellListPacket::AddPlayer(SearchEntity* PPlayer)
     m_offset = packBitsLE(m_data, PPlayer->linkshellid2, m_offset, 32);
     m_offset = packBitsLE(m_data, 0, m_offset, 32); // linkshellid3
 
-    m_offset = packBitsLE(m_data, SEARCH_UNK0x0E, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
     if (PPlayer->seacom_type != 0)
     {
-        m_offset = packBitsLE(m_data, SEARCH_COMMENT, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS2, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
 
-    m_offset = packBitsLE(m_data, SEARCH_LANGUAGE, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
@@ -145,7 +142,7 @@ void CLinkshellListPacket::SetFinal()
  *                                                                       *
  ************************************************************************/
 
-uint8* CLinkshellListPacket::GetData()
+auto CLinkshellListPacket::GetData() -> uint8*
 {
     return m_data;
 }
@@ -156,7 +153,7 @@ uint8* CLinkshellListPacket::GetData()
  *                                                                       *
  ************************************************************************/
 
-uint16 CLinkshellListPacket::GetSize() const
+auto CLinkshellListPacket::GetSize() const -> uint16
 {
     return m_offset / 8 + 20;
 }

--- a/src/search/packets/linkshell_list.cpp
+++ b/src/search/packets/linkshell_list.cpp
@@ -24,6 +24,10 @@
 #include "data_loader.h"
 #include "enums/search_type.h"
 #include "linkshell_list.h"
+#include "search.h"
+
+#include <algorithm>
+#include <cstddef>
 
 CLinkshellListPacket::CLinkshellListPacket(const uint32 linkshellid, const uint32 Total)
 : m_offset(192)
@@ -43,7 +47,7 @@ CLinkshellListPacket::CLinkshellListPacket(const uint32 linkshellid, const uint3
 auto CLinkshellListPacket::AddPlayer(const SearchEntity& player) -> bool
 {
     const uint32 size_offset = m_offset / 8;
-    if ((sizeof(m_data) - size_offset) < (20 + 67))
+    if ((sizeof(m_data) - size_offset) < (searchPacketTrailerSize + searchEntryMaxSize))
     {
         return false; // not enough space available, worst case.
     }
@@ -153,5 +157,5 @@ auto CLinkshellListPacket::GetData() -> uint8*
 
 auto CLinkshellListPacket::GetSize() const -> uint16
 {
-    return m_offset / 8 + 20;
+    return m_offset / 8 + searchPacketTrailerSize;
 }

--- a/src/search/packets/linkshell_list.h
+++ b/src/search/packets/linkshell_list.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CLINKSHELLLISTPACKET_H_
-#define _CLINKSHELLLISTPACKET_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
@@ -30,15 +29,13 @@ public:
     CLinkshellListPacket(uint32 linkshellid, uint32 Total);
     ~CLinkshellListPacket() = default;
 
-    bool AddPlayer(SearchEntity* PPlayer);
+    auto AddPlayer(SearchEntity* PPlayer) -> bool;
     void SetFinal();
 
-    uint8* GetData();
-    uint16 GetSize() const;
+    auto GetData() -> uint8*;
+    auto GetSize() const -> uint16;
 
 private:
     uint32 m_offset{};
     uint8  m_data[1024]{};
 };
-
-#endif

--- a/src/search/packets/linkshell_list.h
+++ b/src/search/packets/linkshell_list.h
@@ -29,7 +29,7 @@ public:
     CLinkshellListPacket(uint32 linkshellid, uint32 Total);
     ~CLinkshellListPacket() = default;
 
-    auto AddPlayer(SearchEntity* PPlayer) -> bool;
+    auto AddPlayer(const SearchEntity& player) -> bool;
     void SetFinal();
 
     auto GetData() -> uint8*;

--- a/src/search/packets/party_list.cpp
+++ b/src/search/packets/party_list.cpp
@@ -22,13 +22,10 @@
 #include "common/utils.h"
 
 #include "data_loader.h"
-#include "search_list.h"
-
-#include <cstring>
-
+#include "enums/search_type.h"
 #include "party_list.h"
 
-CPartyListPacket::CPartyListPacket(uint32 partyid, uint32 Total)
+CPartyListPacket::CPartyListPacket(const uint32 partyid, const uint32 Total)
 : m_offset(192)
 {
     ref<uint8>(m_data, (0x0A)) = 0x80;
@@ -45,64 +42,64 @@ CPartyListPacket::CPartyListPacket(uint32 partyid, uint32 Total)
 
 void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
 {
-    uint32 size_offset = m_offset / 8;
+    const uint32 size_offset = m_offset / 8;
     m_offset += 8;
 
-    m_offset = packBitsLE(m_data, SEARCH_NAME, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
 
-    auto length = PPlayer->name.size();
-    m_offset    = packBitsLE(m_data, length, m_offset, 4);
+    const auto length = PPlayer->name.size();
+    m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
         m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
     }
 
-    m_offset = packBitsLE(m_data, 1, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
 
     if (!(PPlayer->flags1 & 0x4000))
     {
-        m_offset = packBitsLE(m_data, SEARCH_NATION, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
 
-        m_offset = packBitsLE(m_data, SEARCH_JOB, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
 
-        m_offset = packBitsLE(m_data, SEARCH_LEVEL, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
         m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
 
-        m_offset = packBitsLE(m_data, SEARCH_RACE, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
 
-        m_offset = packBitsLE(m_data, SEARCH_RANK, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS1, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
 
-    m_offset = packBitsLE(m_data, SEARCH_ID, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
 
-    // m_offset = packBitsLE(m_data, SEARCH_LINKSHELLRANK,  m_offset, 5);
+    // m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank),  m_offset, 5);
     // m_offset = packBitsLE(m_data, 0, m_offset,8);
 
-    m_offset = packBitsLE(m_data, SEARCH_UNK0x0E, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
     if (PPlayer->seacom_type != 0)
     {
-        m_offset = packBitsLE(m_data, SEARCH_COMMENT, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS2, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
 
-    m_offset = packBitsLE(m_data, SEARCH_LANGUAGE, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
@@ -122,7 +119,7 @@ void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
  *                                                                       *
  ************************************************************************/
 
-uint8* CPartyListPacket::GetData()
+auto CPartyListPacket::GetData() -> uint8*
 {
     return m_data;
 }
@@ -133,7 +130,7 @@ uint8* CPartyListPacket::GetData()
  *                                                                       *
  ************************************************************************/
 
-uint16 CPartyListPacket::GetSize() const
+auto CPartyListPacket::GetSize() const -> uint16
 {
     return m_offset / 8 + 20;
 }

--- a/src/search/packets/party_list.cpp
+++ b/src/search/packets/party_list.cpp
@@ -40,49 +40,49 @@ CPartyListPacket::CPartyListPacket(const uint32 partyid, const uint32 Total)
  *                                                                       *
  ************************************************************************/
 
-void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
+void CPartyListPacket::AddPlayer(const SearchEntity& player)
 {
     const uint32 size_offset = m_offset / 8;
     m_offset += 8;
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
 
-    const auto length = PPlayer->name.size();
+    const auto length = player.name.size();
     m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
-        m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
+        m_offset = packBitsLE(m_data, player.name[c], m_offset, 7);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
+    m_offset = packBitsLE(m_data, player.zone, m_offset, 10);
 
-    if (!(PPlayer->flags1 & 0x4000))
+    if (!(player.flags1 & 0x4000))
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
+        m_offset = packBitsLE(m_data, player.nation, m_offset, 2);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.mjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.sjob, m_offset, 5);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
-        m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.mlvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.slvl, m_offset, 8);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
+        m_offset = packBitsLE(m_data, player.race, m_offset, 4);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.rank, m_offset, 8);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.flags1, m_offset, 16);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
+    m_offset = packBitsLE(m_data, player.id, m_offset, 20);
 
     // m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank),  m_offset, 5);
     // m_offset = packBitsLE(m_data, 0, m_offset,8);
@@ -90,17 +90,17 @@ void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
-    if (PPlayer->seacom_type != 0)
+    if (player.seacom_type != 0)
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
+        m_offset = packBitsLE(m_data, player.seacom_type, m_offset, 32);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
+    m_offset = packBitsLE(m_data, player.flags2, m_offset, 32);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
     {
@@ -109,8 +109,6 @@ void CPartyListPacket::AddPlayer(SearchEntity* PPlayer)
 
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
-
-    destroy(PPlayer);
 }
 
 /************************************************************************

--- a/src/search/packets/party_list.cpp
+++ b/src/search/packets/party_list.cpp
@@ -24,6 +24,10 @@
 #include "data_loader.h"
 #include "enums/search_type.h"
 #include "party_list.h"
+#include "search.h"
+
+#include <algorithm>
+#include <cstddef>
 
 CPartyListPacket::CPartyListPacket(const uint32 partyid, const uint32 Total)
 : m_offset(192)
@@ -40,14 +44,19 @@ CPartyListPacket::CPartyListPacket(const uint32 partyid, const uint32 Total)
  *                                                                       *
  ************************************************************************/
 
-void CPartyListPacket::AddPlayer(const SearchEntity& player)
+auto CPartyListPacket::AddPlayer(const SearchEntity& player) -> bool
 {
     const uint32 size_offset = m_offset / 8;
+    if ((sizeof(m_data) - size_offset) < (searchPacketTrailerSize + searchEntryMaxSize))
+    {
+        return false; // not enough space available, worst case.
+    }
+
     m_offset += 8;
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
 
-    const auto length = player.name.size();
+    const auto length = std::min(player.name.size(), size_t(15));
     m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
@@ -109,6 +118,8 @@ void CPartyListPacket::AddPlayer(const SearchEntity& player)
 
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
+
+    return true;
 }
 
 /************************************************************************
@@ -130,5 +141,5 @@ auto CPartyListPacket::GetData() -> uint8*
 
 auto CPartyListPacket::GetSize() const -> uint16
 {
-    return m_offset / 8 + 20;
+    return m_offset / 8 + searchPacketTrailerSize;
 }

--- a/src/search/packets/party_list.h
+++ b/src/search/packets/party_list.h
@@ -29,7 +29,7 @@ public:
     CPartyListPacket(uint32 partyid, uint32 Total);
     ~CPartyListPacket() = default;
 
-    void AddPlayer(SearchEntity* PPlayer);
+    void AddPlayer(const SearchEntity& player);
 
     auto GetData() -> uint8*;
     auto GetSize() const -> uint16;

--- a/src/search/packets/party_list.h
+++ b/src/search/packets/party_list.h
@@ -29,7 +29,7 @@ public:
     CPartyListPacket(uint32 partyid, uint32 Total);
     ~CPartyListPacket() = default;
 
-    void AddPlayer(const SearchEntity& player);
+    auto AddPlayer(const SearchEntity& player) -> bool;
 
     auto GetData() -> uint8*;
     auto GetSize() const -> uint16;

--- a/src/search/packets/party_list.h
+++ b/src/search/packets/party_list.h
@@ -19,8 +19,7 @@
 ===========================================================================
 */
 
-#ifndef _CPARTYLISTPACKET_H_
-#define _CPARTYLISTPACKET_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
@@ -32,13 +31,11 @@ public:
 
     void AddPlayer(SearchEntity* PPlayer);
 
-    uint8* GetData();
-    uint16 GetSize() const;
+    auto GetData() -> uint8*;
+    auto GetSize() const -> uint16;
 
 private:
     uint32 m_offset{};
 
     uint8 m_data[1024]{};
 };
-
-#endif

--- a/src/search/packets/search_comment.cpp
+++ b/src/search/packets/search_comment.cpp
@@ -23,7 +23,7 @@
 
 #include "common/utils.h"
 
-SearchCommentPacket::SearchCommentPacket(uint32 playerId, const std::string& comment)
+SearchCommentPacket::SearchCommentPacket(const uint32 playerId, const std::string& comment)
 {
     ref<uint8>(data, 0x08) = 154;  // Search comment packet size
     ref<uint8>(data, 0x0A) = 0x80; // Search server packet
@@ -45,12 +45,12 @@ SearchCommentPacket::SearchCommentPacket(uint32 playerId, const std::string& com
     data[0x9A] = 0;
 }
 
-uint8* SearchCommentPacket::GetData()
+auto SearchCommentPacket::GetData() -> uint8*
 {
     return data;
 }
 
-uint16 SearchCommentPacket::GetSize()
+auto SearchCommentPacket::GetSize() const -> uint16
 {
     return 204;
 }

--- a/src/search/packets/search_comment.h
+++ b/src/search/packets/search_comment.h
@@ -29,8 +29,8 @@ class SearchCommentPacket
 public:
     SearchCommentPacket(uint32 playerId, const std::string& comment);
 
-    uint8* GetData();
-    uint16 GetSize();
+    auto GetData() -> uint8*;
+    auto GetSize() const -> uint16;
 
 private:
     uint8 data[204]{};

--- a/src/search/packets/search_list.cpp
+++ b/src/search/packets/search_list.cpp
@@ -22,12 +22,12 @@
 #include "common/utils.h"
 
 #include "data_loader.h"
+#include "enums/search_type.h"
+#include "search_list.h"
 
 #include <cstring>
 
-#include "search_list.h"
-
-CSearchListPacket::CSearchListPacket(uint32 Total)
+CSearchListPacket::CSearchListPacket(const uint32 Total)
 : m_offset(192)
 {
     memset(m_data, 0, sizeof(m_data));
@@ -39,9 +39,9 @@ CSearchListPacket::CSearchListPacket(uint32 Total)
 }
 
 // A maximum of 20 characters can be added to a single packet.
-bool CSearchListPacket::AddPlayer(SearchEntity* PPlayer)
+auto CSearchListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 {
-    uint32 size_offset = m_offset / 8;
+    const uint32 size_offset = m_offset / 8;
     if ((sizeof(m_data) - size_offset) < (20 + 67))
     {
         return false; // not enough space available, worst case.
@@ -49,60 +49,60 @@ bool CSearchListPacket::AddPlayer(SearchEntity* PPlayer)
 
     m_offset += 8;
 
-    auto length = std::min(PPlayer->name.size(), size_t(15));
-    m_offset    = packBitsLE(m_data, SEARCH_NAME, m_offset, 5);
-    m_offset    = packBitsLE(m_data, length, m_offset, 4);
+    const auto length = std::min(PPlayer->name.size(), size_t(15));
+    m_offset          = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
+    m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
         m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_AREA, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
 
     if (!(PPlayer->flags1 & 0x4000))
     {
-        m_offset = packBitsLE(m_data, SEARCH_NATION, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
 
-        m_offset = packBitsLE(m_data, SEARCH_JOB, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
 
-        m_offset = packBitsLE(m_data, SEARCH_LEVEL, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
         m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
 
-        m_offset = packBitsLE(m_data, SEARCH_RACE, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
 
-        m_offset = packBitsLE(m_data, SEARCH_RANK, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS1, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
 
-    m_offset = packBitsLE(m_data, SEARCH_ID, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
 
-    // m_offset = packBitsLE(m_data, SEARCH_LINKSHELLRANK,  m_offset, 5);
+    // m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank),  m_offset, 5);
     // m_offset = packBitsLE(m_data, 0, m_offset,8);
 
-    m_offset = packBitsLE(m_data, SEARCH_UNK0x0E, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
     if (PPlayer->seacom_type != 0)
     {
-        m_offset = packBitsLE(m_data, SEARCH_COMMENT, m_offset, 5);
+        m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
         m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
     }
 
-    m_offset = packBitsLE(m_data, SEARCH_FLAGS2, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
 
-    m_offset = packBitsLE(m_data, SEARCH_LANGUAGE, m_offset, 5);
+    m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
     m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
@@ -135,7 +135,7 @@ void CSearchListPacket::SetFinal()
  *                                                                       *
  ************************************************************************/
 
-uint8* CSearchListPacket::GetData()
+auto CSearchListPacket::GetData() -> uint8*
 {
     return m_data;
 }
@@ -146,7 +146,7 @@ uint8* CSearchListPacket::GetData()
  *                                                                       *
  ************************************************************************/
 
-uint16 CSearchListPacket::GetSize() const
+auto CSearchListPacket::GetSize() const -> uint16
 {
     return m_offset / 8 + 20;
 }

--- a/src/search/packets/search_list.cpp
+++ b/src/search/packets/search_list.cpp
@@ -39,7 +39,7 @@ CSearchListPacket::CSearchListPacket(const uint32 Total)
 }
 
 // A maximum of 20 characters can be added to a single packet.
-auto CSearchListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
+auto CSearchListPacket::AddPlayer(const SearchEntity& player) -> bool
 {
     const uint32 size_offset = m_offset / 8;
     if ((sizeof(m_data) - size_offset) < (20 + 67))
@@ -49,43 +49,43 @@ auto CSearchListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 
     m_offset += 8;
 
-    const auto length = std::min(PPlayer->name.size(), size_t(15));
+    const auto length = std::min(player.name.size(), size_t(15));
     m_offset          = packBitsLE(m_data, static_cast<uint64>(SearchType::Name), m_offset, 5);
     m_offset          = packBitsLE(m_data, length, m_offset, 4);
 
     for (std::size_t c = 0; c < length; ++c)
     {
-        m_offset = packBitsLE(m_data, PPlayer->name[c], m_offset, 7);
+        m_offset = packBitsLE(m_data, player.name[c], m_offset, 7);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Area), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->zone, m_offset, 10);
+    m_offset = packBitsLE(m_data, player.zone, m_offset, 10);
 
-    if (!(PPlayer->flags1 & 0x4000))
+    if (!(player.flags1 & 0x4000))
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Nation), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->nation, m_offset, 2);
+        m_offset = packBitsLE(m_data, player.nation, m_offset, 2);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Job), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mjob, m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->sjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.mjob, m_offset, 5);
+        m_offset = packBitsLE(m_data, player.sjob, m_offset, 5);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Level), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->mlvl, m_offset, 8);
-        m_offset = packBitsLE(m_data, PPlayer->slvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.mlvl, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.slvl, m_offset, 8);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Race), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->race, m_offset, 4);
+        m_offset = packBitsLE(m_data, player.race, m_offset, 4);
 
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Rank), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->rank, m_offset, 8);
+        m_offset = packBitsLE(m_data, player.rank, m_offset, 8);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags1), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags1, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.flags1, m_offset, 16);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Id), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->id, m_offset, 20);
+    m_offset = packBitsLE(m_data, player.id, m_offset, 20);
 
     // m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::LinkshellRank),  m_offset, 5);
     // m_offset = packBitsLE(m_data, 0, m_offset,8);
@@ -93,17 +93,17 @@ auto CSearchListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Unknown0E), m_offset, 5);
     m_offset = packBitsLE(m_data, 0, m_offset, 32);
 
-    if (PPlayer->seacom_type != 0)
+    if (player.seacom_type != 0)
     {
         m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Comment), m_offset, 5);
-        m_offset = packBitsLE(m_data, PPlayer->seacom_type, m_offset, 32);
+        m_offset = packBitsLE(m_data, player.seacom_type, m_offset, 32);
     }
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Flags2), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->flags2, m_offset, 32);
+    m_offset = packBitsLE(m_data, player.flags2, m_offset, 32);
 
     m_offset = packBitsLE(m_data, static_cast<uint64>(SearchType::Language), m_offset, 5);
-    m_offset = packBitsLE(m_data, PPlayer->languages, m_offset, 16);
+    m_offset = packBitsLE(m_data, player.languages, m_offset, 16);
 
     if (m_offset % 8 > 0)
     {
@@ -112,8 +112,6 @@ auto CSearchListPacket::AddPlayer(SearchEntity* PPlayer) -> bool
 
     ref<uint8>(m_data, size_offset) = m_offset / 8 - size_offset - 1; // Entity data size
     ref<uint16>(m_data, (0x08))     = m_offset / 8;                   // Size of the data to send
-
-    destroy(PPlayer);
 
     return true;
 }

--- a/src/search/packets/search_list.cpp
+++ b/src/search/packets/search_list.cpp
@@ -23,8 +23,10 @@
 
 #include "data_loader.h"
 #include "enums/search_type.h"
+#include "search.h"
 #include "search_list.h"
 
+#include <algorithm>
 #include <cstring>
 
 CSearchListPacket::CSearchListPacket(const uint32 Total)
@@ -42,7 +44,7 @@ CSearchListPacket::CSearchListPacket(const uint32 Total)
 auto CSearchListPacket::AddPlayer(const SearchEntity& player) -> bool
 {
     const uint32 size_offset = m_offset / 8;
-    if ((sizeof(m_data) - size_offset) < (20 + 67))
+    if ((sizeof(m_data) - size_offset) < (searchPacketTrailerSize + searchEntryMaxSize))
     {
         return false; // not enough space available, worst case.
     }
@@ -146,5 +148,5 @@ auto CSearchListPacket::GetData() -> uint8*
 
 auto CSearchListPacket::GetSize() const -> uint16
 {
-    return m_offset / 8 + 20;
+    return m_offset / 8 + searchPacketTrailerSize;
 }

--- a/src/search/packets/search_list.h
+++ b/src/search/packets/search_list.h
@@ -28,7 +28,7 @@ class CSearchListPacket
 public:
     CSearchListPacket(uint32 Total);
 
-    auto AddPlayer(SearchEntity* PPlayer) -> bool;
+    auto AddPlayer(const SearchEntity& player) -> bool;
     void SetFinal();
 
     auto GetData() -> uint8*;

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -19,12 +19,11 @@
 ===========================================================================
 */
 
-#ifndef _SEARCH_H_
-#define _SEARCH_H_
+#pragma once
 
 #include "common/cbasetypes.h"
 
-struct search_req
+struct SearchRequest
 {
     uint16        zoneid[15];
     uint8         jobid;
@@ -41,13 +40,13 @@ struct search_req
     uint8         commentType;
 };
 
-class searchPacket
+class SearchPacket
 {
 public:
     // max size of search packet is 1024 in packets
     static constexpr uint16_t max_size = 1024;
 
-    searchPacket(uint8_t* buffer, uint16_t length)
+    SearchPacket(const uint8_t* buffer, const uint16_t length)
     {
         if (length > max_size)
         {
@@ -60,12 +59,12 @@ public:
         size = length;
     }
 
-    uint16_t getSize()
+    auto getSize() const -> uint16_t
     {
         return size;
     }
 
-    uint8_t* getData()
+    auto getData() -> uint8_t*
     {
         return buff_.data();
     }
@@ -74,5 +73,3 @@ private:
     std::array<uint8_t, max_size> buff_;
     uint16_t                      size;
 };
-
-#endif

--- a/src/search/search.h
+++ b/src/search/search.h
@@ -23,6 +23,12 @@
 
 #include "common/cbasetypes.h"
 
+// md5 hash + blowfish key appended by SearchHandler::encrypt()
+inline constexpr uint32 searchPacketTrailerSize = 0x10 + 0x04;
+
+// Worst case packed entity entry; largest real entry is linkshell at 64 bytes
+inline constexpr uint32 searchEntryMaxSize = 67;
+
 struct SearchRequest
 {
     uint16        zoneid[15];

--- a/src/search/search_engine.cpp
+++ b/src/search/search_engine.cpp
@@ -80,6 +80,6 @@ void SearchEngine::onExpireAll(std::vector<std::string>& inputs) const
 
 void SearchEngine::expireAH(const Maybe<uint16> days) const
 {
-    CDataLoader data;
+    const CDataLoader data;
     data.ExpireAHItems(days.value_or(0));
 }

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -26,6 +26,7 @@
 #include "common/utils.h"
 
 #include "data_loader.h"
+#include "enums/search_type.h"
 
 #include <map>
 #include <unordered_set>
@@ -131,7 +132,7 @@ auto SearchHandler::run() -> Task<void>
     socket_.lowest_layer().close(ec);
 }
 
-void SearchHandler::decrypt(uint16_t length)
+void SearchHandler::decrypt(const uint16_t length)
 {
     DebugSocketsFmt("Decrypting packet from IP {} ({} bytes)", ipAddress_, length);
 
@@ -154,7 +155,7 @@ void SearchHandler::decrypt(uint16_t length)
     ref<uint32>(key, 20) = ref<uint32>(buffer_.data(), length - 0x18);
 }
 
-void SearchHandler::encrypt(uint16_t length)
+void SearchHandler::encrypt(const uint16_t length)
 {
     DebugSocketsFmt("Encrypting packet for IP {} ({} bytes)", ipAddress_, length);
 
@@ -163,7 +164,7 @@ void SearchHandler::encrypt(uint16_t length)
 
     md5(reinterpret_cast<uint8*>(key), blowfish_.hash, 24);
 
-    blowfish_init((int8*)blowfish_.hash, 16, blowfish_.P, blowfish_.S[0]);
+    blowfish_init(reinterpret_cast<int8*>(blowfish_.hash), 16, blowfish_.P, blowfish_.S[0]);
 
     md5(buffer_.data() + 8, buffer_.data() + length - 0x18 + 0x04, length - 0x18 - 0x04);
 
@@ -178,7 +179,7 @@ void SearchHandler::encrypt(uint16_t length)
     memcpy(&buffer_[length] - 0x04, key + 16, 4);
 }
 
-bool SearchHandler::validatePacket(uint16_t length)
+auto SearchHandler::validatePacket(const uint16_t length) -> bool
 {
     DebugSocketsFmt("Validating packet from IP {} ({} bytes)", ipAddress_, length);
 
@@ -205,7 +206,7 @@ bool SearchHandler::validatePacket(uint16_t length)
     return true;
 }
 
-inline std::string searchTypeToString(uint8 type)
+inline auto searchTypeToString(const uint8 type) -> std::string
 {
     switch (type)
     {
@@ -230,7 +231,7 @@ inline std::string searchTypeToString(uint8 type)
     }
 }
 
-void SearchHandler::read_func(uint16_t length)
+void SearchHandler::read_func(const uint16_t length)
 {
     if (length != ref<uint16>(buffer_.data(), 0x00) || length < 28)
     {
@@ -291,7 +292,7 @@ void SearchHandler::read_func(uint16_t length)
  *                                                                       *
  ************************************************************************/
 
-void DebugPrintPacket(char* data, uint16_t size)
+void DebugPrintPacket(const uint8* data, const uint16_t size)
 {
     if (!settings::get<bool>("logging.DEBUG_PACKETS"))
     {
@@ -301,7 +302,7 @@ void DebugPrintPacket(char* data, uint16_t size)
     std::string outStr = "\n";
     for (int32 y = 0; y < size; y++)
     {
-        outStr += fmt::format("{:02X} ", (uint8)data[y]);
+        outStr += fmt::format("{:02X} ", data[y]);
         if (((y + 1) % 16) == 0)
         {
             outStr += "\n";
@@ -319,21 +320,21 @@ void DebugPrintPacket(char* data, uint16_t size)
 
 void SearchHandler::HandleGroupListRequest()
 {
-    uint32 partyid      = ref<uint32>(buffer_.data(), 0x10);
-    uint32 allianceid   = ref<uint32>(buffer_.data(), 0x14);
-    uint32 linkshellid1 = ref<uint32>(buffer_.data(), 0x18);
-    uint32 linkshellid2 = ref<uint32>(buffer_.data(), 0x1C);
+    uint32       partyid      = ref<uint32>(buffer_.data(), 0x10);
+    const uint32 allianceid   = ref<uint32>(buffer_.data(), 0x14);
+    uint32       linkshellid1 = ref<uint32>(buffer_.data(), 0x18);
+    uint32       linkshellid2 = ref<uint32>(buffer_.data(), 0x1C);
 
     ShowInfoFmt("SEARCH::PartyID = {}", partyid);
     ShowInfoFmt("SEARCH::LinkshellIDs = {}, {}", linkshellid1, linkshellid2);
 
-    CDataLoader PDataLoader;
+    const CDataLoader PDataLoader;
 
     if (partyid != 0 || allianceid != 0)
     {
-        std::list<SearchEntity*> PartyList = PDataLoader.GetPartyList(partyid, allianceid);
+        const std::list<SearchEntity*> PartyList = PDataLoader.GetPartyList(partyid, allianceid);
 
-        CPartyListPacket PPartyPacket(partyid, (uint32)PartyList.size());
+        CPartyListPacket PPartyPacket(partyid, static_cast<uint32>(PartyList.size()));
 
         for (auto& it : PartyList)
         {
@@ -342,16 +343,16 @@ void SearchHandler::HandleGroupListRequest()
 
         uint16_t length = PPartyPacket.GetSize();
 
-        DebugPrintPacket((char*)PPartyPacket.GetData(), length);
+        DebugPrintPacket(PPartyPacket.GetData(), length);
         searchPackets_.emplace_back(PPartyPacket.GetData(), length);
     }
     else if (linkshellid1 != 0 || linkshellid2 != 0)
     {
-        uint32                   linkshellid   = linkshellid1 == 0 ? linkshellid2 : linkshellid1;
+        const uint32             linkshellid   = linkshellid1 == 0 ? linkshellid2 : linkshellid1;
         std::list<SearchEntity*> LinkshellList = PDataLoader.GetLinkshellList(linkshellid);
 
-        uint32 totalResults  = (uint32)LinkshellList.size();
-        uint32 currentResult = 0;
+        const uint32 totalResults  = static_cast<uint32>(LinkshellList.size());
+        uint32       currentResult = 0;
 
         // Iterate through the linkshell list, splitting up the results into
         // smaller chunks.
@@ -363,7 +364,7 @@ void SearchHandler::HandleGroupListRequest()
 
             while (currentResult < totalResults)
             {
-                bool success = PLinkshellPacket.AddPlayer(*it);
+                const bool success = PLinkshellPacket.AddPlayer(*it);
                 if (!success)
                 {
                     break;
@@ -380,7 +381,7 @@ void SearchHandler::HandleGroupListRequest()
 
             uint16_t length = PLinkshellPacket.GetSize();
 
-            DebugPrintPacket((char*)PLinkshellPacket.GetData(), length);
+            DebugPrintPacket(PLinkshellPacket.GetData(), length);
             searchPackets_.emplace_back(PLinkshellPacket.GetData(), length);
 
         } while (currentResult < totalResults);
@@ -389,10 +390,10 @@ void SearchHandler::HandleGroupListRequest()
 
 void SearchHandler::HandleSearchComment()
 {
-    uint32 playerId = ref<uint32>(buffer_.data(), 0x10);
+    const uint32 playerId = ref<uint32>(buffer_.data(), 0x10);
 
-    CDataLoader PDataLoader;
-    std::string comment = PDataLoader.GetSearchComment(playerId);
+    const CDataLoader PDataLoader;
+    const std::string comment = PDataLoader.GetSearchComment(playerId);
     if (comment.empty())
     {
         return;
@@ -402,25 +403,25 @@ void SearchHandler::HandleSearchComment()
 
     uint16_t length = commentPacket.GetSize();
 
-    DebugPrintPacket((char*)commentPacket.GetData(), length);
+    DebugPrintPacket(commentPacket.GetData(), length);
     searchPackets_.emplace_back(commentPacket.GetData(), length);
 }
 
 void SearchHandler::HandleSearchRequest()
 {
-    const search_req sr = _HandleSearchRequest();
+    const SearchRequest sr = _HandleSearchRequest();
 
-    CDataLoader PDataLoader;
-    int         totalCount = 0;
+    const CDataLoader PDataLoader;
+    int               totalCount = 0;
 
     std::list<SearchEntity*> SearchList = PDataLoader.GetPlayersList(sr, &totalCount);
 
-    uint32 totalResults  = (uint32)SearchList.size();
-    uint32 currentResult = 0;
+    const uint32 totalResults  = static_cast<uint32>(SearchList.size());
+    uint32       currentResult = 0;
 
     // Iterate through the search list, splitting up the results into
     // smaller chunks.
-    std::list<SearchEntity*>::iterator it = SearchList.begin();
+    auto it = SearchList.begin();
 
     do
     {
@@ -445,7 +446,7 @@ void SearchHandler::HandleSearchRequest()
 
         uint16_t length = PSearchPacket.GetSize();
 
-        DebugPrintPacket((char*)PSearchPacket.GetData(), length);
+        DebugPrintPacket(PSearchPacket.GetData(), length);
         searchPackets_.emplace_back(PSearchPacket.GetData(), length);
 
     } while (currentResult < totalResults);
@@ -453,7 +454,7 @@ void SearchHandler::HandleSearchRequest()
 
 void SearchHandler::HandleAuctionHouseRequest()
 {
-    uint8 AHCatID = ref<uint8>(buffer_.data(), 0x16);
+    const uint8 AHCatID = ref<uint8>(buffer_.data(), 0x16);
 
     // 2 - level
     // 3 - race
@@ -464,7 +465,7 @@ void SearchHandler::HandleAuctionHouseRequest()
     // 8 - resistance
     // 9 - name
     std::string OrderByString = "ORDER BY";
-    uint8       paramCount    = ref<uint8>(buffer_.data(), 0x12);
+    const uint8 paramCount    = ref<uint8>(buffer_.data(), 0x12);
     for (uint8 i = 0; i < paramCount; ++i) // Item sort options
     {
         uint8 param = ref<uint32>(buffer_.data(), 0x18 + 8 * i);
@@ -489,15 +490,15 @@ void SearchHandler::HandleAuctionHouseRequest()
     OrderByString.append(" item_basic.itemid");
     const char* OrderByArray = OrderByString.data();
 
-    CDataLoader          PDataLoader;
-    std::vector<ahItem*> ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
+    const CDataLoader                    PDataLoader;
+    const std::vector<AuctionHouseItem*> ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
 
-    uint8 PacketsCount = (uint8)((ItemList.size() / 20) + (ItemList.size() % 20 != 0) + (ItemList.empty()));
+    const uint8 PacketsCount = static_cast<uint8>((ItemList.size() / 20) + (ItemList.size() % 20 != 0) + (ItemList.empty()));
 
     for (uint8 i = 0; i < PacketsCount; ++i)
     {
         CAHItemsListPacket PAHPacket(20 * i);
-        uint16             itemListSize = static_cast<uint16>(ItemList.size());
+        const uint16       itemListSize = static_cast<uint16>(ItemList.size());
 
         PAHPacket.SetItemCount(itemListSize);
 
@@ -507,7 +508,7 @@ void SearchHandler::HandleAuctionHouseRequest()
         }
 
         uint16_t length = PAHPacket.GetSize();
-        DebugPrintPacket((char*)PAHPacket.GetData(), length);
+        DebugPrintPacket(PAHPacket.GetData(), length);
 
         searchPackets_.emplace_back(PAHPacket.GetData(), length);
     }
@@ -515,31 +516,31 @@ void SearchHandler::HandleAuctionHouseRequest()
 
 void SearchHandler::HandleAuctionHouseHistory()
 {
-    uint16 ItemID = ref<uint16>(buffer_.data(), 0x12);
-    uint8  stack  = ref<uint8>(buffer_.data(), 0x15);
+    const uint16 ItemID = ref<uint16>(buffer_.data(), 0x12);
+    const uint8  stack  = ref<uint8>(buffer_.data(), 0x15);
 
-    CDataLoader             PDataLoader;
-    std::vector<ahHistory*> HistoryList = PDataLoader.GetAHItemHistory(ItemID, stack != 0);
-    ahItem                  item        = PDataLoader.GetAHItemFromItemID(ItemID);
+    const CDataLoader                       PDataLoader;
+    const std::vector<AuctionHouseHistory*> HistoryList = PDataLoader.GetAHItemHistory(ItemID, stack != 0);
+    const AuctionHouseItem                  item        = PDataLoader.GetAHItemFromItemID(ItemID);
 
     CAHHistoryPacket PAHPacket = CAHHistoryPacket(item, stack);
 
-    for (auto& i : HistoryList)
+    for (const auto& i : HistoryList)
     {
         PAHPacket.AddItem(i);
     }
 
     uint16_t length = PAHPacket.GetSize();
 
-    DebugPrintPacket((char*)PAHPacket.GetData(), length);
+    DebugPrintPacket(PAHPacket.GetData(), length);
     searchPackets_.emplace_back(PAHPacket.GetData(), length);
 }
 
-search_req SearchHandler::_HandleSearchRequest()
+auto SearchHandler::_HandleSearchRequest() -> SearchRequest
 {
     // This function constructs a `search_req` based on which query should be sent to the database.
     // The results from the database will eventually be sent to the client.
-    search_req sr;
+    SearchRequest sr;
 
     uint32 bitOffset = 0;
 
@@ -578,26 +579,26 @@ search_req SearchHandler::_HandleSearchRequest()
             break;
         }
 
-        uint8 EntryType = (uint8)unpackBitsLE(&buffer_[0x11], bitOffset, 5);
+        const auto EntryType = static_cast<SearchType>(unpackBitsLE(&buffer_[0x11], bitOffset, 5));
         bitOffset += 5;
 
-        if ((EntryType != SEARCH_FRIEND) && (EntryType != SEARCH_LINKSHELL) && (EntryType != SEARCH_LINKSHELL2) && (EntryType != SEARCH_COMMENT) && (EntryType != SEARCH_FLAGS2))
+        if ((EntryType != SearchType::Friend) && (EntryType != SearchType::Linkshell) && (EntryType != SearchType::Linkshell2) && (EntryType != SearchType::Comment) && (EntryType != SearchType::Flags2))
         {
             if ((bitOffset + 3) >= workloadBits) // so 0000000 at the end does not get interpreted as name entry
             {
                 bitOffset = workloadBits;
                 break;
             }
-            sortDescending = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 1);
+            sortDescending = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 1));
             bitOffset += 1;
 
-            isPresent = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 1);
+            isPresent = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 1));
             bitOffset += 1;
         }
 
         switch (EntryType)
         {
-            case SEARCH_NAME:
+            case SearchType::Name:
             {
                 if (isPresent == 0x1) // Name send
                 {
@@ -606,20 +607,20 @@ search_req SearchHandler::_HandleSearchRequest()
                         bitOffset = workloadBits;
                         break;
                     }
-                    nameLen       = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 5);
+                    nameLen       = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 5));
                     name[nameLen] = '\0';
 
                     bitOffset += 5;
 
                     for (unsigned char i = 0; i < nameLen; i++)
                     {
-                        name[i] = (char)unpackBitsLE(&buffer_[0x11], bitOffset, 7);
+                        name[i] = static_cast<char>(unpackBitsLE(&buffer_[0x11], bitOffset, 7));
                         bitOffset += 7;
                     }
                 }
                 break;
             }
-            case SEARCH_AREA: // Area Code Entry - 10 bit
+            case SearchType::Area: // Area Code Entry - 10 bit
             {
                 if (isPresent == 0) // no more Area entries
                 {
@@ -627,17 +628,17 @@ search_req SearchHandler::_HandleSearchRequest()
                 }
                 else // 8 Bit = 1 Byte per Area Code
                 {
-                    areas[areaCount] = (uint16)unpackBitsLE(&buffer_[0x11], bitOffset, 10);
+                    areas[areaCount] = static_cast<uint16>(unpackBitsLE(&buffer_[0x11], bitOffset, 10));
                     areaCount++;
                     bitOffset += 10;
                 }
                 break;
             }
-            case SEARCH_NATION: // Country - 2 bit
+            case SearchType::Nation: // Country - 2 bit
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned char country = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 2);
+                    unsigned char country = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 2));
                     bitOffset += 2;
                     nationid = country;
 
@@ -645,34 +646,34 @@ search_req SearchHandler::_HandleSearchRequest()
                 }
                 break;
             }
-            case SEARCH_JOB: // Job - 5 bit
+            case SearchType::Job: // Job - 5 bit
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned char job = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 5);
+                    unsigned char job = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 5));
                     bitOffset += 5;
                     jobid = job;
                 }
                 break;
             }
-            case SEARCH_LEVEL: // Level- 16 bit
+            case SearchType::Level: // Level- 16 bit
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned char fromLvl = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 8);
+                    unsigned char fromLvl = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 8));
                     bitOffset += 8;
-                    unsigned char toLvl = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 8);
+                    unsigned char toLvl = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 8));
                     bitOffset += 8;
                     minLvl = fromLvl;
                     maxLvl = toLvl;
                 }
                 break;
             }
-            case SEARCH_RACE: // Race - 4 bit
+            case SearchType::Race: // Race - 4 bit
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned char race = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 4);
+                    unsigned char race = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 4));
                     bitOffset += 4;
                     raceid = race;
 
@@ -681,14 +682,14 @@ search_req SearchHandler::_HandleSearchRequest()
                 ShowInfoFmt("SortByRace: {}.", (sortDescending == 0x00) ? "ascending" : "descending");
                 break;
             }
-            case SEARCH_RANK: // Rank - 2 byte
+            case SearchType::Rank: // Rank - 2 byte
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned char fromRank = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 8);
+                    unsigned char fromRank = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 8));
                     bitOffset += 8;
                     minRank              = fromRank;
-                    unsigned char toRank = (unsigned char)unpackBitsLE(&buffer_[0x11], bitOffset, 8);
+                    unsigned char toRank = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 8));
                     bitOffset += 8;
                     maxRank = toRank;
 
@@ -697,9 +698,9 @@ search_req SearchHandler::_HandleSearchRequest()
                 ShowInfoFmt("SortByRank: {}.", (sortDescending == 0x00) ? "ascending" : "descending");
                 break;
             }
-            case SEARCH_COMMENT: // 4 Byte
+            case SearchType::Comment: // 4 Byte
             {
-                commentType = (uint8)unpackBitsLE(&buffer_[0x11], bitOffset, 32);
+                commentType = static_cast<uint8>(unpackBitsLE(&buffer_[0x11], bitOffset, 32));
                 bitOffset += 32;
 
                 ShowInfoFmt("Comment Entry found. ({}).", hex8ToString(commentType));
@@ -707,7 +708,7 @@ search_req SearchHandler::_HandleSearchRequest()
             }
             // the following 4 Entries were generated with /sea (ballista|friend|linkshell|away|inv)
             // so they may be off
-            case SEARCH_LINKSHELL: // 4 Byte
+            case SearchType::Linkshell: // 4 Byte
             {
                 sr.lsId = static_cast<uint32>(unpackBitsLE(&buffer_[0x11], bitOffset, 32));
                 bitOffset += 32;
@@ -715,7 +716,7 @@ search_req SearchHandler::_HandleSearchRequest()
                 ShowInfoFmt("Linkshell Entry found. Value: {}", hex32ToString(sr.lsId.value()));
                 break;
             }
-            case SEARCH_LINKSHELL2: // 4 Byte
+            case SearchType::Linkshell2: // 4 Byte
             {
                 sr.lsId = static_cast<uint32>(unpackBitsLE(&buffer_[0x11], bitOffset, 32));
                 bitOffset += 32;
@@ -723,16 +724,16 @@ search_req SearchHandler::_HandleSearchRequest()
                 ShowInfoFmt("Linkshell2 Entry found. Value: {}", hex32ToString(sr.lsId.value()));
                 break;
             }
-            case SEARCH_FRIEND: // Friend Packet, 0 byte
+            case SearchType::Friend: // Friend Packet, 0 byte
             {
                 ShowInfoFmt("Friend Entry found.");
                 break;
             }
-            case SEARCH_FLAGS1: // Flag Entry #1, 2 byte,
+            case SearchType::Flags1: // Flag Entry #1, 2 byte,
             {
                 if (isPresent == 0x1)
                 {
-                    unsigned short flags1 = (unsigned short)unpackBitsLE(&buffer_[0x11], bitOffset, 16);
+                    unsigned short flags1 = static_cast<unsigned short>(unpackBitsLE(&buffer_[0x11], bitOffset, 16));
                     bitOffset += 16;
 
                     ShowInfoFmt("Flag Entry #1 ({}) found. Sorting: ({}).", hex16ToString(flags1), (sortDescending == 0x00) ? "ascending" : "descending");
@@ -742,9 +743,9 @@ search_req SearchHandler::_HandleSearchRequest()
                 ShowInfoFmt("SortByFlags: {}", (sortDescending == 0 ? "ascending" : "descending"));
                 break;
             }
-            case SEARCH_FLAGS2: // Flag Entry #2 - 4 byte
+            case SearchType::Flags2: // Flag Entry #2 - 4 byte
             {
-                unsigned int flags2 = (unsigned int)unpackBitsLE(&buffer_[0x11], bitOffset, 32);
+                unsigned int flags2 = static_cast<unsigned int>(unpackBitsLE(&buffer_[0x11], bitOffset, 32));
 
                 bitOffset += 32;
                 flags = flags2;
@@ -752,7 +753,7 @@ search_req SearchHandler::_HandleSearchRequest()
             }
             default:
             {
-                ShowInfoFmt("Unknown Search Param {}!", EntryType);
+                ShowInfoFmt("Unknown Search Param {}!", static_cast<uint8>(EntryType));
                 break;
             }
         }
@@ -784,7 +785,7 @@ search_req SearchHandler::_HandleSearchRequest()
     // For example: "/blacklist delete Name" and "/sea all Name"
 }
 
-uint16_t SearchHandler::getNumSessionsInUse(const std::string& ipAddressStr)
+auto SearchHandler::getNumSessionsInUse(const std::string& ipAddressStr) const -> uint16_t
 {
     DebugSocketsFmt("Checking if IP is in use: {}", ipAddressStr);
 
@@ -809,7 +810,7 @@ uint16_t SearchHandler::getNumSessionsInUse(const std::string& ipAddressStr)
         });
 }
 
-void SearchHandler::removeFromUsedIPAddresses(const std::string& ipAddressStr)
+void SearchHandler::removeFromUsedIPAddresses(const std::string& ipAddressStr) const
 {
     DebugSocketsFmt("Removing IP from active set: {}", ipAddressStr);
 
@@ -842,7 +843,7 @@ void SearchHandler::removeFromUsedIPAddresses(const std::string& ipAddressStr)
         });
 }
 
-void SearchHandler::addToUsedIPAddresses(const std::string& ipAddressStr)
+void SearchHandler::addToUsedIPAddresses(const std::string& ipAddressStr) const
 {
     DebugSocketsFmt("Adding IP to active set: {}", ipAddressStr);
 

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -28,6 +28,10 @@
 #include "data_loader.h"
 #include "enums/search_type.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+#include <iterator>
 #include <map>
 #include <unordered_set>
 
@@ -336,9 +340,16 @@ void SearchHandler::HandleGroupListRequest()
 
         CPartyListPacket PPartyPacket(partyid, static_cast<uint32>(PartyList.size()));
 
+        std::size_t membersSent = 0;
         for (const auto& player : PartyList)
         {
-            PPartyPacket.AddPlayer(player);
+            if (!PPartyPacket.AddPlayer(player))
+            {
+                ShowWarningFmt("Party list packet full, sent {} of {} members for party {}", membersSent, PartyList.size(), partyid);
+                break;
+            }
+
+            membersSent++;
         }
 
         uint16_t length = PPartyPacket.GetSize();
@@ -493,21 +504,23 @@ void SearchHandler::HandleAuctionHouseRequest()
     const CDataLoader PDataLoader;
     const auto        ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
 
-    const uint8 PacketsCount = static_cast<uint8>((ItemList.size() / 20) + (ItemList.size() % 20 != 0) + (ItemList.empty()));
+    const std::size_t itemListSize = ItemList.size();
+    const std::size_t PacketsCount = (itemListSize / 20) + (itemListSize % 20 != 0) + (itemListSize == 0);
 
-    for (uint8 i = 0; i < PacketsCount; ++i)
+    for (std::size_t i = 0; i < PacketsCount; ++i)
     {
-        CAHItemsListPacket PAHPacket(20 * i);
-        const uint16       itemListSize = static_cast<uint16>(ItemList.size());
+        const std::size_t firstItem = 20 * i;
 
-        PAHPacket.SetItemCount(itemListSize);
+        CAHItemsListPacket PAHPacket(static_cast<uint16>(firstItem));
 
-        for (uint16 y = 20 * i; (y != 20 * (i + 1)) && (y < itemListSize); ++y)
+        PAHPacket.SetItemCount(static_cast<uint16>(itemListSize));
+
+        for (std::size_t y = firstItem; (y < firstItem + 20) && (y < itemListSize); ++y)
         {
             PAHPacket.AddItem(ItemList.at(y));
         }
 
-        uint16_t length = PAHPacket.GetSize();
+        const uint16_t length = PAHPacket.GetSize();
         DebugPrintPacket(PAHPacket.GetData(), length);
 
         searchPackets_.emplace_back(PAHPacket.GetData(), length);
@@ -607,15 +620,22 @@ auto SearchHandler::_HandleSearchRequest() -> SearchRequest
                         bitOffset = workloadBits;
                         break;
                     }
-                    nameLen       = static_cast<unsigned char>(unpackBitsLE(&buffer_[0x11], bitOffset, 5));
-                    name[nameLen] = '\0';
-
+                    // 5-bit field (0-31) clamped to name's 15 chars; still consume every char
+                    const uint8 rawNameLen = static_cast<uint8>(unpackBitsLE(&buffer_[0x11], bitOffset, 5));
                     bitOffset += 5;
 
-                    for (unsigned char i = 0; i < nameLen; i++)
+                    nameLen       = std::min<uint8>(rawNameLen, sizeof(name) - 1);
+                    name[nameLen] = '\0';
+
+                    for (uint8 i = 0; i < rawNameLen; i++)
                     {
-                        name[i] = static_cast<char>(unpackBitsLE(&buffer_[0x11], bitOffset, 7));
+                        const auto nameChar = static_cast<char>(unpackBitsLE(&buffer_[0x11], bitOffset, 7));
                         bitOffset += 7;
+
+                        if (i < nameLen)
+                        {
+                            name[i] = nameChar;
+                        }
                     }
                 }
                 break;
@@ -628,9 +648,15 @@ auto SearchHandler::_HandleSearchRequest() -> SearchRequest
                 }
                 else // 8 Bit = 1 Byte per Area Code
                 {
-                    areas[areaCount] = static_cast<uint16>(unpackBitsLE(&buffer_[0x11], bitOffset, 10));
-                    areaCount++;
+                    const auto area = static_cast<uint16>(unpackBitsLE(&buffer_[0x11], bitOffset, 10));
                     bitOffset += 10;
+
+                    // client controls entry count; only store while areas[] has room
+                    if (areaCount < std::size(areas))
+                    {
+                        areas[areaCount] = area;
+                        areaCount++;
+                    }
                 }
                 break;
             }

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -332,13 +332,13 @@ void SearchHandler::HandleGroupListRequest()
 
     if (partyid != 0 || allianceid != 0)
     {
-        const std::list<SearchEntity*> PartyList = PDataLoader.GetPartyList(partyid, allianceid);
+        const auto PartyList = PDataLoader.GetPartyList(partyid, allianceid);
 
         CPartyListPacket PPartyPacket(partyid, static_cast<uint32>(PartyList.size()));
 
-        for (auto& it : PartyList)
+        for (const auto& player : PartyList)
         {
-            PPartyPacket.AddPlayer(it);
+            PPartyPacket.AddPlayer(player);
         }
 
         uint16_t length = PPartyPacket.GetSize();
@@ -348,15 +348,15 @@ void SearchHandler::HandleGroupListRequest()
     }
     else if (linkshellid1 != 0 || linkshellid2 != 0)
     {
-        const uint32             linkshellid   = linkshellid1 == 0 ? linkshellid2 : linkshellid1;
-        std::list<SearchEntity*> LinkshellList = PDataLoader.GetLinkshellList(linkshellid);
+        const uint32 linkshellid   = linkshellid1 == 0 ? linkshellid2 : linkshellid1;
+        const auto   LinkshellList = PDataLoader.GetLinkshellList(linkshellid);
 
         const uint32 totalResults  = static_cast<uint32>(LinkshellList.size());
         uint32       currentResult = 0;
 
         // Iterate through the linkshell list, splitting up the results into
         // smaller chunks.
-        std::list<SearchEntity*>::iterator it = LinkshellList.begin();
+        auto it = LinkshellList.begin();
 
         do
         {
@@ -414,7 +414,7 @@ void SearchHandler::HandleSearchRequest()
     const CDataLoader PDataLoader;
     int               totalCount = 0;
 
-    std::list<SearchEntity*> SearchList = PDataLoader.GetPlayersList(sr, &totalCount);
+    const auto SearchList = PDataLoader.GetPlayersList(sr, &totalCount);
 
     const uint32 totalResults  = static_cast<uint32>(SearchList.size());
     uint32       currentResult = 0;
@@ -490,8 +490,8 @@ void SearchHandler::HandleAuctionHouseRequest()
     OrderByString.append(" item_basic.itemid");
     const char* OrderByArray = OrderByString.data();
 
-    const CDataLoader                    PDataLoader;
-    const std::vector<AuctionHouseItem*> ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
+    const CDataLoader PDataLoader;
+    const auto        ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
 
     const uint8 PacketsCount = static_cast<uint8>((ItemList.size() / 20) + (ItemList.size() % 20 != 0) + (ItemList.empty()));
 
@@ -519,9 +519,9 @@ void SearchHandler::HandleAuctionHouseHistory()
     const uint16 ItemID = ref<uint16>(buffer_.data(), 0x12);
     const uint8  stack  = ref<uint8>(buffer_.data(), 0x15);
 
-    const CDataLoader                       PDataLoader;
-    const std::vector<AuctionHouseHistory*> HistoryList = PDataLoader.GetAHItemHistory(ItemID, stack != 0);
-    const AuctionHouseItem                  item        = PDataLoader.GetAHItemFromItemID(ItemID);
+    const CDataLoader      PDataLoader;
+    const auto             HistoryList = PDataLoader.GetAHItemHistory(ItemID, stack != 0);
+    const AuctionHouseItem item        = PDataLoader.GetAHItemFromItemID(ItemID);
 
     CAHHistoryPacket PAHPacket = CAHHistoryPacket(item, stack);
 

--- a/src/search/search_handler.h
+++ b/src/search/search_handler.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <asio/ts/buffer.hpp>
 #include <asio/ts/internet.hpp>
 #include <common/logging.h>
 #include <deque>
@@ -56,11 +55,11 @@ public:
 private:
     void read_func(uint16_t length);
 
-    uint16_t getNumSessionsInUse(const std::string& ipAddressStr);
-    void     addToUsedIPAddresses(const std::string& ipAddressStr);
-    void     removeFromUsedIPAddresses(const std::string& ipAddressStr);
+    auto getNumSessionsInUse(const std::string& ipAddressStr) const -> uint16_t;
+    void addToUsedIPAddresses(const std::string& ipAddressStr) const;
+    void removeFromUsedIPAddresses(const std::string& ipAddressStr) const;
 
-    bool validatePacket(uint16_t length);
+    auto validatePacket(uint16_t length) -> bool;
     void decrypt(uint16_t length);
     void encrypt(uint16_t length);
 
@@ -70,11 +69,11 @@ private:
     void HandleAuctionHouseRequest();
     void HandleAuctionHouseHistory();
 
-    auto _HandleSearchRequest() -> search_req;
+    auto _HandleSearchRequest() -> SearchRequest;
 
     Scheduler&               scheduler_;
     blowfish_t               blowfish_;
-    std::deque<searchPacket> searchPackets_;
+    std::deque<SearchPacket> searchPackets_;
 
     std::string             ipAddress_;
     asio::ip::tcp::socket   socket_;

--- a/src/search/search_listener.h
+++ b/src/search/search_listener.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <asio/ts/buffer.hpp>
 #include <asio/ts/internet.hpp>
 #include <common/logging.h>
 
@@ -31,7 +30,7 @@
 class SearchListener
 {
 public:
-    SearchListener(Scheduler& scheduler, unsigned int port, SynchronizedShared<std::unordered_set<std::string>>& ipWhitelist)
+    SearchListener(Scheduler& scheduler, const unsigned int port, SynchronizedShared<std::unordered_set<std::string>>& ipWhitelist)
     : scheduler_(scheduler)
     , acceptor_(scheduler_.mainContext(), asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port))
     , ipWhitelist_(ipWhitelist)
@@ -51,7 +50,7 @@ private:
 
             if (!ec)
             {
-                auto handler = std::make_shared<SearchHandler>(scheduler_, std::move(socket), ipInFlight_, ipWhitelist_);
+                const auto handler = std::make_shared<SearchHandler>(scheduler_, std::move(socket), ipInFlight_, ipWhitelist_);
                 scheduler_.postToMainThread(handler->run());
             }
             else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Lipstick on a pig:
- Usual codestyle suspects: trailing returns, const, C-style casts, renamed a few structs, moved the main enum to a class, SQL macros, pragma
- Get rid of new/destroy in favor of just moving the values into the vector. This closes a few existing memory leaks.
- Closes a few overflow vectors

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Do searches, use AH...
<!-- Clear and detailed steps to test your changes here -->
