### PR TITLE
[lua] Fix BLU Ecosystem Multiplier (BLU magic doing way too much damage)

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -248,7 +248,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     wsc       = wsc + wsc * bonusWSC -- Bonus WSC from AF3/CA
 
     -- Monster correlation
-    local correlationMultiplier = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0)
+    local correlationBonus = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0) - 1
 
     -- Azure Lore
     if caster:getStatusEffect(xi.effect.AZURE_LORE) then
@@ -325,9 +325,9 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
             -- Add it to our final damage
             if hitsdone == 0 then
-                finaldmg = finaldmg + finalD * (multiplier + correlationMultiplier) * pdif -- first hit gets full multiplier
+                finaldmg = finaldmg + finalD * (multiplier + correlationBonus) * pdif -- first hit gets full multiplier
             else
-                finaldmg = finaldmg + finalD * (1 + correlationMultiplier) * pdif
+                finaldmg = finaldmg + finalD * (1 + correlationBonus) * pdif
             end
 
             hitslanded        = hitslanded + 1
@@ -398,7 +398,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     end
 
     -- Monster correlation
-    local correlationMultiplier = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0)
+    local correlationBonus = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0) - 1
 
     -- Data
     local spellId         = spell:getID()
@@ -408,7 +408,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
 
     -- Final D value
-    local finalDamage    = (initialD + wsc) * (params.multiplier + azureBonus + correlationMultiplier) + statBonus
+    local finalDamage    = (initialD + wsc) * (params.multiplier + azureBonus + correlationBonus) + statBonus
 
     local maccParams =
     {

--- a/scripts/tests/systems/spells/blue_correlation.lua
+++ b/scripts/tests/systems/spells/blue_correlation.lua
@@ -1,0 +1,82 @@
+describe('Blue Magic monster correlation', function()
+    ---@type CClientEntityPair
+    local player
+    ---@type CTestEntity
+    local mob
+
+    -- Correlation is +/-0.25 on the spell's multiplier, not a multiplier on the final damage
+    -- FF11用語辞典 - https://wiki.ffo.jp/html/5472.html
+    --   「優劣によって、各魔法のダメージ倍率に±0.25の補正が入る。最終ダメージに直接25%乗算される訳では無い。」
+    -- BG-wiki - https://www.bg-wiki.com/ffxi/Calculating_Blue_Magic_Damage
+    --   "the multiplier value is raised by 0.25"
+    --
+    -- ecosystemMultiplier() hands back 1.0 for a neutral matchup, so it has to be
+    -- turned into a bonus before it's added to anything. Added raw, every spell
+    -- picks up a flat +1.0.
+    local neutralDamage      = 11
+    local favourableDamage   = 14 -- 1.00 -> 1.25
+    local unfavourableDamage = 8  -- 1.00 -> 0.75
+
+    before_each(function()
+        xi.test.world:setSeed(1)
+
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.BLU,
+                level = 99,
+                zone  = xi.zone.QUFIM_ISLAND,
+            })
+
+        player:setSkillLevel(xi.skill.BLUE_MAGIC, 424)
+        player:addSpell(xi.magic.spell.FOOT_KICK)
+        player.actions:setBlueSpells({ xi.magic.spell.FOOT_KICK })
+
+        mob = player.entities:moveTo(17293357)
+        mob:respawn()
+        mob.assert:isAlive()
+    end)
+
+    local function castFootKick(ecosystemMultiplier)
+        stub('math.randomInt', function(low, _)
+            return low
+        end)
+
+        stub('math.randomFloat', function(_, high)
+            return high
+        end)
+
+        stub('xi.combat.physicalHitRate.getPhysicalHitRate', 1)
+        stub('xi.combat.damage.ecosystemMultiplier', ecosystemMultiplier)
+
+        player:resetRecasts()
+        player:setMP(player:getMaxMP())
+
+        mob:setMaxHP(50000)
+        mob:setHP(50000)
+        mob:updateClaim(player)
+
+        local before = mob:getHP()
+        player.actions:useSpell(mob, xi.magic.spell.FOOT_KICK)
+        xi.test.world:skipTime(10)
+
+        return before - mob:getHP()
+    end
+
+    it('leaves the multiplier alone on a neutral matchup', function()
+        local damage = castFootKick(1.0)
+
+        assert(damage == neutralDamage, string.format('Expected %d, got %d (near %d means the multiplier is being added raw)', neutralDamage, damage, neutralDamage * 2))
+    end)
+
+    it('adds 0.25 to the multiplier on a favourable matchup', function()
+        local damage = castFootKick(1.25)
+
+        assert(damage == favourableDamage, string.format('Expected %d, got %d', favourableDamage, damage))
+    end)
+
+    it('subtracts 0.25 from the multiplier on an unfavourable matchup', function()
+        local damage = castFootKick(0.75)
+
+        assert(damage == unfavourableDamage, string.format('Expected %d, got %d', unfavourableDamage, damage))
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`1218a14533` swapped `calculateCorrelation()` for `ecosystemMultiplier()`, but the old one returned a bonus (0 when neutral) and the new one returns a multiplier (1.0 when neutral) - and the physical/magical call sites still add it to the spell multiplier, so every neutral matchup quietly picks up a flat +1.0. Foot Kick does double damage, Disseverment about 1.9x. Breath and the other callers multiply by it properly so they're fine, this just subtracts 1 at the two blue call sites to turn it back into a bonus - [FF11用語辞典](https://wiki.ffo.jp/html/5472.html) and [BG-wiki](https://www.bg-wiki.com/ffxi/Calculating_Blue_Magic_Damage) both have it as additive. Also added a test that fails without the fix.

## Steps to test these changes
BLU with Foot Kick set, hit any mob that's neutral to it - Foot Kick is Beast, so anything that isn't a Lizard or Plantoid works (colibri, birds, crabs).

1. Cast Foot Kick ~10 times on the unpatched server, note the average
2. Apply the fix, restart, repeat on the same mob type
3. Damage should halve

## Testing

| Before | After |
|-|-|
|<img width="486" height="111" alt="image" src="https://github.com/user-attachments/assets/459a95f5-66de-40ba-88ec-4c3a1d7d6e27" /> | <img width="543" height="134" alt="image" src="https://github.com/user-attachments/assets/6ed471e5-4db6-4db3-a195-591a94175bc9" /> |

# Note
Killer effects are currently incorrect in that they're being fused with the ecosystem multiplier, when they should actually be multiplicative. I'll follow-up with another PR for Killer Effects and break them out separately
