### PR TITLE
[cpp] Fixes mobs not respecting hitboxes when moving to a player

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -113,9 +113,10 @@ auto CMobController::Disengage() -> bool
     PMob->m_neutral  = true;
     m_NeutralTime    = m_Tick;
 
-    rePathCooldownEnd_ = timer::time_point::min();
-    lastRePathTarget_  = {};
-    stuckRePathCount_  = 0;
+    rePathCooldownEnd_  = timer::time_point::min();
+    lastRePathTarget_   = {};
+    lastRePathDistance_ = 10000.0f;
+    stuckRePathCount_   = 0;
 
     lastDirectProbeTarget_.clean();
     lastDirectProbePos_       = {};
@@ -153,10 +154,11 @@ auto CMobController::Engage(const EntityId& target) -> bool
         return false;
     }
 
-    m_firstSpell       = true;
-    rePathCooldownEnd_ = timer::time_point::min();
-    lastRePathTarget_  = {};
-    stuckRePathCount_  = 0;
+    m_firstSpell        = true;
+    rePathCooldownEnd_  = timer::time_point::min();
+    lastRePathTarget_   = {};
+    lastRePathDistance_ = 10000.0f;
+    stuckRePathCount_   = 0;
 
     lastDirectProbeTarget_.clean();
     lastDirectProbePos_       = {};
@@ -215,9 +217,10 @@ void CMobController::Reset()
     ClearFollowTarget();
 
     // Clear pathing state so a respawned mob doesn't inherit stale re-path / direct-probe caches.
-    rePathCooldownEnd_ = timer::time_point::min();
-    lastRePathTarget_  = {};
-    stuckRePathCount_  = 0;
+    rePathCooldownEnd_  = timer::time_point::min();
+    lastRePathTarget_   = {};
+    lastRePathDistance_ = 10000.0f;
+    stuckRePathCount_   = 0;
 
     lastDirectProbeTarget_.clean();
     lastDirectProbePos_       = {};
@@ -1213,7 +1216,7 @@ void CMobController::Move()
             lastDirectProbeTargetPos_ = PTarget->loc.p;
 
             const auto projectedPosition = nearPosition(PTarget->loc.p, 0, rotationToRadian(worldAngle(PMob->loc.p, PTarget->loc.p)));
-            PMob->PAI->PathFind->PathTo(projectedPosition, PATHFLAG_RUN);
+            PMob->PAI->PathFind->PathInRange(projectedPosition, closeDistance, PATHFLAG_RUN);
             lastDirectProbeWasDirect_ = PMob->PAI->PathFind->IsPathDirect();
             if (lastDirectProbeWasDirect_)
             {
@@ -1255,6 +1258,16 @@ void CMobController::Move()
         return;
     }
 
+    // If the mob is following a path and is close enough to the target, and it can see the target, then clear the path and face the target
+    // When a mob is close enough to you but around a corner we need it to walk around the corner to see you again then stop again once it has a visual on you
+    if (isFollowingPath && currentDistance <= closeDistance && CanSeeTargetCached())
+    {
+        PMob->PAI->PathFind->Clear();
+        stuckRePathCount_ = 0;
+        FaceTarget();
+        return;
+    }
+
     // Re-path against attackRange, with lost sight on its own short leash so the mob keeps trying without hammering findPath.
     bool needNewPath   = false;
     bool isStuckRepath = false;
@@ -1270,14 +1283,19 @@ void CMobController::Move()
         const bool cooldownDone    = m_Tick >= rePathCooldownEnd_;
         const bool losCooldownDone = m_Tick >= lostSightRePathCooldownEnd_;
 
+        // If the mob is stuck and has made no movement at all since the last re-path then we need to teleport to the target
+        // Losing sight does not count as being stuck
+        const bool noProgress = currentDistance > lastRePathDistance_ - 1.0f;
+
         targetMoved   = !isWithinDistance(lastRePathTarget_, PTarget->loc.p, attackRange);
         needNewPath   = (outOfRange && (targetMoved || cooldownDone)) || (lostLOS && (targetMoved || losCooldownDone));
-        isStuckRepath = needNewPath && !targetMoved && cooldownDone;
+        isStuckRepath = needNewPath && !targetMoved && cooldownDone && noProgress;
     }
 
     if (needNewPath)
     {
         lastRePathTarget_           = PTarget->loc.p;
+        lastRePathDistance_         = currentDistance;
         rePathCooldownEnd_          = m_Tick + kRePathCooldown;
         lostSightRePathCooldownEnd_ = m_Tick + kLostSightRePathCooldown;
 
@@ -1299,8 +1317,12 @@ void CMobController::Move()
         }
         else
         {
+            // Since we are missing mobs respecting LOS we need to make sure they are allowed to path around corners when they cant see them
+            // PathInRange needs a stop distance check of 0 when the mob cant see the target so it paths to it
+            const float stopDistance = CanSeeTargetCached() ? closeDistance : 0.0f;
+
             const auto projectedPosition = nearPosition(PTarget->loc.p, 0, rotationToRadian(worldAngle(PMob->loc.p, PTarget->loc.p)));
-            PMob->PAI->PathFind->PathTo(projectedPosition, PATHFLAG_RUN);
+            PMob->PAI->PathFind->PathInRange(projectedPosition, stopDistance, PATHFLAG_RUN);
         }
     }
 

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -134,6 +134,7 @@ private:
     timer::time_point rePathCooldownEnd_{ timer::time_point::min() };
     timer::time_point lostSightRePathCooldownEnd_{ timer::time_point::min() };
     position_t        lastRePathTarget_{};
+    float             lastRePathDistance_{ 10000.0f }; // Set the previous re-path to something bigger than what a mob can run to.
     uint8_t           stuckRePathCount_{ 0 };
 
     // Directness probe cache, re-run only when the target or either position changes; an EntityId because it outlives the tick.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
When the recent core refactor was done for pathfind it looks like the `PathInRange` was changed to `PathTo`. The issue with this is that `PathTo` paths directly to the exact coords with nothing to stop it, thus having them walk straight into character models.

Changing this back to `PathInRange` will now respect the character and the mobs hitboxes

Before: https://www.youtube.com/watch?v=mfszW8OAKZ4
After: https://www.youtube.com/watch?v=RPcjQeBmkJ8

**Edit/Update:**
When adding the PathInRange fix we found another issue which I believe the first PR also tried to fix. Since we now have mobs respecting the hitboxes we need a way to check if the mob can see the player behind say a corner of a wall and not just teleport straight to the player and inside its hitbox.

By adding a distance check while the mob is talking towards the player we can now tell the difference between "close enough through a wall" and "close enough to fight". When a mob loses sight of its target it will now path to the exact position instead of short then stop again when it can see the target and is in range.

This also brought up an issue with the stuck/teleport logic. The mob was being counted as stuck anytime it hit the re-path without the player actually moving so simply walking out of LOS it would start counting as being stuck which is not always the case. The new "stuck" if you want to call it basically means the mob made no progress towards the target since the last re-path tick. I have attached a video below to see the new logic in action to see what it looks like when a mob gets stuck.

Pathing around corners: https://www.youtube.com/watch?v=ZF-r_yNAihM
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 17354769
Aggro it from a far distance
Watch it walk up to you and not into your character model
<!-- Clear and detailed steps to test your changes here -->
