### PR TITLE
[lua] Teamwork Quest Modules

### DIFF
--- a/modules/era/lua/quests/sandoria/Advanced_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Advanced_Teamwork.lua
@@ -1,0 +1,59 @@
+-----------------------------------
+-- Advanced Teamwork
+-- Reverts the required number of same-job party members to six.
+-- The May 14, 2015 version update reduced the requirement to two.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/46976
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_advanced_teamwork'
+
+if xi.module.isContentEnabled('ROV') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/Advanced_Teamwork', function(quest)
+        -- Copy of the base handler with partySizeRequirement raised to 6
+        quest.sections[2][xi.zone.WEST_RONFAURE].onEventUpdate[129] = function(player, csid, option, npc)
+            local partySizeRequirement = 6
+            local party = player:getParty()
+            local partySameJobCount = 0
+
+            if #party >= partySizeRequirement then
+                for key, member in pairs(party) do
+                    if
+                        member:getZoneID() ~= player:getZoneID() or
+                        member:checkDistance(player) > 15
+                    then
+                        player:updateEvent(1)
+                        return
+                    else
+                        if player:getMainJob() == member:getMainJob() then
+                            partySameJobCount = partySameJobCount + 1
+                        end
+                    end
+                end
+            else
+                player:updateEvent(1)
+                return
+            end
+
+            if partySameJobCount == partySizeRequirement then
+                quest:setLocalVar(player, 'Prog', 1)
+                player:updateEvent(15, 3)
+                return
+            else
+                player:updateEvent(5, 3)
+                return
+            end
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/sandoria/Intermediate_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Intermediate_Teamwork.lua
@@ -1,0 +1,79 @@
+-----------------------------------
+-- Intermediate Teamwork
+-- Reverts the required number of same-race party members to six.
+-- The May 14, 2015 version update reduced the requirement to two.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/46976
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_intermediate_teamwork'
+
+if xi.module.isContentEnabled('ROV') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/Intermediate_Teamwork', function(quest)
+        -- Copy of the base handler with partySizeRequirement raised to 6
+        quest.sections[2][xi.zone.WEST_RONFAURE].onEventUpdate[129] = function(player, csid, option, npc)
+            local partySizeRequirement = 6
+            local party = player:getParty()
+            local partySameRaceCount = 0
+
+            if #party >= partySizeRequirement then
+                for key, member in pairs(party) do
+                    if
+                        member:getZoneID() ~= player:getZoneID() or
+                        member:checkDistance(player) > 15
+                    then
+                        player:updateEvent(1)
+                        return
+                    else
+                        local pRace = player:getRace()
+                        local mRace = member:getRace()
+
+                        if
+                            (pRace == xi.race.HUME_M or pRace == xi.race.HUME_F) and
+                            (mRace == xi.race.HUME_M or mRace == xi.race.HUME_F)
+                        then
+                            partySameRaceCount = partySameRaceCount + 1
+                        elseif
+                            (pRace == xi.race.ELVAAN_M or pRace == xi.race.ELVAAN_F) and
+                            (mRace == xi.race.ELVAAN_M or mRace == xi.race.ELVAAN_F)
+                        then
+                            partySameRaceCount = partySameRaceCount + 1
+                        elseif
+                            (pRace == xi.race.TARU_M or pRace == xi.race.TARU_F) and
+                            (mRace == xi.race.TARU_M or mRace == xi.race.TARU_F)
+                        then
+                            partySameRaceCount = partySameRaceCount + 1
+                        elseif pRace == xi.race.GALKA and mRace == xi.race.GALKA then
+                            partySameRaceCount = partySameRaceCount + 1
+                        elseif pRace == xi.race.MITHRA and mRace == xi.race.MITHRA then
+                            partySameRaceCount = partySameRaceCount + 1
+                        end
+                    end
+                end
+            else
+                player:updateEvent(1)
+                return
+            end
+
+            if partySameRaceCount >= partySizeRequirement then
+                quest:setLocalVar(player, 'Prog', 1)
+                player:updateEvent(15, 2)
+                return
+            else
+                player:updateEvent(4, 2)
+                return
+            end
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/sandoria/Introduction_to_Teamwork.lua
+++ b/modules/era/lua/quests/sandoria/Introduction_to_Teamwork.lua
@@ -1,0 +1,58 @@
+-----------------------------------
+-- Introduction to Teamwork
+-- Reverts the required number of same-nation party members to six.
+-- The May 14, 2015 version update reduced the requirement to two.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/46976
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_introduction_to_teamwork'
+
+if xi.module.isContentEnabled('ROV') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/Introduction_to_Teamwork', function(quest)
+        -- Copy of the base handler with partySizeRequirement raised to 6
+        quest.sections[2][xi.zone.WEST_RONFAURE].onEventUpdate[129] = function(player, csid, option, npc)
+            local partySizeRequirement = 6
+            local party = player:getParty()
+            local partySameNationCount = 0
+
+            if #party >= partySizeRequirement then
+                for key, member in pairs(party) do
+                    if
+                        member:getZoneID() ~= player:getZoneID() or
+                        member:checkDistance(player) > 15
+                    then
+                        player:updateEvent(1)
+                        return
+                    else
+                        if member:getNation() == player:getNation() then
+                            partySameNationCount = partySameNationCount + 1
+                        end
+                    end
+                end
+            else
+                player:updateEvent(1)
+                return
+            end
+
+            if partySameNationCount >= partySizeRequirement then
+                quest:setLocalVar(player, 'Prog', 1)
+                player:updateEvent(15, 1)
+                return
+            else
+                player:updateEvent(3, 1)
+            end
+        end
+    end)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The quests Introduction to Teamwork / Intermediate Teamwork / Advanced Teamwork were adjusted with the release of ROV to only require 2 people to complete them. Prior to that, it had been six, as demonstrated by the [ROV launch patch notes](https://forum.square-enix.com/ffxi/threads/46976). This PR adds a module for each quest to bring it back to the era requirement of 6 players for completion.

## Steps to test these changes

Load the modules and see each quest now requires 6 players to complete instead of 2.
