### PR TITLE
[test] [core] Unreserve non-confirmed items in confirmTrade

### DIFF
--- a/scripts/tests/systems/trading/confirm_trade.lua
+++ b/scripts/tests/systems/trading/confirm_trade.lua
@@ -1,0 +1,92 @@
+describe('confirmTrade & confirmItem', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.PUP,
+                level = 75,
+                zone  = xi.zone.AHT_URHGAN_WHITEGATE,
+            })
+
+        player:unlockAttachment(xi.item.HARLEQUIN_FRAME)
+        player:unlockAttachment(xi.item.HARLEQUIN_HEAD)
+    end)
+
+    it('can unlock attachment with extra attachment in window', function()
+        assert(player:getCharVar('TateeyaTradeStatus') == 0, 'automaton attachment trading is not unlocked')
+
+        player.entities:gotoAndTrigger('Tateeya', { eventId = 650 })
+
+        assert(player:getCharVar('TateeyaTradeStatus') == 1, 'should unlock automaton attachment trading from Tateeya')
+
+        player:addItem(xi.item.BARRAGE_TURBINE, 2)
+        player:addItem(xi.item.BARRIER_MODULE_II)
+
+        player.actions:tradeNpc('Tateeya',
+            {
+                {
+                    itemId   = xi.item.BARRAGE_TURBINE,
+                    quantity = 1,
+                },
+                {
+                    itemId   = xi.item.BARRIER_MODULE_II,
+                    quantity = 1,
+                }
+            },
+            { eventId = 651 })
+
+        -- TODO: this should probably use hasAttachment but it fails for some reason?
+        -- use "failure to unlock attachment" as "hasAttachment"
+        assert(player:unlockAttachment(xi.item.BARRAGE_TURBINE) == false, 'barrage turbine is unlocked')
+
+        local turbine = player:findItem(xi.item.BARRAGE_TURBINE, xi.inventoryLocation.INVENTORY)
+
+        assert(turbine, 'player still has a barrage turbine in inventory')
+        assert(turbine:getQuantity() == 1, 'player still has a single barrage turbine in inventory')
+        assert(turbine:getReservedValue() == 0, 'the barrage turbine item is not reserved')
+
+        local barrierModule = player:findItem(xi.item.BARRIER_MODULE_II, xi.inventoryLocation.INVENTORY)
+
+        assert(barrierModule, 'player still has a barrier module in inventory')
+        assert(barrierModule:getReservedValue() == 0, 'the barrier module is not reserved')
+
+        player.actions:tradeNpc('Tateeya',
+            {
+                {
+                    itemId   = xi.item.BARRIER_MODULE_II,
+                    quantity = 1,
+                },
+                {
+                    itemId   = xi.item.BARRAGE_TURBINE,
+                    quantity = 1,
+                }
+            },
+            { eventId = 651 })
+
+        -- TODO: this should probably use hasAttachment but it fails for some reason?
+        -- use "failure to unlock attachment" as "hasAttachment"
+        assert(player:unlockAttachment(xi.item.BARRIER_MODULE_II) == false, 'barrier module II is unlocked')
+
+        -- pointer should be stale - search for the barrier module again
+        barrierModule = player:findItem(xi.item.BARRIER_MODULE_II, xi.inventoryLocation.INVENTORY)
+        assert(barrierModule == nil, 'player does not have a barrier module in inventory')
+
+        -- search for the turbine again
+        turbine = player:findItem(xi.item.BARRAGE_TURBINE, xi.inventoryLocation.INVENTORY)
+        assert(turbine, 'player still has a barrage turbine in inventory')
+        assert(turbine:getQuantity() == 1, 'player still has a single barrage turbine in inventory')
+        assert(turbine:getReservedValue() == 0, 'the barrage turbine item is not reserved')
+
+        -- You already have this unlocked
+        player.actions:tradeNpc('Tateeya',
+            {
+                {
+                    itemId   = xi.item.BARRAGE_TURBINE,
+                    quantity = 1,
+                }
+            },
+            { eventId = 652 })
+    end)
+end)

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -5265,9 +5265,10 @@ void CLuaBaseEntity::confirmTrade() const
                 uint32 confirmedItems = PChar->TradeContainer->getConfirmedStatus(slotID);
                 auto   quantity       = (int32)std::min<uint32>(PChar->TradeContainer->getQuantity(slotID), confirmedItems);
 
-                PItem->setReserve(PItem->getReserve() - quantity);
                 if (confirmedItems > 0)
                 {
+                    PItem->setReserve(PItem->getReserve() - quantity);
+
                     uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
                     if (static_cast<uint32>(quantity) >= PChar->TradeContainer->getItem(slotID)->getQuantity())
                     {
@@ -5276,6 +5277,10 @@ void CLuaBaseEntity::confirmTrade() const
                     }
 
                     charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
+                }
+                else
+                {
+                    PItem->setReserve(0);
                 }
             }
         }


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Unreserve non-confirmed items in confirmTrade, add test for confirmTrade with partial trades

## Steps to test these changes

xi_test passes, the test itself was the failure:


this used to fail:
1) unlock an attachment
2) unlock a different attachment with the previous attachment in the trade (i.e. one already unlocked)
3) unlock another attachment with the already unlocked one from step 2
loud warning about how the item is reserved despite it never being eligible to be taken to begin with. this PR fixes that
