### PR TITLE
[module] [lua] Sin Hunting Full Moon Module

### DIFF
--- a/modules/era/lua/quests/windurst/Sin_Hunting.lua
+++ b/modules/era/lua/quests/windurst/Sin_Hunting.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Sin Hunting
+-- Restores the full moon requirement to examine the ??? in Jugner Forest.
+-- The June 17, 2014 version update changed the event to occur regardless
+-- of Vana'diel time and phase of the moon.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_sin_hunting'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/RNG_AF1_Sin_Hunting', function(quest)
+        local jugnerForest  = quest.sections[2][xi.zone.JUGNER_FOREST]
+        local baseOnTrigger = jugnerForest['qm2'].onTrigger
+
+        jugnerForest['qm2'].onTrigger = function(player, npc)
+            if getVanadielMoonCycle() == xi.moonCycle.FULL_MOON then
+                return baseOnTrigger(player, npc)
+            end
+        end
+    end)
+end)
+
+return m


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a module to restore the required full moon condition to the quest "Sin Hunting". This requirement was removed in the [June 17, 2014 version update](https://forum.square-enix.com/ffxi/threads/42614).

## Steps to test these changes

Load the module. Do the quest. See you are blocked from completing it unless the full moon requirement is met.
