### PR TITLE
[C++] [lua] Add support to cleanup negative status effects in battlefield framework

### DIFF
--- a/scripts/battlefields/Bearclaw_Pinnacle/flames_for_the_dead.lua
+++ b/scripts/battlefields/Bearclaw_Pinnacle/flames_for_the_dead.lua
@@ -7,15 +7,16 @@ local ID = zones[xi.zone.BEARCLAW_PINNACLE]
 -----------------------------------
 
 local content = BattlefieldMission:new({
-    zoneId        = xi.zone.BEARCLAW_PINNACLE,
-    battlefieldId = xi.battlefield.id.FLAMES_FOR_THE_DEAD,
-    canLoseExp    = false,
-    maxPlayers    = 6,
-    levelCap      = 99,
-    timeLimit     = utils.minutes(30),
-    index         = 0,
-    entryNpc      = 'Wind_Pillar_1',
-    exitNpc       = 'Wind_Pillar_Exit',
+    zoneId         = xi.zone.BEARCLAW_PINNACLE,
+    battlefieldId  = xi.battlefield.id.FLAMES_FOR_THE_DEAD,
+    canLoseExp     = false,
+    cleanupDebuffs = true,
+    maxPlayers     = 6,
+    levelCap       = 99,
+    timeLimit      = utils.minutes(30),
+    index          = 0,
+    entryNpc       = 'Wind_Pillar_1',
+    exitNpc        = 'Wind_Pillar_Exit',
 
     missionArea           = xi.mission.log_id.COP,
     mission               = xi.mission.id.cop.THREE_PATHS,

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -401,6 +401,7 @@ end
 --  - allowSubjob: Determines if character subjobs are enabled or disabled upon entry. Defaults to true. (optional)
 --  - hasWipeGrace: Grants players a 3 minute grace period on a full wipe before ejecting them. Defaults to true. (optional)
 --  - canLoseExp: Determines if a character loses experience points upon death while inside the battlefield. Defaults to true. (optional)
+--  - cleanupDebuffs: Removes negative status effects from players upon victory. Defaults to false. (optional)
 --  - showTimer: Show the time remaining in the battlefield in the UI for the player. Defaults to true. (optional)
 --  - delayToExit: Amount of time to wait before exiting the battlefield. Defaults to 5 seconds. (optional)
 --  - requiredItems: Items required to be traded to enter the battlefield.
@@ -440,10 +441,11 @@ function Battlefield:new(data)
     obj.grantXPLockout   = data.grantXPLockout
     obj.levelCap         = data.levelCap or 0
     obj.allowSubjob      = (data.allowSubjob == nil or data.allowSubjob) or false
-    obj.allowTrusts      = data.allowTrusts and data.allowTrusts or false
+    obj.allowTrusts      = data.allowTrusts or false
     obj.hasWipeGrace     = (data.hasWipeGrace == nil or data.hasWipeGrace) or false
-    obj.isMission        = data.isMission and data.isMission or false
+    obj.isMission        = data.isMission or false
     obj.canLoseExp       = (data.canLoseExp == nil or data.canLoseExp) or false
+    obj.cleanupDebuffs   = data.cleanupDebuffs or false
     obj.showTimer        = (data.showTimer == nil or data.showTimer) or false
     obj.delayToExit      = data.delayToExit or 5
     obj.requiredItems    = data.requiredItems or {}
@@ -1186,6 +1188,13 @@ end
 
 ---@diagnostic disable-next-line: duplicate-set-field
 function Battlefield:onBattlefieldLeave(player, battlefield, leavecode)
+    if
+        self.cleanupDebuffs and
+        leavecode == xi.battlefield.leaveCode.WON
+    then
+        player:delStatusEffectsByFlag(xi.effectFlag.ERASABLE + xi.effectFlag.WALTZABLE)
+    end
+
     if leavecode == xi.battlefield.leaveCode.WON then
         self:onBattlefieldWin(player, battlefield)
     elseif leavecode == xi.battlefield.leaveCode.LOST then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a boolean you can set in the battlefield setup to clean up negative status effects on victory. This would mainly be used for any story missions we come across (ones that put you in a cutscene afterwards) 

For now just Snoll Tzar, but we can add it to other battlefields as they are captured.

Also cleaned up a couple other booleans in the battlefield handler to reduce cyclomatic complexity.

## Capture
https://youtu.be/Gr5Xh55XM5w?si=3IgoucAVi6R9Ht5A

You can see the DoT wear off just as the cutscene begins, and it does not wear off silently. 

## Steps to test these changes

Run Snoll Tzar, get debuffed (cold wave) and win, watch it clear on victory. 
