### PR TITLE
[module] [lua] Sandy Mission JST Waits

### DIFF
--- a/modules/era/lua/missions/mission_adjustments.lua
+++ b/modules/era/lua/missions/mission_adjustments.lua
@@ -223,6 +223,73 @@ if not xi.module.isContentEnabled('SOA') then
                 end
             end
         end)
+
+        -----------------------------------
+        -- San d'Oria Mission 6-2 "Ranperre's Final Rest": Restores the JST midnight wait for the gate guards to decipher the ancient book.
+        -- The June 17, 2014 version update decreased the required wait.
+        -- Source: https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-%28JST%29-Version-Update
+        -----------------------------------
+        xi.module.modifyInteractionEntry('scripts/missions/sandoria/6_2_Ranperres_Final_Rest', function(mission)
+            local southern = mission.sections[2][xi.zone.SOUTHERN_SAN_DORIA]
+            local northern = mission.sections[2][xi.zone.NORTHERN_SAN_DORIA]
+
+            local handoverEvents =
+            {
+                { section = southern, eventId = 1035 },
+                { section = southern, eventId = 1036 },
+                { section = northern, eventId = 1035 },
+            }
+
+            local gateGuards =
+            {
+                { section = southern, name = 'Ambrotien', waitEvent = 1038 },
+                { section = southern, name = 'Endracion', waitEvent = 1037 },
+                { section = northern, name = 'Grilau', waitEvent = 1037 },
+            }
+
+            -- Start the timer when the book is handed to a gate guard.
+            for _, handover in ipairs(handoverEvents) do
+                local baseHandler = handover.section.onEventFinish[handover.eventId]
+
+                handover.section.onEventFinish[handover.eventId] = function(player, csid, option, npc)
+                    baseHandler(player, csid, option, npc)
+                    mission:setVar(player, 'Timer', 1, JstMidnight())
+                end
+            end
+
+            -- Hold players at the "still deciphering" dialogue until the timer expires.
+            for _, guard in ipairs(gateGuards) do
+                local baseOnTrigger = guard.section[guard.name].onTrigger
+
+                guard.section[guard.name].onTrigger = function(player, npc)
+                    if
+                        player:getMissionStatus(mission.areaId) == 4 and
+                        mission:getVar(player, 'Timer') ~= 0
+                    then
+                        return mission:progressEvent(guard.waitEvent)
+                    end
+
+                    return baseOnTrigger(player, npc)
+                end
+            end
+        end)
+
+        -----------------------------------
+        -- San d'Oria Mission 8-1 "Coming of Age": Restores the JST midnight wait before the final cutscene in Northern San d'Oria.
+        -- The July 8, 2014 version update reduced the wait to one Earth minute.
+        -- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-%28JST%29-Version-Update
+        -----------------------------------
+        xi.module.modifyInteractionEntry('scripts/missions/sandoria/8_1_Coming_of_Age', function(mission)
+            local chateau = mission.sections[2][xi.zone.CHATEAU_DORAGUILLE]
+
+            -- Copy of the base handler with the one minute wait extended to JST midnight
+            chateau.onEventFinish[102] = function(player, csid, option, npc)
+                if mission:complete(player) then
+                    mission:setVar(player, 'Progress', JstMidnight())
+                    player:delKeyItem(xi.ki.DROPS_OF_AMNIO)
+                end
+            end
+        end)
     end)
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR edits the era mission module to add JST midnight waits to [Sandy Mission 6-2](https://forum.square-enix.com/ffxi/threads/42614) and [8-1](https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-%28JST%29-Version-Update?s=2082be200cdb38ad0804d68c934a681a) based on retail patch notes.

## Steps to test these changes

Load the module. Do the mission. See you must wait until JST midnight at a certain point in each rather than one earth minute.
