### PR TITLE
[lua] SAM Unlock Quest QM Fix

### DIFF
--- a/scripts/quests/outlands/Forge_Your_Destiny.lua
+++ b/scripts/quests/outlands/Forge_Your_Destiny.lua
@@ -60,33 +60,35 @@ quest.sections =
                         return quest:messageSpecial(konschtatID.text.BLACKENED_MUST_BE_CLOSER)
                     end
 
-                    local forgerMob = SpawnMob(konschtatID.mob.FORGER)
-                    if not forgerMob then
+                    if not npcUtil.tradeMatches(trade, { { xi.item.LUMP_OF_ORIENTAL_STEEL, 1 } }) then
                         return quest:noAction()
                     end
 
                     if
-                        forgerMob:isSpawned() or
+                        GetMobByID(konschtatID.mob.FORGER):isSpawned() or
                         npc:getLocalVar('forgerNextPopAllowedTime') > GetSystemTime()
                     then
                         return quest:messageSpecial(konschtatID.text.BLACKENED_NOTHING_HAPPENS, xi.item.LUMP_OF_ORIENTAL_STEEL)
                     end
 
-                    if npcUtil.tradeHasExactly(trade, xi.item.LUMP_OF_ORIENTAL_STEEL) then
-                        player:confirmTrade()
-                        forgerMob:updateClaim(player)
-
-                        -- QM is visible, but cannot be used to spawn Forger again until two minutes have elapsed since the NM despawns.
-                        forgerMob:setLocalVar('QMID', npc:getID())
-                        forgerMob:addListener('DESPAWN', 'DESPAWN_' .. konschtatID.mob.FORGER, function(mobArg)
-                            local qmID = mobArg:getLocalVar('QMID')
-
-                            mobArg:removeListener('DESPAWN_' .. konschtatID.mob.FORGER)
-                            GetNPCByID(qmID):setLocalVar('forgerNextPopAllowedTime', GetSystemTime() + 120)
-                        end)
-
-                        return quest:messageSpecial(konschtatID.text.PLACE_BLACKENED_SPOT, xi.item.LUMP_OF_ORIENTAL_STEEL)
+                    local forgerMob = SpawnMob(konschtatID.mob.FORGER)
+                    if not forgerMob then
+                        return quest:noAction()
                     end
+
+                    forgerMob:updateClaim(player)
+                    player:tradeComplete()
+
+                    -- QM is visible, but cannot be used to spawn Forger again until two minutes have elapsed since the NM despawns.
+                    forgerMob:setLocalVar('QMID', npc:getID())
+                    forgerMob:addListener('DESPAWN', 'DESPAWN_' .. konschtatID.mob.FORGER, function(mobArg)
+                        local qmID = mobArg:getLocalVar('QMID')
+
+                        mobArg:removeListener('DESPAWN_' .. konschtatID.mob.FORGER)
+                        GetNPCByID(qmID):setLocalVar('forgerNextPopAllowedTime', GetSystemTime() + 120)
+                    end)
+
+                    return quest:messageSpecial(konschtatID.text.PLACE_BLACKENED_SPOT, xi.item.LUMP_OF_ORIENTAL_STEEL)
                 end,
 
                 onTrigger = function(player, npc)
@@ -112,27 +114,27 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         quest:isVarBitsSet(player, 'Option', 0) and
-                        npcUtil.tradeHasExactly(trade, xi.item.CHUNK_OF_DARKSTEEL_ORE)
+                        npcUtil.tradeMatches(trade, { { xi.item.CHUNK_OF_DARKSTEEL_ORE, 1 } })
                     then
                         return quest:progressEvent(47, 0, xi.item.LUMP_OF_ORIENTAL_STEEL, xi.item.CHUNK_OF_DARKSTEEL_ORE)
                     end
                 end,
 
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'waitTime') == 0 then
-                        if player:findItem(xi.item.LUMP_OF_BOMB_STEEL) then
-                            return quest:progressEvent(49, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
-                        elseif not player:findItem(xi.item.LUMP_OF_ORIENTAL_STEEL) then
-                            if not quest:isVarBitsSet(player, 'Option', 0) then
-                                return quest:progressEvent(44, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
-                            else
-                                return quest:progressEvent(46, 0, xi.item.LUMP_OF_ORIENTAL_STEEL, xi.item.CHUNK_OF_DARKSTEEL_ORE)
-                            end
+                    if quest:getVar(player, 'waitTime') ~= 0 then
+                        return quest:progressEvent(50)
+                    end
+
+                    if player:findItem(xi.item.LUMP_OF_BOMB_STEEL) then
+                        return quest:progressEvent(49, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
+                    elseif not player:findItem(xi.item.LUMP_OF_ORIENTAL_STEEL) then
+                        if not quest:isVarBitsSet(player, 'Option', 0) then
+                            return quest:progressEvent(44, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
                         else
-                            return quest:progressEvent(45, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
+                            return quest:progressEvent(46, 0, xi.item.LUMP_OF_ORIENTAL_STEEL, xi.item.CHUNK_OF_DARKSTEEL_ORE)
                         end
                     else
-                        return quest:progressEvent(50)
+                        return quest:progressEvent(45, xi.item.LUMP_OF_BOMB_STEEL, xi.item.LUMP_OF_ORIENTAL_STEEL)
                     end
                 end,
             },
@@ -140,13 +142,13 @@ quest.sections =
             ['Jaucribaix'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { xi.item.LUMP_OF_BOMB_STEEL, xi.item.SACRED_BRANCH }) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.LUMP_OF_BOMB_STEEL, 1 }, { xi.item.SACRED_BRANCH, 1 } }) then
                         return quest:progressEvent(27)
                     end
                 end,
 
                 onTrigger = function(player, npc)
-                    local waitTime = quest:getVar(player, 'waitTime')
+                    local waitTime      = quest:getVar(player, 'waitTime')
                     local timeRemaining = waitTime - GetSystemTime()
 
                     if waitTime == 0 then
@@ -194,7 +196,7 @@ quest.sections =
             {
                 [27] = function(player, csid, option, npc)
                     -- TODO: Add constant for Vana'diel day in seconds, this is a three game day wait.
-                    player:confirmTrade()
+                    player:tradeComplete()
                     quest:setVar(player, 'waitTime', GetSystemTime() + 10368)
                 end,
 
@@ -225,7 +227,7 @@ quest.sections =
 
                 [47] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.item.LUMP_OF_ORIENTAL_STEEL) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -262,8 +264,7 @@ quest.sections =
                             treantMob:updateClaim(player)
                             player:tradeComplete()
 
-                            -- QM is visible, but cannot be used to spawn Forger again until ten minutes have elapsed
-                            -- since the NM despawns.
+                            -- QM is visible, but cannot be used to spawn Guardian Treant again until ten minutes have elapsed since the NM despawns.
                             treantMob:setLocalVar('QMID', npc:getID())
                             treantMob:addListener('DESPAWN', 'DESPAWN_' .. zitahID.mob.GUARDIAN_TREANT, function(mobArg)
                                 local qmID = mobArg:getLocalVar('QMID')


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes some bugs with the QM in Konschtat Highlands used in the SAM unlock quest "Forge Your Destiny". The order of operations for trade was causing items to not be consumed and any item to pop the mob. The lockout period after spawn/kill was also not working correctly. This PR addresses all of that.

## Steps to test these changes

!addquest 5 129 and progress as normal. See that when you get to the Forger (bomb) NM fight section the trade interactions and lockouts now work properly. See you can fully complete the quest even with these adjustments.
