### PR TITLE
[lua] Sanction Bugfixes

### DIFF
--- a/scripts/globals/besieged.lua
+++ b/scripts/globals/besieged.lua
@@ -215,9 +215,15 @@ xi.besieged.onEventFinish = function(player, csid, option, npc)
     local imperialStanding = player:getCurrency('imperial_standing')
     local mercenaryRank    = xi.besieged.getMercenaryRank(player)
 
+    -- Must have completed ToAU Mission 2.
+    if mercenaryRank == 0 then
+        return
+    end
+
     -- Sanction
     if option == 0 or option == 16 or option == 32 or option == 48 then
         local sanctionCost = 100
+
         if option == 0 then
             sanctionCost = 0
         end
@@ -229,7 +235,7 @@ xi.besieged.onEventFinish = function(player, csid, option, npc)
         local duration = getSanctionDuration(player)
         local subPower = 0 -- getImperialDefenseStats()
 
-        player:delCurrency('imperial_standing', 100)
+        player:delCurrency('imperial_standing', sanctionCost)
         player:delStatusEffectsByFlag(xi.effectFlag.INFLUENCE, true)
         player:addStatusEffect(xi.effect.SANCTION, { power = option / 16, duration = duration, origin = player, subType = subPower })
         player:messageSpecial(ID.text.SANCTION)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes two Sanction related bugs. 

1) Sanction could be picked up by brand new characters without completing mission 2. 
<img width="507" height="49" alt="image" src="https://github.com/user-attachments/assets/a8a3f34e-147e-4f13-8fb3-16b6504dc523" />

2) Sanction deducted 100 ISP even without selecting an additional bonus.

* Sanction now requires a mercenary rank of 1 or higher to access.

* ISP is now only deducted when choosing an additional Sanction bonus. 

## Steps to test these changes

Head to Whitegate on a new character, see you can no longer get Sanction

Complete ToAU mission 2, choose Sanction, don't get 100 ISP deducted. 
