### PR TITLE
[cpp][lua] Adds flag for data modules and makes loading more strict

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -6,7 +6,52 @@ Please see [the module guide on the wiki](https://github.com/LandSandBoat/server
 
 ## Era Accuracy Modules
 
-Lua era-accuracy modules live under `era/lua/` and mirror the main `scripts/` tree where practical. These modules should use `xi.module.isContentEnabled(contentTag)` to decide whether an era override should register. If the relevant content is enabled, return a data-only table such as `{ name = moduleName }`.
+Lua era-accuracy modules live under `era/lua/` and mirror the main `scripts/` tree where practical. These modules should use `xi.module.isContentEnabled(contentTag)` to decide whether an era override should register.
+
+`Module:new` is the registration point: every constructed `Module` adds itself to `xi.module.registry`, which the loader processes after all module files have run. Module files do not return anything so a content gate is just a plain `return`:
+
+```lua
+local m = Module:new('era_magic_burst')
+
+if xi.module.isContentEnabled('SOA') then
+    return
+end
+
+m:addOverride('xi.spells.damage.calculateIfMagicBurst', function(...)
+    -- ...
+end)
+```
+
+Create the `Module` object **before** any content gate: registration happens at construction, so the module always shows up in the startup log and in loader validation, even when a gate means it registers zero overrides.
+
+Modules that only mutate data tables at load time (no overrides) look exactly the same. Since the module object is never used after creation, skip the local (an unused `local m` is a luacheck warning):
+
+```lua
+Module:new('original_pdif_caps')
+
+if xi.module.isContentEnabled('WOTG') then
+    return
+end
+
+xi.combat.physical.pDifWeaponCapTable[xi.skill.HAND_TO_HAND] = 2
+-- ...
+```
+
+Data/library files that other modules `require()` are not modules, they simply return their data table. Since the loader ignores return values, no wrapper or marker is needed, and `require()` gives consumers their own dependency ordering independent of the loader's scan order:
+
+```lua
+return
+{
+    guaranteedItems = guaranteedItems,
+    zonePoolMap     = zonePoolMap,
+}
+```
+
+Command modules register themselves explicitly instead of returning their command table:
+
+```lua
+xi.module.registerCommand('test', commandObj)
+```
 
 Common content tags are:
 

--- a/modules/abyssea/lua/era_HNM_system.lua
+++ b/modules/abyssea/lua/era_HNM_system.lua
@@ -421,5 +421,3 @@ hnmSystem:addOverride('xi.zones.Behemoths_Dominion.mobs.King_Behemoth.onMobDespa
     xi.mob.updateNMSpawnPoint(behemothDomID.mob.BEHEMOTH, behemothSpawnPoints)
     GetMobByID(behemothDomID.mob.BEHEMOTH):setRespawnTime(randomPopTime)
 end)
-
-return hnmSystem

--- a/modules/custom/lua/announce_player_login.lua
+++ b/modules/custom/lua/announce_player_login.lua
@@ -18,5 +18,3 @@ m:addOverride('xi.player.onGameIn', function(player, firstLogin, zoning)
         end)
     end
 end)
-
-return m

--- a/modules/custom/lua/chocobo_raising_qol.lua
+++ b/modules/custom/lua/chocobo_raising_qol.lua
@@ -46,5 +46,3 @@ m:addOverride('xi.server.onServerStart', function()
     -- Original: Leads to absolute max of: 17 + (4 * 9): 53 -> clamped to 45
     -- New: Leads to absolute max of: 20 + (5 * 9): 65 -> clamped to 60
 end)
-
-return m

--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -168,5 +168,3 @@ end
 for _, entry in pairs(nmsToShield) do
     m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobInitialize', entry[1], entry[2]), overrideFunc)
 end
-
-return m

--- a/modules/custom/lua/conquest_regional_npcs_always_up.lua
+++ b/modules/custom/lua/conquest_regional_npcs_always_up.lua
@@ -35,5 +35,3 @@ m:addOverride('xi.conquest.toggleRegionalNPCs', function(zone)
         end
     end
 end)
-
-return m

--- a/modules/custom/lua/custom_HNM_system.lua
+++ b/modules/custom/lua/custom_HNM_system.lua
@@ -173,5 +173,3 @@ hnmSystem:addOverride('xi.zones.Behemoths_Dominion.npcs.qm2.onTrade', function(p
         player:confirmTrade()
     end
 end)
-
-return hnmSystem

--- a/modules/custom/lua/garrison_placeholder_data.lua
+++ b/modules/custom/lua/garrison_placeholder_data.lua
@@ -155,5 +155,3 @@ m:addOverride('xi.garrison.getAllyInfo', function(zoneID, zoneData, nationID)
 
     return allyInfoTable
 end)
-
-return m

--- a/modules/custom/lua/homepoint_heal.lua
+++ b/modules/custom/lua/homepoint_heal.lua
@@ -12,5 +12,3 @@ m:addOverride('xi.homepoint.onTrigger', function(player, csid, index)
     player:addMP(player:getMaxMP())
     super(player, csid, index)
 end)
-
-return m

--- a/modules/custom/lua/mazurka_generates_enmity.lua
+++ b/modules/custom/lua/mazurka_generates_enmity.lua
@@ -48,5 +48,3 @@ m:addOverride('xi.actions.spells.songs.raptor_mazurka.onSpellCast', function(cas
     mazurkaProvoke(caster, target, spell, raptorMazurkaPower)
     return songEffect
 end)
-
-return m

--- a/modules/custom/lua/mission_wardrobe_unlocks.lua
+++ b/modules/custom/lua/mission_wardrobe_unlocks.lua
@@ -73,5 +73,3 @@ m:addOverride('npcUtil.completeMission', function(player, logId, missionId, para
 
     return result
 end)
-
-return m

--- a/modules/custom/lua/moghouse_exit_homepoint.lua
+++ b/modules/custom/lua/moghouse_exit_homepoint.lua
@@ -88,5 +88,3 @@ for zoneName in pairs(exitZones) do
         super(player, csid, option, npc)
     end)
 end
-
-return m

--- a/modules/custom/lua/new_player_linkshell.lua
+++ b/modules/custom/lua/new_player_linkshell.lua
@@ -11,5 +11,3 @@ m:addOverride('xi.player.charCreate', function(player)
     player:addLinkpearl(lsName, true)
     super(player)
 end)
-
-return m

--- a/modules/custom/lua/persist_nm_time_of_deaths.lua
+++ b/modules/custom/lua/persist_nm_time_of_deaths.lua
@@ -59,5 +59,3 @@ for _, entry in pairs(nmsToPersist) do
         end
     end)
 end
-
-return m

--- a/modules/custom/lua/quest_workarounds.lua
+++ b/modules/custom/lua/quest_workarounds.lua
@@ -36,5 +36,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/custom/lua/replace_trust_with_cornelia.lua
+++ b/modules/custom/lua/replace_trust_with_cornelia.lua
@@ -65,5 +65,3 @@ end)
 m:addOverride(string.format('xi.actions.spells.trust.%s.onMobDeath', trustToReplaceName), function(mob)
     -- Intentionally blank
 end)
-
-return m

--- a/modules/custom/lua/soa_remove_imprimatur_gate.lua
+++ b/modules/custom/lua/soa_remove_imprimatur_gate.lua
@@ -10,5 +10,3 @@ m:addOverride('xi.soa.helpers.imprimaturGate', function(player, gateAmount)
     -- Ignore the spending and fame requirements, just return true
     return true
 end)
-
-return m

--- a/modules/custom/lua/test_npcs_in_gm_home.lua
+++ b/modules/custom/lua/test_npcs_in_gm_home.lua
@@ -243,5 +243,3 @@ m:addOverride('xi.zones.GM_Home.Zone.onInitialize', function(zone)
         end,
     })
 end)
-
-return m

--- a/modules/custom/lua/world_first_announcements.lua
+++ b/modules/custom/lua/world_first_announcements.lua
@@ -107,5 +107,3 @@ m:addOverride('npcUtil.completeQuest', function(player, area, quest, params)
     return result
 end)
 ]]
-
-return m

--- a/modules/custom/lua/wotg_decouple_story_missions_from_nation_quests.lua
+++ b/modules/custom/lua/wotg_decouple_story_missions_from_nation_quests.lua
@@ -41,5 +41,3 @@ m:addOverride('xi.wotg.helpers.meetsMission38Reqs', function(player)
     -- Ignore the quest requirements, just return true
     return true
 end)
-
-return m

