### PR TITLE
[core] Do not unequip offhand when switching 1H mainhand

### DIFF
--- a/scripts/tests/systems/items/equip.lua
+++ b/scripts/tests/systems/items/equip.lua
@@ -67,6 +67,50 @@ describe('Equipment', function()
         assert(player:getEquippedItem(xi.slot.SUB) == nil)
     end)
 
+    it('swapping the main weapon keeps a dual-wield offhand', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.NIN, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.KUNAI)
+        player:addItem(xi.item.WAKIZASHI)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:equipItem(xi.item.KUNAI, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BRONZE_KNIFE, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB), 'offhand not equipped')
+
+        player:equipItem(xi.item.WAKIZASHI, nil, xi.slot.MAIN) -- one-handed -> one-handed swap
+
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.WAKIZASHI, 'main did not swap')
+        assert(player:getEquippedItem(xi.slot.SUB), 'offhand wrongly removed on a main swap')
+        assert(player:getEquippedItem(xi.slot.SUB):getID() == xi.item.BRONZE_KNIFE, 'offhand changed')
+    end)
+
+    it('switching from a two-handed weapon with a grip to a one-handed weapon drops the grip', function()
+        player:addItem(xi.item.GREATSWORD)
+        player:addItem(xi.item.POLE_GRIP)
+        player:addItem(xi.item.BRONZE_SWORD)
+        player:equipItem(xi.item.GREATSWORD, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.POLE_GRIP, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB):getID() == xi.item.POLE_GRIP, 'grip not equipped')
+
+        player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN) -- two-handed -> one-handed
+
+        assert(player:getEquippedItem(xi.slot.MAIN):getID() == xi.item.BRONZE_SWORD, 'main did not swap')
+        assert(player:getEquippedItem(xi.slot.SUB) == nil, 'grip should drop on a one-handed main')
+    end)
+
+    it('unequipping the main weapon entirely drops the dual-wield offhand', function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.NIN, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        player:addItem(xi.item.KUNAI)
+        player:addItem(xi.item.BRONZE_KNIFE)
+        player:equipItem(xi.item.KUNAI, nil, xi.slot.MAIN)
+        player:equipItem(xi.item.BRONZE_KNIFE, nil, xi.slot.SUB)
+        assert(player:getEquippedItem(xi.slot.SUB), 'offhand not equipped')
+
+        player.actions:equipSet({ { index = 0, kind = xi.slot.MAIN, container = xi.inv.INVENTORY } })
+
+        assert(player:getEquippedItem(xi.slot.MAIN) == nil, 'main still equipped')
+        assert(player:getEquippedItem(xi.slot.SUB) == nil, 'offhand should drop when the main is removed entirely')
+    end)
+
     it('equipping the same item again is a no-op', function()
         player:addItem(xi.item.BRONZE_SWORD)
         player:equipItem(xi.item.BRONZE_SWORD, nil, xi.slot.MAIN)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2345,8 +2345,7 @@ void RemoveSub(CCharEntity* PChar)
 
 bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID)
 {
-    CItemEquipment* PItem   = dynamic_cast<CItemEquipment*>(PChar->getStorage(containerID)->GetItem(slotID));
-    CItemEquipment* oldItem = PChar->getEquip((SLOTTYPE)equipSlotID);
+    CItemEquipment* PItem = dynamic_cast<CItemEquipment*>(PChar->getStorage(containerID)->GetItem(slotID));
 
     if (PItem == nullptr)
     {
@@ -2360,20 +2359,6 @@ bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 conta
         !PItem->isEquippableByRace(PChar->look.race))
     {
         return false;
-    }
-
-    if (equipSlotID == SLOT_MAIN)
-    {
-        if (!(slotID == PItem->getSlotID() && oldItem && (oldItem->isType(ITEM_WEAPON) && PItem->isType(ITEM_WEAPON)) &&
-              (static_cast<CItemWeapon*>(PItem)->isTwoHanded() && static_cast<CItemWeapon*>(oldItem)->isTwoHanded())))
-        {
-            CItemEquipment* PSubItem = PChar->getEquip(SLOT_SUB);
-
-            if (PSubItem != nullptr && PSubItem->isType(ITEM_EQUIPMENT) && (!PSubItem->IsShield()))
-            {
-                RemoveSub(PChar);
-            }
-        }
     }
 
     UnequipItem(PChar, equipSlotID, Recalculate::No);
@@ -2463,7 +2448,16 @@ bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 conta
                         }
                         break;
                         default:
-                            break;
+                        {
+                            // one-handed main: keep a dual-wield weapon or shield, but drop a grip
+                            auto*      PSubWeapon = dynamic_cast<CItemWeapon*>(PChar->getEquip(SLOT_SUB));
+                            const bool subIsGrip  = PSubWeapon != nullptr && PSubWeapon->getSkillType() == xi::SkillType::None;
+                            if (subIsGrip)
+                            {
+                                UnequipItem(PChar, SLOT_SUB, Recalculate::No);
+                            }
+                        }
+                        break;
                     }
                     if (PChar->PAI->IsEngaged())
                     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Code was removing weapons too eagerly during the processing of the removal of the initial piece of equipment when it should be the processing of the incoming weapon that handles it.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
