### PR TITLE
[docker,alpine] Use GCC for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,8 @@ jobs:
           #   publish: false
           - build_type: Release
             os: alpine
-            compiler: clang
-            compiler_version: 22
+            compiler: gcc
+            compiler_version: 15
             clang_format_version: 22
             tracy: false
             build_modules: false

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -127,6 +127,7 @@ if [[ $COMPILER == clang* || $ENABLE_CLANG_TIDY == ON ]]; then
         clang$LLVM_VERSION \
         clang$LLVM_VERSION-extra-tools \
         compiler-rt \
+        lld$LLVM_VERSION \
         llvm$LLVM_VERSION
     apk cache clean
 fi
@@ -162,6 +163,7 @@ cp -p /xiadmin/build/xi_* /server/ 2> /dev/null || true
 if [[ $COMPILER == clang* || $ENABLE_CLANG_TIDY == ON ]]; then
     export CC=/usr/bin/clang-$LLVM_VERSION
     export CXX=/usr/bin/clang++-$LLVM_VERSION
+    export LDFLAGS="-fuse-ld=lld"
 fi
 
 cmake -G Ninja -S /server -B /xiadmin/build --fresh \


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Works around failing Alpine build. Something wrong with Clang+LD in Release mode. Adds LLD for Alpine Clang builds, but GCC seems faster and it's a simple switch.

## Steps to test these changes

Build Alpine image successfully in Release mode.
