### PR TITLE
[lua, sql] Multiple NM Spawn Window Fixes

### DIFF
--- a/scripts/zones/Bostaunieux_Oubliette/Zone.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/Zone.lua
@@ -51,15 +51,4 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
-zoneObject.onGameHour = function(zone)
-    -- Don't allow Manes or Shii to spawn outside of night
-    if VanadielHour() >= 6 and VanadielHour() < 18 then
-        DisallowRespawn(ID.mob.MANES, true)
-        DisallowRespawn(ID.mob.SHII, true)
-    else
-        DisallowRespawn(ID.mob.MANES, false)
-        DisallowRespawn(ID.mob.SHII, false)
-    end
-end
-
 return zoneObject

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Manes.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Manes.lua
@@ -18,7 +18,8 @@ entity.phList =
     [ID.mob.MANES + 6] = ID.mob.MANES, -- Confirmed on retail
 }
 
-entity.onMobInitialize = function(mob)
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar('killed', 0)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
@@ -26,14 +27,21 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TERROR)
 end
 
-entity.onMobRoam = function(mob)
-    if VanadielHour() >= 6 and VanadielHour() < 18 then -- Despawn if its day
-        DespawnMob(mob:getID())
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        mob:setLocalVar('killed', 1)
     end
+
+    xi.hunts.checkHunt(mob, player, 180)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 180)
+entity.onMobDespawn = function(mob)
+    -- Only a kill starts the lottery cooldown. A natural despawn at the end of
+    -- the spawn window skips it, so placeholders can pop the NM again the same
+    -- or next night.
+    if mob:getLocalVar('killed') == 0 then
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+    end
 end
 
 return entity

--- a/scripts/zones/Bostaunieux_Oubliette/mobs/Shii.lua
+++ b/scripts/zones/Bostaunieux_Oubliette/mobs/Shii.lua
@@ -67,23 +67,31 @@ entity.phList =
     [ID.mob.SHII - 5]  = ID.mob.SHII, -- Confirmed on retail
 }
 
-entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1) -- "has an Additional Effect: Terror in melee attacks"
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar('killed', 0)
     mob:setMod(xi.mod.REGEN, 20) -- "also has an Auto Regen of medium strength" (guessing 20)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1) -- "has an Additional Effect: Terror in melee attacks"
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
     return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TERROR)
 end
 
-entity.onMobRoam = function(mob)
-    if VanadielHour() >= 6 and VanadielHour() < 18 then -- Despawn if its day
-        DespawnMob(mob:getID())
+entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        mob:setLocalVar('killed', 1)
     end
+
+    xi.hunts.checkHunt(mob, player, 179)
 end
 
-entity.onMobDeath = function(mob, player, optParams)
-    xi.hunts.checkHunt(mob, player, 179)
+entity.onMobDespawn = function(mob)
+    -- Only a kill starts the lottery cooldown. A natural despawn at the end of
+    -- the spawn window skips it, so placeholders can pop the NM again the same
+    -- or next night.
+    if mob:getLocalVar('killed') == 0 then
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+    end
 end
 
 return entity

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -1,7 +1,6 @@
 -----------------------------------
 -- Zone: Buburimu_Peninsula (118)
 -----------------------------------
-local ID = zones[xi.zone.BUBURIMU_PENINSULA]
 require('scripts/missions/amk/helpers')
 -----------------------------------
 ---@type TZone
@@ -43,25 +42,6 @@ zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranki
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
-end
-
-zoneObject.onGameHour = function(zone)
-    local hour = VanadielHour()
-    local nmBackoo = GetMobByID(ID.mob.BACKOO)
-
-    if nmBackoo then
-        if hour == 6 then -- backoo time-of-day pop condition open
-            DisallowRespawn(ID.mob.BACKOO, false)
-            if nmBackoo:getRespawnTime() == 0 then
-                nmBackoo:setRespawnTime(1)
-            end
-        elseif hour == 16 then -- backoo despawns
-            DisallowRespawn(ID.mob.BACKOO, true)
-            if nmBackoo:isSpawned() then
-                nmBackoo:spawn(1)
-            end
-        end
-    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Buburimu_Peninsula/mobs/Backoo.lua
+++ b/scripts/zones/Buburimu_Peninsula/mobs/Backoo.lua
@@ -7,16 +7,14 @@
 local entity = {}
 
 entity.onMobInitialize = function(mob)
-    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
+end
 
-    local hour = VanadielHour()
-    if hour >= 6 and hour < 16 then
-        DisallowRespawn(mob:getID(), false)
-    end
+entity.onMobSpawn = function(mob)
+    mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
 entity.onAdditionalEffect = function(mob, target, damage)
