### PR TITLE
[lua] Fix Gration Ready time / Add Flavor Text to Dried Up Fountain

### DIFF
--- a/scripts/zones/FeiYin/IDs.lua
+++ b/scripts/zones/FeiYin/IDs.lua
@@ -22,6 +22,7 @@ zones[xi.zone.FEIYIN] =
         MEMBERS_LEVELS_ARE_RESTRICTED      = 7206,  -- Your party is unable to participate because certain members' levels are restricted.
         FISHING_MESSAGE_OFFSET             = 7251,  -- You can't fish here.
         CHEST_UNLOCKED                     = 7383,  -- You unlock the chest!
+        DRIED_UP_FOUNTAIN                  = 7391,  -- There is a dried up fountain here.
         YOU_FIND_NOTHING                   = 7422,  -- You find nothing.
         EVIL_PRESENCE                      = 7423,  -- You feel a conspicuously evil presence.
         SOUL_OF_TAVNAZIA                   = 7424,  -- You are able to make out the blurred letters. The soul of Tavnazia will never perish.

--- a/scripts/zones/FeiYin/npcs/Dry_Fountain.lua
+++ b/scripts/zones/FeiYin/npcs/Dry_Fountain.lua
@@ -21,7 +21,7 @@ entity.onTrade = function(player, npc, trade)
 end
 
 entity.onTrigger = function(player, npc)
-    player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
+    player:messageSpecial(ID.text.DRIED_UP_FOUNTAIN)
 end
 
 entity.onEventFinish = function(player, csid, option, npc)

--- a/scripts/zones/Misareaux_Coast/mobs/Gration.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Gration.lua
@@ -56,9 +56,9 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
     return skillList[math.randomInt(1, #skillList)]
 end
 
--- All of Grations TP Moves have 0 Ready Time
+-- All of Grations TP Moves have 20ms Ready Time
 entity.onMobSkillReadyTime = function(mob, target, skill)
-    return 0
+    return 20
 end
 
 -- If Gration was spawned with a Picaroon's Shield, Power Attack repeats 2 additional times, otherwise only 1 additional time.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Minor fix, but sets Gration ready time to 20ms instead of 0ms so it produces a "readies" message and ready spikes. 

Also fixes a Fountain we were missing flavor text for I found while doing a BST AF quest.

## Captures
Gration:
https://youtu.be/UhUFH4RA_00?t=558

Fountain:
<img width="603" height="84" alt="image" src="https://github.com/user-attachments/assets/bdf0a243-8080-4d88-92a7-941fb1559a1c" />



## Steps to test these changes
Fight Gration, click the fountain in Fei'Yin
