### PR TITLE
[lua] Update drain add effect caps/rates

### DIFF
--- a/scripts/combat/action_additional_effect_damage.lua
+++ b/scripts/combat/action_additional_effect_damage.lua
@@ -114,7 +114,7 @@ xi.combat.action.executeAddEffectDamage = function(actor, target, fedData)
     end
 
     -- Early return: No proc.
-    if math.randomInt(1, 100) > params.chance then
+    if math.randomInt(1, 10000) > params.chance * 100 then -- proc rates from add effect weapons have at least 2 digits of precision based on testing. input is 0-100 so this should be ok
         return 0, 0, 0
     end
 

--- a/scripts/globals/additional_effects.lua
+++ b/scripts/globals/additional_effects.lua
@@ -564,5 +564,5 @@ xi.additionalEffect.linearProcRate = function(dStat, dStatCap, startingRate, cap
     local rate = ((cappedRate - startingRate) / dStatCap) * math.min(dStat, dStatCap) + startingRate
 
     -- Minimum of 1% is observed on drain weapons. Needs more testing.
-    return math.max(math.floor(rate), 1) -- Rate is ultimately used against a random roll of integers so this is mostly just to indicate it's a whole percent.
+    return math.max(rate, 1)
 end

--- a/scripts/items/bloodsword.lua
+++ b/scripts/items/bloodsword.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 1, 32),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 40, 1, 20),
         basePower       = 40 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/bloody_blade.lua
+++ b/scripts/items/bloody_blade.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 20),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/bloody_lance.lua
+++ b/scripts/items/bloody_lance.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 8, 12),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 7, 9), -- TODO: get more samples
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.PIERCING,

--- a/scripts/items/bloody_rapier.lua
+++ b/scripts/items/bloody_rapier.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 20), -- Needs better data, but looks like Bloody Blade's proc rate
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12), -- Needs better data, but looks like Bloody Blade's proc rate
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.PIERCING,

--- a/scripts/items/bloody_sword.lua
+++ b/scripts/items/bloody_sword.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 18),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/carnage_blade.lua
+++ b/scripts/items/carnage_blade.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 20),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/carnage_lance.lua
+++ b/scripts/items/carnage_lance.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 8, 12),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 7, 9), -- TODO: get more samples
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.PIERCING,

--- a/scripts/items/carnage_rapier.lua
+++ b/scripts/items/carnage_rapier.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 20), -- Needs better data, but looks like Bloody Blade's proc rate
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12), -- Needs better data, but looks like Bloody Blade's proc rate
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.PIERCING,

--- a/scripts/items/carnage_sword.lua
+++ b/scripts/items/carnage_sword.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 10, 18),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 12),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/dainslaif.lua
+++ b/scripts/items/dainslaif.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 1, 32),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 40, 1, 20),
         basePower       = 40 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/deae_gratia.lua
+++ b/scripts/items/deae_gratia.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 22, 29),                              -- TODO: This actually caps above dINT 48 for proc rate
+        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 15, 18),                              -- TODO: This actually caps above dINT 48 for proc rate
         basePower       = 30 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16), -- TODO: check the scaling formula
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.BLUNT,

--- a/scripts/items/muketsu.lua
+++ b/scripts/items/muketsu.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 8, 18),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 13),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,

--- a/scripts/items/muketsu_+1.lua
+++ b/scripts/items/muketsu_+1.lua
@@ -11,7 +11,7 @@ itemObject.onItemAdditionalEffect = function(actor, target, baseAttackDamage, it
 
     local pTable =
     {
-        chance          = xi.additionalEffect.linearProcRate(dStat, 48, 8, 18),
+        chance          = xi.additionalEffect.linearProcRate(dStat, 32, 8, 13),
         basePower       = 8 + utils.clamp(dStat, -3, 16) + utils.clamp(math.floor((dStat - 16) / 2), 0, 16),
         attackType      = xi.attackType.PHYSICAL,
         physicalElement = xi.damageType.SLASHING,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Long story short, my algo to calculate the rates was flawed, so I went and redid the math (I did get some more samples on some.)

Also, rates ended up on exactly half percents a lot so I assume that SE isn't flooring. So I adjusted the calculations to account for the fact that there may be 2 digits of precision.

## Steps to test these changes

use drain weapons, see em work