### PR TITLE
[lua][sql] Windurst 8-2 audit

### DIFF
--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -143,8 +143,12 @@ mission.sections =
             ['Kupipi'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 3 then
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    if missionStatus == 3 then
                         return mission:progressEvent(326, 0, xi.ki.ORASTERY_RING)
+                    elseif missionStatus == 4 then
+                        return mission:event(327, 0, xi.ki.ORASTERY_RING)
                     end
                 end,
             },
@@ -171,6 +175,7 @@ mission.sections =
             onEventFinish =
             {
                 [75] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.BOOK_OF_THE_GODS)
                     player:setMissionStatus(mission.areaId, 10)
                 end,
             },
@@ -190,6 +195,8 @@ mission.sections =
                     then
                         SpawnMob(outerHorutotoID.mob.JESTER_WHOD_BE_KING_OFFSET + 0)
                         SpawnMob(outerHorutotoID.mob.JESTER_WHOD_BE_KING_OFFSET + 1)
+
+                        return mission:messageSpecial(outerHorutotoID.text.GUARDIAN_BLOCKING_WAY)
                     elseif missionStatus == 5 then
                         return mission:progressEvent(71)
                     end
@@ -201,7 +208,7 @@ mission.sections =
                 onMobDeath = function(mob, player, optParams)
                     if
                         player:getMissionStatus(mission.areaId) == 4 and
-                        GetMobByID(mob:getID() - 1):isDead()
+                        GetMobByID(outerHorutotoID.mob.JESTER_WHOD_BE_KING_OFFSET):isDead()
                     then
                         player:setMissionStatus(mission.areaId, 5)
                     end
@@ -213,7 +220,7 @@ mission.sections =
                 onMobDeath = function(mob, player, optParams)
                     if
                         player:getMissionStatus(mission.areaId) == 4 and
-                        GetMobByID(mob:getID() + 1):isDead()
+                        GetMobByID(outerHorutotoID.mob.JESTER_WHOD_BE_KING_OFFSET + 1):isDead()
                     then
                         player:setMissionStatus(mission.areaId, 5)
                     end
@@ -229,13 +236,34 @@ mission.sections =
             },
         },
 
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Janshura-Rashura'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(484)
+                    end
+                end,
+            },
+        },
+
         [xi.zone.WINDURST_WALLS] =
         {
             ['Shantotto'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 7 then
-                        return mission:progressEvent(397, 0, 0, 0, 282)
+                        return mission:progressEvent(397, 0, 0, 0, xi.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
+                    end
+                end,
+            },
+
+            ['Zokima-Rokima'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(376)
                     end
                 end,
             },
@@ -244,6 +272,11 @@ mission.sections =
             {
                 [397] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
+                    player:delKeyItem(xi.ki.MANUSTERY_RING)
+                    player:delKeyItem(xi.ki.OPTISTERY_RING)
+                    player:delKeyItem(xi.ki.AURASTERY_RING)
+                    player:delKeyItem(xi.ki.RHINOSTERY_RING)
+                    player:delKeyItem(xi.ki.ORASTERY_RING)
                     player:setMissionStatus(mission.areaId, 8)
                 end,
             },
@@ -251,14 +284,24 @@ mission.sections =
 
         [xi.zone.WINDURST_WATERS] =
         {
+            ['Mokyokyo'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(764)
+                    end
+                end,
+            },
+
             ['Tosuka-Porika'] =
             {
                 onTrigger = function(player, npc)
-                    if
-                        player:getMissionStatus(mission.areaId) == 1 and
-                        not player:hasKeyItem(xi.ki.OPTISTERY_RING)
-                    then
-                        return mission:progressEvent(801, 0, xi.ki.OPTISTERY_RING)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        if player:hasKeyItem(xi.ki.OPTISTERY_RING) then
+                            return mission:event(802, 0, xi.ki.OPTISTERY_RING)
+                        else
+                            return mission:progressEvent(801, 0, xi.ki.OPTISTERY_RING)
+                        end
                     end
                 end,
             },
@@ -286,16 +329,31 @@ mission.sections =
 
                     if missionStatus == 0 then
                         return mission:progressEvent(588, 0, xi.ki.MANUSTERY_RING)
+                    elseif missionStatus == 1 then
+                        return mission:event(589)
                     elseif missionStatus == 2 then
                         return mission:progressEvent(601, 0, xi.ki.ORASTERY_RING)
+                    elseif missionStatus == 3 then
+                        return mission:event(601, 0, xi.ki.ORASTERY_RING)
                     elseif missionStatus == 6 then
                         return mission:progressEvent(590)
                     elseif missionStatus == 7 then
-                        return mission:progressEvent(589)
+                        return mission:event(591)
                     elseif missionStatus == 8 then
                         return mission:progressEvent(592)
+                    elseif missionStatus == 9 then
+                        return mission:event(593)
                     elseif missionStatus == 10 then
-                        return mission:progressEvent(609)
+                        return mission:progressEvent(609, 0, xi.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
+                    end
+                end,
+            },
+
+            ['Rakoh_Buuma'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(584)
                     end
                 end,
             },
@@ -312,6 +370,7 @@ mission.sections =
                 end,
 
                 [592] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.GLOVE_OF_PERPETUAL_TWILIGHT)
                     player:setMissionStatus(mission.areaId, 9)
                 end,
 
@@ -345,6 +404,11 @@ mission.sections =
                     mission:setVar(player, 'Option', 0)
                 end,
             },
+        },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Apururu'] = mission:event(605),
         },
     },
 }

