### PR TITLE
[core] Navmesh: Generate off-mesh links; Tile staircases; fix tile seams; don't shortcut through corners

### DIFF
--- a/scripts/commands/rebuildnavmesh.lua
+++ b/scripts/commands/rebuildnavmesh.lua
@@ -23,7 +23,7 @@ local config =
     --
     -- Docs:
     -- The y-axis cell size to use for fields. [Limit: > 0] [Units: wu]
-    cellHeight = 0.4,
+    cellHeight = 0.2,
 
     -- Slopes steeper than this angle (in degrees) are marked as unwalkable.
     --
@@ -53,7 +53,7 @@ local config =
     --
     -- Docs:
     -- Maximum ledge height that is considered to still be traversable. [Limit: >=0] [Units: vx]
-    agentMaxClimb = 0.6,
+    agentMaxClimb = 1.0,
 
     -- Maximum length of a single contour edge (in wu). Long edges are split
     -- at this length. 0 = no limit (edges can be any length).
@@ -134,6 +134,12 @@ local config =
 
     -- World-space spheres to carve out of the collision data before rasterization.
     -- skipSpheres = { { x = -496.0, y = -6.5, z = -9932914.5, radius = 100.0 } },
+
+    -- Largest vertical drop (world units) a link may bridge.
+    offMeshMaxDrop = 5.0,
+
+    -- Largest horizontal ledge->landing offset (world units) to search.
+    offMeshHorizReach = 3.0,
 }
 
 commandObj.onTrigger = function(player)

--- a/src/map/ai/helpers/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind.cpp
@@ -244,6 +244,7 @@ void CPathFind::PrunePathWithin(float within)
     }
 
     position_t targetPoint = m_points.back().position;
+    auto*      navMesh     = m_POwner->loc.zone->navMesh();
 
     while (m_points.size() > 1)
     {
@@ -253,6 +254,17 @@ void CPathFind::PrunePathWithin(float within)
         {
             break;
         }
+
+        // only drop the point if the line it opens up is walkable the whole way
+        const position_t& shortcutFrom = m_points.size() > 2 ? m_points[m_points.size() - 3].position : m_POwner->loc.p;
+
+        float reachable[3]{};
+        if (!navMesh->findFurthestValidPoint(shortcutFrom, targetPoint, reachable) ||
+            !isWithinDistance(targetPoint, position_t{ reachable[0], reachable[1], reachable[2], 0, 0 }, 1.0f, true))
+        {
+            break;
+        }
+
         m_points.erase(m_points.end() - 2);
     }
 }
@@ -360,14 +372,21 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     float distanceTo   = distance(m_POwner->loc.p, pos);
     float diff_y       = pos.y - m_POwner->loc.p.y;
 
+    const float stopDistance = StopDistanceForCurrentPoint();
+
     // face point mob is moving towards
     LookAt(pos);
 
