### PR TITLE
[lua] Enforce Game Day Wait for New Outpost Supplies

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1611,7 +1611,6 @@ xi.conquest.overseerOnEventFinish = function(player, csid, option, guardNation, 
         player:delKeyItem(sOutpost.ki)
         player:addCP(sOutpost.cp)
         player:messageSpecial(mOffset) -- 'You've earned conquest points!'
-        player:setCharVar('supplyQuest_started', 0)
         player:setCharVar('supplyQuest_region', 0)
         player:setCharVar('supplyQuest_fresh', 0)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes a bug with outpost supply quests. It ensures that a player must wait until the next game day to pick up another set of supplies - there was a line in the code that was erroneously clearing the wait timer upon turn in. [As verified in retail captures](https://www.youtube.com/watch?v=kD3CT-jTQBI), the wait time is one game day from pick up, not from turn in. It is also possible to turn in the same supplies quest twice on the same day.

## Steps to test these changes

Pick up outpost supplies. Turn them in. Go back to gate guard. See that he doesn't offer you the supplies menu until the next game day after you picked up the previous set of supplies.
