### PR TITLE
Fix missing item name in "The Three Magi" quest dialogue

### DIFF
--- a/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
+++ b/scripts/zones/Heavens_Tower/npcs/Chumimi.lua
@@ -43,9 +43,9 @@ entity.onTrigger = function(player, npc)
         mJob == xi.job.BLM and
         mLvl >= xi.settings.main.AF1_QUEST_LEVEL
     then
-        player:startEvent(260, 0, 613, 0, 0, 0, xi.item.GLOWSTONE) -- Start Quest "The Three Magi" --- NOTE: 5th parameter is "Meteorites" but he doesn't exist ---
+        player:startEvent(260, 0, 613, 0, 0, xi.item.METEORITE, xi.item.GLOWSTONE) -- Start Quest "The Three Magi"
     elseif theThreeMagi == xi.questStatus.QUEST_ACCEPTED then
-        player:startEvent(261, 0, 0, 0, 0, 0, xi.item.GLOWSTONE) -- During Quest "The Three Magi"
+        player:startEvent(261, 0, 0, 0, 0, xi.item.METEORITE, xi.item.GLOWSTONE) -- During Quest "The Three Magi"
     elseif
         theThreeMagi == xi.questStatus.QUEST_COMPLETED and
         recollections == xi.questStatus.QUEST_AVAILABLE and


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a blank/missing item name in the Windurst BLM quest "The Three Magi" (Chumimi, Heaven's Tower).

During Koru-Moru's banter line ("Leave the soi-diddly-soil up to little ol' me! The ___ I have are fantastamundi!"), the item name rendered as a blank space instead of "meteorites."

`scripts/zones/Heavens_Tower/npcs/Chumimi.lua` passes item IDs into `player:startEvent(...)` as positional parameters that the client's cutscene text fills into placeholders. The 5th parameter was hardcoded to `0` in both the "start quest" (event 260) and "during quest" (event 261) calls, with an existing comment noting:

> NOTE: 5th parameter is "Meteorites" but he doesn't exist

That was accurate at the time the comment was written, but item 582 (`meteorite`) is now in `item_basic` and already has an enum entry, `xi.item.METEORITE`, in `scripts/enum/item.lua`. This PR passes that constant in the previously-empty parameter slot for both events, and removes the now-stale comment.

Verified against a retail video capture of this cutscene on [FFXIclopedia](https://ffxiclopedia.fandom.com/) — Koru-Moru's line is confirmed to reference "meteorites."

## Steps to test these changes

1. Create/use a BLM character at or above the AF1 quest level.
2. Talk to Chumimi in Heaven's Tower to start "The Three Magi" (event 260) and (event 261).
3. Confirm Koru-Moru's line now reads "...The meteorites I have are fantastamundi!" instead of leaving a blank space where the item name belongs.

Tested locally on a self-hosted dev server, both before (blank text, matching the reported bug) and after the fix (correct text, matching retail capture).