### PR TITLE
[lua] Clear TODO from Haste Belt

### DIFF
--- a/scripts/items/haste_belt.lua
+++ b/scripts/items/haste_belt.lua
@@ -1,7 +1,9 @@
 -----------------------------------
 -- ID: 15290
 -- Item: Haste Belt
--- Item Effect: 10% haste
+-- Item Effect: Haste +10% (Magic)
+-- Duration: 3 Minutes
+-- Stacks with Haste (spell)
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -10,14 +12,17 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUnequip = function(target, item)
-    target:delStatusEffect(xi.effect.HASTE, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
-end
-
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HASTE_BELT) then
-        -- TODO: Haste applied by the belt should a separate buff from Spell Haste and stacks. Currently overwrites.
-        target:addStatusEffect(xi.effect.HASTE, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HASTE_BELT })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.HASTE)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.HASTE, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HASTE_BELT, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.HASTE)
     end
 end
 
@@ -25,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.HASTE_MAGIC, 1000)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HASTE_BELT)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.HASTE)
 end
 
 return itemObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates Haste Belt, allowing it to stack with the spell Haste. (and other haste effects.)

## Capture
https://youtu.be/FMniKnxWUI4
https://1drv.ms/u/c/87e665e10555c452/IQC7H_tJpQBuRZ13mjEv9DNvAfrez4zh06uy9_tu2uBi3b8?e=jzGhYn 

## Steps to test these changes

!changejob PLD 99
!changesjob WHM 49
!additem Haste_Belt
Equip it
/ma "Haste" <me>
Then use Haste Belt
See two Haste effects on. 
!getmod 167, see effects stack. 