@@ -28,7 +26,9 @@ entity.onMobDeath = function(mob, player, optParams)
 end
 
 entity.onMobDespawn = function(mob)
-    mob:setRespawnTime(math.randomInt(3600, 5400)) -- 60-90 minute respawn, depending on if it's daytime
+    -- 60-90 minute respawn. The spawn window holds a repop that lands past
+    -- 16:00 until the next morning.
+    mob:setRespawnTime(math.randomInt(3600, 5400))
 end
 
 return entity

--- a/scripts/zones/Rolanberry_Fields/mobs/Black_Triple_Stars.lua
+++ b/scripts/zones/Rolanberry_Fields/mobs/Black_Triple_Stars.lua
@@ -30,19 +30,28 @@ entity.phList =
     [ID.mob.BLACK_TRIPLE_STARS[2] - 4] = ID.mob.BLACK_TRIPLE_STARS[2], -- Confirmed on retail (south)
 }
 
-entity.onMobRoam = function(mob)
-    if VanadielHour() >= 6 and VanadielHour() < 18 then -- Despawn if its day
-        DespawnMob(mob:getID())
-    end
+entity.onMobSpawn = function(mob)
+    mob:setLocalVar('killed', 0)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
+    if optParams.isKiller or optParams.noKiller then
+        mob:setLocalVar('killed', 1)
+    end
+
     xi.magian.onMobDeath(mob, player, optParams, set{ 3 })
     xi.hunts.checkHunt(mob, player, 215)
 end
 
 entity.onMobDespawn = function(mob)
     xi.mob.updateNMSpawnPoint(mob)
