### PR TITLE
[lua] Prevent Aerns from casting on spawn

### DIFF
--- a/scripts/mixins/families/aern.lua
+++ b/scripts/mixins/families/aern.lua
@@ -78,6 +78,8 @@ g_mixins.families.aern = function(aernMob)
 
     -- Prevent BSTs and SMNs from summoning pets while idle
     aernMob:addListener('SPAWN', 'AERN_SPAWN', function(mob)
+        mob:setMagicCastingEnabled(false)
+
         if mob:getMainJob() == xi.job.BST then
             mob:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
         elseif mob:getMainJob() == xi.job.SMN then
@@ -99,7 +101,6 @@ g_mixins.families.aern = function(aernMob)
 
     -- Despawn pets when Aern is out of combat
     aernMob:addListener('ROAM_TICK', 'AERN_ROAM', function(mob)
-        mob:setMagicCastingEnabled(false) -- Disable casting when idle
         mob:setAnimationSub(1)
 
         local pet = mob:getPet()
@@ -151,6 +152,10 @@ g_mixins.families.aern = function(aernMob)
                 toggleBracelets(mob)
             end
         end
+    end)
+
+    aernMob:addListener('DISENGAGE', 'AERN_DISENGAGE', function(mob)
+        mob:setMagicCastingEnabled(false) -- Disable casting when idle
     end)
 
     aernMob:addListener('DEATH', 'AERN_DEATH', function(mob, killer)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes a bug where Aerns were able to cast on spawn because the mixin was too slow to them from doing that.

## Steps to test these changes

Kill and Aern, watch it spawn and not cast anything now.
