### PR TITLE
[lua][cpp] Adds price ranks for fame vendors

### DIFF
--- a/scripts/commands/setfamelevel.lua
+++ b/scripts/commands/setfamelevel.lua
@@ -49,7 +49,7 @@ commandObj.onTrigger = function(player, famezone, level, target)
     if level == nil then
         player:printToPlayer(string.format('Fame Zone %s: %s - No other parameters requested.', famezone, fameZoneNames[famezone]))
         return
-    elseif level < 0 or level > 9 then
+    elseif level < 1 or level > 9 then
         error(player, 'You must provide a fame level from 1 to 9.')
         return
     end

--- a/scripts/globals/npc_util.lua
+++ b/scripts/globals/npc_util.lua
@@ -582,7 +582,7 @@ function npcUtil.giveReward(player, params)
     end
 
     if params['fame'] == nil then
-        params['fame'] = 30
+        params['fame'] = 20
     end
 
     if

--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -17,6 +17,67 @@ local southSandyID = zones[xi.zone.SOUTHERN_SAN_DORIA]
 local watersID     = zones[xi.zone.WINDURST_WATERS]
 local woodsID      = zones[xi.zone.WINDURST_WOODS]
 
+-----------------------------------
+-- Fame price ranks
+-- Retail nation fame caps at 250, we store it at 2500 because of decimal values
+-- https://wiki.ffo.jp/html/30558.html
+--
+-- Retail formulas (0-250 fame)
+-- Nations:       ceil(6 + (nation of vendor) / 10 - (nation 2 + nation 3) / 40) | floor((2400 + (nation of vendor) * 4 - (nation 2 + nation 3) + 399) / 400)
+-- Selbina/Rabao: ceil(6 + sandoria / 20 + bastok / 20 - windurst / 20)          | floor((1200 + sandoria + bastok - windurst + 199) / 200)
+-- Norg:          ceil(6 + norg / 10 - (sandoria + bastok + windurst) / 120)     | floor((7200 + norg * 12 - (sandoria + bastok + windurst) + 1199) / 1200)
+-- Jeuno, Aht Urhgan and Tavnazia have no price rank so we default to rank 11
+-----------------------------------
+
+local nationFameAreas =
+{
+    xi.fameArea.SANDORIA,
+    xi.fameArea.BASTOK,
+    xi.fameArea.WINDURST,
+}
+
+-- Grabs price rank which are 1-21
+local getPriceRank = function(player, fameArea)
+    local rank         = 11 -- Standard price rank
+    local minPriceRank = 1  -- Buy x1.10, sell x0.975
+    local maxPriceRank = 21 -- Buy x0.90, sell x1.025
+
+    if
+        fameArea == xi.fameArea.SANDORIA or
+        fameArea == xi.fameArea.BASTOK or
+        fameArea == xi.fameArea.WINDURST
+    then
+        local otherFame = 0
+        for _, nation in ipairs(nationFameAreas) do
+            if nation ~= fameArea then
+                otherFame = otherFame + player:getFame(nation)
+            end
+        end
+
+        rank = math.floor((2400 + player:getFame(fameArea) * 4 - otherFame + 399) / 400)
+    elseif fameArea == xi.fameArea.SELBINA_RABAO then
+        local totalFame = player:getFame(xi.fameArea.SANDORIA) + player:getFame(xi.fameArea.BASTOK) - player:getFame(xi.fameArea.WINDURST)
+
+        rank = math.floor((1200 + totalFame + 199) / 200)
+    elseif fameArea == xi.fameArea.NORG then
+        local nationFame = player:getFame(xi.fameArea.SANDORIA) + player:getFame(xi.fameArea.BASTOK) + player:getFame(xi.fameArea.WINDURST)
+
+        rank = math.floor((7200 + player:getFame(xi.fameArea.NORG) * 12 - nationFame + 1199) / 1200)
+    end
+
+    return math.max(minPriceRank, math.min(maxPriceRank, rank))
+end
+
+---Price the vendor pays the player
+---@param player CBaseEntity
+---@param itemId xi.item
+---@param fameArea xi.fameArea
+---@return integer
+xi.shop.onSellPriceCheck = function(player, itemId, fameArea)
+    local priceRank = getPriceRank(player, fameArea)
+    return math.floor(GetReadOnlyItem(itemId):getBasePrice() * (priceRank + 389) / 400)
+end
+
 -- send general shop dialog to player
 -- stock cuts off after 16 items. if you add more, extras will not display
 -- stock is of form { itemId1, price1, itemId2, price2, ... }
