### PR TITLE
Core: Add navmesh filtering for specific zones

### DIFF
--- a/scripts/commands/rebuildnavmesh.lua
+++ b/scripts/commands/rebuildnavmesh.lua
@@ -128,6 +128,12 @@ local config =
 
     -- Remove walkable spans where the ceiling is lower than agentHeight.
     filterWalkableLowHeightSpans = true,
+
+    -- World-space Y planes to strip from the collision data before rasterization.
+    -- ySkipPlanes = { -60.0, 0.0, 60.0 },
+
+    -- World-space spheres to carve out of the collision data before rasterization.
+    -- skipSpheres = { { x = -496.0, y = -6.5, z = -9932914.5, radius = 100.0 } },
 }
 
 commandObj.onTrigger = function(player)

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -228,6 +228,31 @@ void CLuaZone::rebuildNavmesh(const sol::table& table)
     config.filterLedgeSpans             = table.get_or("filterLedgeSpans", config.filterLedgeSpans);
     config.filterWalkableLowHeightSpans = table.get_or("filterWalkableLowHeightSpans", config.filterWalkableLowHeightSpans);
 
+    if (const auto ySkipPlanes = table.get<sol::optional<sol::table>>("ySkipPlanes"))
+    {
+        for (const auto& [_, value] : *ySkipPlanes)
+        {
+            config.ySkipPlanes.push_back(value.as<float>());
+        }
+    }
+
+    if (const auto skipSpheres = table.get<sol::optional<sol::table>>("skipSpheres"))
+    {
+        for (const auto& [_, value] : *skipSpheres)
+        {
+            const auto sphere = value.as<sol::table>();
+
+            config.skipSpheres.push_back(NavMeshSkipSphere{
+                .center = {
+                    sphere.get_or("x", 0.0f),
+                    sphere.get_or("y", 0.0f),
+                    sphere.get_or("z", 0.0f),
+                },
+                .radius = sphere.get_or("radius", 0.0f),
+            });
+        }
+    }
+
     m_pLuaZone->RebuildNavMesh(config);
 }
 

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -268,6 +268,14 @@ auto MapEngine::init() -> Task<void>
         scheduler_.postToWorkerThread(watchdogWatcher());
     }
 
+    // If this was a "--rebuild-navmeshes" run, we're using xi_map more like a tool. So, bail
+    // out now.
+    if (config_.rebuildNavmeshes)
+    {
+        ShowInfo("Navmeshes rebuilt, exiting...");
+        std::exit(0);
+    }
+
 #ifdef TRACY_ENABLE
     ShowInfo("*** TRACY IS ENABLED ***");
 #endif // TRACY_ENABLE

--- a/src/map/navmesh/navmesh_builder.cpp
+++ b/src/map/navmesh/navmesh_builder.cpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <map>
 #include <unordered_set>
 
 namespace
@@ -47,6 +48,11 @@ constexpr int    DT_TOTAL_REF_BITS      = 22;     // dtNavMesh total bits for ti
 
 // FFXI dat format constant (not tunable)
 constexpr float XIMESH_CELL_SIZE = 4.0f; // Each ximesh grid cell covers 4x4 world units
+
+// A triangle counts as lying on a ySkipPlanes plane when all three vertex Ys are
+// within this distance of it. Phantom planes sit at exact values post-transform,
+// so this only needs to absorb float noise.
+constexpr float Y_SKIP_PLANE_TOLERANCE = 0.01f;
 
 constexpr std::size_t TILE_BATCH_SIZE = 32;
 
@@ -135,7 +141,89 @@ void NavMeshBuilder::getWorldBounds(float* bmin, float* bmax) const
     bmax[2] = worldBmax_[2];
 }
 
