### PR TITLE
[sql][module] Merit module additions and reorganization

### DIFF
--- a/modules/abyssea/sql/job_adjustments.sql
+++ b/modules/abyssea/sql/job_adjustments.sql
@@ -12,9 +12,6 @@
 -- Warrior's Charge: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'warriors_charge';
 
--- Warrior's Charge merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'warriors_charge';
-
 ------------------------------------
 -- White Mage
 ------------------------------------
@@ -25,19 +22,6 @@ UPDATE abilities SET recastTime = 1200 WHERE name = 'martyr';
 -- Devotion: Revert recast from 10 to 20 minutes
 UPDATE abilities SET recastTime = 1200 WHERE name = 'devotion';
 
--- Martyr merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'martyr';
-
--- Devotion merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'devotion';
-
--- Animus Solace: Disable merit upgrades
--- Source: https://forum.square-enix.com/ffxi/threads/55360?_ga=2.195400239.203489549.1557463710-808700183.1440009048
-UPDATE merits SET upgrade = 0 WHERE name = 'animus_solace';
-
--- Animus Misery: Disable merit upgrades
-UPDATE merits SET upgrade = 0 WHERE name = 'animus_misery';
-
 ------------------------------------
 -- Thief
 ------------------------------------
@@ -45,14 +29,8 @@ UPDATE merits SET upgrade = 0 WHERE name = 'animus_misery';
 -- Assassin's Charge: Revert cooldown to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'assassins_charge';
 
--- Assassin's Charge: Change merit value to reduce cooldown by 150 seconds per merit
-UPDATE merits SET value = 150 WHERE name = 'assassins_charge';
-
 -- Feint: Revert cooldown to 10 minutes
 UPDATE abilities SET recastTime = 600 WHERE name = 'feint';
-
--- Feint: Change merit value to reduce cooldown by 120 seconds per merit
-UPDATE merits SET value = 120 WHERE name = 'feint';
 
 ------------------------------------
 -- Dark Knight
@@ -62,28 +40,15 @@ UPDATE merits SET value = 120 WHERE name = 'feint';
 -- Arcane Circle: Revert recast from 5 to 10 minutes
 UPDATE abilities SET recastTime = 600 WHERE name = 'arcane_circle';
 
--- Arcane Circle merit: Revert value to 20 seconds per level
-UPDATE merits SET value = 20 WHERE name = 'arcane_circle_recast';
-
 -- Weapon Bash: Revert recast from 3 to 5 minutes
 UPDATE abilities SET recastTime = 300 WHERE name = 'weapon_bash';
-
--- Weapon Bash merit: Revert value to 10 seconds per level
--- Note: merit is named weapon_bash_effect (provides both recast reduction and effect)
-UPDATE merits SET value = 10 WHERE name = 'weapon_bash_effect';
 
 -- Dark Seal: Revert recast from 5 to 15 minutes
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
 UPDATE abilities SET recastTime = 900 WHERE name = 'dark_seal';
 
--- Dark Seal merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'dark_seal';
-
 -- Diabolic Eye: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'diabolic_eye';
-
--- Diabolic Eye merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'diabolic_eye';
 
 ------------------------------------
 -- Paladin
@@ -93,26 +58,14 @@ UPDATE merits SET value = 150 WHERE name = 'diabolic_eye';
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
 UPDATE abilities SET recastTime = 600 WHERE name = 'holy_circle';
 
--- Holy Circle merit: Revert value to 20 seconds per level
-UPDATE merits SET value = 20 WHERE name = 'holy_circle_recast';
-
 -- Chivalry: Revert recast from 10 to 20 minutes
 UPDATE abilities SET recastTime = 1200 WHERE name = 'chivalry';
 
 -- Fealty: Revert recast from 10 to 20 minutes
 UPDATE abilities SET recastTime = 1200 WHERE name = 'fealty';
 
--- Chivalry merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'chivalry';
-
--- Fealty merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'fealty';
-
 -- Shield Bash: Revert recast from 3 to 5 minutes
 UPDATE abilities SET recastTime = 300 WHERE name = 'shield_bash';
-
--- Shield Bash merit: Revert value to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'shield_bash_recast';
 
 ------------------------------------
 -- Beastmaster
@@ -130,14 +83,8 @@ UPDATE item_equipment SET level = 0 WHERE name = 'pet_food_zeta';
 -- Feral Howl: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'feral_howl';
 
