### PR TITLE
[lua] Sheep in Antlions Clothing Fixes

### DIFF
--- a/scripts/actions/mobskills/sand_pit.lua
+++ b/scripts/actions/mobskills/sand_pit.lua
@@ -41,16 +41,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
                 SpawnMob(spawnId):updateEnmity(target)
             end
         end
-    elseif poolID == 4046 then
-        -- Tuchulcha (Sheep in Antlion's Clothing)
-        -- Resets all enmity
-        local allies = mob:getBattlefield():getAllies()
-        for _, enmAlly in pairs(allies) do
-            mob:resetEnmity(enmAlly)
-        end
-
-        -- Removes all enfeebling effects
-        mob:delStatusEffectsByFlag(xi.effectFlag.ERASABLE)
     end
 
     return xi.effect.BIND

--- a/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
+++ b/scripts/zones/Boneyard_Gully/mobs/Tuchulcha.lua
@@ -73,10 +73,18 @@ entity.onMobSpawn = function(mob)
     mob:setLocalVar('sandpitsUsed', 0)
 
     mob:addListener('WEAPONSKILL_STATE_EXIT', 'TUCHULCHA_SANDPIT', function(tuchulcha, skillId, wasExecuted)
-        if
-            skillId == xi.mobSkill.SANDPIT_1 and
-            tuchulcha:getLocalVar('sandpitTriggered') == 1
-        then
+        if skillId ~= xi.mobSkill.SANDPIT_1 then
+            return
+        end
+
+        -- Reset enmity and remove all negative status effects from Tuchulcha and her allies when she burrows underground.
+        for _, member in pairs(tuchulcha:getBattlefield():getAllies()) do
+            tuchulcha:resetEnmity(member)
+        end
+
+        tuchulcha:delStatusEffectsByFlag(xi.effectFlag.ERASABLE)
+
+        if tuchulcha:getLocalVar('sandpitTriggered') == 1 then
             -- Prevent further teleports until the next triggered Sandpit.
             tuchulcha:setLocalVar('sandpitTriggered', 0)
 
@@ -137,7 +145,7 @@ entity.onMobFight = function(mob, target)
         mob:setLocalVar('sandpitsUsed', pit + 1)
 
         -- Every 25% HP, use Sandpit to burrow to a new location.
-        mob:useMobAbility(xi.mobSkill.SANDPIT_1, nil, 1)
+        mob:useMobAbility(xi.mobSkill.SANDPIT_1, nil, 1, true)
         mob:setLocalVar('sandpitTriggered', 1) -- Protect against multiple teleports.
 
         -- We inject this action after a short delay to create the "dust cloud" effect.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Moves enmity wipe logic into the EXIT_STATE listener to ensure it fires even if players are out range. Also changes the parameters of sandpit so that it will execute even if players are out of range.

## Steps to test these changes

Run sheep in antlions clothing, be very far out of range and trigger sandpit with a !hp 5000 command, see it burrow correctly
