### PR TITLE
[core] Account for recent tick movement on instant casts

### DIFF
--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -40,6 +40,14 @@
 #include "utils/battleutils.h"
 #include "utils/zoneutils.h"
 
+namespace
+{
+
+// distance a player has to cover before a cast counts them as having moved
+constexpr float movementThreshold = 0.3f;
+
+} // namespace
+
 CMagicState::CMagicState(xi::Badge<CState>, CBattleEntity* PEntity, const EntityId& target, SpellID spellid, uint8 flags)
 : CState(PEntity, target)
 , m_PEntity(PEntity)
@@ -87,6 +95,11 @@ auto CMagicState::init() -> StateErrorOr<void>
 
     m_castTime = battleutils::CalculateSpellCastTime(m_PEntity, this);
     m_startPos = m_PEntity->loc.p;
+
+    if (const auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
+    {
+        m_startedMoving = PChar->m_lastMoveDistance > movementThreshold;
+    }
 
     auto targetID = PTarget->id;
 
@@ -620,9 +633,14 @@ auto CMagicState::HasMoved() const -> bool
         return false;
     }
 
+    if (m_startedMoving)
+    {
+        return true;
+    }
+
     float charDistance = distance(m_startPos, m_PEntity->loc.p, true);
 
-    return charDistance > 0.3;
+    return charDistance > movementThreshold;
 }
 
 void CMagicState::TryInterrupt(CBattleEntity* PAttacker)

--- a/src/map/ai/states/magic_state.h
+++ b/src/map/ai/states/magic_state.h
@@ -66,6 +66,7 @@ protected:
     std::unique_ptr<CSpell> m_PSpell;
     timer::duration         m_castTime{};
     position_t              m_startPos;
+    bool                    m_startedMoving{ false };
     bool                    m_interrupted{ false };
     bool                    m_instantCast{ false };
     uint8                   m_flags{ 0 };

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -621,6 +621,7 @@ public:
     position_t m_ActionOffsetPos{}; // action offset position from the action packet(currently only used for repositioning of luopans)
 
     location_t m_previousLocation{};
+    float      m_lastMoveDistance{};
 
     uint32 m_PrevZonelineID; // The ID of the previous zoneline the player went through.
 

--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -66,6 +66,8 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
         PChar->loc.p.rotation = newRotation;
 
         PChar->m_TargID = newTargID;
+
+        PChar->m_lastMoveDistance = distance(PChar->m_previousLocation.p, PChar->loc.p, true);
     }
 
     if (moved)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
tl;dr: with chainspell/Quick Magic the cast may complete before you even get the next position update from the client and LSB is not interrupting chainspell casts as much as it should while the player is running.

This PR tracks the last distance covered on each POS update and accounts for it in the magic state while still respecting the 0.3 leeway.

Retail captures with and without packetflow

[chainspell_no_packetflow_2026-8-5_18_3.zip](https://github.com/user-attachments/files/30767607/chainspell_no_packetflow_2026-8-5_18_3.zip)
[chainspell_packetflow_2026-8-5_17_59.zip](https://github.com/user-attachments/files/30767608/chainspell_packetflow_2026-8-5_17_59.zip)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
