### PR TITLE
[lua] Fix Hydra Equipment

### DIFF
--- a/scripts/items/hydra_doublet.lua
+++ b/scripts/items/hydra_doublet.lua
@@ -1,22 +1,28 @@
 -----------------------------------
 -- ID: 14515
 -- Item: Hydra Doublet
--- Item Effect: 3 mp/tick refresh for 60s
+-- Item Effect: Refresh 3 MP/tick
+-- Duration: 60 Seconds
+-- Stacks with Refresh (spell)
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.REFRESH, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_DOUBLET) ~= nil then
-        target:delStatusEffect(xi.effect.REFRESH, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_DOUBLET)
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_DOUBLET) then
-        target:addStatusEffect(xi.effect.REFRESH, { duration = 60, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_DOUBLET })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_DOUBLET)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.REFRESH)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 60, icon = xi.effect.REFRESH, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_DOUBLET, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.REFRESH)
     end
 end
 
@@ -24,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.REFRESH, 3)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_DOUBLET)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.REFRESH)
 end
 
 return itemObject

--- a/scripts/items/hydra_harness.lua
+++ b/scripts/items/hydra_harness.lua
@@ -1,6 +1,6 @@
 -----------------------------------
 -- ID: 14516
--- Item: hydra_harness
+-- Item: Hydra Harness
 -- Item Effect: Attack +25, Ranged Attack +25
 -- Duration: 3 Minutes
 -----------------------------------
@@ -8,16 +8,20 @@
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ATTACK_BOOST, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HARNESS) ~= nil then
-        target:delStatusEffect(xi.effect.ATTACK_BOOST, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HARNESS)
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_HARNESS) then
-        target:addStatusEffect(xi.effect.ATTACK_BOOST, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_HARNESS })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HARNESS)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.ATTACK_BOOST)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.ATTACK_BOOST, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_HARNESS, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.ATTACK_BOOST)
     end
 end
 
@@ -26,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.RATT, 25)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HARNESS)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.ATTACK_BOOST)
 end
 
 return itemObject

--- a/scripts/items/hydra_haubert.lua
+++ b/scripts/items/hydra_haubert.lua
@@ -1,21 +1,28 @@
 -----------------------------------
 -- ID: 14517
 -- Item: Hydra Haubert
--- Item Effect: 3 mp/tick refresh for 60s
+-- Item Effect: Refresh 3 MP/tick
+-- Duration: 60 Seconds
+-- Stacks with Refresh (spell)
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.REFRESH, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HAUBERT) ~= nil then
-        target:delStatusEffect(xi.effect.REFRESH, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HAUBERT)
-    end
-
     return 0
 end
 
-itemObject.onItemUse = function(target, user)    if target:hasEquipped(xi.item.HYDRA_HAUBERT) then
-        target:addStatusEffect(xi.effect.REFRESH, { duration = 60, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_HAUBERT })
+itemObject.onItemUse = function(target, user)
+    if target:hasEquipped(xi.item.HYDRA_HAUBERT) then
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HAUBERT)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.REFRESH)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 60, icon = xi.effect.REFRESH, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_HAUBERT, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.REFRESH)
     end
 end
 
@@ -23,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.REFRESH, 3)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_HAUBERT)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.REFRESH)
 end
 
 return itemObject

--- a/scripts/items/hydra_mittens.lua
+++ b/scripts/items/hydra_mittens.lua
@@ -1,23 +1,27 @@
 -----------------------------------
 -- ID: 14925
--- Item: hydra_mittens
--- Item Effect: ACC +15 RACC +15
+-- Item: Hydra Mittens
+-- Item Effect: Accuracy +15, Ranged Accuracy +15
 -- Duration: 3 Minutes
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ACCURACY_BOOST, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_MITTENS) ~= nil then
-        target:delStatusEffect(xi.effect.ACCURACY_BOOST, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_MITTENS)
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_MITTENS) then
-        target:addStatusEffect(xi.effect.ACCURACY_BOOST, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_MITTENS })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_MITTENS)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.ACCURACY_BOOST)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.ACCURACY_BOOST, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_MITTENS, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.ACCURACY_BOOST)
     end
 end
 
@@ -26,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.RACC, 15)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_MITTENS)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.ACCURACY_BOOST)
 end
 
 return itemObject

--- a/scripts/items/hydra_spats.lua
+++ b/scripts/items/hydra_spats.lua
@@ -1,23 +1,27 @@
 -----------------------------------
 -- ID: 15681