--- Feral Howl merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'feral_howl';
-
 -- Killer Instinct: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'killer_instinct';
-
--- Killer Instinct merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'killer_instinct';
 
 ------------------------------------
 -- Bard
@@ -166,9 +113,6 @@ WHERE (zonetype & (@TYPE_CITY | @TYPE_OUTDOORS)) <> 0;
 -- Warding Circle: Revert recast from 5 to 10 minutes
 UPDATE abilities SET recastTime = 600 WHERE name = 'warding_circle';
 
--- Warding Circle merit: Revert value to 20 seconds per level
-UPDATE merits SET value = 20 WHERE name = 'warding_circle_recast';
-
 -- Sekkanoki: Adjust level requirement from 40 to 60
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(06/21/2010)
 UPDATE abilities SET level = 60 WHERE name = 'sekkanoki';
@@ -177,14 +121,8 @@ UPDATE abilities SET level = 60 WHERE name = 'sekkanoki';
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
 UPDATE abilities SET recastTime = 900 WHERE name = 'blade_bash';
 
--- Blade Bash merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'blade_bash';
-
 -- Shikikoyo: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'shikikoyo';
-
--- Shikikoyo merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'shikikoyo';
 
 ------------------------------------
 -- Ranger
@@ -199,9 +137,6 @@ UPDATE abilities SET `range` = 10 WHERE name = 'shadowbind';
 
 -- Flashy Shot: revert recast from 10 to 20 minutes
 UPDATE abilities SET recastTime = 1200 WHERE name = 'flashy_shot';
-
--- Flashy Shot merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'flashy_shot';
 
 -----------------------------------
 -- Ninja
@@ -222,14 +157,8 @@ UPDATE abilities SET recastTime = 300, recastId = 146 WHERE name = 'innin';
 -- Jump: Revert recast from 1 minute to 1.5 minutes
 UPDATE abilities SET recastTime = 90 WHERE name = 'jump';
 
--- Jump merit: Revert value from 2 seconds per level to 3 seconds per level
-UPDATE merits SET value = 3 WHERE name = 'jump_recast';
-
 -- High Jump: Revert recast from 2 minutes to 3 minutes
 UPDATE abilities SET recastTime = 180 WHERE name = 'high_jump';
-
--- High Jump merit: Revert value from 4 seconds per level to 6 seconds per level
-UPDATE merits SET value = 6 WHERE name = 'high_jump_recast';
 
 -- Super Jump: Revert range from 12.5 to 9.5 yalms
 UPDATE abilities SET `range` = 9.5 WHERE name = 'super_jump';
@@ -237,28 +166,11 @@ UPDATE abilities SET `range` = 9.5 WHERE name = 'super_jump';
 -- Spirit Link: Revert recast from 1.5 minutes to 3 minutes
 UPDATE abilities SET recastTime = 180 WHERE name = 'spirit_link';
 
--- Spirit Link merit: Revert value from 4 seconds per level to 6 seconds per level
-UPDATE merits SET value = 6 WHERE name = 'spirit_link_recast';
-
 -- Ancient Circle: Revert recast from 5 to 10 minutes
 UPDATE abilities SET recastTime = 600 WHERE name = 'ancient_circle';
 
--- Ancient Circle merit: Revert value from 10 to 20 seconds per level
-UPDATE merits SET value = 20 WHERE name = 'ancient_circle_recast';
-
 -- Deep Breathing: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'deep_breathing';
-
--- Deep Breathing merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'deep_breathing';
-
------------------------------------
--- Summoner
------------------------------------
-
--- Summoning Magic Casting Time Merit: Repurposed to Spirit MP cost merit. Revert merit value from 5 to 1 per level.
--- Source: https://forum.square-enix.com/ffxi/threads/22099-March-27-2012-%28JST%29-Version-Update
-UPDATE merits SET value = 1 WHERE name = 'summoning_magic_cast_time';
 
 -----------------------------------
 -- Corsair
@@ -272,14 +184,8 @@ UPDATE abilities SET recastTime = 7 WHERE name = 'double-up';
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
 UPDATE abilities SET recastTime = 900 WHERE name = 'snake_eye';
 
--- Snake Eye merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'snake_eye';
-
 -- Fold: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'fold';
