### PR TITLE
[lua] Adjust Crimson-toothed Pawberry's Astral Flow behavior

### DIFF
--- a/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
+++ b/scripts/zones/Temple_of_Uggalepih/mobs/Crimson-toothed_Pawberry.lua
@@ -2,11 +2,7 @@
 -- Area: Temple of Uggalepih
 --   NM: Crimson-toothed Pawberry
 -----------------------------------
-mixins =
-{
-    require('scripts/mixins/families/tonberry'),
-    require('scripts/mixins/job_special')
-}
+mixins = { require('scripts/mixins/families/tonberry') }
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
@@ -28,7 +24,31 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:useMobAbility(xi.mobSkill.ASTRAL_FLOW_1)
+    mob:setLocalVar('[2hour]HPP', math.randomInt(40, 50))
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+end
+
+entity.onMobFight = function(mob, target)
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
+    if mob:getHPP() >= mob:getLocalVar('[2hour]HPP') then
+        return
+    end
+
+    local currentTime = GetSystemTime()
+    if mob:getLocalVar('[2hour]Time') == 0 then
+        mob:setLocalVar('[2hour]Time', currentTime)
+    end
+
+    if currentTime < mob:getLocalVar('[2hour]Time') then
+        return
+    end
+
+    -- Handle 2 Hour
+    mob:useMobAbility(xi.mobSkill.ASTRAL_FLOW_1)
+    mob:setLocalVar('[2hour]Time', currentTime + 60)
 end
 
 entity.onMobDeath = function(mob, player, optParams)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the astral flow behavior of Crimson-toothed Pawberry to reuse the ability every 60 seconds after the initial hpp trigger.

https://youtu.be/rCrpwaxnZdg

## Steps to test these changes

Fight the Pawberry.
