### PR TITLE
[lua] Fix Garlaige Incinerator Door

### DIFF
--- a/scripts/zones/Garlaige_Citadel/IDs.lua
+++ b/scripts/zones/Garlaige_Citadel/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.GARLAIGE_CITADEL] =
         SPARKLING_LIGHT               = 7282,  -- The ground is sparkling with a strange light.
         A_GATE_OF_STURDY_STEEL        = 7294,  -- A gate of sturdy steel.
         OPEN_WITH_THE_RIGHT_KEY       = 7300,  -- You might be able to open it with the right key.
+        GARLAIGE_KEY_BROKE            = 7301,  -- The <item> broke...
         BANISHING_GATES               = 7309,  -- The first banishing gate begins to open...
         BANISHING_GATES_CLOSING       = 7312,  -- The first banishing gate starts to close.
         YOU_FIND_NOTHING              = 7316,  -- You find nothing special.

--- a/scripts/zones/Garlaige_Citadel/npcs/_5kr.lua
+++ b/scripts/zones/Garlaige_Citadel/npcs/_5kr.lua
@@ -10,10 +10,8 @@ local ID = zones[xi.zone.GARLAIGE_CITADEL]
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if
-        trade:hasItemQty(xi.item.GARLAIGE_KEY, 1) and
-        trade:getItemCount() == 1
-    then
+    if npcUtil.tradeMatches(trade, { { xi.item.GARLAIGE_KEY, 1 } }) then
+        player:messageSpecial(ID.text.GARLAIGE_KEY_BROKE, 0, xi.item.GARLAIGE_KEY)
         player:startEvent(4) -- Open the door
     end
 end
@@ -26,6 +24,12 @@ entity.onTrigger = function(player, npc)
         player:startEvent(5)
     else
         player:messageSpecial(ID.text.OPEN_WITH_THE_RIGHT_KEY)
+    end
+end
+
+entity.onEventFinish = function(player, csid, option, npc)
+    if csid == 4 then
+        player:tradeComplete()
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes the door that leads to the Incinerator in Garlaige to properly break the players key when used.

## Capture

https://youtu.be/gJmcA0jS9ok?si=NdmMySUrkjuha4L_&t=1119

## Steps to test these changes

!pos 139 -6 127 200
!additem Garlaige_Key
Trade it to the door, have it break 
