### PR TITLE
[module] [lua] The Circle of Time Era Module

### DIFF
--- a/modules/era/lua/quests/jeuno/The_Circle_of_Time.lua
+++ b/modules/era/lua/quests/jeuno/The_Circle_of_Time.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- The Circle of Time (BRD AF3)
+-- Restores the JST midnight wait for the star ring buried in the perennial snow.
+-- The June 17, 2014 version update shortened the wait to about one minute.
+-- The quest appears in the Japanese notes only; the English notes omit it from the list.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/42611
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_the_circle_of_time'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/The_Circle_of_Time', function(quest)
+        local xarcabard = quest.sections[2][xi.zone.XARCABARD]
+
+        -- Copy of the base handler with the 30 second wait extended to JST midnight.
+        xarcabard.onEventFinish[3] = function(player, csid, option, npc)
+            if option == 0 then
+                quest:setVar(player, 'Buried', JstMidnight()) -- Module change: the ring is purified at JST midnight.
+            end
+        end
+    end)
+end)
+
+return m

--- a/scripts/quests/jeuno/The_Circle_of_Time.lua
+++ b/scripts/quests/jeuno/The_Circle_of_Time.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- The Circle of Time
+-- The Circle of Time (BRD AF3)
 -----------------------------------
 -- Log ID: 3, Quest ID: 65
 -- !addquest 3 65


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds an era module for the BRD AF3 quest "The Circle of Time" which restores the JST midnight wait for burying the star ring. This was reduced in a [2014 version update.](https://forum.square-enix.com/ffxi/threads/42611) I also added something to the recently converted quest lua's header for description purposes.

## Steps to test these changes

Run the module. Do the quest. See you have to wait until JST midnight instead of one earth minute.