-    if (distanceTo <= m_distanceFromPoint + stepDistance)
-    {
-        m_distanceMoved += distanceTo - m_distanceFromPoint;
+    // step along the exact bearing; loc.p.rotation is a byte and lags behind LookAt()
+    const float horizontalToPoint = distance(m_POwner->loc.p, pos, true) + FLT_EPSILON;
+    const float directionX        = (pos.x - m_POwner->loc.p.x) / horizontalToPoint;
+    const float directionZ        = (pos.z - m_POwner->loc.p.z) / horizontalToPoint;
 
-        if (m_distanceFromPoint == 0)
+    if (distanceTo <= stopDistance + stepDistance)
+    {
+        m_distanceMoved += distanceTo - stopDistance;
+
+        if (stopDistance == 0)
         {
             m_POwner->loc.p.x = pos.x;
             m_POwner->loc.p.y = pos.y;
@@ -375,10 +394,8 @@ void CPathFind::StepTo(const position_t& pos, bool run)
         }
         else
         {
-            float radians = (1 - (float)m_POwner->loc.p.rotation / 256) * 2 * (float)M_PI;
-
-            m_POwner->loc.p.x += cosf(radians) * (distanceTo - m_distanceFromPoint);
-            m_POwner->loc.p.z += sinf(radians) * (distanceTo - m_distanceFromPoint);
+            m_POwner->loc.p.x += directionX * (distanceTo - stopDistance);
+            m_POwner->loc.p.z += directionZ * (distanceTo - stopDistance);
             if (abs(diff_y) > .5f)
             {
                 // Don't step too far vertically by simply utilizing the slope
@@ -399,10 +416,8 @@ void CPathFind::StepTo(const position_t& pos, bool run)
     {
         m_distanceMoved += stepDistance;
         // take a step towards target point
-        float radians = (1 - (float)m_POwner->loc.p.rotation / 256) * 2 * (float)M_PI;
-
-        m_POwner->loc.p.x += cosf(radians) * stepDistance;
-        m_POwner->loc.p.z += sinf(radians) * stepDistance;
+        m_POwner->loc.p.x += directionX * stepDistance;
+        m_POwner->loc.p.z += directionZ * stepDistance;
         if (abs(diff_y) > .5f)
         {
             // Don't step too far vertically by simply utilizing the slope
@@ -557,14 +572,26 @@ bool CPathFind::IsPatrolling()
 
 bool CPathFind::AtPoint(const position_t& pos)
 {
-    if (m_distanceFromPoint == 0)
+    const float stopDistance = StopDistanceForCurrentPoint();
+
+    if (stopDistance == 0)
     {
         return isWithinDistance(m_POwner->loc.p, pos, 0.1f);
     }
     else
     {
-        return isWithinDistance(m_POwner->loc.p, pos, m_distanceFromPoint + 0.2f);
+        return isWithinDistance(m_POwner->loc.p, pos, stopDistance + 0.2f);
     }
+}
+
+auto CPathFind::StopDistanceForCurrentPoint() const -> float
+{
+    if (m_currentPoint >= static_cast<int16>(m_points.size()) - 1)
+    {
+        return m_distanceFromPoint;
+    }
+
+    return 0.0f;
 }
 
 bool CPathFind::InWater()

--- a/src/map/ai/helpers/pathfind.h
+++ b/src/map/ai/helpers/pathfind.h
@@ -128,6 +128,9 @@ private:
     // finds a random path around the given point
     bool FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags);
 
+    // stop distance for the current point; only the destination stops short
+    auto StopDistanceForCurrentPoint() const -> float;
+
     void AddPoints(std::vector<pathpoint_t>&& points, bool reverse = false);
 
     void FinishedPath();

--- a/src/map/lua/lua_zone.cpp
+++ b/src/map/lua/lua_zone.cpp
@@ -227,6 +227,9 @@ void CLuaZone::rebuildNavmesh(const sol::table& table)
     config.filterLowHangingObstacles    = table.get_or("filterLowHangingObstacles", config.filterLowHangingObstacles);
     config.filterLedgeSpans             = table.get_or("filterLedgeSpans", config.filterLedgeSpans);
     config.filterWalkableLowHeightSpans = table.get_or("filterWalkableLowHeightSpans", config.filterWalkableLowHeightSpans);
+    config.generateOffMeshLinks         = table.get_or("generateOffMeshLinks", config.generateOffMeshLinks);
+    config.offMeshMaxDrop               = table.get_or("offMeshMaxDrop", config.offMeshMaxDrop);
+    config.offMeshHorizReach            = table.get_or("offMeshHorizReach", config.offMeshHorizReach);
 
     if (const auto ySkipPlanes = table.get<sol::optional<sol::table>>("ySkipPlanes"))
     {

--- a/src/map/navmesh/navmesh_builder.cpp
+++ b/src/map/navmesh/navmesh_builder.cpp
@@ -42,7 +42,7 @@ namespace
 
 // Recast/Detour constants (not tunable)
 constexpr uint16 SAMPLE_POLYFLAGS_WALK  = 0x0001; // RecastDemo/Include/Sample.h
-constexpr int    TILE_BORDER_PADDING    = 3;      // Extra cells beyond walkableRadius for tile stitching (Sample_TileMesh.cpp)
+constexpr int    TILE_BORDER_PADDING    = 8;      // Extra cells beyond walkableRadius for tile stitching; <8 leaves eroded seam gaps on continuous terrain
 constexpr float  MIN_DETAIL_SAMPLE_DIST = 0.9f;   // Recast clamps non-zero detailSampleDist to >= 0.9
 constexpr int    DT_MAX_TILE_BITS       = 14;     // dtNavMesh max bits for tile indexing
 constexpr int    DT_TOTAL_REF_BITS      = 22;     // dtNavMesh total bits for tile + poly refs

--- a/src/map/navmesh/navmesh_builder.cpp
+++ b/src/map/navmesh/navmesh_builder.cpp
@@ -26,6 +26,7 @@
 
 #include <map/ximesh/iximesh.h>
 
+#include <DetourCommon.h>
 #include <DetourNavMesh.h>
 #include <DetourNavMeshBuilder.h>
 #include <Recast.h>
@@ -56,6 +57,10 @@ constexpr float Y_SKIP_PLANE_TOLERANCE = 0.01f;
 
 constexpr std::size_t TILE_BATCH_SIZE = 32;
 
+// Off-mesh link generation limits
+constexpr int   OFFMESH_MAX_PER_TILE = 256;  // hard cap; excess dropped with a warning
+constexpr float OFFMESH_DEDUP_DIST   = 1.0f; // links whose start AND end are within this are dupes
+
 auto transform(const std::array<float, 9>& rot, const std::array<float, 3>& trans, const float* vertex) -> std::array<float, 3>
 {
     return {
@@ -63,6 +68,289 @@ auto transform(const std::array<float, 9>& rot, const std::array<float, 3>& tran
         rot[1] * vertex[0] + rot[4] * vertex[1] + rot[7] * vertex[2] + trans[1],
         rot[2] * vertex[0] + rot[5] * vertex[1] + rot[8] * vertex[2] + trans[2],
     };
+}
+
+// Scan each walkable poly's ledge (border) edges.
+// Where a walkable surface sits below within the drop window, link the ledge down to it.
+// Landings come only from this tile's own detail mesh, so both endpoints are real polys.
+// Detour space, Y up.
+auto buildOffMeshConnections(const rcPolyMesh& pmesh, const rcPolyMeshDetail& dmesh, const NavMeshConfig& config, const int tileX, const int tileY) -> TileOffMeshConnections
+{
+    TileOffMeshConnections out;
+
+    const int    vertsPerPoly = pmesh.nvp;
+    const float  cellSize     = pmesh.cs;
+    const float  cellHeight   = pmesh.ch;
+    const float* boundsMin    = pmesh.bmin;
+    const float  minDrop      = config.agentMaxClimb; // below this Recast already connects in-mesh
+    const float  maxDrop      = config.offMeshMaxDrop;
+    const float  maxReach     = std::max(config.offMeshHorizReach, config.agentRadius);
+    const float  linkRadius   = std::max(config.agentRadius, cellSize);
+
+    const auto polyVertToWorld = [&](const int vertIndex, float* outXyz)
+    {
+        outXyz[0] = boundsMin[0] + pmesh.verts[vertIndex * 3 + 0] * cellSize;
+        outXyz[1] = boundsMin[1] + pmesh.verts[vertIndex * 3 + 1] * cellHeight;
+        outXyz[2] = boundsMin[2] + pmesh.verts[vertIndex * 3 + 2] * cellSize;
+    };
+
+    // Union-find of walk-connected polys; skip a link whose landing shares the source poly's component.
+    std::vector<int> parent(pmesh.npolys);
+    for (int p = 0; p < pmesh.npolys; ++p)
+    {
+        parent[p] = p;
+    }
+
+    const auto findRoot = [&](int x) -> int
+    {
+        while (parent[x] != x)
+        {
+            parent[x] = parent[parent[x]];
+            x         = parent[x];
+        }
+        return x;
+    };
+
+    for (int p = 0; p < pmesh.npolys; ++p)
+    {
+        const unsigned short* poly = &pmesh.polys[p * 2 * vertsPerPoly];
+        for (int j = 0; j < vertsPerPoly; ++j)
+        {
+            if (poly[j] == RC_MESH_NULL_IDX)
+            {
+                break;
+            }
+
+            const unsigned short neighborPoly = poly[vertsPerPoly + j];
+            if (neighborPoly == RC_MESH_NULL_IDX || (neighborPoly & 0x8000)) // border or tile portal, not internal
+            {
+                continue;
+            }
+
+            const int rootA = findRoot(p);
+            const int rootB = findRoot(neighborPoly);
+            if (rootA != rootB)
+            {
+                parent[rootA] = rootB;
+            }
+        }
+    }
+
+    // Per-poly xz-AABB of the detail surface, to cull the height search.
+    struct PolyAABB
+    {
+        float xmin, xmax, zmin, zmax;
+    };
+
+    std::vector<PolyAABB> aabb(pmesh.npolys);
+    for (int p = 0; p < pmesh.npolys; ++p)
+    {
+        const int detailBase      = dmesh.meshes[p * 4 + 0];
+        const int detailVertCount = dmesh.meshes[p * 4 + 1];
+        auto      box             = PolyAABB{ FloatMax, FloatLowest, FloatMax, FloatLowest };
+        for (int i = 0; i < detailVertCount; ++i)
+        {
+            const float* vert = &dmesh.verts[(detailBase + i) * 3];
+            box.xmin          = std::min(box.xmin, vert[0]);
+            box.xmax          = std::max(box.xmax, vert[0]);
+            box.zmin          = std::min(box.zmin, vert[2]);
+            box.zmax          = std::max(box.zmax, vert[2]);
+        }
+        aabb[p] = box;
+    }
+
+    // Highest walkable detail-surface Y at (x, z) within [loY, hiY], excluding srcPoly, plus the poly it lands on (used by the same-component skip below).
+    const auto sampleBelow = [&](const float x, const float z, const float loY, const float hiY, const int srcPoly, float& outY, int& outPoly) -> bool
+    {
+        bool  found = false;
+        float best  = FloatLowest;
+        for (int p = 0; p < pmesh.npolys; ++p)
+        {
+            if (p == srcPoly || pmesh.areas[p] != RC_WALKABLE_AREA)
+            {
+                continue;
+            }
+
+            const auto& box = aabb[p];
+            if (x < box.xmin - 0.01f || x > box.xmax + 0.01f || z < box.zmin - 0.01f || z > box.zmax + 0.01f)
+            {
+                continue;
+            }
+
+            const int detailBase = dmesh.meshes[p * 4 + 0];
+            const int triBase    = dmesh.meshes[p * 4 + 2];
+            const int triCount   = dmesh.meshes[p * 4 + 3];
+            for (int t = 0; t < triCount; ++t)
+            {
+                const unsigned char* tri = &dmesh.tris[(triBase + t) * 4];
+                const float*         va  = &dmesh.verts[(detailBase + tri[0]) * 3];
+                const float*         vb  = &dmesh.verts[(detailBase + tri[1]) * 3];
+                const float*         vc  = &dmesh.verts[(detailBase + tri[2]) * 3];
+
+                const float probe[3] = { x, 0.0f, z };
+                float       y        = 0.0f;
+                if (dtClosestHeightPointTriangle(probe, va, vb, vc, y) && y >= loY && y <= hiY && y > best)
+                {
+                    best    = y;
+                    found   = true;
+                    outPoly = p;
+                }
+            }
+        }
+
+        if (found)
+        {
+            outY = best;
+        }
+
+        return found;
+    };
+
+    std::vector<OffMeshCandidate> candidates;
+    for (int p = 0; p < pmesh.npolys; ++p)
+    {
+        if (pmesh.areas[p] != RC_WALKABLE_AREA)
+        {
+            continue;
+        }
+
+        const unsigned short* poly = &pmesh.polys[p * 2 * vertsPerPoly];
+
+        int   vertCount   = 0;
+        float centroid[3] = { 0.0f, 0.0f, 0.0f };
+        for (int j = 0; j < vertsPerPoly; ++j)
+        {
+            if (poly[j] == RC_MESH_NULL_IDX)
+            {
+                break;
+            }
+
+            float worldVert[3];
+            polyVertToWorld(poly[j], worldVert);
+            centroid[0] += worldVert[0];
+            centroid[1] += worldVert[1];
+            centroid[2] += worldVert[2];
+            vertCount++;
+        }
+
+        if (vertCount < 3)
+        {
+            continue;
+        }
+
+        centroid[0] /= static_cast<float>(vertCount);
+        centroid[1] /= static_cast<float>(vertCount);
+        centroid[2] /= static_cast<float>(vertCount);
+
+        for (int j = 0; j < vertCount; ++j)
+        {
+            // Only ledge edges: RC_MESH_NULL_IDX is a solid border; internal neighbours and tile-portal edges (0x8000) are skipped.
+            if (poly[vertsPerPoly + j] != RC_MESH_NULL_IDX)
+            {
+                continue;
+            }
+
+            float edgeA[3];
+            float edgeB[3];
+            polyVertToWorld(poly[j], edgeA);
+            polyVertToWorld(poly[(j + 1) % vertCount], edgeB);
+            float edgeMid[3];
+            dtVlerp(edgeMid, edgeA, edgeB, 0.5f);
+
+            // Outward direction (away from the poly centroid), in the xz-plane.
+            float       outwardX   = edgeMid[0] - centroid[0];
+            float       outwardZ   = edgeMid[2] - centroid[2];
+            const float outwardLen = std::sqrt(outwardX * outwardX + outwardZ * outwardZ);
+            if (outwardLen < 1e-4f)
+            {
+                continue;
+            }
+
+            outwardX /= outwardLen;
+            outwardZ /= outwardLen;
+
+            const float ledgeY       = edgeMid[1];
+            float       landingX     = 0.0f;
+            float       landingY     = 0.0f;
+            float       landingZ     = 0.0f;
+            int         landingPoly  = -1;
+            bool        foundLanding = false;
+            for (float reach = linkRadius; reach <= maxReach + 1e-3f; reach += 0.5f)
+            {
+                const float probeX = edgeMid[0] + outwardX * reach;
+                const float probeZ = edgeMid[2] + outwardZ * reach;
+
+                if (sampleBelow(probeX, probeZ, ledgeY - maxDrop, ledgeY - minDrop, p, landingY, landingPoly))
+                {
+                    landingX     = probeX;
+                    landingZ     = probeZ;
+                    foundLanding = true;
+                    break; // nearest landing wins
+                }
+            }
+
+            if (!foundLanding)
+            {
+                continue;
+            }
+
+            // Skip when the landing is already walk-reachable within this tile.
+            if (findRoot(landingPoly) == findRoot(p))
+            {
+                continue;
+            }
+
+            candidates.push_back(OffMeshCandidate{
+                .start = { edgeMid[0] - outwardX * linkRadius, ledgeY, edgeMid[2] - outwardZ * linkRadius }, // pulled just inside the source poly
+                .end   = { landingX, landingY, landingZ },
+            });
+        }
+    }
+
+    // Drop near-duplicate links (a long ledge spans many edges -> parallel dupes).
+    const auto closeBy = [](const float* a, const float* b) -> bool
+    {
+        return dtVdistSqr(a, b) < OFFMESH_DEDUP_DIST * OFFMESH_DEDUP_DIST;
+    };
+
+    std::vector<OffMeshCandidate> unique;
+    for (const auto& c : candidates)
+    {
+        const bool dupe = std::any_of(unique.begin(), unique.end(), [&](const OffMeshCandidate& u)
+                                      {
+                                          return closeBy(c.start, u.start) && closeBy(c.end, u.end);
+                                      });
+        if (!dupe)
+        {
+            unique.push_back(c);
+        }
+    }
+
+    // Cap per tile, logging what was dropped rather than truncating silently.
+    if (static_cast<int>(unique.size()) > OFFMESH_MAX_PER_TILE)
+    {
+        ShowWarningFmt("NavMeshBuilder: tile ({}, {}) generated {} off-mesh links, capping at {}",
+                       tileX,
+                       tileY,
+                       unique.size(),
+                       OFFMESH_MAX_PER_TILE);
+        unique.resize(OFFMESH_MAX_PER_TILE);
+    }
+
+    out.count = static_cast<int>(unique.size());
+    out.verts.reserve(static_cast<std::size_t>(out.count) * 6);
+    for (const auto& c : unique)
+    {
+        out.verts.insert(out.verts.end(), { c.start[0], c.start[1], c.start[2], c.end[0], c.end[1], c.end[2] });
+    }
+
+    // All links are walkable and two-way (mirroring retail mob pathing).
+    out.rad.assign(out.count, linkRadius);
+    out.flags.assign(out.count, SAMPLE_POLYFLAGS_WALK);
+    out.areas.assign(out.count, RC_WALKABLE_AREA);
+    out.dir.assign(out.count, DT_OFFMESH_CON_BIDIR);
+
+    return out;
 }
 
 } // namespace
@@ -509,6 +797,14 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
     }
 
     //
+    // Auto-generated off-mesh connections (drop / step links across ledges)
+    //
+
+    const auto offMesh = config.generateOffMeshLinks
+                             ? buildOffMeshConnections(*pmesh, *dmesh, config, tx, ty)
+                             : TileOffMeshConnections{};
+
+    //
     // Build Detour tile data
     //
 
@@ -525,13 +821,13 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
         .detailVertsCount = dmesh->nverts,
         .detailTris       = dmesh->tris,
         .detailTriCount   = dmesh->ntris,
-        .offMeshConVerts  = nullptr,
-        .offMeshConRad    = nullptr,
-        .offMeshConFlags  = nullptr,
-        .offMeshConAreas  = nullptr,
-        .offMeshConDir    = nullptr,
-        .offMeshConUserID = nullptr,
-        .offMeshConCount  = 0,
+        .offMeshConVerts  = offMesh.count ? offMesh.verts.data() : nullptr,
+        .offMeshConRad    = offMesh.count ? offMesh.rad.data() : nullptr,
+        .offMeshConFlags  = offMesh.count ? offMesh.flags.data() : nullptr,
+        .offMeshConAreas  = offMesh.count ? offMesh.areas.data() : nullptr,
+        .offMeshConDir    = offMesh.count ? offMesh.dir.data() : nullptr,
+        .offMeshConUserID = nullptr, // unused; Detour defaults ids when null
+        .offMeshConCount  = offMesh.count,
         .userId           = 0,
         .tileX            = tx,
         .tileY            = ty,
@@ -561,10 +857,11 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
     rcFreePolyMeshDetail(dmesh);
 
     return {
-        .tx       = tx,
-        .ty       = ty,
-        .data     = navData,
-        .dataSize = navDataSize,
+        .tx           = tx,
+        .ty           = ty,
+        .data         = navData,
+        .dataSize     = navDataSize,
+        .offMeshCount = offMesh.count,
     };
 }
 
@@ -714,7 +1011,8 @@ auto NavMeshBuilder::buildAsync(Scheduler& scheduler, const std::string& zoneNam
     // Add tiles to navmesh (addTile is not thread-safe)
     //
 
-    auto tilesBuilt = 0;
+    auto tilesBuilt  = 0;
+    auto offMeshCons = 0;
     for (const auto& result : results)
     {
         if (result.data)
@@ -726,6 +1024,7 @@ auto NavMeshBuilder::buildAsync(Scheduler& scheduler, const std::string& zoneNam
                 continue;
             }
             tilesBuilt++;
+            offMeshCons += result.offMeshCount;
         }
     }
 
@@ -739,6 +1038,6 @@ auto NavMeshBuilder::buildAsync(Scheduler& scheduler, const std::string& zoneNam
     const auto endTime    = timer::now();
     const auto durationMs = timer::count_milliseconds(endTime - startTime);
 
-    ShowInfoFmt("Built {} nav tiles in {}x{} grid for {} ({}) in {}ms", tilesBuilt, tw, th, zoneName, zoneID, durationMs);
+    ShowInfoFmt("Built {} nav tiles ({} off-mesh links) in {}x{} grid for {} ({}) in {}ms", tilesBuilt, offMeshCons, tw, th, zoneName, zoneID, durationMs);
     co_return navMesh;
 }

--- a/src/map/navmesh/navmesh_builder.cpp
+++ b/src/map/navmesh/navmesh_builder.cpp
@@ -74,7 +74,7 @@ auto transform(const std::array<float, 9>& rot, const std::array<float, 3>& tran
 // Where a walkable surface sits below within the drop window, link the ledge down to it.
 // Landings come only from this tile's own detail mesh, so both endpoints are real polys.
 // Detour space, Y up.
-auto buildOffMeshConnections(const rcPolyMesh& pmesh, const rcPolyMeshDetail& dmesh, const NavMeshConfig& config, const int tileX, const int tileY) -> TileOffMeshConnections
+auto buildOffMeshConnections(const rcPolyMesh& pmesh, const rcPolyMeshDetail& dmesh, const NavMeshConfig& config, const int tileX, const int tileY, const std::vector<std::array<float, 9>>& barriers) -> TileOffMeshConnections
 {
     TileOffMeshConnections out;
 
@@ -206,6 +206,76 @@ auto buildOffMeshConnections(const rcPolyMesh& pmesh, const rcPolyMeshDetail& dm
         return found;
     };
 
+    // barrier triangles reduced to xz segments + a Y span, to veto links that clip through walls
+    struct BarrierWall
+    {
+        float x1, z1, x2, z2, yMin, yMax;
+    };
+
+    std::vector<BarrierWall> walls;
+    walls.reserve(barriers.size());
+    for (const auto& b : barriers)
+    {
+        const float* v[3] = { &b[0], &b[3], &b[6] };
+
+        int   bi = 0;
+        int   bj = 1;
+        float bd = -1.0f;
+        for (int i = 0; i < 3; ++i)
+        {
+            for (int j = i + 1; j < 3; ++j)
+            {
+                const float dx = v[i][0] - v[j][0];
+                const float dz = v[i][2] - v[j][2];
+                const float dd = dx * dx + dz * dz;
+                if (dd > bd)
+                {
+                    bd = dd;
+                    bi = i;
+                    bj = j;
+                }
+            }
+        }
+
+        walls.push_back(BarrierWall{ v[bi][0], v[bi][2], v[bj][0], v[bj][2], std::min({ v[0][1], v[1][1], v[2][1] }), std::max({ v[0][1], v[1][1], v[2][1] }) });
+    }
+
+    // segment (a -> b) crosses segment (c -> d) in the xz-plane
+    const auto segmentsCrossXZ = [](const float* a, const float* b, float cx, float cz, float dx, float dz) -> bool
+    {
+        const auto side = [](float px, float pz, float qx, float qz, float rx, float rz)
+        {
+            return (rz - pz) * (qx - px) - (rx - px) * (qz - pz);
+        };
+
+        const float d1 = side(cx, cz, dx, dz, a[0], a[2]);
+        const float d2 = side(cx, cz, dx, dz, b[0], b[2]);
+        const float d3 = side(a[0], a[2], b[0], b[2], cx, cz);
+        const float d4 = side(a[0], a[2], b[0], b[2], dx, dz);
+        return (d1 > 0.0f) != (d2 > 0.0f) && (d3 > 0.0f) != (d4 > 0.0f);
+    };
+
+    // only a wall rising more than a climb-height above the ledge blocks the drop; one sitting at
+    // the ledge is its own drop-face, which must not veto the link. detour Y is up-positive
+    const auto crossesBarrier = [&](const float* start, const float* end) -> bool
+    {
+        const float ledgeY = std::max(start[1], end[1]);
+        for (const auto& w : walls)
+        {
+            if (w.yMax <= ledgeY + config.agentMaxClimb)
+            {
+                continue;
+            }
+
+            if (segmentsCrossXZ(start, end, w.x1, w.z1, w.x2, w.z2))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    };
+
     std::vector<OffMeshCandidate> candidates;
     for (int p = 0; p < pmesh.npolys; ++p)
     {
@@ -300,9 +370,18 @@ auto buildOffMeshConnections(const rcPolyMesh& pmesh, const rcPolyMeshDetail& dm
                 continue;
             }
 
+            const float start[3] = { edgeMid[0] - outwardX * linkRadius, ledgeY, edgeMid[2] - outwardZ * linkRadius }; // pulled just inside the source poly
+            const float end[3]   = { landingX, landingY, landingZ };
+
+            // drop through a wall/rail, not an open ledge
+            if (crossesBarrier(start, end))
+            {
+                continue;
+            }
+
             candidates.push_back(OffMeshCandidate{
-                .start = { edgeMid[0] - outwardX * linkRadius, ledgeY, edgeMid[2] - outwardZ * linkRadius }, // pulled just inside the source poly
-                .end   = { landingX, landingY, landingZ },
+                .start = { start[0], start[1], start[2] },
+                .end   = { end[0], end[1], end[2] },
             });
         }
     }
@@ -800,9 +879,26 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
     // Auto-generated off-mesh connections (drop / step links across ledges)
     //
 
-    const auto offMesh = config.generateOffMeshLinks
-                             ? buildOffMeshConnections(*pmesh, *dmesh, config, tx, ty)
-                             : TileOffMeshConnections{};
+    TileOffMeshConnections offMesh;
+    if (config.generateOffMeshLinks)
+    {
+        // barrier triangles (detour space) so off-mesh links can't route through walls/rails
+        std::vector<std::array<float, 9>> barriers;
+        for (int i = 0; i < numTris; ++i)
+        {
+            if (tileMesh.areas[i] != RC_NULL_AREA)
+            {
+                continue;
+            }
+
+            const int i0 = tileMesh.indices[i * 3 + 0];
+            const int i1 = tileMesh.indices[i * 3 + 1];
+            const int i2 = tileMesh.indices[i * 3 + 2];
+            barriers.push_back({ tileMesh.verts[i0 * 3 + 0], tileMesh.verts[i0 * 3 + 1], tileMesh.verts[i0 * 3 + 2], tileMesh.verts[i1 * 3 + 0], tileMesh.verts[i1 * 3 + 1], tileMesh.verts[i1 * 3 + 2], tileMesh.verts[i2 * 3 + 0], tileMesh.verts[i2 * 3 + 1], tileMesh.verts[i2 * 3 + 2] });
+        }
+
+        offMesh = buildOffMeshConnections(*pmesh, *dmesh, config, tx, ty, barriers);
+    }
 
     //
     // Build Detour tile data
@@ -821,11 +917,11 @@ auto NavMeshBuilder::buildTile(const int tx, const int ty, const rcConfig& cfg, 
         .detailVertsCount = dmesh->nverts,
         .detailTris       = dmesh->tris,
         .detailTriCount   = dmesh->ntris,
-        .offMeshConVerts  = offMesh.count ? offMesh.verts.data() : nullptr,
-        .offMeshConRad    = offMesh.count ? offMesh.rad.data() : nullptr,
-        .offMeshConFlags  = offMesh.count ? offMesh.flags.data() : nullptr,
-        .offMeshConAreas  = offMesh.count ? offMesh.areas.data() : nullptr,
-        .offMeshConDir    = offMesh.count ? offMesh.dir.data() : nullptr,
+        .offMeshConVerts  = offMesh.verts.data(),
+        .offMeshConRad    = offMesh.rad.data(),
+        .offMeshConFlags  = offMesh.flags.data(),
+        .offMeshConAreas  = offMesh.areas.data(),
+        .offMeshConDir    = offMesh.dir.data(),
         .offMeshConUserID = nullptr, // unused; Detour defaults ids when null
         .offMeshConCount  = offMesh.count,
         .userId           = 0,

--- a/src/map/navmesh/navmesh_builder.h
+++ b/src/map/navmesh/navmesh_builder.h
@@ -65,6 +65,24 @@ struct TileResult
     int            ty{};
     unsigned char* data{};
     int            dataSize{};
+    int            offMeshCount{};
+};
+
+// Off-mesh links for one tile, in the SoA layout dtNavMeshCreateParams wants.
+struct TileOffMeshConnections
+{
+    std::vector<float>          verts; // 6 floats per link: start xyz, end xyz (Detour space)
+    std::vector<float>          rad;
+    std::vector<unsigned short> flags;
+    std::vector<unsigned char>  areas;
+    std::vector<unsigned char>  dir;
+    int                         count{};
+};
+
+struct OffMeshCandidate
+{
+    float start[3];
+    float end[3];
 };
 
 class NavMeshBuilder

--- a/src/map/navmesh/navmesh_config.h
+++ b/src/map/navmesh/navmesh_config.h
@@ -34,11 +34,11 @@ struct NavMeshSkipSphere
 struct NavMeshConfig
 {
     float cellSize{ 0.5f };               // Previous xiNavmeshes value: 0.4
-    float cellHeight{ 0.4f };             // Previous xiNavmeshes value: 0.2
+    float cellHeight{ 0.2f };             // Previous xiNavmeshes value: 0.2
     float walkableSlopeAngle{ 46.0f };    // Previous xiNavmeshes value: 46.0
     float agentHeight{ 2.0f };            // Previous xiNavmeshes value: 1.8
     float agentRadius{ 0.5f };            // Previous xiNavmeshes value: 0.3
-    float agentMaxClimb{ 0.6f };          // Previous xiNavmeshes value: 0.6
+    float agentMaxClimb{ 1.0f };          // Previous xiNavmeshes value: 0.6
     float maxEdgeLen{ 0.0f };             // Previous xiNavmeshes value: 12.0
     float maxSimplificationError{ 1.3f }; // Previous xiNavmeshes value: 1.3
     int   minRegionArea{ 8 };             // Previous xiNavmeshes value: 8
@@ -63,4 +63,9 @@ struct NavMeshConfig
     // remove stray geometry parked far outside the playable area, which would otherwise
     // inflate the world bounds and with them the tile grid.
     std::vector<NavMeshSkipSphere> skipSpheres{};
+
+    // Auto-generate off-mesh drop/step links across ledges Recast severs; zone-wide.
+    bool  generateOffMeshLinks{ true };
+    float offMeshMaxDrop{ 5.0f };    // largest vertical drop (wu) a link may bridge
+    float offMeshHorizReach{ 3.0f }; // largest horizontal ledge->landing offset (wu)
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Several fixes aimed at specific failures.

### Off-mesh links
This is what I started with originally, this fixes issues with maps where certain sections (which I'll call "islands") do not have direct actual walkable terrain between each other but where mobs can still aggro and be pulled.

Below is an example in Newton Movalpolos
<img width="1697" height="871" alt="image" src="https://github.com/user-attachments/assets/d671ea87-6505-4fc3-8140-cb3e53d404be" />

With the current meshes, the mob (in the red section) cannot reach the player and ends up just wallhacking through the gap.

This PR adds the automated addition of **bi-directional** off-mesh links anywhere such one-way drops are encountered.

<img width="1310" height="824" alt="image" src="https://github.com/user-attachments/assets/b133eca5-f54e-404e-8c2c-ea3e96426320" />

Do note this was tested and reflects how these exact mobs path on retail in the exact situation.
The parameters for the maximum allowed drop height is "customizable" but nothing is exposed to allow zone-specific settings just yet.

The off-mesh link generation is custom but the data plumbing and math are adapted from Recast/Detour:
  - [Sample_TileMesh.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/RecastDemo/Source/Sample_TileMesh.cpp#L1135-L1141)
- [Sample_SoloMesh.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/RecastDemo/Source/Sample_SoloMesh.cpp#L693-L699)
- [InputGeom.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/RecastDemo/Source/InputGeom.cpp#L469-L482)
- [RecastMeshDetail.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/Recast/Source/RecastMeshDetail.cpp#L95-L121)
- [DetourCommon.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/Detour/Source/DetourCommon.cpp#L204-L230)
- [OffMeshConnectionTool.cpp](https://github.com/recastnavigation/recastnavigation/blob/1078bfe346d9bb560faa748c8fde2e7aae73a3ab/RecastDemo/Source/OffMeshConnectionTool.cpp#L81-L128)

See the diff here https://sruon.github.io/xi-visualizer/#/navmesh-diff?repo=sruon%2FxiNavmeshes&a=base&b=navmesh_seam_fix&zone=Newton_Movalpolos

### Staircase tiling
This fixes issues with maps ending up with disconnected islands, leading mobs to wallhack instead of taking the proper path (Dynamis - Jeuno, Cloisters of * etc..)

I noticed while looking at the Mhaura boat that the staircase was not getting tiled and traced it to the navmesh builder excluding them because they rise 1U per step, exceeding the walkableClimb (defined as floor(agentMaxClimb / cellHeight) = 1 cell == 0.4u). 

Increasing agentMaxClimb to 1.0 and reducing cellHeight to 0.2 allows the effective climb to become 1.0, enabling staircases to be meshed.

Some examples
<img width="2128" height="656" alt="image" src="https://github.com/user-attachments/assets/ac7e3fa0-d091-415f-9625-79487976c7c9" />
<img width="2128" height="656" alt="image" src="https://github.com/user-attachments/assets/a9230688-c730-4f8e-9872-6ee49b61c167" />
<img width="2128" height="656" alt="image" src="https://github.com/user-attachments/assets/5a92b60f-cdf4-434c-b83d-aeb5fff2f1c9" />

https://sruon.github.io/xi-visualizer/#/navmesh-diff?repo=sruon%2FxiNavmeshes&a=base&b=navmesh_seam_fix&zone=Dynamis-Jeuno

### Seam stitching
While testing the off-mesh links I noticed mobs were taking a much longer route than necessary and would in a very obvious fashion do a 180 and go through another path when I walked through a certain spot.

Looking at the mesh I noticed certain parts were missing entirely despite having legitimate terrain in the ximesh. Traced it to edge trimming occurring during the bake process in between tiles.

This PR expands the border context provided to the builder to 9 cells instead of the current 4. Note that this slightly increases mesh generation times.

Couple of examples:
<img width="4333" height="1509" alt="image" src="https://github.com/user-attachments/assets/e90ca614-030b-4422-a8d9-2c631f418d54" />
<img width="2128" height="656" alt="image" src="https://github.com/user-attachments/assets/39328b9c-b88b-4123-a0bb-49205e1cb17c" />

https://sruon.github.io/xi-visualizer/#/navmesh-diff?repo=sruon%2FxiNavmeshes&a=base&b=navmesh_seam_fix&zone=Dynamis-Windurst

### Navmesh corners cutting
Mobs could walk through walls while chasing. 

The navmesh hands them a path whose corners exist to route around obstacles, but the path-following code counted a corner as reached from several units away, so it skipped the corner and cut straight across whatever that corner was avoiding. 

Two smaller issues did the same thing: waypoints near the destination were dropped without checking the shortcut was walkable, and the heading was rounded off, causing a slight deviation.

<img width="1150" height="560" alt="navmesh_corner_cutting" src="https://github.com/user-attachments/assets/596351b4-43df-4206-9559-5b831224e49a" />

## Steps to test these changes
Rebuild your meshes and reproduce known issues. It won't be perfect until we can have zone-specific settings.

<!-- Clear and detailed steps to test your changes here -->