@@ -25,7 +86,7 @@ xi.shop.general = function(player, stock, log)
     local priceMultiplier = 1
 
     if log then
-        priceMultiplier = (1 + (0.20 * (9 - player:getFameLevel(log)) / 8)) * xi.settings.main.SHOP_PRICE
+        priceMultiplier = xi.settings.main.SHOP_PRICE
     else
         log = -1
     end
@@ -33,7 +94,14 @@ xi.shop.general = function(player, stock, log)
     player:createShop(#stock, log)
 
     for _, stockItem in ipairs(stock) do
-        player:addShopItem(stockItem[1], math.floor(stockItem[2] * priceMultiplier), stockItem[3])
+        local price = stockItem[2]
+
+        -- Nation fame price rank adjustment
+        if log ~= -1 then
+            price = math.max(1, math.floor(price * (111 - getPriceRank(player, log)) / 100))
+        end
+
+        player:addShopItem(stockItem[1], math.floor(price * priceMultiplier), stockItem[3])
     end
 
     player:sendMenu(xi.menuType.SHOP)

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -5008,6 +5008,7 @@ void CLuaBaseEntity::createShop(uint8 size, const sol::object& arg1)
     if (arg1 != sol::lua_nil && arg1.is<double>())
     {
         PChar->Container->setType(arg1.as<uint8>());
+        PChar->Container->setShopFameArea(arg1.as<uint8>());
     }
 }
 

--- a/src/map/packets/c2s/0x084_shop_sell_req.cpp
+++ b/src/map/packets/c2s/0x084_shop_sell_req.cpp
@@ -22,6 +22,7 @@
 #include "0x084_shop_sell_req.h"
 
 #include "entities/char_entity.h"
+#include "lua/luautils.h"
 #include "packets/s2c/0x03d_shop_sell.h"
 #include "trade_container.h"
 
@@ -41,6 +42,10 @@ void GP_CLI_COMMAND_SHOP_SELL_REQ::process(MapSession* PSession, CCharEntity* PC
         quantity = std::min(quantity, PItem->getQuantity());
         // Store item-to-sell in the last slot of the shop container
         PChar->Container->setItem(PChar->Container->getExSize(), this->ItemNo, this->ItemIndex, quantity);
-        PChar->pushPacket<GP_SERV_COMMAND_SHOP_SELL>(this->ItemIndex, PItem->getBasePrice());
+
+        // Fame adjusted price
+        const auto sellPrice = luautils::callGlobal<uint32>("xi.shop.onSellPriceCheck", PChar, this->ItemNo, PChar->Container->getShopFameArea());
+
+        PChar->pushPacket<GP_SERV_COMMAND_SHOP_SELL>(this->ItemIndex, sellPrice);
     }
 }

--- a/src/map/packets/c2s/0x085_shop_sell_set.cpp
+++ b/src/map/packets/c2s/0x085_shop_sell_set.cpp
@@ -25,6 +25,7 @@
 #include "entities/char_entity.h"
 #include "enums/msg_std.h"
 #include "enums/packet_c2s.h"
+#include "lua/luautils.h"
 #include "packets/s2c/0x009_message.h"
 #include "packets/s2c/0x01d_item_same.h"
 #include "trade_container.h"