-
--- Fold merit: Revert value to 150 seconds per level
-UPDATE merits SET value = 150 WHERE name = 'fold';
 
 -- Quick Draw: Revert range from 22 to 15 yalms
 UPDATE abilities SET `range` = 15 WHERE name = 'quick_draw';

--- a/modules/abyssea/sql/merit_adjustments.sql
+++ b/modules/abyssea/sql/merit_adjustments.sql
@@ -1,0 +1,218 @@
+-----------------------------------
+-- Abyssea merit adjustments.
+-- Reverts merits to their pre-Abyssea values.
+-----------------------------------
+
+-----------------------------------
+-- Non Job Specific Merits
+-- Reverts several categories that had their total merit point upgrades increased along with adding new categories
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_Supplemental_(05/09/2011)
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(12/14/2011)
+-----------------------------------
+
+-- HP-MP
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'max_hp';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'max_mp';
+
+-- Disable max merits
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'max_merits';
+
+-- Attributes
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'str';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'dex';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'vit';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'agi';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'int';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'mnd';
+UPDATE `merits` SET `upgrade` = 5 WHERE `name` = 'chr';
+
+-- Combat Skills
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'h2h';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'dagger';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'sword';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'gsword';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'axe';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'gaxe';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'scythe';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'polearm';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'katana';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'gkatana';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'club';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'staff';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'archery';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'marksmanship';
+UPDATE `merits` SET `upgrade` = 8 WHERE `name` = 'throwing';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'guarding_skill';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'evasion_skill';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'shield_skill';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'parrying_skill';
+
+-- Others
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'enmity_increase';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'enmity_decrease';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'crit_hit_rate';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'enemy_crit_rate';
+UPDATE `merits` SET `upgrade` = 4 WHERE `name` = 'spell_interuption_rate';
+
+-- Weapon Skills
+-- Disable out of era merit weaponskills
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'shijin_spiral';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'exenterator';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'requiescat';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'resolution';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'ruinator';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'upheaval';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'entropy';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'stardiver';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'blade_shun';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'tachi_shoha';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'realmrazer';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'shattersoul';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'apex_arrow';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'last_stand';
+
+-----------------------------------
+-- Job ability merit value reverts
+-- Unless otherwise noted, sourced from: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+-----------------------------------
+
+-----------------------------------
+-- Warrior
+-----------------------------------
+
+-- Warrior's Charge merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'warriors_charge';
+
+-----------------------------------
+-- White Mage
+-----------------------------------
+
+-- Martyr merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'martyr';
+
+-- Devotion merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'devotion';
+
+-- Animus Solace/Animus Misery: Disable merit upgrades
+-- Source: https://forum.square-enix.com/ffxi/threads/55360?_ga=2.195400239.203489549.1557463710-808700183.1440009048
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'animus_solace';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'animus_misery';
+
+-----------------------------------
+-- Thief
+-----------------------------------
+
+-- Assassin's Charge merit: Reduce cooldown by 150 seconds per merit
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'assassins_charge';
+
+-- Feint merit: Reduce cooldown by 120 seconds per merit
+UPDATE `merits` SET `value` = 120 WHERE `name` = 'feint';
+
+-----------------------------------
+-- Dark Knight
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+-----------------------------------
+
+-- Arcane Circle merit: Revert value to 20 seconds per level
+UPDATE `merits` SET `value` = 20 WHERE `name` = 'arcane_circle_recast';
+
+-- Weapon Bash merit: Revert value to 10 seconds per level
+-- Note: merit is named weapon_bash_effect (provides both recast reduction and effect)
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'weapon_bash_effect';
+
+-- Dark Seal merit: Revert value to 150 seconds per level
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'dark_seal';
+
+-- Diabolic Eye merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'diabolic_eye';
+
+-----------------------------------
+-- Paladin
+-----------------------------------
+
+-- Holy Circle merit: Revert value to 20 seconds per level
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+UPDATE `merits` SET `value` = 20 WHERE `name` = 'holy_circle_recast';
+
+-- Chivalry merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'chivalry';
+
+-- Fealty merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'fealty';
+
+-- Shield Bash merit: Revert value to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'shield_bash_recast';
+
+-----------------------------------
+-- Beastmaster
+-----------------------------------
+
+-- Feral Howl merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'feral_howl';
+
+-- Killer Instinct merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'killer_instinct';
+
+-----------------------------------
+-- Samurai
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+-----------------------------------
+
+-- Warding Circle merit: Revert value to 20 seconds per level
+UPDATE `merits` SET `value` = 20 WHERE `name` = 'warding_circle_recast';
+
+-- Blade Bash merit: Revert value to 150 seconds per level
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'blade_bash';
+
+-- Shikikoyo merit: Revert value to 150 seconds per level
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'shikikoyo';
+
+-----------------------------------
+-- Ranger
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+-----------------------------------
+
+-- Flashy Shot merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'flashy_shot';
+
+-----------------------------------
+-- Dragoon
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
+-----------------------------------
+
+-- Jump merit: Revert value from 2 seconds per level to 3 seconds per level
+UPDATE `merits` SET `value` = 3 WHERE `name` = 'jump_recast';
+
+-- High Jump merit: Revert value from 4 seconds per level to 6 seconds per level
+UPDATE `merits` SET `value` = 6 WHERE `name` = 'high_jump_recast';
+
+-- Spirit Link merit: Revert value from 4 seconds per level to 6 seconds per level
+UPDATE `merits` SET `value` = 6 WHERE `name` = 'spirit_link_recast';
+
+-- Ancient Circle merit: Revert value from 10 to 20 seconds per level
+UPDATE `merits` SET `value` = 20 WHERE `name` = 'ancient_circle_recast';
+
+-- Deep Breathing merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'deep_breathing';
+
+-----------------------------------
+-- Summoner
+-----------------------------------
+
+-- Summoning Magic Casting Time merit: Repurposed to Spirit MP cost merit. Revert merit value from 5 to 1 per level.
+-- Source: https://forum.square-enix.com/ffxi/threads/22099-March-27-2012-%28JST%29-Version-Update
+UPDATE `merits` SET `value` = 1 WHERE `name` = 'summoning_magic_cast_time';
+
+-----------------------------------
+-- Corsair
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+-----------------------------------
+
+-- Snake Eye merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'snake_eye';
+
+-- Fold merit: Revert value to 150 seconds per level
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'fold';

