### PR TITLE
[core] Unreserve partial confirmed stack on NPC trades

### DIFF
--- a/scripts/tests/systems/trading/confirm_trade.lua
+++ b/scripts/tests/systems/trading/confirm_trade.lua
@@ -24,6 +24,9 @@ describe('confirmTrade & confirmItem', function()
         player:addItem(xi.item.BARRAGE_TURBINE, 2)
         player:addItem(xi.item.BARRIER_MODULE_II)
 
+        local turbineAttachment = player:findItem(xi.item.BARRAGE_TURBINE, xi.inventoryLocation.INVENTORY):getSubID()
+        local moduleAttachment  = player:findItem(xi.item.BARRIER_MODULE_II, xi.inventoryLocation.INVENTORY):getSubID()
+
         player.actions:tradeNpc('Tateeya',
             {
                 {
@@ -37,9 +40,7 @@ describe('confirmTrade & confirmItem', function()
             },
             { eventId = 651 })
 
-        -- TODO: this should probably use hasAttachment but it fails for some reason?
-        -- use "failure to unlock attachment" as "hasAttachment"
-        assert(player:unlockAttachment(xi.item.BARRAGE_TURBINE) == false, 'barrage turbine is unlocked')
+        assert(player:hasAttachment(turbineAttachment), 'barrage turbine is unlocked')
 
         local turbine = player:findItem(xi.item.BARRAGE_TURBINE, xi.inventoryLocation.INVENTORY)
 
@@ -65,9 +66,7 @@ describe('confirmTrade & confirmItem', function()
             },
             { eventId = 651 })
 
-        -- TODO: this should probably use hasAttachment but it fails for some reason?
-        -- use "failure to unlock attachment" as "hasAttachment"
-        assert(player:unlockAttachment(xi.item.BARRIER_MODULE_II) == false, 'barrier module II is unlocked')
+        assert(player:hasAttachment(moduleAttachment), 'barrier module II is unlocked')
 
         -- pointer should be stale - search for the barrier module again
         barrierModule = player:findItem(xi.item.BARRIER_MODULE_II, xi.inventoryLocation.INVENTORY)
@@ -88,5 +87,27 @@ describe('confirmTrade & confirmItem', function()
                 }
             },
             { eventId = 652 })
+    end)
+
+    it('does not leave a reserve when only part of a stack is confirmed', function()
+        player.entities:gotoAndTrigger('Tateeya', { eventId = 650 })
+
+        player:addItem(xi.item.BARRAGE_TURBINE, 2)
+
+        -- Tateeya confirms a single item out of the traded stack
+        player.actions:tradeNpc('Tateeya',
+            {
+                {
+                    itemId   = xi.item.BARRAGE_TURBINE,
+                    quantity = 2,
+                }
+            },
+            { eventId = 651 })
+
+        local turbine = player:findItem(xi.item.BARRAGE_TURBINE, xi.inventoryLocation.INVENTORY)
+
+        assert(turbine, 'player still has a barrage turbine in inventory')
+        assert(turbine:getQuantity() == 1, 'only the confirmed turbine was taken')
+        assert(turbine:getReservedValue() == 0, 'the leftover turbine is not reserved')
     end)
 end)

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -5265,10 +5265,10 @@ void CLuaBaseEntity::confirmTrade() const
                 uint32 confirmedItems = PChar->TradeContainer->getConfirmedStatus(slotID);
                 auto   quantity       = (int32)std::min<uint32>(PChar->TradeContainer->getQuantity(slotID), confirmedItems);
 
+                PItem->setReserve(0);
+
                 if (confirmedItems > 0)
                 {
-                    PItem->setReserve(PItem->getReserve() - quantity);
-
                     uint8 invSlotID = PChar->TradeContainer->getInvSlotID(slotID);
                     if (static_cast<uint32>(quantity) >= PChar->TradeContainer->getItem(slotID)->getQuantity())
                     {
@@ -5277,10 +5277,6 @@ void CLuaBaseEntity::confirmTrade() const
                     }
 
                     charutils::UpdateItem(PChar, LOC_INVENTORY, invSlotID, -quantity);
-                }
-                else
-                {
-                    PItem->setReserve(0);
                 }
             }
         }

--- a/src/map/lua/lua_item.cpp
+++ b/src/map/lua/lua_item.cpp
@@ -124,7 +124,7 @@ auto CLuaItem::state() const -> ItemState
     return m_readItem->state();
 }
 
