### PR TITLE
[lua, sql] NM Respawn Times pt. 2

### DIFF
--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker_NM.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Bloodsucker_NM.lua
@@ -66,7 +66,7 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.GIL_MAX, 6000)
     mob:addImmunity(xi.immunity.TERROR)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(3600)
+    mob:setRespawnTime(3600) -- 1 hour
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)

--- a/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
+++ b/scripts/zones/Gusgen_Mines/mobs/Juggler_Hecatomb.lua
@@ -19,7 +19,7 @@ entity.spawnPoints =
 
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400)) -- 21 to 24 hours
+    mob:setRespawnTime(math.randomInt(3600, 7200)) -- 1 to 2 hours
 end
 
 entity.onMobInitialize = function(mob)

--- a/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
+++ b/scripts/zones/Ordelles_Caves/mobs/Morbolger.lua
@@ -61,7 +61,7 @@ entity.spawnPoints =
 
 entity.onMobInitialize = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400)) -- 21 to 24 hours
+    mob:setRespawnTime(math.randomInt(3600, 7200)) -- 1 to 2 hours
 
     mob:setMobMod(xi.mobMod.ALWAYS_AGGRO, 1) -- "Aggros regardless of level"
 end
@@ -74,7 +74,7 @@ end
 
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400)) -- 21 to 24 hours
+    mob:setRespawnTime(math.randomInt(3600, 7200)) -- 1 to 2 hours
 end
 
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -12148,7 +12148,7 @@ INSERT INTO `mob_groups` VALUES (20,233,167,'Arioch',0,32,2388,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (21,6393,167,'Bloodsucker',300,0,174,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (22,1505,167,'Gespenst',300,0,950,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (23,2548,167,'Manes',0,32,2879,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (24,5138,167,'Bloodsucker_NM',3600,0,2892,3400,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (24,5138,167,'Bloodsucker_NM',0,0,2892,3400,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (25,482,167,'Bodach',0,128,0,7500,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (26,6723,167,'Garbage_Gel',0,128,0,0,0,0,NULL);
 
@@ -13790,7 +13790,7 @@ INSERT INTO `mob_groups` VALUES (28,2783,196,'Myconid',300,0,1760,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (29,1329,196,'Feu_Follet',300,0,827,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (30,3912,196,'Thunder_Elemental',300,4,2412,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (31,1160,196,'Earth_Elemental',300,4,735,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (32,2165,196,'Juggler_Hecatomb',86400,0,1417,6950,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (32,2165,196,'Juggler_Hecatomb',0,0,1417,6950,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (33,3320,196,'Rancid_Ooze',300,0,2075,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (34,4943,196,'Gallinipper',300,0,926,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (35,113,196,'Amphisbaena',300,0,74,0,0,0,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts another set of NMs to have their retail accurate respawn timers. These are all left over relics from 75 cap era. This includes:

- Juggler Hecatomb - [JP wiki](https://wiki.ffo.jp/html/13250.html)
- Bloodsucker (this one is not changing, I just added a comment and confirmed the timer) - [patch notes](https://forum.square-enix.com/ffxi/threads/41813)
- Morbolger - [JP wiki](https://wiki.ffo.jp/html/5587.html)

## Steps to test these changes

!spawnmob the above and witness the shortened retail accurate timers.