-void NavMeshBuilder::gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out) const
+// A triangle sits on a skip plane when all three vertices are within tolerance of it.
+// Requiring all three leaves sloped geometry that merely crosses the plane alone.
+auto NavMeshBuilder::onYSkipPlane(const float y0, const float y1, const float y2, const std::vector<float>& ySkipPlanes) -> bool
+{
+    return std::any_of(
+        ySkipPlanes.begin(),
+        ySkipPlanes.end(),
+        [&](const float plane)
+        {
+            return std::abs(y0 - plane) <= Y_SKIP_PLANE_TOLERANCE &&
+                   std::abs(y1 - plane) <= Y_SKIP_PLANE_TOLERANCE &&
+                   std::abs(y2 - plane) <= Y_SKIP_PLANE_TOLERANCE;
+        });
+}
+
+// A triangle is carved out when all three vertices fall inside a skip sphere.
+// Requiring all three leaves geometry that merely clips the sphere alone.
+auto NavMeshBuilder::insideSkipSphere(const float* v0, const float* v1, const float* v2, const std::vector<NavMeshSkipSphere>& skipSpheres) -> bool
+{
+    const auto contains = [](const NavMeshSkipSphere& sphere, const float* vertex)
+    {
+        const auto dx = vertex[0] - sphere.center[0];
+        const auto dy = vertex[1] - sphere.center[1];
+        const auto dz = vertex[2] - sphere.center[2];
+
+        const auto dx2 = dx * dx;
+        const auto dy2 = dy * dy;
+        const auto dz2 = dz * dz;
+
+        return (dx2 + dy2 + dz2) <= (sphere.radius * sphere.radius);
+    };
+
+    return std::any_of(
+        skipSpheres.begin(),
+        skipSpheres.end(),
+        [&](const NavMeshSkipSphere& sphere)
+        {
+            return contains(sphere, v0) && contains(sphere, v1) && contains(sphere, v2);
+        });
+}
+
+void NavMeshBuilder::getFilteredWorldBounds(const NavMeshConfig& config, float* bmin, float* bmax) const
+{
+    if (config.ySkipPlanes.empty() && config.skipSpheres.empty())
+    {
+        getWorldBounds(bmin, bmax);
+        return;
+    }
+
+    for (int axis = 0; axis < 3; ++axis)
+    {
+        bmin[axis] = FloatMax;
+        bmax[axis] = FloatLowest;
+    }
+
+    const auto& blocks = xiMesh_->blocks();
+
+    for (const auto& [key, ptb] : preTransformed_)
+    {
+        const auto& block = blocks[key >> 16];
+
+        for (std::size_t tri = 0; tri < block.metas.size(); ++tri)
+        {
+            const auto* v0 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 0]) * 3];
+            const auto* v1 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 1]) * 3];
+            const auto* v2 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 2]) * 3];
+
+            if (onYSkipPlane(v0[1], v1[1], v2[1], config.ySkipPlanes) ||
+                insideSkipSphere(v0, v1, v2, config.skipSpheres))
+            {
+                continue;
+            }
+
+            for (int axis = 0; axis < 3; ++axis)
+            {
+                bmin[axis] = std::min({ bmin[axis], v0[axis], v1[axis], v2[axis] });
+                bmax[axis] = std::max({ bmax[axis], v0[axis], v1[axis], v2[axis] });
+            }
+        }
+    }
+}
+
+void NavMeshBuilder::gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out, const std::vector<float>& ySkipPlanes, const std::vector<NavMeshSkipSphere>& skipSpheres) const
 {
     out.verts.clear();
     out.indices.clear();
@@ -185,6 +273,19 @@ void NavMeshBuilder::gatherTrianglesInAABB(const float* bmin, const float* bmax,
 
                 for (std::size_t tri = 0; tri < block.metas.size(); ++tri)
                 {
+                    if (!ySkipPlanes.empty() || !skipSpheres.empty())
+                    {
+                        const auto* v0 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 0]) * 3];
+                        const auto* v1 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 1]) * 3];
+                        const auto* v2 = &ptb.worldVerts[static_cast<std::size_t>(block.indices[tri * 3 + 2]) * 3];
+
+                        if (onYSkipPlane(v0[1], v1[1], v2[1], ySkipPlanes) ||
+                            insideSkipSphere(v0, v1, v2, skipSpheres))
+                        {
+                            continue;
+                        }
+                    }
+
                     const auto i0 = vertexBase + block.indices[tri * 3 + 0];
                     const auto i1 = vertexBase + block.indices[tri * 3 + 1];
                     const auto i2 = vertexBase + block.indices[tri * 3 + 2];
@@ -234,7 +335,7 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
     const float gatherBmax[3] = { expandedBmax[0], -expandedBmin[1], -expandedBmin[2] };
 
     GatheredMesh tileMesh;
