### PR TITLE
[lua] Add missing title to BLU AF1 Quest Beginnings

### DIFF
--- a/scripts/quests/ahtUrhgan/BLU_AF1_Beginnings.lua
+++ b/scripts/quests/ahtUrhgan/BLU_AF1_Beginnings.lua
@@ -16,7 +16,8 @@ local quest = Quest:new(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS
 
 quest.reward =
 {
-    item = xi.item.IMMORTALS_SCIMITAR,
+    item  = xi.item.IMMORTALS_SCIMITAR,
+    title = xi.title.BRANDED_BY_THE_FIVE_SERPENTS,
 }
 
 local brandKeyItems =


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds the missing title that should be rewarded for completing Beginnings.

https://wiki.ffo.jp/html/3309.html

## Steps to test these changes

Complete the quest, receive title.