--- a/modules/era/lua/actions/abilities/pets/abyssea_avatar_bloodpacts.lua
+++ b/modules/era/lua/actions/abilities/pets/abyssea_avatar_bloodpacts.lua
@@ -5,13 +5,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'abyssea_avatar_bloodpacts'
+local m = Module:new('abyssea_avatar_bloodpacts')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Shining Ruby
@@ -293,5 +291,3 @@ m:addOverride('xi.actions.abilities.pets.dream_shroud.onPetAbility', function(ta
 
     return 0
 end)
-
-return m

--- a/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
+++ b/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
@@ -6,13 +6,11 @@ require('modules/module_utils')
 require('scripts/globals/automaton')
 -----------------------------------
 
-local moduleName = 'attachments'
+local m = Module:new('attachments')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Reduces Enmity boost from Strobe                                 : https://wiki.ffo.jp/html/8610.html
 -- Reduces Store TP from Inhibitor                                  : https://wiki.ffo.jp/html/8625.html
@@ -548,5 +546,3 @@ m:addOverride('xi.actions.abilities.pets.automaton.economizer.onAutomatonAbility
 
     return automaton:addMP(mpRecovered)
 end)
-
-return m

--- a/modules/era/lua/actions/abilities/pets/hastega.lua
+++ b/modules/era/lua/actions/abilities/pets/hastega.lua
@@ -5,13 +5,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'hastega'
+local m = Module:new('hastega')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.actions.abilities.pets.hastega.onPetAbility', function(target, pet, petskill, summoner, action)
     local duration = 180
@@ -33,5 +31,3 @@ m:addOverride('xi.actions.abilities.pets.hastega.onPetAbility', function(target,
 
     return typeEffect
 end)
-
-return m

--- a/modules/era/lua/actions/abilities/pets/rov_avatar_bloodpacts.lua
+++ b/modules/era/lua/actions/abilities/pets/rov_avatar_bloodpacts.lua
@@ -8,13 +8,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'rov_avatar_bloodpacts'
+local m = Module:new('rov_avatar_bloodpacts')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Axe Kick
@@ -834,5 +832,3 @@ end)
 -- Volt Strike
 -----------------------------------
 -- TODO: Volt Strike is not currently coded at time of this comment but should be set to 1.0 for fTPSubsequentHits. Loses Crit Scaling.
-
-return m

--- a/modules/era/lua/actions/spells/spell_adjustments.lua
+++ b/modules/era/lua/actions/spells/spell_adjustments.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'rov_spell_adjustments'
+local m = Module:new('rov_spell_adjustments')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Enfeebling Magic
@@ -200,5 +198,3 @@ for _, entry in ipairs(sanSpellOverrides) do
         return damage
     end)
 end
-
-return m

