### PR TITLE
[Core] [C++] Interrupt ranged attack when losing target

### DIFF
--- a/src/map/ai/states/range_state.cpp
+++ b/src/map/ai/states/range_state.cpp
@@ -164,16 +164,19 @@ auto CRangeState::Update(const timer::time_point tick) -> bool
 
         action_t action{};
         auto*    cast_errorMsg = dynamic_cast<GP_SERV_COMMAND_BATTLE_MESSAGE*>(m_errorMsg.get());
-        if (m_errorMsg && (!cast_errorMsg || cast_errorMsg->getMessageId() != MsgBasic::CannotSee))
+
+        // Target is untargetable (e.g., Super Jump, Worm roaming, Antlion burrowing etc.)
+        if (PTarget && PTarget->PAI->IsUntargetable())
+        {
+            InterruptRangedAttack(action);
+        }
+        else if (m_errorMsg && (!cast_errorMsg || cast_errorMsg->getMessageId() != MsgBasic::CannotSee))
         {
             if (auto* PChar = dynamic_cast<CCharEntity*>(m_PEntity))
             {
                 PChar->pushPacket(m_errorMsg->copy());
             }
-            // reset aim time so interrupted players only have to wait the correct 2.7s until next shot
-            m_aimTime = 0s;
-            ActionInterrupts::RangedInterrupt(m_PEntity);
-            m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", m_PEntity, nullptr, &action);
+            InterruptRangedAttack(action);
         }
         else
         {
@@ -297,6 +300,14 @@ auto CRangeState::CanUseRangedAttack(CBattleEntity* PTarget, const bool isEndOfA
     }
 
     return true;
+}
+
+void CRangeState::InterruptRangedAttack(action_t& action)
+{
+    // reset aim time so interrupted players only have to wait the correct 2s until next shot
+    m_aimTime = 0s;
+    ActionInterrupts::RangedInterrupt(m_PEntity);
+    m_PEntity->PAI->EventHandler.triggerListener("RANGE_STATE_EXIT", m_PEntity, nullptr, &action);
 }
 
 auto CRangeState::HasMoved() const -> bool

--- a/src/map/ai/states/range_state.h
+++ b/src/map/ai/states/range_state.h
@@ -23,6 +23,8 @@
 
 #include "state.h"
 
+struct action_t;
+
 class CRangeState : public CState
 {
 public:
@@ -41,6 +43,7 @@ protected:
     auto Update(timer::time_point tick) -> bool override;
     void Cleanup(timer::time_point tick) override;
     auto CanUseRangedAttack(CBattleEntity* PTarget, bool isEndOfAttack) -> bool;
+    void InterruptRangedAttack(action_t& action);
     auto HasMoved() const -> bool;
 
     // This will likely need to be re-adjusted when states tick more precisely. Changed in 2012. https://wiki.ffo.jp/html/1734.html


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a check to ranged state to ensure the target is still able to be targeted at the end of the ranged attack. This fixes several potential bugs that could occur with worms, antlions and potentially Super Jump.

Refactored the code slightly to avoid having to paste code at @WinterSolstice8 advice. 

## Capture  
https://youtu.be/XU12-beGYk4?si=LQu3Mnp2kVa2t0HS

## Steps to test these changes

Aim a shot at a worm, watch it burrow, see the ranged attack fail. 