-void CLuaItem::setReservedValue(uint8 reserved)
+void CLuaItem::setReservedValue(uint32 reserved)
 {
     if (!m_writeItem)
     {
@@ -134,7 +134,7 @@ void CLuaItem::setReservedValue(uint8 reserved)
     m_writeItem->setReserve(reserved);
 }
 
-uint8 CLuaItem::getReservedValue()
+auto CLuaItem::getReservedValue() -> uint32
 {
     return m_readItem->getReserve();
 }

--- a/src/map/lua/lua_item.h
+++ b/src/map/lua/lua_item.h
@@ -62,9 +62,9 @@ public:
     void setSubType(uint8 subtype); // set the item's sub type
     bool isSubType(uint8 subtype);  // check the item's sub type
 
-    auto  state() const -> ItemState;       // current ItemState (xi.itemState.*)
-    void  setReservedValue(uint8 reserved); // set the item's reserved value
-    uint8 getReservedValue();               // get the item's reserved value
+    auto state() const -> ItemState;        // current ItemState (xi.itemState.*)
+    void setReservedValue(uint32 reserved); // set the item's reserved value
+    auto getReservedValue() -> uint32;      // get the item's reserved value
 
     auto   getName() -> std::string; // get the item's name
     uint16 getILvl();                // get the item's ilvl

--- a/src/map/packets/c2s/0x036_item_transfer.cpp
+++ b/src/map/packets/c2s/0x036_item_transfer.cpp
@@ -27,12 +27,17 @@
 #include "packets/s2c/0x053_systemmes.h"
 #include "status_effect_container.h"
 #include "trade_container.h"
-#include "utils/synthutils.h"
+
+#include <algorithm>
+#include <array>
 
 namespace
 {
 
-const auto auditTrade = [](Scheduler& scheduler, CCharEntity* PChar, CBaseEntity* PNpc, uint32_t itemId, uint8_t quantity)
+// 8 trade window slots plus gil
+constexpr uint8 MAX_TRADE_SLOTS = 9;
+
+const auto auditTrade = [](Scheduler& scheduler, const CCharEntity* PChar, const CBaseEntity* PNpc, uint32_t itemId, uint32_t quantity)
 {
     if (settings::get<bool>("map.AUDIT_PLAYER_TRADES"))
     {
@@ -60,7 +65,7 @@ auto GP_CLI_COMMAND_ITEM_TRANSFER::validate(MapSession* PSession, const CCharEnt
 {
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent, BlockedState::Monstrosity })
-        .range("ItemNum", this->ItemNum, 1, 9);
+        .range("ItemNum", this->ItemNum, 1, MAX_TRADE_SLOTS);
 }
 
 void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PChar) const
@@ -90,6 +95,8 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
 
     PChar->TradeContainer->Clean();
 
+    std::array<CItem*, MAX_TRADE_SLOTS> tradeItems{};
+
     for (int32 slotId = 0; slotId < this->ItemNum; ++slotId)
     {
         const uint8_t  invSlotId = this->PropertyItemIndexTbl[slotId];
@@ -97,9 +104,21 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
 
         CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(invSlotId);
 
-        if (PItem == nullptr || PItem->getQuantity() < quantity)
+        if (!PItem)
         {
-            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with invalid item {} ({})!", PChar->getName(), PNpc->getName(), PItem->getName(), PItem->getID());
+            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with an empty inventory slot {}!", PChar->getName(), PNpc->getName(), invSlotId);
+            return;
+        }
+
+        if (PItem->getQuantity() < quantity)
+        {
+            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with {} of item {} ({}) they do not have!", PChar->getName(), PNpc->getName(), quantity, PItem->getName(), PItem->getID());
+            return;
+        }
+
+        if (std::find(tradeItems.begin(), tradeItems.begin() + slotId, PItem) != tradeItems.begin() + slotId)
+        {
+            ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with duplicate inventory slot {}!", PChar->getName(), PNpc->getName(), invSlotId);
             return;
         }
 
@@ -109,11 +128,20 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
             return;
         }
 
-        if (PItem->isSubType(ITEM_LOCKED))
+        if (PItem->isSubType(ITEM_LOCKED) || PItem->isBusy())
         {
             ShowErrorFmt("GP_CLI_COMMAND_ITEM_TRANSFER: {} trying to trade NPC {} with locked item {} ({})!", PChar->getName(), PNpc->getName(), PItem->getName(), PItem->getID());
             return;
         }
+
+        tradeItems[slotId] = PItem;
+    }
+
+    for (int32 slotId = 0; slotId < this->ItemNum; ++slotId)
+    {
+        CItem*         PItem     = tradeItems[slotId];
+        const uint8_t  invSlotId = this->PropertyItemIndexTbl[slotId];
+        const uint32_t quantity  = this->ItemNumTbl[slotId];
 
         // TODO: Don't pass around Scheduler& through PSession
         auditTrade(*PSession->scheduler, PChar, PNpc, PItem->getID(), quantity);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Packet handler already refuses reserved stacks upfront so its safe to move the setReserve call. 

Resolves issues when trading a stack of a certain item but the NPC only confirms one.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