-    gatherTrianglesInAABB(gatherBmin, gatherBmax, tileMesh);
+    gatherTrianglesInAABB(gatherBmin, gatherBmax, tileMesh, config.ySkipPlanes, config.skipSpheres);
     if (tileMesh.verts.empty())
     {
         return {};
@@ -475,7 +576,7 @@ auto NavMeshBuilder::buildAsync(Scheduler& scheduler, const std::string& zoneNam
 
     float worldBmin[3];
     float worldBmax[3];
-    getWorldBounds(worldBmin, worldBmax);
+    getFilteredWorldBounds(config, worldBmin, worldBmax);
 
     // No geometry was gathered (empty or null ximesh) - nothing to build.
     if (worldBmin[0] > worldBmax[0])

--- a/src/map/navmesh/navmesh_builder.h
+++ b/src/map/navmesh/navmesh_builder.h
@@ -73,12 +73,19 @@ public:
     explicit NavMeshBuilder(const IXiMesh& xiMesh);
 
     void getWorldBounds(float* bmin, float* bmax) const;
-    void gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out) const;
+
+    void getFilteredWorldBounds(const NavMeshConfig& config, float* bmin, float* bmax) const;
+
+    void gatherTrianglesInAABB(const float* bmin, const float* bmax, GatheredMesh& out, const std::vector<float>& ySkipPlanes = {}, const std::vector<NavMeshSkipSphere>& skipSpheres = {}) const;
+
     auto buildAsync(Scheduler& scheduler, const std::string& zoneName, uint16 zoneID, const NavMeshConfig& config) -> Task<dtNavMesh*>;
 
 private:
     auto buildTile(int tx, int ty, const rcConfig& cfg, const NavMeshConfig& config, float tileWorldSize) const -> TileResult;
     auto worldToCell(float x, float z) const -> CellCoord;
+
+    static auto onYSkipPlane(float y0, float y1, float y2, const std::vector<float>& ySkipPlanes) -> bool;
+    static auto insideSkipSphere(const float* v0, const float* v1, const float* v2, const std::vector<NavMeshSkipSphere>& skipSpheres) -> bool;
 
     struct PreTransformedBlock
     {

--- a/src/map/navmesh/navmesh_config.h
+++ b/src/map/navmesh/navmesh_config.h
@@ -21,6 +21,16 @@
 
 #pragma once
 
+#include <array>
+#include <vector>
+
+// A world-space sphere used to carve stray triangles out of the collision data.
+struct NavMeshSkipSphere
+{
+    std::array<float, 3> center{};
+    float                radius{};
+};
+
 struct NavMeshConfig
 {
     float cellSize{ 0.5f };               // Previous xiNavmeshes value: 0.4
@@ -41,4 +51,16 @@ struct NavMeshConfig
     bool filterLowHangingObstacles{ true };
     bool filterLedgeSpans{ true };
     bool filterWalkableLowHeightSpans{ true };
+
+    // World-space Y planes to strip from the gathered collision triangles. A triangle
+    // is discarded when all three vertices lie on one of these planes (within a small
+    // tolerance). Used to remove phantom collision planes from bad zone geometry;
+    // sloped or non-flat triangles near a listed Y are unaffected.
+    std::vector<float> ySkipPlanes{};
+
+    // World-space spheres to carve out of the gathered collision triangles. A triangle
+    // is discarded when all three vertices lie inside one of these spheres. Used to
+    // remove stray geometry parked far outside the playable area, which would otherwise
+    // inflate the world bounds and with them the tile grid.
+    std::vector<NavMeshSkipSphere> skipSpheres{};
 };

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -466,6 +466,63 @@ void CZone::LoadZoneSettings()
     }
 }
 