--- Item: hydra_spats
--- Item Effect: Eva +15
--- Duration: 20 Minutes
+-- Item: Hydra Spats
+-- Item Effect: Evasion +15
+-- Duration: 3 Minutes
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.EVASION_BOOST, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_SPATS) ~= nil then
-        target:delStatusEffect(xi.effect.EVASION_BOOST, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_SPATS)
-    end
-
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_SPATS) then
-        target:addStatusEffect(xi.effect.EVASION_BOOST, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_SPATS })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_SPATS)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.EVASION_BOOST)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.EVASION_BOOST, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_SPATS, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.EVASION_BOOST)
     end
 end
 
@@ -25,7 +29,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.EVA, 15)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_SPATS)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.EVASION_BOOST)
 end
 
 return itemObject

--- a/scripts/items/hydra_tiara.lua
+++ b/scripts/items/hydra_tiara.lua
@@ -1,23 +1,27 @@
 -----------------------------------
 -- ID: 15261
--- Item: hydra_tiara
+-- Item: Hydra Tiara
 -- Item Effect: Crit Rate +7% **Needs validation**
 -- Duration: 3 Minutes
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
-itemObject.onItemCheck = function(target, user)
-    if target:getStatusEffectBySource(xi.effect.POTENCY, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIARA) ~= nil then
-        target:delStatusEffect(xi.effect.POTENCY, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIARA)
-    end
-
+itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_TIARA) then
-        target:addStatusEffect(xi.effect.POTENCY, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_TIARA })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIARA)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.POTENCY)
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.POTENCY, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_TIARA, flag = xi.effectFlag.NO_LOSS_MESSAGE })
+        end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.POTENCY)
     end
 end
 
@@ -25,7 +29,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.CRITHITRATE, 7)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIARA)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.POTENCY)
 end
 
 return itemObject

--- a/scripts/items/hydra_tights.lua
+++ b/scripts/items/hydra_tights.lua
@@ -1,27 +1,28 @@
 -----------------------------------
 -- ID: 15596
 -- Item: Hydra Tights
--- Item Effect: 10% haste
--- Duration: 3 minutes
+-- Item Effect: Haste +10% (Magic)
+-- Duration: 3 Minutes
+-- Stacks with Haste (spell)
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
-itemObject.onItemCheck = function(target, user)
-    if target:getStatusEffectBySource(xi.effect.HASTE, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIGHTS) ~= nil then
-        target:delStatusEffect(xi.effect.HASTE, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIGHTS)
-    end
-
+itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
 itemObject.onItemUse = function(target, user)
     if target:hasEquipped(xi.item.HYDRA_TIGHTS) then
-        if not target:hasStatusEffect(xi.effect.HASTE) then
-            target:addStatusEffect(xi.effect.HASTE, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_TIGHTS })
+        local effect = target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIGHTS)
+        if effect then
+            effect:resetStartTime()
+            effect:setIcon(xi.effect.HASTE)
         else
-            target:messageBasic(xi.msg.basic.NO_EFFECT)
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 180, icon = xi.effect.HASTE, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.HYDRA_TIGHTS, flag = xi.effectFlag.NO_LOSS_MESSAGE })
         end
+
+        target:messageBasic(xi.msg.basic.GAINS_EFFECT_OF_STATUS, xi.effect.HASTE)
     end
 end
 
@@ -29,7 +30,12 @@ itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.HASTE_MAGIC, 1000)
 end
 
+itemObject.onItemUnequip = function(target, item)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.HYDRA_TIGHTS)
+end
+
 itemObject.onEffectLose = function(target, effect)
+    target:messageBasic(xi.msg.basic.STATUS_WEARS_OFF, xi.effect.HASTE)
 end
 
 return itemObject


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes several pieces of Hydra equipment.

* Hydra Doublet / Hydra Haubert now stack with Refresh, as noted by the JP Wiki : https://wiki.ffo.jp/html/12226.html
* Hydra Tights now stack with Haste, as noted by the JP Wiki : https://wiki.ffo.jp/html/16434.html
* All Hydra equipment now loses its effect when taken off or zoning.

## Capture
https://youtu.be/xEe9B5xEr0Q
https://1drv.ms/u/c/87e665e10555c452/IQB5TtdbTY77SqVz7UtMugUBAVRc8FT--KBbglEliB2zCSo?e=mqgg3o

## Steps to test these changes

!changejob PLD 99
!changesjob RDM 49
Cast Refresh on yourself
Use Hydra Haubert
See 7/tick refresh - 3 from refresh, 3 from armor, 1 from auto refresh

Try the other Hydra pieces.

Special thanks to @siknoz for providing so many item captures in the capture discord.