--- a/modules/rov/sql/job_adjustments.sql
+++ b/modules/rov/sql/job_adjustments.sql
@@ -20,15 +20,6 @@ UPDATE abilities SET recastTime = 300 WHERE name = 'dodge';
 -- Chakra: Revert recast from 3 to 5 minutes
 UPDATE abilities SET recastTime = 300 WHERE name = 'chakra';
 
--- Focus Recast merit: Revert value from 4 to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'focus_recast';
-
--- Dodge Recast merit: Revert value from 4 to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'dodge_recast';
-
--- Chakra Recast merit: Revert value from 6 to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'chakra_recast';
-
 -- Max HP Boost: Revert trait levels to 35/55/70
 UPDATE traits SET level = 35 WHERE name = 'max hp boost' AND job = 2 AND rank = 2;
 UPDATE traits SET level = 55 WHERE name = 'max hp boost' AND job = 2 AND rank = 3;
@@ -40,41 +31,12 @@ UPDATE traits SET level = 70 WHERE name = 'max hp boost' AND job = 2 AND rank = 
 ------------------------------------
 
 ------------------------------------
--- Black Mage
--- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
-------------------------------------
-
--- Disable OOE BLM Group 2 merits
-UPDATE merits SET upgrade = 0 WHERE name = 'anc_magic_attack_bonus';
-UPDATE merits SET upgrade = 0 WHERE name = 'anc_magic_burst_dmg';
-UPDATE merits SET upgrade = 0 WHERE name = 'ele_magic_acc';
-UPDATE merits SET upgrade = 0 WHERE name = 'ele_magic_debuff_duration';
-UPDATE merits SET upgrade = 0 WHERE name = 'ele_magic_debuff_effect';
-UPDATE merits SET upgrade = 0 WHERE name = 'aspir_absorption_amount';
-
-------------------------------------
--- Red Mage
--- https://forum.square-enix.com/ffxi/threads/55751-August.-6-2019-%28JST%29-Version-Update
-------------------------------------
-
--- Disable OOE RDM Group 2 merits
-UPDATE merits SET upgrade = 0 WHERE name = 'enfeebling_magic_duration';
-UPDATE merits SET upgrade = 0 WHERE name = 'magic_accuracy';
-UPDATE merits SET upgrade = 0 WHERE name = 'enhancing_magic_duration';
-UPDATE merits SET upgrade = 0 WHERE name = 'immunobreak_chance';
-UPDATE merits SET upgrade = 0 WHERE name = 'enspell_damage';
-UPDATE merits SET upgrade = 0 WHERE name = 'melee_accuracy';
-
-------------------------------------
 -- Paladin
 ------------------------------------
 
 -- Rampart: Revert recast from 3 to 5 minutes
 -- Source: https://forum.square-enix.com/ffxi/threads/56444-February-12-2020-%28JST%29-Version-Update
 UPDATE abilities SET recastTime = 300 WHERE name = 'rampart';