+namespace
+{
+
+// TODO: These should be baked into per-zone navmesh configs, and should be assumed to have been
+//     : already applied to the xiNavmeshes submodule repo.
+void applyZoneNavMeshOverrides(const xi::ZoneId zoneId, NavMeshConfig& config)
+{
+    // Ceizak Battlegrounds carries a small island of stray triangles parked around
+    // Z = -9932912, roughly ten million units outside a zone whose grid only covers
+    // +/- 640 x 600. Left in, it stretches the world bounds and with them the tile
+    // grid: 38x310421 tiles, nearly all empty, taking over three minutes to walk.
+    if (zoneId == xi::ZoneId::CeizakBattlegrounds && config.skipSpheres.empty())
+    {
+        config.skipSpheres = {
+            NavMeshSkipSphere{ .center = { -496.0f, -6.5f, -9932914.5f }, .radius = 100.0f },
+        };
+    }
+
+    // An explicitly-supplied list (e.g. from !rebuildnavmesh) wins over the
+    // per-zone defaults below.
+    if (!config.ySkipPlanes.empty())
+    {
+        return;
+    }
+
+    //
+    // For some reason, there are staggered flat planes below the regularly navigable areas.
+    // These were observed by hand, and then given these exceptions.
+    //
+
+    if (zoneId == xi::ZoneId::NewtonMovalpolos)
+    {
+        config.ySkipPlanes = { 48.0f, 52.0f, 56.0f };
+    }
+
+    if (zoneId == xi::ZoneId::OldtonMovalpolos)
+    {
+        config.ySkipPlanes = { 32.0f, 40.0f, 48.0f, 52.0f, 56.0f, 60.0f };
+    }
+
+    // Similar to above, all the Cloisters have big flat planes below the regular
+    // navigable areas. Cloisters are BCNM zones with 3x staggered copies of the
+    // arena, so the plane repeats at each copy's altitude.
+    const auto isCloister = zoneId == xi::ZoneId::CloisterOfFlames ||
+                            zoneId == xi::ZoneId::CloisterOfFrost ||
+                            zoneId == xi::ZoneId::CloisterOfGales ||
+                            zoneId == xi::ZoneId::CloisterOfStorms ||
+                            zoneId == xi::ZoneId::CloisterOfTides ||
+                            zoneId == xi::ZoneId::CloisterOfTremors;
+    if (isCloister)
+    {
+        config.ySkipPlanes = { -60.0f, 0.0f, 60.0f };
+    }
+}
+
+} // namespace
+
 auto CZone::LoadNavMesh() -> Task<void>
 {
     auto       navMesh = std::make_unique<CNavMesh>(static_cast<uint16>(GetID()));
@@ -479,7 +536,11 @@ auto CZone::LoadNavMesh() -> Task<void>
 
     NavMeshBuilder builder(*xiMesh_);
 
-    auto* dtNavMesh = co_await builder.buildAsync(scheduler_, getName(), static_cast<uint16>(GetID()), NavMeshConfig{});
+    auto config = NavMeshConfig{};
+
+    applyZoneNavMeshOverrides(GetID(), config);
+
+    auto* dtNavMesh = co_await builder.buildAsync(scheduler_, getName(), static_cast<uint16>(GetID()), config);
     if (dtNavMesh && navMesh->installNavMesh(dtNavMesh))
     {
         navMesh->save(file);
@@ -490,11 +551,14 @@ auto CZone::LoadNavMesh() -> Task<void>
     DebugNavmesh("CZone::LoadNavMesh: Build failed for zone (%s)", getName().c_str());
 }
 
-void CZone::RebuildNavMesh(const NavMeshConfig& config)
+void CZone::RebuildNavMesh(const NavMeshConfig& configIn)
 {
     const auto  zoneName  = getName();
     const auto  zoneID    = static_cast<uint16>(GetID());
     const auto* xiMeshPtr = xiMesh_.get();
+
+    auto config = configIn;
+    applyZoneNavMeshOverrides(GetID(), config);
 
     scheduler_.postToMainThread(
         [this, zoneName, zoneID, config, xiMeshPtr]() -> Task<void>


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Garbage in, garbage out. We feed the ximesh collision data to recast, and it poops out a navmesh for detour to use to create paths. In some zones, there are mysterious flat planes underneath the regular navigable area, which seem like they are sometimes getting in the way of regular navigation.

This PR adds some rules to cull them before we send triangles into recast, so the resulting navmeshes don't consider them.

Newton before (notice the planes on the ground):
<img width="3625" height="928" alt="image" src="https://github.com/user-attachments/assets/1da22831-f49b-4297-b5f6-413c591569c6" />

The cloister zones (notice the planes under each area):
<img width="1438" height="1294" alt="image" src="https://github.com/user-attachments/assets/26b7fb00-2bc3-4122-a96d-60597ed4c40e" />

Newton (after):
<img width="2205" height="975" alt="image" src="https://github.com/user-attachments/assets/67bbf5bd-d56f-49f7-bad3-b90404488a6c" />

Cloisters (after):
<img width="1888" height="1276" alt="image" src="https://github.com/user-attachments/assets/1f5cca6e-ed07-4bd7-80a9-9554cfde698a" />

This also makes the use of `--rebuild-navmeshes` more like a tool, exiting as the server is about to start. I highly recommend until we eventually regenerate the navmeshes subrepo that servers make running `xi_map --rebuild-navmeshes` a part of their maintenance routine/scripts.

This also adds a small cull for a couple of triangles in Ceizak Battlegrounds, which were bloating their generation time (and size) out hugely.