### PR TITLE
[lua] Flame Spout Trade Fix

### DIFF
--- a/scripts/zones/Ifrits_Cauldron/IDs.lua
+++ b/scripts/zones/Ifrits_Cauldron/IDs.lua
@@ -21,6 +21,7 @@ zones[xi.zone.IFRITS_CAULDRON] =
         MEMBERS_LEVELS_ARE_RESTRICTED = 7027,  -- Your party is unable to participate because certain members' levels are restricted.
         CONQUEST_BASE                 = 7072,  -- Tallying conquest results...
         REGION_POINTS_SANDORIA        = 7137,  -- San d'Oria's region points have increased!
+        FIRE_HAS_BEEN_PUT_OUT         = 7257,  -- The fire has been put out with your <item>.
         ALTAR_COMPLETED               = 7261,  -- You have already made an offering today.
         ALTAR_INSPECT                 = 7262,  -- This looks like the altar where offerings are to be placed.
         ALTAR_OFFERING                = 7263,  -- You place your offering of <item> on the altar.

--- a/scripts/zones/Ifrits_Cauldron/npcs/Flame_Spout.lua
+++ b/scripts/zones/Ifrits_Cauldron/npcs/Flame_Spout.lua
@@ -3,13 +3,16 @@
 --  NPC: Flame Spout
 -- !pos 193.967 -0.400 19.492 205
 -----------------------------------
+local ID = zones[xi.zone.IFRITS_CAULDRON]
+-----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrade = function(player, npc, trade)
-    if npcUtil.tradeHas(trade, xi.item.ICE_CLUSTER) then
-        player:confirmTrade()
-        GetNPCByID(npc:getID() + 5):openDoor(90)
+    if npcUtil.tradeMatches(trade, { { xi.item.ICE_CLUSTER, 1 } }) then
+        player:tradeComplete()
+        player:messageSpecial(ID.text.FIRE_HAS_BEEN_PUT_OUT, 0, xi.item.ICE_CLUSTER)
+        GetNPCByID(npc:getID() + 5):openDoor(10)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implements proper trade dialogue when the Flame Spout in Ifrit's Cauldron is extinguished with an ice cluster. This PR also lowers the time the Flame Spout stays down to be accurate to [retail captures](https://drive.google.com/file/d/1vvG5T0WdPnufunrAKOo_br99AbO4ZcSi/view?usp=sharing).

## Steps to test these changes

Go to IC and find a Flame Spout. Trade it an Ice Cluster. See it works. Trade it anything else and see it doesn't.