--- a/scripts/zones/FeiYin/DefaultActions.lua
+++ b/scripts/zones/FeiYin/DefaultActions.lua
@@ -1,3 +1,3 @@
 return {
-    ['_no4'] = { event = 15 },
+    ['_no4'] = { event = 11 },
 }

--- a/scripts/zones/Outer_Horutoto_Ruins/DefaultActions.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/DefaultActions.lua
@@ -1,7 +1,8 @@
 local ID = zones[xi.zone.OUTER_HORUTOTO_RUINS]
 
 return {
-    ['_5e9']  = { text = ID.text.DOOR_FIRMLY_SHUT },
+    ['_5e5'] = { messageSpecial = ID.text.HIDDEN_DOOR_FIRMLY_SHUT },
+    ['_5e9'] = { text = ID.text.DOOR_FIRMLY_SHUT },
     ['_5eb'] = { messageSpecial = ID.text.DOOR_FIRMLY_SHUT },
-    ['qm1'] = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
+    ['qm1']  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
+++ b/scripts/zones/Outer_Horutoto_Ruins/IDs.lua
@@ -27,6 +27,7 @@ zones[xi.zone.OUTER_HORUTOTO_RUINS] =
         DOOR_FIRMLY_SHUT              = 7278,  -- The door is firmly shut.
         ALL_G_ORBS_ENERGIZED          = 7281,  -- The six Mana Orbs have been successfully energized with magic!
         CHEST_UNLOCKED                = 7304,  -- You unlock the chest!
+        HIDDEN_DOOR_FIRMLY_SHUT       = 7313,  -- It appears to be a hidden door, but it is firmly shut.
         IF_HAD_ORBS                   = 7362,  -- You sense that if you had <keyitem>, <keyitem>, <keyitem>, or <keyitem>, something might happen.
         CANNOT_ENTER_BATTLEFIELD      = 7365,  -- You cannot enter this battlefield with the key item: <keyitem> in your possession.
         MUST_WAIT_LONGER              = 7366,  -- It appears you must wait longer to commence the battle.

--- a/sql/mob_spawn_points.sql
+++ b/sql/mob_spawn_points.sql
@@ -72463,8 +72463,8 @@ INSERT INTO `mob_spawn_points` VALUES (17572197,0,'Jack_of_Cups','Jack of Cups',
 INSERT INTO `mob_spawn_points` VALUES (17572198,0,'Jack_of_Batons','Jack of Batons',61,62,62,-291.000,0.001,-657.000,126,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572199,0,'Jack_of_Swords','Jack of Swords',62,62,62,-291.000,0.001,-659.000,130,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572200,0,'Jack_of_Coins','Jack of Coins',63,62,62,-291.000,0.001,-661.000,127,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17572201,0,'Queen_of_Swords','Queen of Swords',64,72,72,-422.000,0.001,618.000,239,NULL,NULL);
-INSERT INTO `mob_spawn_points` VALUES (17572202,0,'Queen_of_Coins','Queen of Coins',65,72,72,-422.000,0.001,621.000,16,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17572201,0,'Queen_of_Swords','Queen of Swords',64,72,72,-423.000,-0.500,621.000,0,NULL,NULL);
+INSERT INTO `mob_spawn_points` VALUES (17572202,0,'Queen_of_Coins','Queen of Coins',65,72,72,-423.000,-0.500,619.000,217,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572203,0,'Thunder_Elemental','Thunder Elemental',66,75,75,-576.613,-1.014,739.999,0,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572204,0,'Custom_Cardian','Custom Cardian',67,1,1,427.215,-8.021,732.387,27,NULL,NULL);
 INSERT INTO `mob_spawn_points` VALUES (17572205,0,'Custom_Cardian','Custom Cardian',67,1,1,429.615,-8.000,731.649,69,NULL,NULL);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes many mistakes with Windurst 8-2 using the capture by Wiggo https://drive.google.com/open?id=1KXP7rQQg8nLuIg9UU-xAMOyuCxYVwleX

- KI were not properly handled.
- A lot of the optional text was incorrect. 
- A lot of events were not passing in their KI text.
- Two default actions were incorrect on doors.
- The mob spawn points were incorrect.

## Steps to test these changes

Run Windurst 8-2 from start to finish. Always talk to a person a second time