-
--- Rampart merit: Revert value from 4 to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'rampart_recast';
 
 ------------------------------------
 -- Ranger
@@ -88,28 +50,6 @@ UPDATE abilities SET recastTime = 300 WHERE name = 'velocity_shot';
 -- Source: https://forum.square-enix.com/ffxi/threads/47481-Jun-25-2015-%28JST%29-Version-Update
 UPDATE skill_ranks SET rng = 2 WHERE name = 'archery';
 UPDATE skill_ranks SET rng = 2 WHERE name = 'marksmanship';
-
-------------------------------------
--- Bard
--- Source: https://forum.square-enix.com/ffxi/threads/55360-May.-10-2019-%28JST%29-Version-Update
-------------------------------------
-
--- Foe Sirvente/Adventurer's Dirge: Set merit ranks to 5 and merit value to 5 per rank.
-UPDATE merits SET upgrade = 5, value = 5 WHERE name IN ('foe_sirvente', 'adventurers_dirge');
-
--- Disable OOE BRD Group 2 merits
-UPDATE merits SET upgrade = 0 WHERE name IN ('con_anima', 'con_brio');
-
------------------------------------
--- Ninja
--- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
-------------------------------------
-
--- Disable OOE NIN Group 2 merits
-UPDATE merits SET upgrade = 0 WHERE name = 'yonin_effect';
-UPDATE merits SET upgrade = 0 WHERE name = 'innin_effect';
-UPDATE merits SET upgrade = 0 WHERE name = 'nin_magic_accuracy';
-UPDATE merits SET upgrade = 0 WHERE name = 'nin_magic_attack';
 
 ------------------------------------
 -- Dragoon

