### PR TITLE
[lua] Olduum Quest Fixes

### DIFF
--- a/scripts/quests/ahtUrhgan/Olduum.lua
+++ b/scripts/quests/ahtUrhgan/Olduum.lua
@@ -78,8 +78,8 @@ quest.sections =
             onEventFinish =
             {
                 [6] = function(player, csid, option, npc)
-                    player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
                     if quest:complete(player) then
+                        player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
                         player:delKeyItem(xi.ki.DKHAAYAS_RESEARCH_JOURNAL)
                     end
                 end,
@@ -94,9 +94,9 @@ quest.sections =
                     if
                         not player:hasItem(xi.item.OLDUUM_RING) and
                         not hasQuestKeyItem(player) and
-                        npcUtil.tradeHasExactly(trade, xi.item.PICKAXE)
+                        npcUtil.tradeMatches(trade, { { xi.item.PICKAXE, 1 } })
                     then
-                        if math.randomInt(1, 10) > 5 then
+                        if math.randomInt(1, 100) <= 50 then
                             quest:setVar(player, 'Prog', math.randomInt(1, 3))
 
                             return quest:progressEvent(0, { [0] = keyItems[quest:getVar(player, 'Prog')] })
@@ -110,14 +110,14 @@ quest.sections =
 
             onEventFinish =
             {
-                [0] = function(player, npc, trade)
+                [0] = function(player, csid, option, npc)
                     if player:getLocalVar('mineFail') == 1 then
                         player:setLocalVar('mineFail', 0)
-                        player:confirmTrade()
                     else
                         player:addKeyItem(keyItems[quest:getVar(player, 'Prog')])
-                        player:confirmTrade()
                     end
+
+                    player:tradeComplete()
                 end,
             },
         },
@@ -156,39 +156,9 @@ quest.sections =
             onEventFinish =
             {
                 [8] = function(player, csid, option, npc)
-                    npcUtil.giveItem(player, xi.item.LIGHTNING_BAND)
-                    player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
-                    quest:setVar(player, 'Prog', 0)
-                end,
-            },
-        },
-
-        [xi.zone.WAJAOM_WOODLANDS] =
-        {
-            ['Leypoint'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:hasItem(xi.item.LIGHTNING_BAND) then
-                        return quest:messageSpecial(zones[player:getZoneID()].text.LEYPOINT + 1, xi.item.LIGHTNING_BAND)
-                    end
-                end,
-
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.LIGHTNING_BAND) then
-                        if player:getFreeSlotsCount() == 0 then
-                            return quest:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED)
-                        else
-                            return quest:progressEvent(2)
-                        end
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [2] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.OLDUUM_RING) then
-                        player:confirmTrade()
+                    if npcUtil.giveItem(player, xi.item.LIGHTNING_BAND) then
+                        player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
+                        quest:setVar(player, 'Prog', 0)
                     end
                 end,
             },
@@ -202,9 +172,9 @@ quest.sections =
                     if
                         not player:hasItem(xi.item.OLDUUM_RING) and
                         not hasQuestKeyItem(player) and
-                        npcUtil.tradeHasExactly(trade, xi.item.PICKAXE)
+                        npcUtil.tradeMatches(trade, { { xi.item.PICKAXE, 1 } })
                     then
-                        if math.randomInt(1, 10) > 5 then
+                        if math.randomInt(1, 100) <= 50 then
                             quest:setVar(player, 'Prog', math.randomInt(1, 3))
 
                             return quest:progressEvent(0, { [0] = keyItems[quest:getVar(player, 'Prog')] })
@@ -218,31 +188,45 @@ quest.sections =
 
             onEventFinish =
             {
-                [0] = function(player, npc, trade)
+                [0] = function(player, csid, option, npc)
                     if player:getLocalVar('mineFail') == 1 then
                         player:setLocalVar('mineFail', 0)
-                        player:confirmTrade()
                     else
                         player:addKeyItem(keyItems[quest:getVar(player, 'Prog')])
-                        player:confirmTrade()
                     end
+
+                    player:tradeComplete()
                 end,
             },
         },
-    },
 
-    -- Section: Quest accepted or completed
-    {
-        check = function(player, status, vars)
-            return status >= xi.questStatus.QUEST_AVAILABLE
-        end,
-
-        [xi.zone.AYDEEWA_SUBTERRANE] =
+        [xi.zone.WAJAOM_WOODLANDS] =
         {
-            ['Excavation_Site'] =
+            ['Leypoint'] =
             {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.LIGHTNING_BAND, 1 } }) then
+                        if player:getFreeSlotsCount() == 0 then
+                            return quest:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED)
+                        else
+                            return quest:progressEvent(2)
+                        end
+                    end
+                end,
+
                 onTrigger = function(player, npc)
-                    return quest:message(zones[player:getZoneID()].text.NOTHING_HAPPENS)
+                    if player:hasItem(xi.item.LIGHTNING_BAND) then
+                        return quest:messageSpecial(zones[player:getZoneID()].text.LEYPOINT + 1, xi.item.LIGHTNING_BAND)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [2] = function(player, csid, option, npc)
+                    if npcUtil.giveItem(player, xi.item.OLDUUM_RING) then
+                        player:tradeComplete()
+                    end
                 end,
             },
         },

--- a/scripts/zones/Aydeewa_Subterrane/DefaultActions.lua
+++ b/scripts/zones/Aydeewa_Subterrane/DefaultActions.lua
@@ -1,8 +1,9 @@
 local ID = zones[xi.zone.AYDEEWA_SUBTERRANE]
 
 return {
-    ['blank_omens']    = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm9']            = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['qm10']           = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
-    ['Mushroom_Patch'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['blank_omens'    ] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm9'            ] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm10'           ] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['Excavation_Site'] = { messageSpecial = ID.text.NOTHING_HAPPENS         },
+    ['Mushroom_Patch' ] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes a bug where if you had a full inventory you would still lose your key item and have to go get another one. It also modernizes the file a bit with proper trade logic. Also, it deletes some duplicative code.

## Steps to test these changes

Flag the quest. Try to turn things in at all stages with full inventory. See it all works once you get space and you aren't forced to repeat it with key items incorrectly being consumed like before.

## Captures

Siknoz

Quests - Toau - Olduum + Trade For Ring
https://youtu.be/cbnVAcIAXCA
https://1drv.ms/u/c/87e665e10555c452/IQCazPZhDW0FRplaJn55DNUMAWudlUj9BFvygDIjPijjaZA?e=v8KcTf
