### PR TITLE
[module] [lua] Enveloped in Darkness Era Module

### DIFF
--- a/modules/era/lua/quests/sandoria/Enveloped_in_Darkness.lua
+++ b/modules/era/lua/quests/sandoria/Enveloped_in_Darkness.lua
@@ -1,0 +1,42 @@
+-----------------------------------
+-- Enveloped in Darkness (RDM AF2)
+-- Restores the JST midnight wait for the boots and crawler blood buried
+-- at the digging spot in the Crawlers' Nest.
+-- The June 17, 2014 version update shortened the wait to about 30 seconds.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_enveloped_in_darkness'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness', function(quest)
+        local crawlersNest = quest.sections[2][xi.zone.CRAWLERS_NEST]
+
+        -- Copy of the base handler with the 30 second wait extended to JST midnight.
+        crawlersNest.onEventFinish[4] = function(player, csid, option, npc)
+            if option == 1 then
+                -- Set purification time.
+                quest:setVar(player, 'Time', JstMidnight()) -- Module change: the boots are purified at JST midnight.
+
+                -- Delete Key items.
+                player:delKeyItem(xi.ki.CRAWLER_BLOOD)
+                player:delKeyItem(xi.ki.OLD_BOOTS)
+
+                -- Message when acepting to bury boots and blood.
+                player:messageSpecial(zones[xi.zone.CRAWLERS_NEST].text.YOU_BURY_THE, xi.ki.OLD_BOOTS, xi.ki.CRAWLER_BLOOD)
+            end
+        end
+    end)
+end)
+
+return m

--- a/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
+++ b/scripts/quests/sandoria/RDM_AF2_Enveloped_in_Darkness.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Enveloped in Darkness
+-- Enveloped in Darkness (RDM AF2)
 -- Variable Prefix: [0][85]
 -----------------------------------
 -- ZONE                 NPC          POS


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR creates an era module for the RDM AF2 quest "Enveloped in Darkness" to restore the wait to JST midnight. This was changed in a [2014 version update](https://forum.square-enix.com/ffxi/threads/42614).

## Steps to test these changes

Load the module. Edit server settings appropriately. Run the quest. Be forced to wait until JST midnight.