--- a/modules/rov/sql/merit_adjustments.sql
+++ b/modules/rov/sql/merit_adjustments.sql
@@ -1,0 +1,74 @@
+-----------------------------------
+-- Rhapsodies of Vana'diel merit adjustments.
+-- Reverts merits to their pre-RoV values.
+-----------------------------------
+
+-----------------------------------
+-- Monk
+-- Source: https://forum.square-enix.com/ffxi/threads/52969
+-----------------------------------
+
+-- Focus Recast merit: Revert value from 4 to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'focus_recast';
+
+-- Dodge Recast merit: Revert value from 4 to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'dodge_recast';
+
+-- Chakra Recast merit: Revert value from 6 to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'chakra_recast';
+
+-----------------------------------
+-- Black Mage
+-- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
+-----------------------------------
+
+-- Disable OOE BLM Group 2 merits
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'anc_magic_attack_bonus';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'anc_magic_burst_dmg';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'ele_magic_acc';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'ele_magic_debuff_duration';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'ele_magic_debuff_effect';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'aspir_absorption_amount';
+
+-----------------------------------
+-- Red Mage
+-- Source: https://forum.square-enix.com/ffxi/threads/55751-August.-6-2019-%28JST%29-Version-Update
+-----------------------------------
+
+-- Disable OOE RDM Group 2 merits
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'enfeebling_magic_duration';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'magic_accuracy';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'enhancing_magic_duration';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'immunobreak_chance';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'enspell_damage';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'melee_accuracy';
+
+-----------------------------------
+-- Paladin
+-- Source: https://forum.square-enix.com/ffxi/threads/56444-February-12-2020-%28JST%29-Version-Update
+-----------------------------------
+
+-- Rampart merit: Revert value from 4 to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'rampart_recast';
+
+-----------------------------------
+-- Bard
+-- Source: https://forum.square-enix.com/ffxi/threads/55360-May.-10-2019-%28JST%29-Version-Update
+-----------------------------------
+
+-- Foe Sirvente/Adventurer's Dirge: Revert value value to 5 per rank.
+UPDATE `merits` SET `value` = 5 WHERE `name` IN ('foe_sirvente', 'adventurers_dirge');
+
+-- Disable OOE BRD Group 2 merits
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` IN ('con_anima', 'con_brio');
+
+-----------------------------------
+-- Ninja
+-- Source: https://forum.square-enix.com/ffxi/threads/55525-June.-10-2019-%28JST%29-Version-Update
+-----------------------------------
+
+-- Disable OOE NIN Group 2 merits
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'yonin_effect';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'innin_effect';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'nin_magic_accuracy';
+UPDATE `merits` SET `upgrade` = 0 WHERE `name` = 'nin_magic_attack';

--- a/modules/soa/sql/job_adjustments.sql
+++ b/modules/soa/sql/job_adjustments.sql
@@ -30,9 +30,6 @@ UPDATE abilities SET recastTime = 120 WHERE name = 'sic';
 -- Ready: Revert charge recast from 30 to 60 seconds
 UPDATE abilities SET recastTime = 60 WHERE name = 'ready';
 
--- Sic merit: Revert value from 2 to 4 seconds per level
-UPDATE merits SET value = 4 WHERE name = 'sic_recast';
-
 ------------------------------------
 -- Ranger
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/29/2013)
@@ -41,8 +38,8 @@ UPDATE merits SET value = 4 WHERE name = 'sic_recast';
 -- Scavenge: Revert recast from 3 to 5 minutes
 UPDATE abilities SET recastTime = 300 WHERE name = 'scavenge';
 
--- Scavenge merit: Revert value from increase effect per level to 10 seconds per level
-UPDATE merits SET value = 10 WHERE name = 'scavenge';
+-- Recycle: Revert job trait to be merit unlocked
+UPDATE traits SET meritid = 2694, level = 75 WHERE name = 'recycle';
 
 -----------------------------------
 -- Ninja
@@ -52,9 +49,6 @@ UPDATE merits SET value = 10 WHERE name = 'scavenge';
 -- Sange: Revert recast from 5 to 15 minutes
 UPDATE abilities SET recastTime = 900 WHERE name = 'sange';
 
--- Sange merit: Revert value from 25 ranged accuracy to 150 seconds recast reduction
-UPDATE merits SET value = 150 WHERE name = 'sange';
-
 ------------------------------------
 -- Dragoon
 -- Source: https://forum.square-enix.com/ffxi/threads/44090-Sep-9-2014-%28JST%29-Version-Update
@@ -62,9 +56,6 @@ UPDATE merits SET value = 150 WHERE name = 'sange';
 
 -- Strafe: Revert from level based trait to merit unlocked at 75
 UPDATE traits SET meritid = 2886, level = 75, value = 0 WHERE name = 'strafe';
-
--- Strafe merit: Revert value from 10 to 5 per upgrade
-UPDATE merits SET value = 5 WHERE name = 'strafe_effect';
 
 -- Wyvern Breath: Revert activation time from 1 second to 3 seconds
 -- TODO: Revert skill prepare animation to display skill ready spikes

--- a/modules/soa/sql/merit_adjustments.sql
+++ b/modules/soa/sql/merit_adjustments.sql
@@ -1,0 +1,36 @@
+-----------------------------------
+-- Seekers of Adoulin merit adjustments.
+-- Reverts merits to their pre-SoA values.
+-----------------------------------
+
+-----------------------------------
+-- Beastmaster
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/29/2013)
+-----------------------------------
+
+-- Sic merit: Revert value from 2 to 4 seconds per level
+UPDATE `merits` SET `value` = 4 WHERE `name` = 'sic_recast';
+
+-----------------------------------
+-- Ranger
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(04/29/2013)
+-----------------------------------
+
+-- Scavenge merit: Revert value from increase effect per level to 10 seconds per level
+UPDATE `merits` SET `value` = 10 WHERE `name` = 'scavenge';
+
+-----------------------------------
+-- Ninja
+-- Source: https://forum.square-enix.com/ffxi/threads/44592-Oct-7-2014-%28JST%29-Version-Update
+-----------------------------------
+
+-- Sange merit: Revert value from 25 ranged accuracy to 150 seconds recast reduction
+UPDATE `merits` SET `value` = 150 WHERE `name` = 'sange';
+
+-----------------------------------
+-- Dragoon
+-- Source: https://forum.square-enix.com/ffxi/threads/44090-Sep-9-2014-%28JST%29-Version-Update
+-----------------------------------
+
+-- Strafe merit: Revert value from 10 to 5 per upgrade
+UPDATE `merits` SET `value` = 5 WHERE `name` = 'strafe_effect';

--- a/modules/wotg/sql/job_adjustments.sql
+++ b/modules/wotg/sql/job_adjustments.sql
@@ -20,9 +20,6 @@ UPDATE `abilities` SET `range` = 6.0 WHERE `name` = 'martyr';
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/11/2008)
 UPDATE `abilities` SET `recastTime` = 180 WHERE `name` = 'reward';
 
--- Reward merit: Revert value to 6 seconds per level
-UPDATE `merits` SET `value` = 6 WHERE `name` = 'reward';
-
 -- Sic: Allow use with jug pets in addition to charmed mobs
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(11/09/2009)
 UPDATE `abilities` SET `addType` = 192 WHERE `name` = 'sic';

--- a/modules/wotg/sql/merit_adjustments.sql
+++ b/modules/wotg/sql/merit_adjustments.sql
@@ -1,0 +1,137 @@
+-----------------------------------
+-- WotG merit adjustments.
+-- Reverts merits to their pre-WotG values.
+-----------------------------------
+
+-- Reverts total maximum group 2 job merits from 6 to 3
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(06/09/2008)
+
+-- WAR Group 2 (catagoryid 31)
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'warriors_charge';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'tomahawk';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'savagery';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'aggressive_aim';
+
+-- MNK Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'mantra';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'formless_strikes';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'invigorate';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'penance';
+
+-- WHM Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'martyr';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'devotion';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'protectra_v';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'shellra_v';
+
+-- BLM Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'flare_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'freeze_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'tornado_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'quake_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'burst_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'flood_ii';
+
+-- RDM Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'dia_iii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'slow_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'paralyze_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'phalanx_ii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'bio_iii';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'blind_ii';
+
+-- THF Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'assassins_charge';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'feint';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'aura_steal';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'ambush';
+
+-- PLD Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'fealty';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'chivalry';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'iron_will';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'guardian';
+
+-- DRK Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'dark_seal';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'diabolic_eye';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'muted_soul';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'desperate_blows_effect';
+
+-- BST Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'feral_howl';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'killer_instinct';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'beast_affinity';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'beast_healer';
+
+-- BRD Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'nightingale';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'troubadour';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'foe_sirvente';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'adventurers_dirge';
+
+-- RNG Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'stealth_shot';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'flashy_shot';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'snapshot';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'recycle';
+
+-- SAM Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'shikikoyo';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'blade_bash';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'ikishoten';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'overwhelm';
+
+-- NIN Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'sange';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'ninja_tool_expertise';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'katon_san';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'hyoton_san';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'huton_san';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'doton_san';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'raiton_san';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'suiton_san';
+
+-- DRG Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'deep_breathing';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'angon';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'empathy';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'strafe_effect';
+
+-- SMN Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'meteor_strike';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'heavenly_strike';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'wind_blade';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'geocrush';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'thunderstorm';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'grandfall';
+
+-- BLU Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'convergence';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'diffusion';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'enchainment';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'assimilation';
+
+-- COR Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'snake_eye';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'fold';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'winning_streak';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'loaded_deck';
+
+-- PUP Group 2
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'role_reversal';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'ventriloquy';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'fine_tuning';
+UPDATE `merits` SET `upgrade` = 3 WHERE `name` = 'optimization';
+
+-----------------------------------
+-- Job ability merit value reverts
+-----------------------------------
+
+-----------------------------------
+-- Beastmaster
+-----------------------------------
+
+-- Reward merit: Revert value to 6 seconds per level
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/11/2008)
+UPDATE `merits` SET `value` = 6 WHERE `name` = 'reward';


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Reorganizes all SQL module listings that touched the `merits.sql` file to be organized in a separate `merit_adjustsments.sql` per expansion breakdown.
- Adds new adjustments to all merits that had their max upgrades increased in Abyssea/WotG. Also blocks being able to upgrade weaponskills and max merits.
- Trait adjustment for RNG to block receiving recycle without meriting it first

## Steps to test these changes

- Load all expansion module folders
- Attempt to skill up weaponskills or max merits, see that the category is unable to be interacted with
- See that group 2 merits in job categories cannot be upgraded past three levels