@@ -111,8 +112,9 @@ void GP_CLI_COMMAND_SHOP_SELL_SET::process(MapSession* PSession, CCharEntity* PC
         return;
     }
 
-    const auto basePrice = PItem->getBasePrice();
-    const auto cost      = quantity * basePrice;
+    // Fame adjusted price
+    const auto unitPrice = luautils::callGlobal<uint32>("xi.shop.onSellPriceCheck", PChar, itemId, PChar->Container->getShopFameArea());
+    const auto cost      = quantity * unitPrice;
     if (charutils::UpdateItem(PChar, LOC_INVENTORY, slotId, -static_cast<int32>(quantity)) == 0)
     {
         ShowWarningFmt("GP_CLI_COMMAND_SHOP_SELL_SET: Player {} failed to remove item ID {} from inventory!", PChar->getName(), PItem->getID());
@@ -121,7 +123,7 @@ void GP_CLI_COMMAND_SHOP_SELL_SET::process(MapSession* PSession, CCharEntity* PC
 
     charutils::UpdateItem(PChar, LOC_INVENTORY, 0, cost);
     // TODO: Don't pass around Scheduler& through PSession
-    auditSale(*PSession->scheduler, PChar, itemId, quantity, basePrice);
+    auditSale(*PSession->scheduler, PChar, itemId, quantity, unitPrice);
     ShowInfo("GP_CLI_COMMAND_SHOP_SELL_SET: Player '%s' sold %u of itemID %u (Total: %u gil) [to VENDOR] ", PChar->getName(), quantity, itemId, cost);
     PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(nullptr, itemId, quantity, MsgStd::Sell);
     PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -228,6 +228,16 @@ void CTradeContainer::setType(uint8 type)
     m_type = type;
 }
 
+uint8 CTradeContainer::getShopFameArea() const
+{
+    return m_shopFameArea;
+}
+
+void CTradeContainer::setShopFameArea(uint8 fameArea)
+{
+    m_shopFameArea = fameArea;
+}
+
 void CTradeContainer::unreserveUnconfirmed()
 {
     for (uint8 slotID = 0; slotID < CONTAINER_SIZE; ++slotID)
@@ -251,9 +261,10 @@ void CTradeContainer::unreserveUnconfirmed()
 
 void CTradeContainer::Clean()
 {
-    m_type       = 0;
-    m_ItemsCount = 0;
-    m_exSize     = 0;
+    m_type         = 0;
+    m_shopFameArea = 0xFF; // match the lua side default value
+    m_ItemsCount   = 0;
+    m_exSize       = 0;
 
     m_PItem.clear();
     m_PItem.resize(CONTAINER_SIZE, nullptr);

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -50,6 +50,7 @@ public:
     CTradeContainer();
 
     uint8  getType() const;
+    uint8  getShopFameArea() const;
     uint8  getItemsCount() const;
     uint8  getSlotCount();     // Number of occupied cells
     uint32 getTotalQuantity(); // Total number of items (gil counts as 1)
@@ -64,6 +65,7 @@ public:
     uint8  getExSize() const;
 
     void setType(uint8 type);
+    void setShopFameArea(uint8 fameArea);
     void setItemsCount(uint8 count);
     void setItem(uint8 slotID, CItem* item);
     void setRestriction(uint8 slotID, SlotRestriction restriction);
@@ -79,9 +81,10 @@ public:
     void Clean(); // we clean the container
 
 private:
-    uint8 m_type{};       // Container type (crystal type, store nation, etc.)
-    uint8 m_ItemsCount{}; // The number of items in the container (set by yourself)
-    uint8 m_exSize{};     // Can be used as a custom delineation point inside a container
+    uint8 m_type{};               // Container type (crystal type, store nation, etc.)
+    uint8 m_shopFameArea{ 0xFF }; // Fame area for shop price ranks
+    uint8 m_ItemsCount{};         // The number of items in the container (set by yourself)
+    uint8 m_exSize{};             // Can be used as a custom delineation point inside a container
 
     std::vector<CItem*>          m_PItem;
     std::vector<uint8>           m_slotID;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Follow up PR to capping fame points and correct fame values for quests: https://github.com/LandSandBoat/server/pull/10940 and https://github.com/LandSandBoat/server/pull/10930

JP Wiki: https://wiki.ffo.jp/html/30558.html

> It is linked to Fame, but while the Fame Rank has 9 tiers, this index has a more granular scale of 21 tiers.
> 
> If the selling price of an item is set to the standard price (100%)—which corresponds to the selling price in regions where prices do not fluctuate, such as Jeuno*1, Atoragan, and Adoulin—the selling price varies in 1% increments from 110% (minimum, Rank 1) to 90% (maximum, Rank 21), while the selling price varies in 0.75% increments (below 100%) or 0.25% increments (100% or higher) from 92.5% (minimum, Rank 1) to 102.5% (highest—Rank 21), in increments of 0.75% (below 100%) or 0.25% (100% or higher).

<img width="669" height="110" alt="image" src="https://github.com/user-attachments/assets/0bc8a74a-ebd7-48ac-b487-eda403cf65ec" />

> Price Level Rank for the 3 Nations = ceil(6 + that nation's reputation value / 10 - the combined reputation values of the other 2 nations / 40)
> Serlina Rabao's Price Level Rank = ceil(6 + San d'Oria's reputation value / 20 + Bastok's reputation value / 20 - Windurst's reputation value / 20)
> Tenryudo in Norg's Price Level = ceil(6 + Reputation Value / 10 - Total Reputation of the 3 Nations / 120)
> (ceil is the ceiling function, which rounds up to the nearest integer)

I followed the same the guild shop prices works and decided to move the functions to lua in the core call. For this reason the formulas you see have to be changed in order to get the correct precision values.

Shop prices change based on rank:
<img width="1229" height="689" alt="image" src="https://github.com/user-attachments/assets/93e4318a-032c-4e1f-976f-50fdb51fac5e" />

Monti has varified that the JP wiki chart and rank formulas match retail 1:1 in every scenario that was tested. Further information is in the previous PR https://github.com/LandSandBoat/server/pull/10930 because its the entire reason we know the fame values of the quests.

Google doc with example values: https://docs.google.com/spreadsheets/d/1xoFzFarw-H8qiV0utJoSsFQwhqdw2d5aotvVggLGAtc/edit?gid=1695732643#gid=1695732643

> **Methodology to obtain the values listed above**
> - To determine the fame values of quests, I used [price ranks](https://wiki.ffo.jp/html/30558.html) to determine how much they give. Price rank always increases after 100 fame if you are not experiencing fame drag from other nations. My test characters for getting these values are an Elvaan from Sandy and a Taru from Windurst for this reason. They start with 100 fame in their nation that I tested quests in (7 from nation and 3 from race).
> - I would move my fame value right to a new price rank by completing a repeatable quest with a known fame value.
> Right at the start of the new price rank, I would complete a quest and then go back to the repeatable quest, turning in the quests one at a time and then going to the vendor to see if my price rank moved to a new tier. Once the price rank moved up I would subtract the number of repeatable turn-ins to get the fame value of the quest.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!zone southern sandy
!gotoname Ostalia
!getfame check everything is 1
!additem damascus_ingot
Sell it and see the value 9875 because you are fame 0 and price rank 6

!setfamelevel 0 9  <- sets your fame level to 9 for sandy
sell dingot again see its 10,250
<img width="306" height="46" alt="image" src="https://github.com/user-attachments/assets/afc8b9dd-e990-46a9-8022-882ea5ff9500" />

Further testing done by @montijin once the correct values are submitted for vendor prices they match to retail 1:1 for the correct price rank
<img width="962" height="431" alt="image" src="https://github.com/user-attachments/assets/e32dadf8-3a29-427a-8086-0212dc3409f3" />

<!-- Clear and detailed steps to test your changes here -->
