### PR TITLE
[lua] Fix Economizer in PUP Module

### DIFF
--- a/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
+++ b/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
@@ -494,7 +494,7 @@ local activationThresholds =
     [3] = 60,
 }
 
-m:addOverride('xi.actions.abilities.pets.automaton.economizer.onEquip', function(pet)
+m:addOverride('xi.actions.abilities.pets.attachments.economizer.onEquip', function(pet)
     pet:addListener('AUTOMATON_ATTACHMENT_CHECK', 'ATTACHMENT_ECONOMIZER', function(automaton, target)
         -- If Economizer is still on cooldown, do nothing.
         if automaton:hasRecast(xi.recast.ABILITY, xi.mobSkill.ECONOMIZER_AUTOMATON) then


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a mistake I made in this module, was trying to override the wrong function. 

## Steps to test these changes

See Economizer not activate at 0 Dark Maneuvers with the module enabled.