### PR TITLE
[cpp] Fix onSpawn for mob and npc in instances

### DIFF
--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -261,17 +261,17 @@ auto CInstanceLoader::LoadInstance() const -> CInstance*
         // Finish setting up Mobs
         m_PInstance->ForEachMob([&](CMobEntity* PMob)
         {
-            luautils::OnMobInitialize(PMob);
-            m_PInstance->FindPartyForMob(PMob);
-            luautils::ApplyMixins(PMob);
-            ((CMobEntity*)PMob)->saveModifiers();
-            ((CMobEntity*)PMob)->saveMobModifiers();
-
             // Add to cache
             luautils::LoadLuaObjectFromFile(
                 fmt::format("./scripts/zones/{}/mobs/{}.lua",
                             PMob->loc.zone->getName(),
                             PMob->getName()));
+
+            luautils::OnMobInitialize(PMob);
+            m_PInstance->FindPartyForMob(PMob);
+            luautils::ApplyMixins(PMob);
+            ((CMobEntity*)PMob)->saveModifiers();
+            ((CMobEntity*)PMob)->saveMobModifiers();
         });
         // clang-format on
 
@@ -279,13 +279,13 @@ auto CInstanceLoader::LoadInstance() const -> CInstance*
         // Finish setting up NPCs
         m_PInstance->ForEachNpc([&](CNpcEntity* PNpc)
         {
-            luautils::OnNpcSpawn(PNpc);
-
             // Add to cache
             luautils::LoadLuaObjectFromFile(
                 fmt::format("./scripts/zones/{}/npcs/{}.lua",
                             PNpc->loc.zone->getName(),
                             PNpc->getName()));
+
+            luautils::OnNpcSpawn(PNpc);
         });
         // clang-format on
 

--- a/src/map/instance_loader.cpp
+++ b/src/map/instance_loader.cpp
@@ -257,37 +257,37 @@ auto CInstanceLoader::LoadInstance() const -> CInstance*
             m_PInstance->InsertNPC(PNpc);
         }
 
-        // clang-format off
+        // Cache every entity script before running any handler.
+        // Entities may rely on one-another.
+        m_PInstance->ForEachMob(
+            [](CMobEntity* PMob)
+            {
+                luautils::OnEntityLoad(PMob);
+            });
+
+        m_PInstance->ForEachNpc(
+            [](CNpcEntity* PNpc)
+            {
+                luautils::OnEntityLoad(PNpc);
+            });
+
         // Finish setting up Mobs
-        m_PInstance->ForEachMob([&](CMobEntity* PMob)
-        {
-            // Add to cache
-            luautils::LoadLuaObjectFromFile(
-                fmt::format("./scripts/zones/{}/mobs/{}.lua",
-                            PMob->loc.zone->getName(),
-                            PMob->getName()));
+        m_PInstance->ForEachMob(
+            [&](CMobEntity* PMob)
+            {
+                luautils::OnMobInitialize(PMob);
+                m_PInstance->FindPartyForMob(PMob);
+                luautils::ApplyMixins(PMob);
+                PMob->saveModifiers();
+                PMob->saveMobModifiers();
+            });
 
-            luautils::OnMobInitialize(PMob);
-            m_PInstance->FindPartyForMob(PMob);
-            luautils::ApplyMixins(PMob);
-            ((CMobEntity*)PMob)->saveModifiers();
-            ((CMobEntity*)PMob)->saveMobModifiers();
-        });
-        // clang-format on
-
-        // clang-format off
         // Finish setting up NPCs
-        m_PInstance->ForEachNpc([&](CNpcEntity* PNpc)
-        {
-            // Add to cache
-            luautils::LoadLuaObjectFromFile(
-                fmt::format("./scripts/zones/{}/npcs/{}.lua",
-                            PNpc->loc.zone->getName(),
-                            PNpc->getName()));
-
-            luautils::OnNpcSpawn(PNpc);
-        });
-        // clang-format on
+        m_PInstance->ForEachNpc(
+            [](CNpcEntity* PNpc)
+            {
+                luautils::OnNpcSpawn(PNpc);
+            });
 
         // Cache Instance script (TODO: This will be done multiple times, don't do that)
         luautils::LoadLuaObjectFromFile(instanceutils::GetInstanceData(m_PInstance->GetID()).filename);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

Correct the order the onSpawn is read in instances for mob and npc.


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
On server restart we can see the issues in assaults for example. 
If we modify the .lua of the mob or npc, the onSpawn will work properly, until the next server restart.