+
+    -- Only a kill starts the lottery cooldown. A natural despawn at the end of
+    -- the spawn window skips it, so placeholders can pop the NM again the same
+    -- or next night.
+    if mob:getLocalVar('killed') == 0 then
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+    end
 end
 
 return entity

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -8999,7 +8999,7 @@ INSERT INTO `mob_groups` VALUES (51,3148,118,'Pixie',0,128,2001,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (52,2213,118,'Ketos',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (53,4734,118,'Botulus_Rex',0,128,0,0,9999,0,NULL);
 INSERT INTO `mob_groups` VALUES (54,1642,118,'Goblin_Bounty_Hunter',300,0,1030,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (55,5344,118,'Backoo',0,128,3140,2700,0,0,'WOTG');
+INSERT INTO `mob_groups` VALUES (55,5344,118,'Backoo',0,0,3140,2700,0,0,'WOTG');
 INSERT INTO `mob_groups` VALUES (56,3608,118,'Shoal_Pugil',300,0,248,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (57,5733,118,'Snipper',300,0,482,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (58,4853,118,'Abyssdiver',0,128,0,0,0,0,NULL);

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -40796,7 +40796,7 @@ INSERT INTO `mob_spawn_points` VALUES (17227968,0,'Midnight_Wings','Midnight Win
 INSERT INTO `mob_spawn_points` VALUES (17227969,0,'Midnight_Wings','Midnight Wings',21,22,23,5.551,-15.261,-175.506,127,20,6);
 INSERT INTO `mob_spawn_points` VALUES (17227970,0,'Midnight_Wings','Midnight Wings',21,22,23,42.119,-15.519,-174.449,127,19,5);
 INSERT INTO `mob_spawn_points` VALUES (17227971,0,'Midnight_Wings','Midnight Wings',21,22,23,-8.722,-15.518,-183.142,127,18,4);
-INSERT INTO `mob_spawn_points` VALUES (17227972,0,'Black_Triple_Stars','Black Triple Stars',31,26,27,5.000,-15.000,-142.000,127,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17227972,0,'Black_Triple_Stars','Black Triple Stars',31,26,27,5.000,-15.000,-142.000,127,18,6);
 INSERT INTO `mob_spawn_points` VALUES (17227973,0,'Goblin_Mugger','Goblin Mugger',22,26,27,-66.749,-8.112,-177.084,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17227974,13,'Goblin_Pathfinder','Goblin Pathfinder',23,31,32,-89.561,-7.541,-194.824,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17227975,0,'Goblins_Bee','Goblin\'s Bee',24,23,25,1.000,1.000,1.000,0,NULL,NULL);
@@ -40816,7 +40816,7 @@ INSERT INTO `mob_spawn_points` VALUES (17227988,0,'Midnight_Wings','Midnight Win
 INSERT INTO `mob_spawn_points` VALUES (17227989,0,'Midnight_Wings','Midnight Wings',21,22,23,81.784,-15.991,-310.662,108,19,5);
 INSERT INTO `mob_spawn_points` VALUES (17227990,0,'Midnight_Wings','Midnight Wings',21,22,23,47.666,-15.005,-212.265,45,18,4);
 INSERT INTO `mob_spawn_points` VALUES (17227991,0,'Midnight_Wings','Midnight Wings',21,22,23,83.638,-15.754,-296.826,30,20,6);
-INSERT INTO `mob_spawn_points` VALUES (17227992,0,'Black_Triple_Stars','Black Triple Stars',31,26,27,76.000,-15.000,-209.000,127,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17227992,0,'Black_Triple_Stars','Black Triple Stars',31,26,27,76.000,-15.000,-209.000,127,18,6);
 INSERT INTO `mob_spawn_points` VALUES (17227993,0,'Berry_Grub','Berry Grub',10,27,28,48.333,-24.076,-127.291,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17227994,0,'Berry_Grub','Berry Grub',10,27,28,119.000,-24.000,-284.000,58,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17227995,0,'Berry_Grub','Berry Grub',10,27,28,259.110,-31.674,-225.993,127,NULL,NULL);
@@ -44200,7 +44200,7 @@ INSERT INTO `mob_spawn_points` VALUES (17260609,6,'Zombie','Zombie',12,20,21,-42
 INSERT INTO `mob_spawn_points` VALUES (17260610,7,'Zombie','Zombie',12,20,21,-482.997,-16.383,-223.502,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17260611,8,'Ghoul','Ghoul',13,20,21,-361.735,-8.500,-202.387,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17260612,0,'Will-o-the-Wisp','Will-o\'-the-Wisp',14,25,27,-444.580,-8.890,-189.219,217,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17260613,0,'Backoo','Backoo',55,37,37,-409.210,-7.740,-219.861,227,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17260613,0,'Backoo','Backoo',55,37,37,-409.210,-7.740,-219.861,227,6,16);
 INSERT INTO `mob_spawn_points` VALUES (17260614,0,'Bogy','Bogy',15,23,24,-357.743,-0.392,-322.516,55,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17260615,0,'Bogy','Bogy',15,23,24,-359.172,-0.142,-325.244,127,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17260616,9,'Goblin_Ambusher','Goblin Ambusher',9,18,19,-194.742,-9.064,-84.503,21,NULL,NULL);
@@ -63134,7 +63134,7 @@ INSERT INTO `mob_spawn_points` VALUES (17461311,0,'Garm','Garm',8,64,66,-64.503,
 INSERT INTO `mob_spawn_points` VALUES (17461312,0,'Garm','Garm',8,64,66,-67.164,-0.003,-137.894,222,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461313,0,'Garm','Garm',8,64,66,-59.881,0.033,-149.115,34,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461314,1,'Garm','Garm',8,64,66,-64.340,0.010,-145.718,126,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17461315,0,'Shii','Shii',12,70,71,-58.681,-0.500,-134.123,31,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17461315,0,'Shii','Shii',12,70,71,-58.681,-0.500,-134.123,31,18,6);
 INSERT INTO `mob_spawn_points` VALUES (17461316,0,'Funnel_Bats','Funnel Bats',4,52,55,-94.299,0.016,-182.361,60,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461317,0,'Dark_Aspic','Dark Aspic',9,52,54,-95.255,0.949,-178.594,243,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461318,0,'Funnel_Bats','Funnel Bats',4,52,55,-61.474,0.559,-162.786,220,NULL,NULL);
@@ -63290,7 +63290,7 @@ INSERT INTO `mob_spawn_points` VALUES (17461467,0,'Bloodsucker','Bloodsucker',21
 INSERT INTO `mob_spawn_points` VALUES (17461468,0,'Bloodsucker','Bloodsucker',21,65,68,-58.546,17.000,-159.800,63,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461469,0,'Gespenst','Gespenst',28,68,70,-54.623,16.999,-146.783,84,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461470,2,'Gespenst','Gespenst',28,68,70,-40.852,16.996,-178.257,39,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17461471,0,'Manes','Manes',23,72,73,-60.400,17.000,-138.000,60,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17461471,0,'Manes','Manes',23,72,73,-60.400,17.000,-138.000,60,18,6);
 INSERT INTO `mob_spawn_points` VALUES (17461472,0,'Bloodsucker','Bloodsucker',21,65,68,-17.073,16.985,-142.532,22,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461473,0,'Bloodsucker','Bloodsucker',21,65,68,-16.466,16.923,-156.272,61,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17461474,0,'Bloodsucker','Bloodsucker',21,65,68,-6.624,16.955,-139.502,204,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This pull request fixes bugs with multiple NMs that can only spawn during certain periods of the day. It essentially takes the model from this PR https://github.com/LandSandBoat/server/pull/10850 and applies it where relevant to fix the same bugs with Shii, Manes, and Backoo.

## Steps to test these changes

!spawnmob Shii, Manes or Backoo and witness they no longer can respawn repeatedly after being killed.