--- a/modules/era/lua/actions/weaponskills/archery.lua
+++ b/modules/era/lua/actions/weaponskills/archery.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_archery'
+local m = Module:new('toau_archery')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Flaming Arrow
@@ -162,5 +160,3 @@ m:addOverride('xi.actions.weaponskills.namas_arrow.onUseWeaponSkill', function(p
 
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/automaton.lua
+++ b/modules/era/lua/actions/weaponskills/automaton.lua
@@ -3,12 +3,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'wotg_automaton'
-
-local m = Module:new(moduleName)
+local m = Module:new('wotg_automaton')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
 
 -----------------------------------
@@ -301,5 +299,3 @@ m:addOverride('xi.actions.abilities.pets.automaton.string_clipper.onAutomatonAbi
 
     return info.damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/axe.lua
+++ b/modules/era/lua/actions/weaponskills/axe.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_axe'
+local m = Module:new('toau_axe')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Raging Axe
@@ -227,5 +225,3 @@ m:addOverride('xi.actions.weaponskills.primal_rend.onUseWeaponSkill', function(p
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/club.lua
+++ b/modules/era/lua/actions/weaponskills/club.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_club'
+local m = Module:new('toau_club')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Shining Strike
@@ -250,5 +248,3 @@ m:addOverride('xi.actions.weaponskills.mystic_boon.onUseWeaponSkill', function(p
 
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/dagger.lua
+++ b/modules/era/lua/actions/weaponskills/dagger.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_dagger'
+local m = Module:new('toau_dagger')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Wasp Sting
@@ -319,5 +317,3 @@ m:addOverride('xi.actions.weaponskills.mordant_rime.onUseWeaponSkill', function(
 
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/great_axe.lua
+++ b/modules/era/lua/actions/weaponskills/great_axe.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_great_axe'
+local m = Module:new('toau_great_axe')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Shield Break
 m:addOverride('xi.actions.weaponskills.shield_break.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
@@ -256,5 +254,3 @@ m:addOverride('xi.actions.weaponskills.kings_justice.onUseWeaponSkill', function
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/great_katana.lua
+++ b/modules/era/lua/actions/weaponskills/great_katana.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_great_katana'
+local m = Module:new('toau_great_katana')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Tachi: Enpi
@@ -262,5 +260,3 @@ m:addOverride('xi.actions.weaponskills.tachi_rana.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/great_sword.lua
+++ b/modules/era/lua/actions/weaponskills/great_sword.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_great_sword'
+local m = Module:new('toau_great_sword')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Hard Slash
@@ -181,5 +179,3 @@ m:addOverride('xi.actions.weaponskills.scourge.onUseWeaponSkill', function(playe
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/hand_to_hand.lua
+++ b/modules/era/lua/actions/weaponskills/hand_to_hand.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_hand_to_hand'
+local m = Module:new('toau_hand_to_hand')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Combo
@@ -212,5 +210,3 @@ m:addOverride('xi.actions.weaponskills.stringing_pummel.onUseWeaponSkill', funct
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/katana.lua
+++ b/modules/era/lua/actions/weaponskills/katana.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_katana'
+local m = Module:new('toau_katana')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Blade: Rin
@@ -249,5 +247,3 @@ m:addOverride('xi.actions.weaponskills.blade_kamu.onUseWeaponSkill', function(pl
 
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/marksmanship.lua
+++ b/modules/era/lua/actions/weaponskills/marksmanship.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_marksmanship'
+local m = Module:new('toau_marksmanship')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Hot Shot
@@ -193,5 +191,3 @@ m:addOverride('xi.actions.weaponskills.leaden_salute.onUseWeaponSkill', function
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doMagicWeaponskill(player, target, wsID, params, tp, action, primary)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/polearm.lua
+++ b/modules/era/lua/actions/weaponskills/polearm.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_polearm'
+local m = Module:new('toau_polearm')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Double Thrust
@@ -196,5 +194,3 @@ m:addOverride('xi.actions.weaponskills.drakesbane.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/scythe.lua
+++ b/modules/era/lua/actions/weaponskills/scythe.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_scythe'
+local m = Module:new('toau_scythe')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Slice
@@ -228,5 +226,3 @@ m:addOverride('xi.actions.weaponskills.insurgency.onUseWeaponSkill', function(pl
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/staff.lua
+++ b/modules/era/lua/actions/weaponskills/staff.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_staff'
+local m = Module:new('toau_staff')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Heavy Swing
@@ -289,5 +287,3 @@ m:addOverride('xi.actions.weaponskills.garland_of_bliss.onUseWeaponSkill', funct
 
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/actions/weaponskills/sword.lua
+++ b/modules/era/lua/actions/weaponskills/sword.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'toau_sword'
+local m = Module:new('toau_sword')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Fast Blade
@@ -398,5 +396,3 @@ m:addOverride('xi.actions.weaponskills.expiacion.onUseWeaponSkill', function(pla
     local damage, criticalHit, tpHits, extraHits = xi.weaponskills.doPhysicalWeaponskill(player, target, wsID, params, tp, action, primary, taChar)
     return tpHits, extraHits, criticalHit, damage
 end)
-
-return m

--- a/modules/era/lua/battlefields/mission_level_caps.lua
+++ b/modules/era/lua/battlefields/mission_level_caps.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'cop_level_caps'
+local m = Module:new('cop_level_caps')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Apply level caps after server initialization when all battlefields are loaded
 m:addOverride('xi.server.onServerStart', function()
@@ -56,5 +54,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end
 end)
-
-return m

--- a/modules/era/lua/combat/basic/tp.lua
+++ b/modules/era/lua/combat/basic/tp.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'soa_tp_gain'
+local m = Module:new('soa_tp_gain')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- all entities will use the this formula
 -- gainee is unused, in the normal code we need to pull objtype but not here
@@ -32,5 +30,3 @@ m:addOverride('xi.combat.tp.calculateTPReturn', function(gainee, delay)
 
     return math.floor(tpReturn)
 end)
-
-return m

--- a/modules/era/lua/combat/magic_burst.lua
+++ b/modules/era/lua/combat/magic_burst.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_magic_burst'
+local m = Module:new('era_magic_burst')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.spells.damage.calculateIfMagicBurst', function(caster, target, spellElement, magicBurstTier)
     if spellElement <= xi.element.NONE then
@@ -20,5 +18,3 @@ m:addOverride('xi.spells.damage.calculateIfMagicBurst', function(caster, target,
 
     return 1.25 + 0.05 * utils.clamp(magicBurstTier, 1, 5)
 end)
-
-return m

--- a/modules/era/lua/combat/pdif_caps.lua
+++ b/modules/era/lua/combat/pdif_caps.lua
@@ -4,10 +4,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'original_pdif_caps'
+Module:new('original_pdif_caps')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
 
 xi.combat.physical.pDifWeaponCapTable[xi.skill.HAND_TO_HAND    ] = 2
@@ -28,5 +28,3 @@ xi.combat.physical.pDifWeaponCapTable[xi.skill.AUTOMATON_MAGIC ] = 2
 xi.combat.physical.pDifWeaponCapTable[xi.skill.ARCHERY         ] = 3
 xi.combat.physical.pDifWeaponCapTable[xi.skill.MARKSMANSHIP    ] = 3
 xi.combat.physical.pDifWeaponCapTable[xi.skill.THROWING        ] = 3
-
-return { name = moduleName }

--- a/modules/era/lua/combat/physical_hit_rate.lua
+++ b/modules/era/lua/combat/physical_hit_rate.lua
@@ -6,16 +6,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'physical_hit_rate'
+local m = Module:new('physical_hit_rate')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.combat.physicalHitRate.getPhysicalHitRateCap', function(attacker, slot)
     return 0.95
 end)
-
-return m

--- a/modules/era/lua/combat/skillchain.lua
+++ b/modules/era/lua/combat/skillchain.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_skillchain'
+local m = Module:new('era_skillchain')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local chainMultipliers =
 {
@@ -128,5 +126,3 @@ m:addOverride('xi.combat.skillchain.calculateSkillchainDamage', function(actor, 
 
     return finalDamage
 end)
-
-return m

--- a/modules/era/lua/data/fame_rank_points.lua
+++ b/modules/era/lua/data/fame_rank_points.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'old_fame_rank_points'
+local m = Module:new('old_fame_rank_points')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -29,5 +27,3 @@ m:addOverride('xi.server.onServerStart', function()
         [9] = 2450,
     }
 end)
-
-return m

--- a/modules/era/lua/data/scavenge_data.lua
+++ b/modules/era/lua/data/scavenge_data.lua
@@ -1,5 +1,7 @@
 -----------------------------------
--- Data file consumed by job_adjustments.lua for Scavenge zone pools
+-- Data file consumed by job_utils/ranger.lua for Scavenge zone pools
+-- Not a module: the loader ignores return values, so this plain table is
+-- only ever seen by the modules that require() this file.
 -- Source: https://ffxiclopedia.fandom.com/wiki/Scavenge/Items
 -----------------------------------
 

--- a/modules/era/lua/effects/composure.lua
+++ b/modules/era/lua/effects/composure.lua
@@ -6,18 +6,14 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_effect_composure'
+local m = Module:new('era_effect_composure')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.effects.composure.onEffectGain', function(target, effect)
     local power = math.floor(target:getMainLvl() / 5)
 
     effect:addMod(xi.mod.ACC, power)
 end)
-
-return m

--- a/modules/era/lua/effects/era_signet_duration.lua
+++ b/modules/era/lua/effects/era_signet_duration.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_signet_duration'
+local m = Module:new('era_signet_duration')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.conquest.bestowSignet', function(player, pNation, pRank, mOffset)
     super(player, pNation, pRank, mOffset)
@@ -21,5 +19,3 @@ m:addOverride('xi.conquest.bestowSignet', function(player, pNation, pRank, mOffs
         signet:setDuration(signet:getDuration() - 3 * 3600 * 1000)
     end
 end)
-
-return m

--- a/modules/era/lua/effects/era_signet_effects.lua
+++ b/modules/era/lua/effects/era_signet_effects.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'cop_signet'
+local m = Module:new('cop_signet')
 
 if xi.module.isContentEnabled('TOAU') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.effects.signet.onEffectGain', function(target, effect)
     target:addLatent(xi.latent.SIGNET_BONUS, 0, xi.mod.DEF, 0)
@@ -50,5 +48,3 @@ m:addOverride('xi.effects.healing.onEffectTick', function(target, effect)
         end
     end
 end)
-
-return m

--- a/modules/era/lua/effects/level_restriction.lua
+++ b/modules/era/lua/effects/level_restriction.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_effect_level_restriction'
+local m = Module:new('era_effect_level_restriction')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.effects.level_restriction.onEffectGain', function(target, effect)
     super(target, effect)
@@ -22,5 +20,3 @@ m:addOverride('xi.effects.level_restriction.onEffectLose', function(target, effe
     super(target, effect)
     xi.job_utils.summoner.applySpiritPerpetuationCost(target)
 end)
-
-return m

--- a/modules/era/lua/effects/weight.lua
+++ b/modules/era/lua/effects/weight.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'soa_magic_adjustments'
+local m = Module:new('soa_magic_adjustments')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Gravity: Revert weight to apply an evasion down penalty
 -- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
@@ -19,5 +17,3 @@ m:addOverride('xi.effects.weight.onEffectGain', function(target, effect)
 
     effect:addMod(xi.mod.EVA, -10)
 end)
-
-return m

--- a/modules/era/lua/globals/equipment/unlocking_a_myth.lua
+++ b/modules/era/lua/globals/equipment/unlocking_a_myth.lua
@@ -7,13 +7,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'unlocking_a_myth'
+local m = Module:new('unlocking_a_myth')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local weaponList =
 {
@@ -64,5 +62,3 @@ for _, weaponName in ipairs(weaponList) do
         item:setWeaponskillPointsNeeded(xi.equipment.vigilWeaponRequiredWsPoints(target))
     end)
 end
-
-return m

--- a/modules/era/lua/globals/exp_curve.lua
+++ b/modules/era/lua/globals/exp_curve.lua
@@ -7,13 +7,11 @@
 require('modules/module_utils')
 -----------------------------------
 
-local moduleName = 'original_exp_curve'
+local m = Module:new('original_exp_curve')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.expDifficultyCurve.loadExpDifficultyCurve', function()
     local incrediblyEasyPreyLevel  = 255
@@ -35,5 +33,3 @@ m:addOverride('xi.expDifficultyCurve.loadExpDifficultyCurve', function()
     -- Load into C++
     LoadExpDifficultyCurves(expToDifficultyTable, incrediblyEasyPreyLevel, incrediblyEasyPreyMinExp)
 end)
-
-return m

--- a/modules/era/lua/globals/helm/helm_adjustments.lua
+++ b/modules/era/lua/globals/helm/helm_adjustments.lua
@@ -9,7 +9,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_helm_adjustments'
+Module:new('era_helm_adjustments')
 
 local removalsByContent =
 {
@@ -99,5 +99,3 @@ for _, entry in ipairs(removalsByContent) do
         applyRemovals(entry.removals)
     end
 end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/homepoint.lua
+++ b/modules/era/lua/globals/homepoint.lua
@@ -6,13 +6,11 @@
 require('modules/module_utils')
 require('scripts/globals/interaction/interaction_global')
 -----------------------------------
-local moduleName = 'homepoint_era_menu'
+local m = Module:new('homepoint_era_menu')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local function showHomepointCustomMenu(player, npc)
     local triggerTarget = npc
@@ -62,5 +60,3 @@ m:addOverride('xi.homepoint.onTrigger', function(player, csid, index)
     local npc = player:getCursorTarget()
     showHomepointCustomMenu(player, npc)
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/automaton.lua
+++ b/modules/era/lua/globals/job_utils/automaton.lua
@@ -8,13 +8,11 @@ require('modules/module_utils')
 require('scripts/globals/automaton')
 require('scripts/globals/pets/automaton')
 -----------------------------------
-local moduleName = 'automaton_global'
+local m = Module:new('automaton_global')
 
 if not xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local maneuverList =
 {
@@ -104,5 +102,3 @@ m:addOverride('xi.automaton.onUseManeuver', function(player, target, ability, ac
 
     return target:getOverloadChance(element)
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/beastmaster.lua
+++ b/modules/era/lua/globals/job_utils/beastmaster.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_beastmaster'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_beastmaster')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Reward: Override pet food healing values to pre-Abyssea values
@@ -99,11 +98,3 @@ if not xi.module.isContentEnabled('WOTG') then
         end
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/corsair.lua
+++ b/modules/era/lua/globals/job_utils/corsair.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_corsair'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_corsair')
 
 -----------------------------------
 -- Rhapsodies of Vana'diel Era
@@ -382,9 +381,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         return damage
     end)
 end
-
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/dark_knight.lua
+++ b/modules/era/lua/globals/job_utils/dark_knight.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_dark_knight'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_dark_knight')
 
 -----------------------------------
 -- Seekers of Adoulin Era
@@ -96,11 +95,3 @@ if not xi.module.isContentEnabled('WOTG') then
         effect:addMod(xi.mod.ARCANA_KILLER, effect:getPower())
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/dragoon.lua
+++ b/modules/era/lua/globals/job_utils/dragoon.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_dragoon'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_dragoon')
 
 -- Keep these sections in the old module init order: ROV -> SOA -> ABYSSEA -> WOTG.
 -- Expansion settings are cumulative, so each section only checks its own expansion.
@@ -548,11 +547,3 @@ if not xi.module.isContentEnabled('WOTG') then
         master:removeListener('PET_WYVERN_EXP')
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/monk.lua
+++ b/modules/era/lua/globals/job_utils/monk.lua
@@ -3,14 +3,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_monk'
+local m = Module:new('era_job_utils_monk')
 
 -- If RoV or later is enabled, no changes.
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Focus: Revert to flat +20 ACC only
 m:addOverride('xi.effects.focus.onEffectGain', function(target, effect)
@@ -104,5 +102,3 @@ end)
 --     effect:addMod(xi.mod.STORETP, 180)
 --     effect:addMod(xi.mod.HASTE_MAGIC, -6000)
 -- end)
-
-return m

--- a/modules/era/lua/globals/job_utils/ninja.lua
+++ b/modules/era/lua/globals/job_utils/ninja.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_ninja'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_ninja')
 
 -- Register RoV reverts only before RoV content is enabled.
 if not xi.module.isContentEnabled('ROV') then
@@ -63,11 +62,3 @@ if not xi.module.isContentEnabled('WOTG') then
         return dmg
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/paladin.lua
+++ b/modules/era/lua/globals/job_utils/paladin.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_paladin'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_paladin')
 
 -- Register RoV reverts only before RoV content is enabled.
 if not xi.module.isContentEnabled('ROV') then
@@ -122,11 +121,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         return damage
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/puppetmaster.lua
+++ b/modules/era/lua/globals/job_utils/puppetmaster.lua
@@ -3,12 +3,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_puppetmaster'
-
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_puppetmaster')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
 
 -- Overdrive: Revert duration from 180 to 60 seconds : https://wiki.ffo.jp/html/954.html
@@ -138,5 +136,3 @@ m:addOverride('xi.job_utils.puppetmaster.onAbilityUseRepair', function(player, t
 
     ability:setMsg(xi.msg.basic.USES_JA)
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/ranger.lua
+++ b/modules/era/lua/globals/job_utils/ranger.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_ranger'
-local m = Module:new(moduleName)
+local m = Module:new('era_job_utils_ranger')
 
 -- Register RoV reverts only before RoV content is enabled.
 if not xi.module.isContentEnabled('ROV') then
@@ -155,11 +154,3 @@ if not xi.module.isContentEnabled('WOTG') then
     m:addOverride('xi.effects.unlimited_shot.onEffectGain', function(target, effect)
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/samurai.lua
+++ b/modules/era/lua/globals/job_utils/samurai.lua
@@ -3,14 +3,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_samurai'
+local m = Module:new('era_job_utils_samurai')
 
 -- If Abyssea or later is enabled, no changes.
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Warding Circle: Revert duration from 3 minutes to 1 minute
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(02/13/2012)
@@ -129,5 +127,3 @@ m:addOverride('xi.effects.seigan.onEffectGain', function(target, effect)
 
     effect:addMod(xi.mod.DEF, jpValue * 3)
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/summoner.lua
+++ b/modules/era/lua/globals/job_utils/summoner.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- Module: Summoner spirit perpetuation cost helpers
 -----------------------------------
-local moduleName = 'era_job_utils_summoner'
+require('modules/module_utils')
+-----------------------------------
+Module:new('era_job_utils_summoner')
 
 xi.job_utils.summoner = xi.job_utils.summoner or {}
 
@@ -51,5 +53,3 @@ xi.job_utils.summoner.applySpiritPerpetuationCost = function(caster)
         caster:setMod(xi.mod.AVATAR_PERPETUATION, math.max(0, baseCost - meritReduction))
     end
 end
-
-return { name = moduleName }

--- a/modules/era/lua/globals/job_utils/thief.lua
+++ b/modules/era/lua/globals/job_utils/thief.lua
@@ -3,14 +3,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_thief'
+local m = Module:new('era_job_utils_thief')
 
 -- If Abyssea or later is enabled, no changes.
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Assassin's Charge: Remove Quadruple Attack
 m:addOverride('xi.effects.assassins_charge.onEffectGain', function(target, effect)
@@ -34,5 +32,3 @@ m:addOverride('xi.job_utils.thief.useFeint', function(player, target, ability, a
 
     player:addStatusEffect(xi.effect.FEINT, { power = 150, duration = 60, origin = player })
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/warrior.lua
+++ b/modules/era/lua/globals/job_utils/warrior.lua
@@ -3,14 +3,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_warrior'
+local m = Module:new('era_job_utils_warrior')
 
 -- If Abyssea or later is enabled, no changes.
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Warrior's Charge: Remove Triple Attack bonus
 m:addOverride('xi.effects.warriors_charge.onEffectGain', function(target, effect)
@@ -26,5 +24,3 @@ m:addOverride('xi.job_utils.warrior.useWarriorsCharge', function(player, target,
 
     return xi.effect.WARRIORS_CHARGE
 end)
-
-return m

--- a/modules/era/lua/globals/job_utils/white_mage.lua
+++ b/modules/era/lua/globals/job_utils/white_mage.lua
@@ -3,14 +3,12 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_job_utils_white_mage'
+local m = Module:new('era_job_utils_white_mage')
 
 -- If Abyssea or later is enabled, no changes.
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Martyr: Apply merit recast reduction, remove merit healing bonus
 m:addOverride('xi.job_utils.white_mage.useMartyr', function(player, target, ability, action)
@@ -45,5 +43,3 @@ m:addOverride('xi.job_utils.white_mage.useDevotion', function(player, target, ab
 
     return healMP
 end)
-
-return m

--- a/modules/era/lua/globals/old_nm_respawn_timers.lua
+++ b/modules/era/lua/globals/old_nm_respawn_timers.lua
@@ -18,18 +18,17 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-
-local moduleName = 'era_old_nm_respawn_timers'
+local m = Module:new('era_old_nm_respawn_timers')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
 
+-----------------------------------
 local shakhramiID = zones[xi.zone.MAZE_OF_SHAKHRAMI]
 local feiyinID    = zones[xi.zone.FEIYIN]
 local bostauID    = zones[xi.zone.BOSTAUNIEUX_OUBLIETTE]
 -----------------------------------
-local m = Module:new(moduleName)
 
 -----------------------------------
 -- Simple timed NMs
@@ -223,5 +222,3 @@ m:addOverride('xi.zones.Bostaunieux_Oubliette.Zone.onInitialize', function(zone)
         SpawnMob(bostauID.mob.BLOODSUCKER)
     end
 end)
-
-return m

--- a/modules/era/lua/globals/pets.lua
+++ b/modules/era/lua/globals/pets.lua
@@ -5,18 +5,14 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_globals_pets'
+local m = Module:new('era_globals_pets')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.pet.spawnPet', function(caster, petID, state, target)
     super(caster, petID, state, target)
 
     xi.job_utils.summoner.applySpiritPerpetuationCost(caster)
 end)
-
-return m

--- a/modules/era/lua/globals/pets/automaton.lua
+++ b/modules/era/lua/globals/pets/automaton.lua
@@ -4,13 +4,11 @@
 require('modules/module_utils')
 require('scripts/globals/pets/automaton')
 -----------------------------------
-local moduleName = 'automaton_pet'
+local m = Module:new('automaton_pet')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 -- Sets Maneuver Duration back to 60 seconds, without scaling time while in combat : https://wiki.ffo.jp/html/32936.html
 m:addOverride('xi.pets.automaton.onMobSpawn', function(mob)
@@ -43,7 +41,7 @@ end
 applyEraFrameHPReductions()
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
 
 -- Adds Frame Specific DT Taken Modifiers. / Removes Valoredge Block : https://wiki.ffo.jp/html/19739.html / https://wiki.ffo.jp/html/31705.html
@@ -88,7 +86,7 @@ xi.pets.automaton.skillCaps.heads[xi.automaton.head.SHARPSHOT ][xi.skill.AUTOMAT
 xi.pets.automaton.skillCaps.heads[xi.automaton.head.STORMWAKER][xi.skill.AUTOMATON_MAGIC ] = -1
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
 
 -- Removes Frame Specific DT Taken Modifiers for Automaton Frames & Removes Valoredge Block : https://wiki.ffo.jp/html/19739.html / https://wiki.ffo.jp/html/31705.html
@@ -96,5 +94,3 @@ xi.pets.automaton.frameMods[xi.automaton.frame.HARLEQUIN ] = {}
 xi.pets.automaton.frameMods[xi.automaton.frame.VALOREDGE ] = {}
 xi.pets.automaton.frameMods[xi.automaton.frame.SHARPSHOT ] = {}
 xi.pets.automaton.frameMods[xi.automaton.frame.STORMWAKER] = {}
-
-return m

--- a/modules/era/lua/globals/pets/avatar.lua
+++ b/modules/era/lua/globals/pets/avatar.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'soa_avatar_base_damage'
+local m = Module:new('soa_avatar_base_damage')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.pets.avatar.calculateAvatarWeaponDamage', function(pet)
     local weaponDamage = (pet:getMainLvl() + 2) / 2
@@ -20,5 +18,3 @@ m:addOverride('xi.pets.avatar.calculateAvatarWeaponDamage', function(pet)
     pet:setDamage(weaponDamage, xi.slot.MAIN)
     pet:setDamage(weaponDamage, xi.slot.RANGED)
 end)
-
-return m

--- a/modules/era/lua/globals/valeriano_shop_adjust.lua
+++ b/modules/era/lua/globals/valeriano_shop_adjust.lua
@@ -5,13 +5,11 @@
 require('modules/module_utils')
 require('scripts/globals/shop')
 -----------------------------------
-local moduleName = 'valeriano_shop_adjust'
+local m = Module:new('valeriano_shop_adjust')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.shop.handleValerianoShop', function(player, npc)
     local zoneTable =
@@ -44,5 +42,3 @@ m:addOverride('xi.shop.handleValerianoShop', function(player, npc)
     player:showText(npc, zones[zoneId].text.VALERIANO_SHOP_DIALOG)
     xi.shop.general(player, stock, zoneTable[zoneId][2])
 end)
-
-return m

--- a/modules/era/lua/items/flask_of_deodorizer.lua
+++ b/modules/era/lua/items/flask_of_deodorizer.lua
@@ -4,13 +4,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_deodorizer_duration'
-
+local m = Module:new('era_deodorizer_duration')
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.items.flask_of_deodorizer.onItemUse', function(target, user)
     if not target:hasStatusEffect(xi.effect.DEODORIZE) then
@@ -19,5 +16,3 @@ m:addOverride('xi.items.flask_of_deodorizer.onItemUse', function(target, user)
         target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end)
-
-return m

--- a/modules/era/lua/items/pinch_of_prism_powder.lua
+++ b/modules/era/lua/items/pinch_of_prism_powder.lua
@@ -4,13 +4,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_prism_powder_duration'
-
+local m = Module:new('era_prism_powder_duration')
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.items.pinch_of_prism_powder.onItemUse', function(target, user)
     if target:hasStatusEffect(xi.effect.INVISIBLE) then
@@ -19,5 +16,3 @@ m:addOverride('xi.items.pinch_of_prism_powder.onItemUse', function(target, user)
 
     target:addStatusEffect(xi.effect.INVISIBLE, { power = 1, duration = math.floor(math.random(90, 360) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
 end)
-
-return m

--- a/modules/era/lua/items/pinch_of_rainbow_powder.lua
+++ b/modules/era/lua/items/pinch_of_rainbow_powder.lua
@@ -4,13 +4,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_rainbow_powder_duration'
-
+local m = Module:new('era_rainbow_powder_duration')
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.items.pinch_of_rainbow_powder.onItemUse', function(target, user)
     if target:hasStatusEffect(xi.effect.INVISIBLE) then
@@ -19,5 +16,3 @@ m:addOverride('xi.items.pinch_of_rainbow_powder.onItemUse', function(target, use
 
     target:addStatusEffect(xi.effect.INVISIBLE, { power = 1, duration = math.floor(180 * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
 end)
-
-return m

--- a/modules/era/lua/items/pot_of_silent_oil.lua
+++ b/modules/era/lua/items/pot_of_silent_oil.lua
@@ -4,18 +4,13 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_silent_oil_duration'
-
+local m = Module:new('era_silent_oil_duration')
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.items.pot_of_silent_oil.onItemUse', function(target, user)
     if not target:hasStatusEffect(xi.effect.SNEAK) then
         target:addStatusEffect(xi.effect.SNEAK, { power = 1, duration = math.floor(math.random(90, 360) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
     end
 end)
-
-return m

--- a/modules/era/lua/missions/mission_adjustments.lua
+++ b/modules/era/lua/missions/mission_adjustments.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_mission_adjustments'
-local m = Module:new(moduleName)
+local m = Module:new('era_mission_adjustments')
 
 -- Keep sections in the previous module init order.
 if not xi.module.isContentEnabled('ROV') then
@@ -292,11 +291,3 @@ if not xi.module.isContentEnabled('SOA') then
         end)
     end)
 end
-
--- Return a real module only when a content gate registered overrides.
--- Otherwise return a data-only table to avoid a "No overrides found" loader warning.
-if #m.overrides > 0 then
-    return m
-end
-
-return { name = moduleName }

--- a/modules/era/lua/quests/jeuno/Apocalypse_Nigh.lua
+++ b/modules/era/lua/quests/jeuno/Apocalypse_Nigh.lua
@@ -9,13 +9,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_apocalypse_nigh'
-
+local m = Module:new('era_quest_apocalypse_nigh')
 if xi.module.isContentEnabled('TVR') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -70,5 +67,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/Chocobos_Wounds.lua
+++ b/modules/era/lua/quests/jeuno/Chocobos_Wounds.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_chocobos_wounds'
+local m = Module:new('era_quest_chocobos_wounds')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -81,5 +79,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/Northward.lua
+++ b/modules/era/lua/quests/jeuno/Northward.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_northward'
+local m = Module:new('era_quest_northward')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -24,5 +22,3 @@ m:addOverride('xi.server.onServerStart', function()
         }
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/Shadows_of_the_Departed.lua
+++ b/modules/era/lua/quests/jeuno/Shadows_of_the_Departed.lua
@@ -9,13 +9,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_shadows_of_the_departed'
-
+local m = Module:new('era_quest_shadows_of_the_departed')
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -47,5 +44,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/Storms_of_Fate.lua
+++ b/modules/era/lua/quests/jeuno/Storms_of_Fate.lua
@@ -8,13 +8,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_storms_of_fate'
-
+local m = Module:new('era_quest_storms_of_fate')
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -30,5 +27,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/The_Circle_of_Time.lua
+++ b/modules/era/lua/quests/jeuno/The_Circle_of_Time.lua
@@ -8,13 +8,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_the_circle_of_time'
-
+local m = Module:new('era_quest_the_circle_of_time')
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -30,5 +27,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/jeuno/The_Gobbiebag_Part_1_to_10.lua
+++ b/modules/era/lua/quests/jeuno/The_Gobbiebag_Part_1_to_10.lua
@@ -5,13 +5,11 @@
 require('modules/module_utils')
 require('scripts/quests/jeuno/helpers')
 -----------------------------------
-local moduleName = 'era_gobbiebag_fame_requirements'
+local m = Module:new('era_gobbiebag_fame_requirements')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local eraFameRequirements =
 {
@@ -32,5 +30,3 @@ m:addOverride('xi.jeuno.helpers.GobbiebagQuest.new', function(self, params)
 
     return super(self, params)
 end)
-
-return m

--- a/modules/era/lua/quests/otherAreas/A_Hard_Days_Knight.lua
+++ b/modules/era/lua/quests/otherAreas/A_Hard_Days_Knight.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_a_hard_days_knight'
+local m = Module:new('era_quest_a_hard_days_knight')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -21,5 +19,3 @@ m:addOverride('xi.server.onServerStart', function()
         table.remove(quest.sections, 3)
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/outlands/The_Kuftal_Tour.lua
+++ b/modules/era/lua/quests/outlands/The_Kuftal_Tour.lua
@@ -6,13 +6,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'the_kuftal_tour'
+local m = Module:new('the_kuftal_tour')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -36,5 +34,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/sandoria/Advanced_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Advanced_Teamwork.lua
@@ -7,13 +7,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_advanced_teamwork'
-
+local m = Module:new('era_quest_advanced_teamwork')
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -55,5 +52,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/sandoria/Enveloped_in_Darkness.lua
+++ b/modules/era/lua/quests/sandoria/Enveloped_in_Darkness.lua
@@ -8,13 +8,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_enveloped_in_darkness'
-
+local m = Module:new('era_quest_enveloped_in_darkness')
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -38,5 +35,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/sandoria/Intermediate_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Intermediate_Teamwork.lua
@@ -7,13 +7,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_intermediate_teamwork'
-
+local m = Module:new('era_quest_intermediate_teamwork')
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -75,5 +72,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/sandoria/Introduction_to_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Introduction_to_Teamwork.lua
@@ -7,13 +7,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_introduction_to_teamwork'
-
+local m = Module:new('era_quest_introduction_to_teamwork')
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -54,5 +51,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/quests/windurst/Sin_Hunting.lua
+++ b/modules/era/lua/quests/windurst/Sin_Hunting.lua
@@ -8,13 +8,10 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_sin_hunting'
-
+local m = Module:new('era_quest_sin_hunting')
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.server.onServerStart', function()
     super()
@@ -30,5 +27,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/era/lua/zones/Aht_Urhgan_Whitegate/npcs/aht_urhgan_whitegate_vendors.lua
+++ b/modules/era/lua/zones/Aht_Urhgan_Whitegate/npcs/aht_urhgan_whitegate_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'aht_urhgan_whitegate_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('aht_urhgan_whitegate_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Gavrie: Remove Automaton Oil +3 from shop inventory
@@ -72,5 +71,3 @@ if not xi.module.isContentEnabled('SOA') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Al_Zahbi/npcs/al_zahbi_vendors.lua
+++ b/modules/era/lua/zones/Al_Zahbi/npcs/al_zahbi_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'al_zahbi_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('al_zahbi_vendors_adjust')
 
 if not xi.module.isContentEnabled('WOTG') then
     -- Zafif: Remove Reprisal
@@ -57,5 +56,3 @@ if not xi.module.isContentEnabled('WOTG') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Bastok_Markets/npcs/bastok_markets_vendors.lua
+++ b/modules/era/lua/zones/Bastok_Markets/npcs/bastok_markets_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'bastok_markets_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('bastok_markets_vendors_adjust')
 
 if not xi.module.isContentEnabled('ROV') then
     -- Harmodios: Rework stock for in era items and conquest standing requirements
@@ -178,5 +177,3 @@ if not xi.module.isContentEnabled('WOTG') then
         xi.shop.nation(player, stock, xi.nation.BASTOK)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Bastok_Mines/npcs/bastok_mines_vendors.lua
+++ b/modules/era/lua/zones/Bastok_Mines/npcs/bastok_mines_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'bastok_mines_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('bastok_mines_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Boytz: Remove Republic Waystone from stock
@@ -90,5 +89,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.nation(player, stock, xi.nation.BASTOK)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Caedarva_Mire/npcs/qm8.lua
+++ b/modules/era/lua/zones/Caedarva_Mire/npcs/qm8.lua
@@ -5,13 +5,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'lamian_fang_key_tally_timer'
+local m = Module:new('lamian_fang_key_tally_timer')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Caedarva_Mire.npcs.qm8.onTrigger', function(player, npc)
     local ID = zones[xi.zone.CAEDARVA_MIRE]
@@ -24,5 +22,3 @@ m:addOverride('xi.zones.Caedarva_Mire.npcs.qm8.onTrigger', function(player, npc)
         player:messageSpecial(ID.text.NOTHING_OUT_OF_ORDINARY)
     end
 end)
-
-return m

--- a/modules/era/lua/zones/Castle_Oztroja/Zone.lua
+++ b/modules/era/lua/zones/Castle_Oztroja/Zone.lua
@@ -7,13 +7,13 @@
 require('modules/module_utils')
 require('scripts/globals/treasure')
 -----------------------------------
-local moduleName = 'pre_rmt_drops'
+-- NOTE: When re-enabling the override below, capture the module again:
+-- local m = Module:new('pre_rmt_drops')
+Module:new('pre_rmt_drops')
 
 if xi.module.isContentEnabled('COP') then
-    return { name = moduleName }
+    return
 end
-
-return { name = moduleName }
 
 --[[
 -- This Module is disabled until the new treasure system is tested an appropiate amount of time.

--- a/modules/era/lua/zones/Kazham/npcs/kazham_vendors.lua
+++ b/modules/era/lua/zones/Kazham/npcs/kazham_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'kazham_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('kazham_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Toji Mumosulah: Removes OOE spell scrolls from stock
@@ -73,5 +72,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.general(player, stock, xi.fameArea.WINDURST)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Lower_Jeuno/npcs/lower_jeuno_vendors.lua
+++ b/modules/era/lua/zones/Lower_Jeuno/npcs/lower_jeuno_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'lower_jeuno_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('lower_jeuno_vendors_adjust')
 
 if not xi.module.isContentEnabled('SOA') then
     -- Pawkrix: Remove Bowl of Goblin Stew 880 from stock
@@ -199,5 +198,3 @@ if not xi.module.isContentEnabled('ROV') then
         end
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Metalworks/npcs/Nogga.lua
+++ b/modules/era/lua/zones/Metalworks/npcs/Nogga.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'nogga_shop_adjust'
+local m = Module:new('nogga_shop_adjust')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Metalworks.npcs.Nogga.onTrigger', function(player, npc)
     local stock =
@@ -22,5 +20,3 @@ m:addOverride('xi.zones.Metalworks.npcs.Nogga.onTrigger', function(player, npc)
     player:showText(npc, zones[xi.zone.METALWORKS].text.NOGGA_SHOP_DIALOG)
     xi.shop.nation(player, stock, xi.nation.BASTOK)
 end)
-
-return m

--- a/modules/era/lua/zones/Mhaura/npcs/Pikini-Mikini.lua
+++ b/modules/era/lua/zones/Mhaura/npcs/Pikini-Mikini.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'mhaura_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('mhaura_vendors_adjust')
 
 if not xi.module.isContentEnabled('SOA') then
     m:addOverride('xi.zones.Mhaura.npcs.Pikini-Mikini.onTrigger', function(player, npc)
@@ -28,5 +27,3 @@ if not xi.module.isContentEnabled('SOA') then
         xi.shop.general(player, stock, xi.fameArea.WINDURST)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Nashmau/npcs/nashmau_vendors.lua
+++ b/modules/era/lua/zones/Nashmau/npcs/nashmau_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'nashmau_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('nashmau_vendors_adjust')
 
 if not xi.module.isContentEnabled('SOA') then
     -- Yoyoroon: Removes many PUP attachments
@@ -93,5 +92,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Norg/npcs/Solby-Maholby.lua
+++ b/modules/era/lua/zones/Norg/npcs/Solby-Maholby.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'solby_maholby_shop_adjust'
+local m = Module:new('solby_maholby_shop_adjust')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Norg.npcs.Solby-Maholby.onTrigger', function(player, npc)
     local stock =
@@ -22,5 +20,3 @@ m:addOverride('xi.zones.Norg.npcs.Solby-Maholby.onTrigger', function(player, npc
     player:showText(npc, zones[xi.zone.NORG].text.SOLBYMAHOLBY_SHOP_DIALOG, 0, 0, 0, 0, true, false)
     xi.shop.general(player, stock)
 end)
-
-return m

--- a/modules/era/lua/zones/Northern_San_dOria/npcs/Mulaujeant.lua
+++ b/modules/era/lua/zones/Northern_San_dOria/npcs/Mulaujeant.lua
@@ -15,13 +15,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'era_quest_missionary_man'
+local m = Module:new('era_quest_missionary_man')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Northern_San_dOria.npcs.Mulaujeant.onEventFinish', function(player, csid, option, npc)
     if csid == 698 then
@@ -35,5 +33,3 @@ m:addOverride('xi.zones.Northern_San_dOria.npcs.Mulaujeant.onEventFinish', funct
         npcUtil.giveKeyItem(player, xi.ki.SUBLIME_STATUE_OF_THE_GODDESS)
     end
 end)
-
-return m

--- a/modules/era/lua/zones/Northern_San_dOria/npcs/northern_san_doria_vendors.lua
+++ b/modules/era/lua/zones/Northern_San_dOria/npcs/northern_san_doria_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'northern_san_doria_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('northern_san_doria_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Arlenne: Rework stock for in era items and conquest standing requirements
@@ -74,5 +73,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.nation(player, stock, xi.nation.SANDORIA)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Port_Bastok/npcs/Numa.lua
+++ b/modules/era/lua/zones/Port_Bastok/npcs/Numa.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'numa_shop_adjust'
+local m = Module:new('numa_shop_adjust')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Port_Bastok.npcs.Numa.onTrigger', function(player, npc)
     local stock =
@@ -33,5 +31,3 @@ m:addOverride('xi.zones.Port_Bastok.npcs.Numa.onTrigger', function(player, npc)
     player:showText(npc, zones[xi.zone.PORT_BASTOK].text.NUMA_SHOP_DIALOG)
     xi.shop.nation(player, stock, xi.nation.BASTOK)
 end)
-
-return m

--- a/modules/era/lua/zones/Port_Jeuno/npcs/Gekko.lua
+++ b/modules/era/lua/zones/Port_Jeuno/npcs/Gekko.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'gekko_shop_adjust'
+local m = Module:new('gekko_shop_adjust')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Port_Jeuno.npcs.Gekko.onTrigger', function(player, npc)
     local stock =
@@ -28,5 +26,3 @@ m:addOverride('xi.zones.Port_Jeuno.npcs.Gekko.onTrigger', function(player, npc)
     player:showText(npc, zones[xi.zone.PORT_JEUNO].text.DUTY_FREE_SHOP_DIALOG)
     xi.shop.general(player, stock)
 end)
-
-return m

--- a/modules/era/lua/zones/Port_San_dOria/npcs/Coullave.lua
+++ b/modules/era/lua/zones/Port_San_dOria/npcs/Coullave.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'coullave_shop_adjust'
+local m = Module:new('coullave_shop_adjust')
 
 if xi.module.isContentEnabled('WOTG') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Port_San_dOria.npcs.Coullave.onTrigger', function(player, npc)
     local stock =
@@ -33,5 +31,3 @@ m:addOverride('xi.zones.Port_San_dOria.npcs.Coullave.onTrigger', function(player
     player:showText(npc, zones[xi.zone.PORT_SAN_DORIA].text.COULLAVE_SHOP_DIALOG)
     xi.shop.nation(player, stock, xi.nation.SANDORIA)
 end)
-
-return m

--- a/modules/era/lua/zones/Port_Windurst/npcs/port_windurst_vendors.lua
+++ b/modules/era/lua/zones/Port_Windurst/npcs/port_windurst_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'port_windurst_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('port_windurst_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Hohbiba-Mubiba: Rework inventory for era stock and conquest standing requirements
@@ -105,5 +104,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.nation(player, stock, xi.nation.WINDURST)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Rabao/npcs/rabao_vendors.lua
+++ b/modules/era/lua/zones/Rabao/npcs/rabao_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'rabao_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('rabao_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Brave Ox: Remove post-era scrolls (Cure VI, Protect V, Shell V, Crusade)
@@ -73,5 +72,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/RoMaeve/Zone.lua
+++ b/modules/era/lua/zones/RoMaeve/Zone.lua
@@ -11,13 +11,11 @@ xi.module.ensureTable('xi.zones.RoMaeve')
 -----------------------------------
 local ID = zones[xi.zone.ROMAEVE]
 -----------------------------------
-local moduleName = 'era_moongate_time'
+local m = Module:new('era_moongate_time')
 
 if xi.module.isContentEnabled('ROV') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 local function activateRoMaeve(zone)
     local validMoon    = (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON)
@@ -65,5 +63,3 @@ m:addOverride('xi.zones.RoMaeve.Zone.onGameHour', function(zone)
     super(zone)
     activateRoMaeve(zone)
 end)
-
-return m

--- a/modules/era/lua/zones/Selbina/npcs/Dohdjuma.lua
+++ b/modules/era/lua/zones/Selbina/npcs/Dohdjuma.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'dohdjuma_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('dohdjuma_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     m:addOverride('xi.zones.Selbina.npcs.Dohdjuma.onTrigger', function(player, npc)
@@ -26,5 +25,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.general(player, stock, xi.fameArea.SELBINA_RABAO)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Southern_San_dOria/npcs/southern_san_doria_vendors.lua
+++ b/modules/era/lua/zones/Southern_San_dOria/npcs/southern_san_doria_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'southern_san_doria_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('southern_san_doria_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Ashene: Rework stock for in era items and conquest standing requirements
@@ -142,5 +141,3 @@ if not xi.module.isContentEnabled('WOTG') then
         xi.shop.nation(player, stock, xi.nation.SANDORIA)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Tavnazian_Safehold/npcs/tavnazian_safehold_vendors.lua
+++ b/modules/era/lua/zones/Tavnazian_Safehold/npcs/tavnazian_safehold_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'tavnazian_safehold_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('tavnazian_safehold_vendors_adjust')
 
 if not xi.module.isContentEnabled('SOA') then
     -- Nilerouche: Removes OOE spell scrolls from stock
@@ -61,5 +60,3 @@ if not xi.module.isContentEnabled('SOA') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Upper_Jeuno/npcs/upper_jeuno_vendors.lua
+++ b/modules/era/lua/zones/Upper_Jeuno/npcs/upper_jeuno_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'upper_jeuno_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('upper_jeuno_vendors_adjust')
 
 if not xi.module.isContentEnabled('ROV') then
     -- Antonia: Remove job point related weapons from stock
@@ -71,5 +70,3 @@ if not xi.module.isContentEnabled('ROV') then
         xi.shop.general(player, stock)
     end)
 end
-
-return m

--- a/modules/era/lua/zones/Windurst_Waters/npcs/Churano-Shurano.lua
+++ b/modules/era/lua/zones/Windurst_Waters/npcs/Churano-Shurano.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'disable_magicked_astrolabe'
+local m = Module:new('disable_magicked_astrolabe')
 
 if xi.module.isContentEnabled('SOA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Windurst_Waters.npcs.Churano-Shurano.onTrigger', function(player, npc)
     player:startEvent(280)
@@ -21,5 +19,3 @@ end)
 
 m:addOverride('xi.zones.Windurst_Waters.npcs.Churano-Shurano.onEventFinish', function(player, csid, option, npc)
 end)
-
-return m

--- a/modules/era/lua/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
+++ b/modules/era/lua/zones/Windurst_Waters/npcs/Orez-Ebrez.lua
@@ -4,13 +4,11 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'orez_ebrez_shop_adjust'
+local m = Module:new('orez_ebrez_shop_adjust')
 
 if xi.module.isContentEnabled('ABYSSEA') then
-    return { name = moduleName }
+    return
 end
-
-local m = Module:new(moduleName)
 
 m:addOverride('xi.zones.Windurst_Waters.npcs.Orez-Ebrez.onTrigger', function(player, npc)
     local stock =
@@ -36,5 +34,3 @@ m:addOverride('xi.zones.Windurst_Waters.npcs.Orez-Ebrez.onTrigger', function(pla
     player:showText(npc, zones[xi.zone.WINDURST_WATERS].text.OREZEBREZ_SHOP_DIALOG)
     xi.shop.nation(player, stock, xi.nation.WINDURST)
 end)
-
-return m

--- a/modules/era/lua/zones/Windurst_Woods/npcs/windurst_woods_vendors.lua
+++ b/modules/era/lua/zones/Windurst_Woods/npcs/windurst_woods_vendors.lua
@@ -3,8 +3,7 @@
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local moduleName = 'windurst_woods_vendors_adjust'
-local m = Module:new(moduleName)
+local m = Module:new('windurst_woods_vendors_adjust')
 
 if not xi.module.isContentEnabled('ABYSSEA') then
     -- Mono Nchaa: Rework stock for in era items and conquest standing requirements
@@ -61,5 +60,3 @@ if not xi.module.isContentEnabled('ABYSSEA') then
         xi.shop.nation(player, stock, xi.nation.WINDURST)
     end)
 end
-
-return m

--- a/modules/example/commands/test.lua
+++ b/modules/example/commands/test.lua
@@ -2,6 +2,8 @@
 -- func: test
 -- desc: A test command module
 -----------------------------------
+require('modules/module_utils')
+-----------------------------------
 ---@type TCommand
 local commandObj = {}
 
@@ -20,4 +22,4 @@ commandObj.onTrigger = function(player)
     double_print(player, 'Test print')
 end
 
-return commandObj
+xi.module.registerCommand('test', commandObj)

--- a/modules/example/lua/modify_interaction_entry_example.lua
+++ b/modules/example/lua/modify_interaction_entry_example.lua
@@ -27,5 +27,3 @@ m:addOverride('xi.server.onServerStart', function()
         end
     end)
 end)
-
-return m

--- a/modules/module_utils.lua
+++ b/modules/module_utils.lua
@@ -4,6 +4,10 @@
 xi = xi or {}
 xi.module = xi.module or {}
 
+-- Module:new adds every Module it creates to this list automatically
+-- That means this is the new registration point for modules
+xi.module.registry = xi.module.registry or {}
+
 --
 -- applyOverride: Provides the "super" functionality for overriding functions
 --
@@ -43,6 +47,14 @@ xi.module.modifyInteractionEntry = function(filename, modifyFunc)
     InteractionGlobal.lookup:removeContainer(res) -- Remove the resource from the container
     modifyFunc(res) -- Run function to modify resource
     InteractionGlobal.lookup:addContainer(res) -- Re-add resource to container
+end
+
+-- Registration point for command modules
+xi.module.registerCommand = function(name, commandObj)
+    printf('Registering module command: !%s', name)
+
+    xi.commands = xi.commands or {}
+    xi.commands[name] = commandObj
 end
 
 xi.module.isContentEnabled = function(contentTag)
@@ -92,6 +104,8 @@ function Module:new(name)
     obj.name = name
     obj.overrides = {}
     obj.enabled = false
+
+    table.insert(xi.module.registry, obj)
 
     return obj
 end

--- a/modules/testing/lua/Empty_Mobs_model_IDs.lua
+++ b/modules/testing/lua/Empty_Mobs_model_IDs.lua
@@ -144,5 +144,3 @@ m:addOverride('xi.zones.GM_Home.Zone.onInitialize', function(zone)
         mob:spawn()
     end
 end)
-
-return m

--- a/src/map/utils/moduleutils.cpp
+++ b/src/map/utils/moduleutils.cpp
@@ -239,6 +239,11 @@ void LoadLuaModules(IPP mapIPP)
 
     const auto currentPort = mapIPP.getPort() == 0 ? settings::get<uint16>("network.MAP_PORT") : mapIPP.getPort();
 
+    lua[sol::create_if_nil]["xi"]["module"]["registry"] = lua.create_table();
+
+    sol::table registry = lua["xi"]["module"]["registry"];
+
+    // Start loading modules
     for (const auto& entry : expandedList)
     {
         const auto path = std::filesystem::path(entry).relative_path();
@@ -248,84 +253,71 @@ void LoadLuaModules(IPP mapIPP)
             continue;
         }
 
-        const auto filename = path.filename().generic_string();
-        const auto res      = lua.safe_script_file(path.generic_string());
+        const auto registrySizeBefore = registry.size();
+
+        const auto res = lua.safe_script_file(path.generic_string());
         if (!res.valid())
         {
             const sol::error err = res;
-            ShowError("Failed to load module: %s", filename);
+            ShowError("Failed to load module: %s", path.filename().generic_string());
             ShowError(err.what());
             continue;
         }
 
-        if (res.get_type() != sol::type::table)
+        // Tells you where the module came from
+        for (auto i = registrySizeBefore + 1; i <= registry.size(); ++i)
         {
-            ShowError("Failed to load module: Invalid object returned from: %s", filename);
-            continue;
+            registry[i]["filename"] = path.filename().generic_string();
         }
+    }
 
-        const sol::table table = res;
+    // Process everything now
+    for (std::size_t i = 1; i <= registry.size(); ++i)
+    {
+        const sol::table module = registry[i];
 
-        if (table["cmdprops"].valid() && table["onTrigger"].valid())
+        const auto moduleName = module.get_or("name", std::string{});
+        const auto filename   = module.get_or("filename", std::string{});
+        ShowInfo(fmt::format("=== Module: {} ===", moduleName));
+
+        bool anyPortFiltered = false;
+
+        const auto declaredOverrides = module.get_or("overrides", std::vector<sol::table>{});
+
+        const auto prevOverrideCount = overrides.size();
+        for (auto& override : declaredOverrides)
         {
-            const auto commandName = path.stem().generic_string();
-            ShowInfo(fmt::format("Registering module command: !{}", commandName));
-            lua[sol::create_if_nil]["xi"]["commands"][commandName] = table;
-            continue;
-        }
+            const auto name  = override["name"].get<std::string>();
+            const auto func  = override["func"];
+            const auto parts = split(name, ".");
 
-        if (table["overrides"].valid())
-        {
-            const auto moduleName = table.get_or("name", std::string{});
-            ShowInfo(fmt::format("=== Module: {} ===", moduleName));
+            DebugModules(fmt::format("Preparing override: {}", name));
 
-            bool anyPortFiltered = false;
-
-            const auto prevOverrideCount = overrides.size();
-            for (auto& override : table.get_or("overrides", std::vector<sol::table>{}))
+            if (parts.size() >= 3 && parts[0] == "xi" && parts[1] == "zones")
             {
-                const auto name  = override["name"].get<std::string>();
-                const auto func  = override["func"];
-                const auto parts = split(name, ".");
-
-                DebugModules(fmt::format("Preparing override: {}", name));
-
-                // Multi-process: skip overrides targeting zones on a different port
-                if (parts.size() >= 3 && parts[0] == "xi" && parts[1] == "zones")
+                const auto& zoneName = parts[2];
+                const auto  portIt   = zoneSettingsPorts.find(zoneName);
+                if (portIt != zoneSettingsPorts.end() && portIt->second != currentPort)
                 {
-                    const auto& zoneName = parts[2];
-                    const auto  portIt   = zoneSettingsPorts.find(zoneName);
-                    if (portIt != zoneSettingsPorts.end() && portIt->second != currentPort)
-                    {
-                        DebugModules(fmt::format("{} exists on a different port ({}), skipping", zoneName, portIt->second));
-                        anyPortFiltered = true;
-                        continue;
-                    }
+                    DebugModules(fmt::format("{} exists on a different port ({}), skipping", zoneName, portIt->second));
+                    anyPortFiltered = true;
+                    continue;
                 }
-
-                overrides.emplace(name.substr(0, name.rfind('.')),
-                                  Override{
-                                      .filename     = filename,
-                                      .overrideName = name,
-                                      .nameParts    = parts,
-                                      .func         = func,
-                                  });
             }
 
-            // Only warn if no overrides were added AND none were intentionally skipped
-            // due to targeting zones on a different map process port.
-            if (!anyPortFiltered && overrides.size() == prevOverrideCount)
-            {
-                ShowError("No overrides found in module: %s", filename);
-            }
-
-            // NOTE: This continue is for the expandedList loop
-            // TODO: Flatten all of this surrounding logic so it's less fragile
-            continue;
+            overrides.emplace(name.substr(0, name.rfind('.')),
+                              Override{
+                                  .filename     = filename,
+                                  .overrideName = name,
+                                  .nameParts    = parts,
+                                  .func         = func,
+                              });
         }
 
-        // TODO: Differentiate invalid table vs data-only table in modules directory
-        // ShowError("Failed to find valid table fields in module: %s", filename);
+        if (!anyPortFiltered && overrides.size() == prevOverrideCount)
+        {
+            DebugModules(fmt::format("No overrides registered in module (data-only or content-gated): {}", filename));
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
# Edit:
Changes how lua modules register themselves with the loader, so module files no longer have to return anything. Removes the fake `return { name = moduleName }` placeholder pattern/made up stuff that I introduced in my last PR (which was hiding a real bug instead of fixing it).

**Problems I was trying to fix from the previous iteration**
1. If a module hit a content gate and bailed out early, it had to return *something* or the loader complained. So I basically just faked the return because it needed something to return...bad me.
2. To make thins even worse if a module registered overrides and then returned the placeholder (or nothing) instead of `m`, all of those overrides were silently thrown away. No nothing...they just did not work so awesome for me.

### The hopefully final fix?
`Module:new` now signs the module in the moment you create it. There is a list (`xi.module.registry`), and creating a module adds itself to that list automatically. After all module files have run, the loader then walks the list and hooks everything up. What files return no longer matters at all so there is nothing to return, nothing to fake, and nothing to forget.

A module now looks like this:
```lua
local m = Module:new('era_magic_burst')

if xi.module.isContentEnabled('SOA') then
    return -- no more fake returns
end

m:addOverride('xi.spells.damage.calculateIfMagicBurst', function(...) end)
-- no return at the end
```

You MUST create the module (m =) **BEFORE** any content gates, so it always registers and always shows in the startup log even when the gates mean it registers zero overrides (which is now perfectly legal instead of an error).

A few things to note:
- data-only modules (ones that just edit tables at load time, like the era pDIF caps) are now completely ordinary modules that happen to have no overrides
- data files that other modules use `require()` (like the scavenge item pools) just plainly return their table like any normal lua file 
- command modules call `xi.module.registerCommand('name', commandObj)` instead of returning their command table.
- The loader only errors for real problems now...a script that fails to run, or an override that points at something that doesn't exist

- Removed every placeholder return and every `return m` across all module files
- Removed the `local moduleName` locals and the name just goes into the module like it did before
- Removed some redundant `if #m.overrides > 0` guards that were left over

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Start the server see no errors when modules are properly loaded

Tested all errors loading modules with/without dataOnly, etc.
<img width="1086" height="46" alt="image" src="https://github.com/user-attachments/assets/97fe04a7-9aa4-4756-b95d-4a112cef3011" />

<!-- Clear and detailed steps to test your changes here -->
