### PR TITLE
[lua] Fix CoP 5-2 and Container:isVarBitsSet bug

### DIFF
--- a/scripts/globals/interaction/container.lua
+++ b/scripts/globals/interaction/container.lua
@@ -198,7 +198,7 @@ function Container:isVarBitsSet(player, name, ...)
         sum = sum + bit.lshift(1, bitNum)
     end
 
-    return bit.band(player:getVar(self.varPrefix .. name), sum) ~= 0
+    return bit.band(player:getVar(self.varPrefix .. name), sum) == sum
 end
 
 ---@param player CBaseEntity

--- a/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
+++ b/scripts/missions/cop/5_2_Desires_of_Emptiness.lua
@@ -64,7 +64,10 @@ local memoryFluxOnTrigger = function(player, npc)
     then
         SpawnMob(fluxInfo[2]):updateClaim(player)
         return mission:messageSpecial(promyvionVahzlID.text.ON_NM_SPAWN)
-    elseif not mission:isVarBitsSet(player, 'Option', fluxInfo[1] + 3) then
+    elseif
+        mission:isVarBitsSet(player, 'Option', fluxInfo[1]) and
+        not mission:isVarBitsSet(player, 'Option', fluxInfo[1] + 3)
+    then
         return mission:progressCutscene(fluxInfo[3])
     end
 end
@@ -121,27 +124,21 @@ mission.sections =
             ['Propagator'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if not mission:isVarBitsSet(player, 'Option', 0) then
-                        mission:setVarBit(player, 'Option', 0)
-                    end
+                    mission:setVarBit(player, 'Option', 0)
                 end,
             },
 
             ['Solicitor'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if not mission:isVarBitsSet(player, 'Option', 1) then
-                        mission:setVarBit(player, 'Option', 1)
-                    end
+                    mission:setVarBit(player, 'Option', 1)
                 end,
             },
 
             ['Ponderer'] =
             {
                 onMobDeath = function(mob, player, optParams)
-                    if not mission:isVarBitsSet(player, 'Option', 2) then
-                        mission:setVarBit(player, 'Option', 2)
-                    end
+                    mission:setVarBit(player, 'Option', 2)
                 end,
             },
 
@@ -180,12 +177,11 @@ mission.sections =
         [xi.zone.SPIRE_OF_VAHZL] =
         {
             onZoneIn = function(player, prevZone)
-                if mission:getVar(player, 'Status') == 1 then
-                    if bit.rshift(mission:getVar(player, 'Option'), 3) == 7 then
-                        return 20
-                    else
-                        return 21
-                    end
+                local missionStatus = mission:getVar(player, 'Status')
+                if missionStatus == 0 then
+                    return 21
+                elseif missionStatus == 1 then
+                    return 20
                 end
             end,
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes CoP 5-2 as well as a bug in Container:isVarBitsSet.

CoP 5-2:
- You could enter Spire of Vahzl if you never fought an NM (Status == 0). This fixes that.
- You could trigger an event if the NM was alive. This fixes that.
- Container:isVarBitsSet should be doing an exact match. Fixing this function corrects quests/bastok/Stamp_hunt.lua and quests/ahtUrhgan/Arts_and_Crafts.lua. CoP 5-2 was doing an odd check later on to correct for the bug in isVarBitsSet.

## Steps to test these changes

Run through CoP 5-2 as well as Stamp Hunt and Arts and Crafts.
