### PR TITLE
[C++] Improve Automaton Inhibitor Logic

### DIFF
--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -1584,10 +1584,17 @@ auto CAutomatonController::TryTPMove() -> bool
 
         bool attemptChain = (PAutomaton->getMod(xi::Mod::AUTO_TP_EFFICIENCY) != 0);
 
+        const CStatusEffect* PSCEffect = PTarget->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Skillchain, 0);
+
+        // Skillchain has been started, wait 4 seconds until skillchain window is open before executing weaponskill.
+        if (attemptChain && PSCEffect && PSCEffect->GetStartTime() + 4s >= timer::now())
+        {
+            return false;
+        }
+
         if (attemptChain)
         {
-            const CStatusEffect* PSCEffect = PTarget->StatusEffectContainer->GetStatusEffect(xi::StatusEffect::Skillchain, 0);
-            if (PSCEffect && PSCEffect->GetStartTime() + 3s < timer::now())
+            if (PSCEffect)
             {
                 std::list<SKILLCHAIN_ELEMENT> resonanceProperties;
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Automatons were attempting to skillchain too early in many cases with Inhibitor on - this was because of a race condition that could happen with Inhibitor where it saw the masters TP was under 900, causing the automaton to dump their weaponskill early. This adds a return when resonance is active so they hold their TP until the skillchain is ready to be formed, ending the race condition.

This also adjusts the time they wait from 3s to 4s.

## Steps to test these changes

Change job to PUP, equip your automaton with Inhibitor, test out making skillchains - see they actually land them every time. 
