### PR TITLE
[core] Batch periodic character persistence into a single sweep

### DIFF
--- a/src/common/database/caching_database.cpp
+++ b/src/common/database/caching_database.cpp
@@ -85,13 +85,21 @@ auto db::CachingDatabase::getState() -> detail::ConnectionState&
     return state;
 }
 
-auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet>
+// Find-or-prepare the cached statement for this query on the given connection.
+auto db::CachingDatabase::prepareCached(detail::ConnectionState& connState, const std::string& rawQuery) -> PreparedStatement&
 {
-    TracyZoneScoped;
-    TracyZoneString(rawQuery);
+    auto it = connState.statements.find(rawQuery);
+    if (it == connState.statements.end())
+    {
+        it = connState.statements.emplace(rawQuery, connState.connection->prepare(rawQuery)).first;
+    }
 
-    const auto queryType = detail::validateQueryLeadingKeyword(rawQuery);
-    if (queryType == ResultSetType::Invalid)
+    return *it->second;
+}
+
+auto db::CachingDatabase::runWithRetry(const std::string& rawQuery, const Fn<std::unique_ptr<ResultSet>(detail::ConnectionState&) const>& operation) -> std::unique_ptr<ResultSet>
+{
+    if (detail::validateQueryLeadingKeyword(rawQuery) == ResultSetType::Invalid)
     {
         ShowErrorFmt("Invalid query: {}", rawQuery);
         return nullptr;
@@ -105,31 +113,6 @@ auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector
 
     auto& state = getState();
 
-    const auto operation = [&](detail::ConnectionState& connState) -> std::unique_ptr<ResultSet>
-    {
-        // Lazily prepare-and-cache the statement for this query.
-        auto it = connState.statements.find(rawQuery);
-        if (it == connState.statements.end())
-        {
-            it = connState.statements.emplace(rawQuery, connState.connection->prepare(rawQuery)).first;
-        }
-
-        DebugSQLFmt("preparedStmt: {}", rawQuery);
-
-        const auto& stmt = it->second;
-
-        // NOTE: Everything is 1-indexed.
-        int counter = 0;
-        for (const auto& param : params)
-        {
-            stmt->bind(++counter, param);
-        }
-
-        const auto queryTimer = makeQueryTimer(rawQuery);
-
-        return (queryType == ResultSetType::Select) ? stmt->executeQuery(rawQuery) : stmt->executeUpdate(rawQuery);
-    };
-
     const auto queryRetryCount = 1 + settings::get<uint32>("network.SQL_QUERY_RETRY_COUNT");
     for (auto i = 0U; i < queryRetryCount; ++i)
     {
@@ -141,6 +124,7 @@ auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector
                 state.statements.clear();
                 state.connection = createConnection();
             }
+
             return operation(state);
         }
         catch (const std::exception& e)
@@ -157,6 +141,56 @@ auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector
     ShowCritical("Query Failed after %d retries: %s", queryRetryCount, rawQuery.c_str());
     std::this_thread::sleep_for(1s);
     std::terminate();
+}
+
+auto db::CachingDatabase::execute(const std::string& rawQuery, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet>
+{
+    TracyZoneScoped;
+    TracyZoneString(rawQuery);
+
+    const auto queryType = detail::validateQueryLeadingKeyword(rawQuery);
+
+    const auto operation = [&](detail::ConnectionState& connState) -> std::unique_ptr<ResultSet>
+    {
+        auto& stmt = prepareCached(connState, rawQuery);
+
+        DebugSQLFmt("preparedStmt: {}", rawQuery);
+
+        // NOTE: Everything is 1-indexed.
+        int counter = 0;
+        for (const auto& param : params)
+        {
+            stmt.bind(++counter, param);
+        }
+
+        const auto queryTimer = makeQueryTimer(rawQuery);
+
+        if (queryType == ResultSetType::Select)
+        {
+            return stmt.executeQuery(rawQuery);
+        }
+
+        return stmt.executeUpdate(rawQuery);
+    };
+
+    return runWithRetry(rawQuery, operation);
+}
+
+auto db::CachingDatabase::executeBulk(const std::string& rawQuery, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet>
+{
+    TracyZoneScoped;
+    TracyZoneString(rawQuery);
+
+    const auto operation = [&](detail::ConnectionState& connState) -> std::unique_ptr<ResultSet>
+    {
+        auto& stmt = prepareCached(connState, rawQuery);
+
+        const auto queryTimer = makeQueryTimer(rawQuery);
+
+        return stmt.executeBulkUpdate(rawQuery, params);
+    };
+
+    return runWithRetry(rawQuery, operation);
 }
 
 auto db::CachingDatabase::getSchema() -> std::string

--- a/src/common/database/caching_database.h
+++ b/src/common/database/caching_database.h
@@ -26,6 +26,7 @@
 #include <common/database/database.h>
 #include <common/database/prepared_statement.h>
 
+#include <common/types/fn.h>
 #include <common/types/hash_map.h>
 
 #include <memory>
@@ -50,6 +51,7 @@ class CachingDatabase : public Database
 {
 public:
     auto execute(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
+    auto executeBulk(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
 
     auto getSchema() -> std::string override;
     auto getVersion() -> std::string override;
@@ -61,6 +63,14 @@ protected:
 private:
     // The calling thread's connection state for this backend, connecting lazily on first use.
     auto getState() -> detail::ConnectionState&;
+
+    // Find-or-prepare the cached statement for this query on the given connection.
+    auto prepareCached(detail::ConnectionState& connState, const std::string& query) -> PreparedStatement&;
+
+    // Validate the query, then run `operation` on this thread's connection, retrying on connection loss.
+    //
+    // Terminates if the connection can't be re-established.
+    auto runWithRetry(const std::string& query, const Fn<std::unique_ptr<ResultSet>(detail::ConnectionState&) const>& operation) -> std::unique_ptr<ResultSet>;
 };
 
 } // namespace db

--- a/src/common/database/database.h
+++ b/src/common/database/database.h
@@ -30,9 +30,13 @@
 #include <common/database/bound_value.h>
 #include <common/database/result_set.h>
 
+#include <fmt/format.h>
+
 #include <memory>
 #include <string>
 #include <string_view>
+#include <tuple>
+#include <type_traits>
 #include <utility>
 
 // @note Everything in sql:: database-land is 1-indexed, not 0-indexed.
@@ -48,6 +52,11 @@ public:
     // Returns a queryable result set for SELECT-like queries, a rows-affected result set for
     // UPDATE-like queries, or nullptr if the query is invalid.
     virtual auto execute(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> = 0;
+
+    // As execute, but sends every row of `params` in one round trip.
+    //
+    // Row width comes from the statement's own placeholder count, so `params` must be a whole number of rows.
+    virtual auto executeBulk(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> = 0;
 
     // The database name, ie. xidb.
     virtual auto getSchema() -> std::string = 0;
@@ -77,6 +86,13 @@ auto preparedStmt(const std::string& rawQuery, Args&&... args) -> std::unique_pt
 
 template <typename... Args>
 auto preparedStmt(Scheduler& scheduler, const std::string& rawQuery, Args&&... args) -> Task<std::unique_ptr<ResultSet>>;
+
+// Send every row of `rows` through `query` in one round trip.
+//
+// `project` turns one row into a tuple of values, one per placeholder, and every row must yield the same types.
+// Numeric columns only.
+template <typename T, typename ProjectFn>
+void executeBulk(const std::string& query, const std::vector<T>& rows, ProjectFn project);
 
 auto escapeString(std::string_view str) -> std::string;
 auto escapeString(const std::string& str) -> std::string;
@@ -122,6 +138,34 @@ auto preparedStmt(const std::string& rawQuery, Args&&... args) -> std::unique_pt
 
     const auto params = detail::lowerBoundValues(std::forward<Args>(args)...);
     return getDatabase().execute(rawQuery, params);
+}
+
+template <typename T, typename ProjectFn>
+void executeBulk(const std::string& query, const std::vector<T>& rows, ProjectFn project)
+{
+    TracyZoneScoped;
+
+    if (rows.empty())
+    {
+        return;
+    }
+
+    using Row = std::remove_cvref_t<decltype(project(rows.front()))>;
+
+    std::vector<BoundValue> params;
+    params.reserve(rows.size() * std::tuple_size_v<Row>);
+
+    for (const auto& row : rows)
+    {
+        std::apply(
+            [&](const auto&... values)
+            {
+                (detail::lowerBoundValue(params, values), ...);
+            },
+            project(row));
+    }
+
+    getDatabase().executeBulk(query, params);
 }
 
 template <typename... Args>

--- a/src/common/database/libmariadb/libmariadb_prepared_statement.cpp
+++ b/src/common/database/libmariadb/libmariadb_prepared_statement.cpp
@@ -21,6 +21,9 @@
 
 #include <common/database/libmariadb/libmariadb_prepared_statement.h>
 
+#include <common/types/fn.h>
+#include <common/xi.h>
+
 #include <cstring>
 #include <memory>
 #include <string>
@@ -35,6 +38,32 @@ namespace
 // Initial per-column fetch buffer for text columns. Larger values (blobs, long strings) are pulled
 // in full with a follow-up mysql_stmt_fetch_column once the real length is known.
 constexpr unsigned long kInitialColumnBuffer = 256;
+
+// Signedness comes from the storage type, so only the width matters here.
+template <typename T>
+constexpr auto fieldTypeFor() -> enum_field_types
+{
+    if constexpr (std::is_same_v<T, float>)
+    {
+        return MYSQL_TYPE_FLOAT;
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        return MYSQL_TYPE_DOUBLE;
+    }
+    else if constexpr (sizeof(T) == 1)
+    {
+        return MYSQL_TYPE_TINY;
+    }
+    else if constexpr (sizeof(T) == 2)
+    {
+        return MYSQL_TYPE_SHORT;
+    }
+    else
+    {
+        return MYSQL_TYPE_LONG;
+    }
+}
 
 } // namespace
 
@@ -375,6 +404,94 @@ auto db::LibMariaDBPreparedStatement::executeQuery(const std::string& query) -> 
         resetBindings();
         throw;
     }
+}
+
+auto db::LibMariaDBPreparedStatement::executeBulkUpdate(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet>
+{
+    TracyZoneScoped;
+
+    const auto columnCount = static_cast<std::size_t>(mysql_stmt_param_count(stmt_));
+    if (params.empty() || columnCount == 0)
+    {
+        return std::make_unique<LibMariaDBResultSet>(std::size_t{ 0 }, query);
+    }
+
+    if (params.size() % columnCount != 0)
+    {
+        throw std::runtime_error(fmt::format("bulk binding got {} values for a {}-placeholder statement", params.size(), columnCount));
+    }
+
+    const auto rowCount = params.size() / columnCount;
+
+    // MariaDB wants one contiguous typed array per column, so transpose the row-major parameters.
+    // The first row fixes each column's type and every later row has to match it.
+    std::vector<std::vector<char>> storage(columnCount);
+    std::vector<MYSQL_BIND>        binds(columnCount);
+
+    for (std::size_t column = 0; column < columnCount; ++column)
+    {
+        std::visit(
+            [&]<typename U>(const U&)
+            {
+                if constexpr (std::is_arithmetic_v<U>)
+                {
+                    // vector<bool> has no usable data(), so booleans travel as TINY.
+                    using Cell = std::conditional_t<std::is_same_v<U, bool>, uint8, U>;
+
+                    storage[column].resize(sizeof(Cell) * rowCount);
+
+                    auto* cells = reinterpret_cast<Cell*>(storage[column].data());
+                    for (std::size_t row = 0; row < rowCount; ++row)
+                    {
+                        const auto* cell = std::get_if<U>(&params[row * columnCount + column]);
+                        if (cell == nullptr)
+                        {
+                            throw std::runtime_error(fmt::format("bulk binding needs one type per column, row {} differs at column {}", row, column));
+                        }
+
+                        cells[row] = static_cast<Cell>(*cell);
+                    }
+
+                    binds[column].buffer      = cells;
+                    binds[column].buffer_type = fieldTypeFor<Cell>();
+                    binds[column].is_unsigned = std::is_unsigned_v<Cell>;
+                }
+                else
+                {
+                    // Strings and blobs would need a stride buffer and a length array; nothing bulk-writes them.
+                    throw std::runtime_error("bulk binding supports numeric columns only");
+                }
+            },
+            params[column]);
+    }
+
+    // The statement is cached and reused, so the array size must never outlive this call.
+    // A stale one would make the next single-row execute read past its parameters.
+    const auto restoreArraySize = xi::finally<Fn<void()>>(
+        [this]()
+        {
+            constexpr unsigned int one = 1;
+            mysql_stmt_attr_set(stmt_, STMT_ATTR_ARRAY_SIZE, &one);
+            resetBindings();
+        });
+
+    const auto arraySize = static_cast<unsigned int>(rowCount);
+    if (mysql_stmt_attr_set(stmt_, STMT_ATTR_ARRAY_SIZE, &arraySize) != 0)
+    {
+        throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+    }
+
+    if (mysql_stmt_bind_param(stmt_, binds.data()) != 0)
+    {
+        throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+    }
+
+    if (mysql_stmt_execute(stmt_) != 0)
+    {
+        throw detail::libmariadb::Error(mysql_stmt_errno(stmt_), mysql_stmt_error(stmt_));
+    }
+
+    return std::make_unique<LibMariaDBResultSet>(static_cast<std::size_t>(mysql_stmt_affected_rows(stmt_)), query);
 }
 
 auto db::LibMariaDBPreparedStatement::executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet>

--- a/src/common/database/libmariadb/libmariadb_prepared_statement.h
+++ b/src/common/database/libmariadb/libmariadb_prepared_statement.h
@@ -66,6 +66,7 @@ public:
     auto bind(int index, const BoundValue& value) -> void override;
     auto executeQuery(const std::string& query) -> std::unique_ptr<ResultSet> override;
     auto executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet> override;
+    auto executeBulkUpdate(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
 
 private:
     enum class CellKind

--- a/src/common/database/prepared_statement.h
+++ b/src/common/database/prepared_statement.h
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace db
 {
@@ -43,6 +44,11 @@ public:
 
     // Execute as an UPDATE-like query, returning a rows-affected result set.
     virtual auto executeUpdate(const std::string& query) -> std::unique_ptr<ResultSet> = 0;
+
+    // Execute every parameter set in `params` in one round trip, using MariaDB's bulk array binding.
+    //
+    // Row-major, one value per placeholder. Numeric columns only; strings and blobs throw.
+    virtual auto executeBulkUpdate(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> = 0;
 };
 
 } // namespace db

--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -102,6 +102,8 @@ set(MAP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/merit.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_spell_container.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_spell_container.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/persist_batch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/persist_batch.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_spell_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mob_spell_list.h
     ${CMAKE_CURRENT_SOURCE_DIR}/mobskill.cpp

--- a/src/map/attack.cpp
+++ b/src/map/attack.cpp
@@ -23,6 +23,7 @@
 #include "ai/ai_container.h"
 #include "attackround.h"
 #include "data/enums/mob_mod.h"
+#include "entities/automaton_entity.h"
 #include "entities/battle_entity.h"
 #include "items/item_weapon.h"
 #include "job_points.h"

--- a/src/map/attackround.cpp
+++ b/src/map/attackround.cpp
@@ -443,7 +443,6 @@ void CAttackRound::ProcFollowUpAttacks()
                                 if (PAmmo->getQuantity() == 1)
                                 {
                                     charutils::UnequipItem(PChar, SLOT_AMMO);
-                                    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
                                 }
 
                                 charutils::UpdateItem(PChar, loc, slot, -1);

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -1071,71 +1071,32 @@ void CCharEntity::ClearTrusts()
     ReloadPartyInc();
 }
 
-void CCharEntity::RequestPersist(CHAR_PERSIST toPersist)
+auto CCharEntity::persist() const -> CharPersist
 {
-    dataToPersist |= toPersist;
+    return persist_;
 }
 
-bool CCharEntity::PersistData()
+void CCharEntity::setPersist(CharPersist toPersist)
 {
-    bool didPersist = false;
-
-    if (!charVarChanges.empty())
-    {
-        for (auto&& charVarName : charVarChanges)
-        {
-            charutils::PersistCharVar(this->id, charVarName.c_str(), charVarCache[charVarName].first, charVarCache[charVarName].second);
-        }
-
-        charVarChanges.clear();
-        didPersist = true;
-    }
-
-    if (!dataToPersist)
-    {
-        return didPersist;
-    }
-    else
-    {
-        didPersist = true;
-    }
-
-    if (dataToPersist & CHAR_PERSIST::EQUIP)
-    {
-        charutils::SaveCharEquip(this);
-        charutils::SaveCharLook(this);
-    }
-
-    if (dataToPersist & CHAR_PERSIST::POSITION)
-    {
-        charutils::SaveCharPosition(this);
-    }
-
-    if (dataToPersist & CHAR_PERSIST::EFFECTS)
-    {
-        StatusEffectContainer->SaveStatusEffects(true);
-    }
-
-    /* TODO
-    if (dataToPersist & CHAR_PERSIST::LINKSHELL)
-    {
-        charutils::SaveCharLinkshells(this);
-    }
-    */
-
-    dataToPersist = 0;
-    return didPersist;
+    persist_ |= toPersist;
 }
 
-bool CCharEntity::PersistData(timer::time_point tick)
+void CCharEntity::clearPersist(CharPersist toPersist)
 {
-    if (tick < nextDataPersistTime || !PersistData())
+    persist_ &= ~toPersist;
+}
+
+void CCharEntity::takeCharVarChanges(std::vector<CharVarChange>& out)
+{
+    out.reserve(out.size() + charVarChanges.size());
+
+    for (const auto& charVarName : charVarChanges)
     {
-        return false;
+        const auto& cached = charVarCache[charVarName];
+        out.push_back({ id, charVarName, cached.first, cached.second });
     }
 
-    nextDataPersistTime = tick + TIME_BETWEEN_PERSIST;
-    return true;
+    charVarChanges.clear();
 }
 
 auto CCharEntity::Tick(timer::time_point tick) -> Task<void>

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "aman.h"
+#include "enums/char_persist.h"
 #include "event_info.h"
 #include "gmcall_container.h"
 #include "inventory_sync_state.h"
@@ -40,18 +41,15 @@
 #include <common/types/maybe.h>
 
 #include <array>
-#include <bitset>
 #include <deque>
-#include <map>
 #include <memory>
-#include <set>
 #include <unordered_set>
 
-#include "automaton_entity.h"
+#include "persist_batch.h"
+
 #include "battle_entity.h"
 #include "linkshell.h"
 #include "maze.h"
-#include "packets/s2c/base.h"
 #include "pet_entity.h"
 
 #include <map/entities/types/automaton_info.h>
@@ -63,8 +61,6 @@
 #define MAX_MISSIONAREA  15
 #define MAX_MISSIONID    851
 #define MAX_ABYSSEAZONES 9
-
-#define TIME_BETWEEN_PERSIST 2min
 
 class CItemWeapon;
 class CTrustEntity;
@@ -238,13 +234,6 @@ enum CHAR_SUBSTATE
     SUBSTATE_NONE = 0,
     SUBSTATE_IN_CS,
     SUBSTATE_LAST,
-};
-
-enum CHAR_PERSIST : uint8
-{
-    EQUIP    = 0x01,
-    POSITION = 0x02,
-    EFFECTS  = 0x04,
 };
 
 enum class WarpRequest : uint8
@@ -697,9 +686,10 @@ public:
     void ClearTrusts();
     void RemoveTrust(CTrustEntity*);
 
-    void RequestPersist(CHAR_PERSIST toPersist);
-    bool PersistData();
-    bool PersistData(timer::time_point tick);
+    auto persist() const -> CharPersist;
+    void setPersist(CharPersist toPersist);
+    void clearPersist(CharPersist toPersist);
+    void takeCharVarChanges(std::vector<CharVarChange>& out);
 
     auto Tick(timer::time_point) -> Task<void> override;
     void PostTick() override;
@@ -827,8 +817,7 @@ private:
     std::unordered_set<std::string>                        charVarChanges;
     std::unordered_set<uint32>                             charTriggerAreaIDs; // Holds any TriggerArea IDs that the player is currently within the bounds of
 
-    uint8             dataToPersist = 0;
-    timer::time_point nextDataPersistTime{};
+    CharPersist persist_{};
 
     // TODO: Don't use raw ptrs for this, but don't duplicate whole packets with unique_ptr either.
     std::deque<std::unique_ptr<CBasicPacket>> PacketList;          // The list of packets to be sent to the character during the next network cycle

--- a/src/map/enums/CMakeLists.txt
+++ b/src/map/enums/CMakeLists.txt
@@ -8,6 +8,7 @@ set(ENUMS_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/action/react_kind.h
     ${CMAKE_CURRENT_SOURCE_DIR}/action/resolution.h
     ${CMAKE_CURRENT_SOURCE_DIR}/automaton.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/char_persist.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_area.h
     ${CMAKE_CURRENT_SOURCE_DIR}/chat_message_type.h
     ${CMAKE_CURRENT_SOURCE_DIR}/emote.h

--- a/src/map/enums/char_persist.h
+++ b/src/map/enums/char_persist.h
@@ -1,0 +1,38 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+
+#include <magic_enum/magic_enum.hpp>
+
+// What a character still owes the database, drained by MapEngine::persistSweep.
+enum class CharPersist : uint8
+{
+    None     = 0x00,
+    Equip    = 0x01, // char_equip
+    Position = 0x02,
+    Effects  = 0x04,
+    Look     = 0x08, // char_look, char_style, chars.isstylelocked
+};
+
+using namespace magic_enum::bitwise_operators;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -5419,7 +5419,6 @@ void CLuaBaseEntity::equipItem(const uint16 itemID, const sol::object& container
         if (const auto* PItem = dynamic_cast<CItemEquipment*>(PChar->getStorage(containerID)->GetItem(slotId)))
         {
             charutils::EquipItem(PChar, slotId, equipSlot.is<uint8>() ? equipSlot.as<uint8>() : PItem->getSlotType(), containerID);
-            PChar->RequestPersist(CHAR_PERSIST::EQUIP);
         }
     }
 }

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -64,7 +64,9 @@
 #include "packets/s2c/0x05a_motionmes.h"
 #include "packets/s2c/0x0f9_res.h"
 
+#include "persist_batch.h"
 #include "utils/battleutils.h"
+
 #include "utils/charutils.h"
 #include "utils/instanceutils.h"
 #include "utils/itemutils.h"
@@ -4789,8 +4791,7 @@ void Terminate()
             PZone->ForEachChar(
                 [](CCharEntity* PChar)
                 {
-                    PChar->PersistData();
-                    charutils::SaveCharPosition(PChar);
+                    persist::flush(PChar, IsLogout::Yes);
                     charutils::SaveCharStats(PChar);
                     charutils::SaveCharExp(PChar, PChar->GetMJob());
                 });

--- a/src/map/map_constants.h
+++ b/src/map/map_constants.h
@@ -23,6 +23,7 @@
 
 #include <array>
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 
 using namespace std::chrono_literals;
@@ -63,6 +64,9 @@ static constexpr auto kGarbageCollectionInterval = 15min;
 
 // The rate at which we persist any outstanding changes to volatile server vars
 static constexpr auto kPersistVolatileServerVarsInterval = 1min;
+
+// The rate at which we flush dirty characters to the database
+static constexpr auto kPersistSweepInterval = 5s;
 
 // The rate at which we pump the ZMQ queues
 static constexpr auto kIPCPumpInterval = 100ms;

--- a/src/map/map_engine.cpp
+++ b/src/map/map_engine.cpp
@@ -39,6 +39,7 @@
 #include "map_statistics.h"
 #include "mob_spell_list.h"
 #include "monstrosity.h"
+#include "persist_batch.h"
 #include "roe.h"
 #include "spell.h"
 #include "status_effect_container.h"
@@ -239,6 +240,13 @@ auto MapEngine::init() -> Task<void>
         persistVolatileServerVarsToken_ = scheduler_.intervalOnMainThread(kPersistVolatileServerVarsInterval, serverutils::PersistVolatileServerVars);
         pumpIPCToken_                   = scheduler_.intervalOnMainThread(kIPCPumpInterval, message::handle_incoming);
         flushStatisticsToken_           = scheduler_.intervalOnMainThread(kTimeServerTickInterval, std::bind(&MapNetworking::flushStatistics, networking_.get()));
+
+        persistSweepToken_ = scheduler_.intervalOnMainThread(
+            kPersistSweepInterval,
+            [this]() -> Task<void>
+            {
+                co_await persistSweep();
+            });
     }
 
     zoneutils::TOTDChange(vanadiel_time::get_totd()); // This tells the zones to spawn stuff based on time of day conditions (such as undead at night)
@@ -366,6 +374,35 @@ void MapEngine::garbageCollect() const
     TracyZoneScoped;
 
     luautils::garbageCollectFull();
+}
+
+auto MapEngine::persistSweep() -> Task<void>
+{
+    TracyZoneScoped;
+
+    PersistBatch batch;
+
+    zoneutils::ForEachZone(
+        [&](CZone* PZone)
+        {
+            PZone->ForEachChar(
+                [&](CCharEntity* PChar)
+                {
+                    // mid-teardown characters are written by persist::flush instead
+                    if (PChar->status == xi::Status::Disappear || PChar->status == xi::Status::Shutdown)
+                    {
+                        return;
+                    }
+
+                    batch.add(PChar);
+                });
+        });
+
+    co_await scheduler_.spawnOnWorkerThread(
+        [batch = std::move(batch)]() mutable
+        {
+            batch.write();
+        });
 }
 
 void MapEngine::onStats(std::vector<std::string>& inputs) const

--- a/src/map/map_engine.h
+++ b/src/map/map_engine.h
@@ -68,6 +68,8 @@ public:
     void sessionCleanup() const;
     void garbageCollect() const;
 
+    auto persistSweep() -> Task<void>;
+
     //
     // Commands callbacks
     //
@@ -98,6 +100,7 @@ private:
     Maybe<Scheduler::Token> persistVolatileServerVarsToken_;
     Maybe<Scheduler::Token> pumpIPCToken_;
     Maybe<Scheduler::Token> flushStatisticsToken_;
+    Maybe<Scheduler::Token> persistSweepToken_;
 
     std::unique_ptr<MapStatistics> mapStatistics_;
     std::unique_ptr<MapNetworking> networking_;

--- a/src/map/map_session_container.cpp
+++ b/src/map/map_session_container.cpp
@@ -22,6 +22,7 @@
 #include "map_session_container.h"
 
 #include "map_session.h"
+#include "persist_batch.h"
 #include "status_effect_container.h"
 
 #include "entities/char_entity.h"
@@ -248,7 +249,8 @@ void MapSessionContainer::cleanupSessions(IPP mapIPP)
                     // Player session is attached to this map process and has stopped responding.
                     if (!otherMap)
                     {
-                        map_session_data->PChar->StatusEffectContainer->SaveStatusEffects(true);
+                        persist::flush(PChar, IsLogout::Yes);
+
                         db::preparedStmt("DELETE FROM accounts_sessions WHERE charid = ?", map_session_data->charID);
 
                         // Save position if d/c or logout/shutdown

--- a/src/map/packets/c2s/0x015_pos.cpp
+++ b/src/map/packets/c2s/0x015_pos.cpp
@@ -72,6 +72,8 @@ void GP_CLI_COMMAND_POS::process(MapSession* PSession, CCharEntity* PChar) const
     {
         PChar->updatemask |= UPDATE_POS; // Indicate that we want to update this PChar's PChar->loc or targID
 
+        PChar->setPersist(CharPersist::Position);
+
         if (PChar->loc.zone != nullptr)
         {
             PChar->loc.zone->onEntityMoved(PChar);

--- a/src/map/packets/c2s/0x050_equip_set.cpp
+++ b/src/map/packets/c2s/0x050_equip_set.cpp
@@ -86,7 +86,6 @@ auto GP_CLI_COMMAND_EQUIP_SET::validate(MapSession* PSession, const CCharEntity*
 void GP_CLI_COMMAND_EQUIP_SET::process(MapSession* PSession, CCharEntity* PChar) const
 {
     charutils::EquipItem(PChar, this->PropertyItemIndex, this->EquipKind, this->Category);
-    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
     PChar->retriggerLatents = true; // retrigger all latents later because our gear has changed

--- a/src/map/packets/c2s/0x051_equipset_set.cpp
+++ b/src/map/packets/c2s/0x051_equipset_set.cpp
@@ -104,7 +104,6 @@ void GP_CLI_COMMAND_EQUIPSET_SET::process(MapSession* PSession, CCharEntity* PCh
         charutils::EquipItem(PChar, this->Equipment[i].ItemIndex, this->Equipment[i].EquipKind, this->Equipment[i].Category);
     }
 
-    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
     luautils::CheckForGearSet(PChar); // check for gear set on gear change
     PChar->UpdateHealth();
     PChar->retriggerLatents = true; // retrigger all latents later because our gear has changed

--- a/src/map/packets/c2s/0x053_lockstyle.cpp
+++ b/src/map/packets/c2s/0x053_lockstyle.cpp
@@ -61,7 +61,7 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
             if (PChar->getStyleLocked())
             {
                 charutils::SetStyleLock(PChar, false);
-                PChar->RequestPersist(CHAR_PERSIST::EQUIP);
+                PChar->setPersist(CharPersist::Look);
                 updateClientAppearance(PChar);
             }
         }
@@ -194,7 +194,7 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
                 PChar->pushPacket<GP_SERV_COMMAND_LOCKSTYLE_ERROR>(failedItemIds);
             }
 
-            PChar->RequestPersist(CHAR_PERSIST::EQUIP);
+            PChar->setPersist(CharPersist::Look);
             updateClientAppearance(PChar);
         }
         break;
@@ -202,7 +202,7 @@ void GP_CLI_COMMAND_LOCKSTYLE::process(MapSession* PSession, CCharEntity* PChar)
         {
             charutils::SetStyleLock(PChar, true);
             charutils::UpdateRemovedSlotsLookForLockStyle(PChar);
-            PChar->RequestPersist(CHAR_PERSIST::EQUIP);
+            PChar->setPersist(CharPersist::Look);
             updateClientAppearance(PChar);
         }
         break;

--- a/src/map/packets/c2s/0x100_myroom_job.cpp
+++ b/src/map/packets/c2s/0x100_myroom_job.cpp
@@ -154,7 +154,6 @@ void GP_CLI_COMMAND_MYROOM_JOB::process(MapSession* PSession, CCharEntity* PChar
     charutils::BuildingCharAbilityTable(PChar);
     charutils::BuildingCharWeaponSkills(PChar);
     charutils::LoadJobChangeGear(PChar);
-    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
 
     // If the player has a teleport effect and they change jobs, cancel the teleport/warps you
     // Retail does cancel your teleport/warp if you change subs if someone else ports/warps

--- a/src/map/packets/c2s/0x102_extended_job.cpp
+++ b/src/map/packets/c2s/0x102_extended_job.cpp
@@ -22,6 +22,7 @@
 #include "0x102_extended_job.h"
 
 #include "blue_spell.h"
+#include "entities/automaton_entity.h"
 #include "entities/char_entity.h"
 #include "packets/s2c/0x061_clistatus.h"
 #include "packets/s2c/0x0ac_command_data.h"

--- a/src/map/persist_batch.cpp
+++ b/src/map/persist_batch.cpp
@@ -1,0 +1,142 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "persist_batch.h"
+
+#include <unordered_set>
+
+#include "entities/char_entity.h"
+#include "status_effect_container.h"
+#include "utils/charutils.h"
+
+#include <common/database.h>
+#include <common/synchronized.h>
+#include <common/tracy.h>
+
+namespace
+{
+
+// Characters already updated by teardown. Held for the duration of any write so sweeps and
+// teardowns can't interleave.
+Synchronized<std::unordered_set<uint32>> flushedAtTeardown;
+
+void writeRows(const PersistBatch& batch)
+{
+    charutils::SaveCharPositions(batch.positions);
+    effects::SaveEffectRows(batch.replaceEffectsFor, batch.effectRows);
+    charutils::SaveCharEquips(batch.replaceEquipFor, batch.equipRows);
+    charutils::SaveCharAppearances(batch.appearances);
+    charutils::PersistCharVars(batch.charVars);
+}
+
+} // namespace
+
+void PersistBatch::add(CCharEntity* PChar, const IsLogout logout)
+{
+    const auto pending = PChar->persist();
+    PChar->clearPersist(pending);
+
+    if ((pending & CharPersist::Position) != CharPersist::None)
+    {
+        positions.push_back({
+            .charid   = PChar->id,
+            .rotation = PChar->loc.p.rotation,
+            .x        = PChar->loc.p.x,
+            .y        = PChar->loc.p.y,
+            .z        = PChar->loc.p.z,
+            .boundary = PChar->loc.boundary,
+        });
+    }
+
+    if ((pending & CharPersist::Effects) != CharPersist::None)
+    {
+        replaceEffectsFor.push_back(PChar->id);
+
+        const auto rows = PChar->StatusEffectContainer->BuildPersistRows(logout);
+        effectRows.insert(effectRows.end(), rows.begin(), rows.end());
+    }
+
+    if ((pending & CharPersist::Equip) != CharPersist::None)
+    {
+        replaceEquipFor.push_back(PChar->id);
+
+        const auto slots = charutils::BuildCharEquipSlots(PChar);
+        equipRows.insert(equipRows.end(), slots.begin(), slots.end());
+    }
+
+    if ((pending & CharPersist::Look) != CharPersist::None)
+    {
+        appearances.push_back(charutils::BuildCharAppearance(PChar));
+    }
+
+    PChar->takeCharVarChanges(charVars);
+}
+
+void PersistBatch::write()
+{
+    TracyZoneScoped;
+
+    flushedAtTeardown.write(
+        [this](std::unordered_set<uint32>& flushed)
+        {
+            if (!flushed.empty())
+            {
+                const auto dropRow = [&](const auto& row)
+                {
+                    return flushed.contains(row.charid);
+                };
+
+                const auto dropKey = [&](const uint32 charid)
+                {
+                    return flushed.contains(charid);
+                };
+
+                std::erase_if(positions, dropRow);
+                std::erase_if(replaceEffectsFor, dropKey);
+                std::erase_if(effectRows, dropRow);
+                std::erase_if(replaceEquipFor, dropKey);
+                std::erase_if(equipRows, dropRow);
+                std::erase_if(appearances, dropRow);
+                std::erase_if(charVars, dropRow);
+
+                flushed.clear();
+            }
+
+            writeRows(*this);
+        });
+}
+
+void persist::flush(CCharEntity* PChar, const IsLogout logout)
+{
+    TracyZoneScoped;
+
+    PChar->StatusEffectContainer->DropEffectsForTransition(logout);
+
+    PersistBatch batch;
+    batch.add(PChar, logout);
+
+    flushedAtTeardown.write(
+        [&](std::unordered_set<uint32>& flushed)
+        {
+            writeRows(batch);
+            flushed.insert(PChar->id);
+        });
+}

--- a/src/map/persist_batch.h
+++ b/src/map/persist_batch.h
@@ -1,0 +1,116 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/cbasetypes.h>
+
+#include <common/types/flag.h>
+
+#include <array>
+#include <string>
+#include <vector>
+
+class CCharEntity;
+
+// Whether the character is leaving for good, as opposed to zoning or just being swept.
+using IsLogout = xi::Flag<struct IsLogoutTag>;
+
+struct CharPosition
+{
+    uint32 charid{};
+    uint8  rotation{};
+    float  x{};
+    float  y{};
+    float  z{};
+    uint16 boundary{};
+};
+
+struct CharEquipSlot
+{
+    uint32 charid{};
+    uint8  equipSlotId{};
+    uint8  slotId{};
+    uint8  containerId{};
+};
+
+struct CharAppearance
+{
+    uint32                charid{};
+    std::array<uint16, 8> look{};       // head, body, hands, legs, feet, main, sub, ranged
+    std::array<uint16, 8> styleItems{}; // same order as look
+    bool                  styleLocked{};
+};
+
+struct PersistedEffect
+{
+    uint32 charid{};
+    uint16 effectId{};
+    uint16 icon{};
+    uint16 power{};
+    uint32 tick{};
+    uint32 duration{};
+    uint32 subId{};
+    uint16 subPower{};
+    uint16 tier{};
+    uint32 flags{};
+    uint32 timestamp{};
+    uint16 sourceType{};
+    uint32 sourceTypeParam{};
+    uint32 originId{};
+};
+
+struct CharVarChange
+{
+    uint32      charid{};
+    std::string name;
+    int32       value{};
+    uint32      expiry{};
+};
+
+struct PersistBatch
+{
+    std::vector<CharPosition> positions;
+
+    std::vector<uint32>          replaceEffectsFor;
+    std::vector<PersistedEffect> effectRows;
+
+    std::vector<uint32>        replaceEquipFor;
+    std::vector<CharEquipSlot> equipRows;
+
+    std::vector<CharAppearance> appearances;
+
+    std::vector<CharVarChange> charVars;
+
+    // Add PC to current batch (main thread)
+    void add(CCharEntity* PChar, IsLogout logout = IsLogout::No);
+
+    // Write all pending changes (worker)
+    void write();
+};
+
+namespace persist
+{
+
+// Write one character now, outside of the periodic sweep.
+void flush(CCharEntity* PChar, IsLogout logout);
+
+} // namespace persist

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -34,10 +34,13 @@ When a status effect is gained twice on a player. It can do one or more of the f
 #include "common/timer.h"
 #include "data/enums/weather.h"
 
+#include <common/database.h>
 #include <common/types/hash_map.h>
 
 #include <array>
 #include <cstring>
+
+#include "map_constants.h"
 
 #include "data/loader.h"
 #include "lua/luautils.h"
@@ -530,6 +533,8 @@ bool CStatusEffectContainer::AddStatusEffect(std::unique_ptr<CStatusEffect> PSta
         {
             CCharEntity* PChar = (CCharEntity*)m_POwner;
 
+            PChar->setPersist(CharPersist::Effects);
+
             if (PStatusEffect->GetIcon() != 0)
             {
                 UpdateStatusIcons();
@@ -619,6 +624,8 @@ void CStatusEffectContainer::RemoveStatusEffect(CStatusEffect* PStatusEffect, co
         if (m_POwner->objtype == TYPE_PC)
         {
             auto* PChar = static_cast<CCharEntity*>(m_POwner);
+
+            PChar->setPersist(CharPersist::Effects);
 
             if (notice != EffectNotice::Silent && PStatusEffect->GetIcon() != 0 && !(PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::NoLossMessage)))
             {
@@ -1613,6 +1620,9 @@ void CStatusEffectContainer::LoadStatusEffects()
         AddStatusEffect(std::move(PStatusEffect));
     }
 
+    // nothing changed since the read
+    static_cast<CCharEntity*>(m_POwner)->clearPersist(CharPersist::Effects);
+
     m_POwner->UpdateHealth(); // after loading the effects, recalculate the maximum amount of HP/MP
 }
 
@@ -1622,23 +1632,19 @@ void CStatusEffectContainer::LoadStatusEffects()
  *                                                                       *
  ************************************************************************/
 
-void CStatusEffectContainer::SaveStatusEffects(bool logout)
+auto CStatusEffectContainer::BuildPersistRows(const IsLogout logout) -> std::vector<PersistedEffect>
 {
-    // Print entity name and bail out if entity isn't a player.
+    std::vector<PersistedEffect> rows;
+
     if (m_POwner->objtype != TYPE_PC)
     {
-        ShowDebug("Non-player entity %s (ID: %d) attempt to save Status Effect.", m_POwner->getName(), m_POwner->id);
-
-        return;
+        return rows;
     }
-
-    db::preparedStmt("DELETE FROM char_effects WHERE charid = ?", m_POwner->id);
 
     for (const auto& PStatusEffect : m_StatusEffectSet)
     {
         if ((logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Logout)) || (!logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::OnZone)))
         {
-            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
             continue;
         }
 
@@ -1650,61 +1656,113 @@ void CStatusEffectContainer::SaveStatusEffects(bool logout)
         const auto durationSeconds     = timer::count_seconds(PStatusEffect->GetDuration());
         const auto realDurationSeconds = timer::count_seconds(PStatusEffect->GetStartTime() + PStatusEffect->GetDuration() - timer::now());
 
-        if (realDurationSeconds > 0 || durationSeconds == 0)
+        if (!(realDurationSeconds > 0 || durationSeconds == 0))
         {
-            // save power of utsusemi and blink
-            if (PStatusEffect->GetStatusID() == xi::StatusEffect::CopyImage)
-            {
-                PStatusEffect->SetSubPower(m_POwner->getMod(xi::Mod::UTSUSEMI));
-            }
-            else if (PStatusEffect->GetStatusID() == xi::StatusEffect::Blink)
-            {
-                PStatusEffect->SetPower(m_POwner->getMod(xi::Mod::BLINK));
-            }
+            continue;
+        }
 
-            uint32 duration = 0;
+        // save power of utsusemi and blink
+        if (PStatusEffect->GetStatusID() == xi::StatusEffect::CopyImage)
+        {
+            PStatusEffect->SetSubPower(m_POwner->getMod(xi::Mod::UTSUSEMI));
+        }
+        else if (PStatusEffect->GetStatusID() == xi::StatusEffect::Blink)
+        {
+            PStatusEffect->SetPower(m_POwner->getMod(xi::Mod::BLINK));
+        }
 
-            if (durationSeconds > 0)
+        uint32 duration = 0;
+
+        if (durationSeconds > 0)
+        {
+            if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::OfflineTick))
             {
-                if (PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::OfflineTick))
+                duration = static_cast<uint32>(durationSeconds);
+            }
+            else
+            {
+                if (realDurationSeconds > 0)
                 {
-                    duration = static_cast<uint32>(durationSeconds);
+                    duration = static_cast<uint32>(realDurationSeconds);
                 }
                 else
                 {
-                    if (realDurationSeconds > 0)
-                    {
-                        duration = static_cast<uint32>(realDurationSeconds);
-                    }
-                    else
-                    {
-                        continue;
-                    }
+                    continue;
                 }
             }
+        }
 
-            uint32 tick      = static_cast<uint32>(timer::count_seconds(PStatusEffect->GetTickTime()));
-            auto   timestamp = earth_time::timestamp(timer::to_utc(PStatusEffect->GetStartTime()));
+        rows.push_back({
+            .charid          = m_POwner->id,
+            .effectId        = static_cast<uint16>(PStatusEffect->GetStatusID()),
+            .icon            = PStatusEffect->GetIcon(),
+            .power           = PStatusEffect->GetPower(),
+            .tick            = static_cast<uint32>(timer::count_seconds(PStatusEffect->GetTickTime())),
+            .duration        = duration,
+            .subId           = PStatusEffect->GetSubID(),
+            .subPower        = PStatusEffect->GetSubPower(),
+            .tier            = PStatusEffect->GetTier(),
+            .flags           = static_cast<uint32>(PStatusEffect->GetEffectFlags()),
+            .timestamp       = earth_time::timestamp(timer::to_utc(PStatusEffect->GetStartTime())),
+            .sourceType      = PStatusEffect->GetSourceType(),
+            .sourceTypeParam = PStatusEffect->GetSourceTypeParam(),
+            .originId        = PStatusEffect->GetOriginID(),
+        });
+    }
 
-            db::preparedStmt("INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp, sourcetype, sourcetypeparam, originid) "
-                             "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                             m_POwner->id,
-                             static_cast<uint16>(PStatusEffect->GetStatusID()),
-                             PStatusEffect->GetIcon(),
-                             PStatusEffect->GetPower(),
-                             tick,
-                             duration,
-                             PStatusEffect->GetSubID(),
-                             PStatusEffect->GetSubPower(),
-                             PStatusEffect->GetTier(),
-                             static_cast<uint32>(PStatusEffect->GetEffectFlags()),
-                             timestamp,
-                             PStatusEffect->GetSourceType(),
-                             PStatusEffect->GetSourceTypeParam(),
-                             PStatusEffect->GetOriginID());
+    return rows;
+}
+
+void CStatusEffectContainer::DropEffectsForTransition(const IsLogout logout)
+{
+    // Print entity name and bail out if entity isn't a player.
+    if (m_POwner->objtype != TYPE_PC)
+    {
+        ShowDebug("Non-player entity %s (ID: %d) attempt to drop Status Effects.", m_POwner->getName(), m_POwner->id);
+
+        return;
+    }
+
+    for (const auto& PStatusEffect : m_StatusEffectSet)
+    {
+        if ((logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::Logout)) || (!logout && PStatusEffect->HasEffectFlag(xi::StatusEffectFlag::OnZone)))
+        {
+            RemoveStatusEffect(PStatusEffect.get(), EffectNotice::Silent);
         }
     }
+
     DeleteStatusEffects();
+}
+
+void effects::SaveEffectRows(const std::vector<uint32>& replaceFor, const std::vector<PersistedEffect>& rows)
+{
+    TracyZoneScoped;
+
+    if (replaceFor.empty())
+    {
+        return;
+    }
+
+    db::transaction(
+        [&]()
+        {
+            db::executeBulk(
+                "DELETE FROM char_effects WHERE charid = ?",
+                replaceFor,
+                [](uint32 charid)
+                {
+                    return std::make_tuple(charid);
+                });
+
+            db::executeBulk(
+                "INSERT INTO char_effects (charid, effectid, icon, power, tick, duration, subid, subpower, tier, flags, timestamp, sourcetype, sourcetypeparam, originid) "
+                "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                rows,
+                [](const PersistedEffect& row)
+                {
+                    return std::make_tuple(row.charid, row.effectId, row.icon, row.power, row.tick, row.duration, row.subId, row.subPower, row.tier, row.flags, row.timestamp, row.sourceType, row.sourceTypeParam, row.originId);
+                });
+        });
 }
 
 /************************************************************************

--- a/src/map/status_effect_container.h
+++ b/src/map/status_effect_container.h
@@ -27,6 +27,7 @@
 #include <set>
 #include <utility>
 
+#include "persist_batch.h"
 #include "status_effect.h"
 
 /************************************************************************
@@ -101,8 +102,9 @@ public:
     void TickEffects(timer::time_point tick);
     void TickRegen(timer::time_point tick);
 
-    void LoadStatusEffects();                    // We load the character effects
-    void SaveStatusEffects(bool logout = false); // We keep the character effects
+    void LoadStatusEffects();                       // We load the character effects
+    void DropEffectsForTransition(IsLogout logout); // Remove the effects that don't survive a zone change or logout
+    auto BuildPersistRows(IsLogout logout) -> std::vector<PersistedEffect>;
 
     auto  GetEffectsCount(xi::StatusEffect ID) -> uint8;               // We get the number of effects with the specified ID
     auto  GetEffectsCountWithFlag(xi::StatusEffectFlag flag) -> uint8; // We get the number of effects with the specified flag
@@ -201,5 +203,7 @@ namespace effects
 void        LoadEffectsParameters();
 uint16      GetEffectElement(uint16 effect);
 std::string GetEffectName(uint16 effect);
+
+void SaveEffectRows(const std::vector<uint32>& replaceFor, const std::vector<PersistedEffect>& rows);
 
 }; // namespace effects

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5942,7 +5942,6 @@ bool RemoveAmmo(CCharEntity* PChar, int quantity)
             uint8 slot = eloc ? eloc->Slot : 0;
             uint8 loc  = eloc ? static_cast<uint8>(eloc->Container) : 0;
             charutils::UnequipItem(PChar, SLOT_AMMO);
-            PChar->RequestPersist(CHAR_PERSIST::EQUIP);
             charutils::UpdateItem(PChar, loc, slot, -quantity);
             PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);
             return true;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -28,10 +28,14 @@
 #include "common/vana_time.h"
 #include <fmt/ranges.h>
 
+#include <common/database.h>
 #include <common/types/hash_map.h>
 
 #include <array>
 #include <chrono>
+
+#include "map_constants.h"
+#include "persist_batch.h"
 
 #include "lua/luautils.h"
 
@@ -2311,6 +2315,8 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
 
         PChar->inventorySyncState().queueEquipChange(LOC_INVENTORY, 0, static_cast<SLOTTYPE>(equipSlotID), PItem, Equipping::No);
 
+        PChar->setPersist(CharPersist::Equip | CharPersist::Look);
+
         if (recalculate)
         {
             charutils::BuildingCharSkillsTable(PChar);
@@ -3440,6 +3446,8 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
 
     PChar->updatemask |= UPDATE_HP;
     PChar->updatemask |= UPDATE_LOOK;
+
+    PChar->setPersist(CharPersist::Equip | CharPersist::Look);
 }
 
 /************************************************************************
@@ -3490,7 +3498,6 @@ void CheckValidEquipment(CCharEntity* PChar)
     }
 
     BuildingCharWeaponSkills(PChar);
-    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
 }
 
 void RemoveAllEquipment(CCharEntity* PChar)
@@ -3510,7 +3517,6 @@ void RemoveAllEquipment(CCharEntity* PChar)
     CheckUnarmedWeapon(PChar);
 
     BuildingCharWeaponSkills(PChar);
-    PChar->RequestPersist(CHAR_PERSIST::EQUIP);
 }
 
 /************************************************************************
@@ -5916,6 +5922,39 @@ void SaveCharPosition(CCharEntity* PChar)
                      PChar->id);
 }
 
+void PersistCharVars(const std::vector<CharVarChange>& rows)
+{
+    TracyZoneScoped;
+
+    if (rows.empty())
+    {
+        return;
+    }
+
+    db::transaction(
+        [&]()
+        {
+            for (const auto& row : rows)
+            {
+                PersistCharVar(row.charid, row.name, row.value, row.expiry);
+            }
+        });
+}
+
+void SaveCharPositions(const std::vector<CharPosition>& rows)
+{
+    TracyZoneScoped;
+
+    // not an upsert: `chars` has a BEFORE INSERT trigger that fires even on update
+    db::executeBulk(
+        "UPDATE chars SET pos_rot = ?, pos_x = ?, pos_y = ?, pos_z = ?, boundary = ? WHERE charid = ?",
+        rows,
+        [](const CharPosition& row)
+        {
+            return std::make_tuple(row.rotation, row.x, row.y, row.z, row.boundary, row.charid);
+        });
+}
+
 /* TODO: Move linkshell persistence here
 void SaveCharLinkshells(CCharEntity* PChar)
 {
@@ -6171,66 +6210,124 @@ void SavePrevZoneLineID(CCharEntity* PChar, uint32 ZoneLineID)
                      PChar->id);
 }
 
+auto BuildCharEquipSlots(const CCharEntity* PChar) -> std::vector<CharEquipSlot>
+{
+    std::vector<CharEquipSlot> rows;
+
+    for (uint8 i = 0; i < 18; ++i)
+    {
+        if (const auto eloc = PChar->equipLocation(i))
+        {
+            rows.push_back({ .charid = PChar->id, .equipSlotId = i, .slotId = eloc->Slot, .containerId = static_cast<uint8>(eloc->Container) });
+        }
+    }
+
+    return rows;
+}
+
 void SaveCharEquip(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    for (uint8 i = 0; i < 18; ++i)
-    {
-        auto eloc = PChar->equipLocation(i);
-        if (!eloc)
-        {
-            db::preparedStmt("DELETE FROM char_equip WHERE charid = ? AND equipslotid = ? LIMIT 1", PChar->id, i);
-        }
-        else
-        {
-            db::preparedStmt("INSERT INTO char_equip "
-                             "SET charid = ?, equipslotid = ?, slotid = ?, containerid = ? "
-                             "ON DUPLICATE KEY UPDATE slotid  = ?, containerid = ?",
-                             PChar->id,
-                             i,
-                             eloc->Slot,
-                             static_cast<uint8>(eloc->Container),
-                             eloc->Slot,
-                             static_cast<uint8>(eloc->Container));
-        }
-    }
+    SaveCharEquips({ PChar->id }, BuildCharEquipSlots(PChar));
 }
 
-void SaveCharLook(CCharEntity* PChar)
+void SaveCharEquips(const std::vector<uint32>& replaceFor, const std::vector<CharEquipSlot>& rows)
 {
     TracyZoneScoped;
 
-    look_t* look = (PChar->getStyleLocked() ? &PChar->mainlook : &PChar->look);
-    db::preparedStmt("UPDATE char_look "
-                     "SET head = ?, body = ?, hands = ?, legs = ?, feet = ?, main = ?, sub = ?, ranged = ? "
-                     "WHERE charid = ?",
-                     look->head,
-                     look->body,
-                     look->hands,
-                     look->legs,
-                     look->feet,
-                     look->main,
-                     look->sub,
-                     look->ranged,
-                     PChar->id);
+    if (replaceFor.empty())
+    {
+        return;
+    }
 
-    db::preparedStmt("UPDATE chars SET isstylelocked = ? WHERE charid = ?", PChar->getStyleLocked() ? 1 : 0, PChar->id);
+    db::transaction(
+        [&]()
+        {
+            db::executeBulk(
+                "DELETE FROM char_equip WHERE charid = ?",
+                replaceFor,
+                [](uint32 charid)
+                {
+                    return std::make_tuple(charid);
+                });
 
-    db::preparedStmt("INSERT INTO char_style (charid, head, body, hands, legs, feet, main, sub, ranged) "
-                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE "
-                     "charid = VALUES(charid), head = VALUES(head), body = VALUES(body), "
-                     "hands = VALUES(hands), legs = VALUES(legs), feet = VALUES(feet), "
-                     "main = VALUES(main), sub = VALUES(sub), ranged = VALUES(ranged)",
-                     PChar->id,
-                     PChar->styleItems[SLOT_HEAD],
-                     PChar->styleItems[SLOT_BODY],
-                     PChar->styleItems[SLOT_HANDS],
-                     PChar->styleItems[SLOT_LEGS],
-                     PChar->styleItems[SLOT_FEET],
-                     PChar->styleItems[SLOT_MAIN],
-                     PChar->styleItems[SLOT_SUB],
-                     PChar->styleItems[SLOT_RANGED]);
+            db::executeBulk(
+                "INSERT INTO char_equip (charid, equipslotid, slotid, containerid) VALUES (?,?,?,?)",
+                rows,
+                [](const CharEquipSlot& row)
+                {
+                    return std::make_tuple(row.charid, row.equipSlotId, row.slotId, row.containerId);
+                });
+        });
+}
+
+auto BuildCharAppearance(const CCharEntity* PChar) -> CharAppearance
+{
+    const look_t* look = [&]()
+    {
+        if (PChar->getStyleLocked())
+        {
+            return &PChar->mainlook;
+        }
+
+        return &PChar->look;
+    }();
+
+    return {
+        .charid      = PChar->id,
+        .look        = { look->head, look->body, look->hands, look->legs, look->feet, look->main, look->sub, look->ranged },
+        .styleItems  = { PChar->styleItems[SLOT_HEAD], PChar->styleItems[SLOT_BODY], PChar->styleItems[SLOT_HANDS], PChar->styleItems[SLOT_LEGS], PChar->styleItems[SLOT_FEET], PChar->styleItems[SLOT_MAIN], PChar->styleItems[SLOT_SUB], PChar->styleItems[SLOT_RANGED] },
+        .styleLocked = PChar->getStyleLocked(),
+    };
+}
+
+void SaveCharAppearances(const std::vector<CharAppearance>& rows)
+{
+    TracyZoneScoped;
+
+    if (rows.empty())
+    {
+        return;
+    }
+
+    const auto slotRow = [](uint32 charid, const std::array<uint16, 8>& slots)
+    {
+        return std::make_tuple(charid, slots[0], slots[1], slots[2], slots[3], slots[4], slots[5], slots[6], slots[7]);
+    };
+
+    db::transaction(
+        [&]()
+        {
+            // upsert, not update: char_look rows aren't created by the char_insert trigger
+            db::executeBulk(
+                "INSERT INTO char_look (charid, head, body, hands, legs, feet, main, sub, ranged) VALUES (?,?,?,?,?,?,?,?,?) "
+                "ON DUPLICATE KEY UPDATE head = VALUES(head), body = VALUES(body), hands = VALUES(hands), "
+                "legs = VALUES(legs), feet = VALUES(feet), main = VALUES(main), sub = VALUES(sub), ranged = VALUES(ranged)",
+                rows,
+                [&](const CharAppearance& row)
+                {
+                    return slotRow(row.charid, row.look);
+                });
+
+            db::executeBulk(
+                "UPDATE chars SET isstylelocked = ? WHERE charid = ?",
+                rows,
+                [](const CharAppearance& row)
+                {
+                    return std::make_tuple(row.styleLocked, row.charid);
+                });
+
+            db::executeBulk(
+                "INSERT INTO char_style (charid, head, body, hands, legs, feet, main, sub, ranged) VALUES (?,?,?,?,?,?,?,?,?) "
+                "ON DUPLICATE KEY UPDATE head = VALUES(head), body = VALUES(body), hands = VALUES(hands), "
+                "legs = VALUES(legs), feet = VALUES(feet), main = VALUES(main), sub = VALUES(sub), ranged = VALUES(ranged)",
+                rows,
+                [&](const CharAppearance& row)
+                {
+                    return slotRow(row.charid, row.styleItems);
+                });
+        });
 }
 
 /************************************************************************
@@ -8150,8 +8247,7 @@ void removeCharFromZone(CCharEntity* PChar)
         PChar->loc.zone->DecreaseZoneCounter(PChar);
     }
 
-    PChar->StatusEffectContainer->SaveStatusEffects(PChar->PSession->shuttingDown == 1);
-    PChar->PersistData();
+    persist::flush(PChar, IsLogout(PChar->PSession->shuttingDown == 1));
     charutils::SavePlayTime(PChar);
     charutils::SaveCharStats(PChar);
     charutils::SaveCharExp(PChar, PChar->GetMJob());

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -24,8 +24,11 @@
 #include "common/cbasetypes.h"
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "entities/char_entity.h"
+#include "persist_batch.h"
 
 using Recalculate       = xi::Flag<struct RecalculateTag>;
 using IncludeRecycleBin = xi::Flag<struct IncludeRecycleBinTag>;
@@ -194,8 +197,13 @@ bool  canUseWeaponSkill(CCharEntity* PChar, uint16 wsid);
 void SaveCharJob(const CCharEntity* PChar, xi::Job job); // save the level for the selected character's jobs
 void SaveCharExp(const CCharEntity* PChar, xi::Job job); // save experience for the selected character’s chosen job
 void SaveCharEquip(CCharEntity* PChar);                  // preserve the character’s equipment and appearance
-void SaveCharLook(CCharEntity* PChar);                   // saves a character's appearance based on style locking
 void SaveCharPosition(CCharEntity* PChar);               // save the character's position (x/y/z)
+void SaveCharPositions(const std::vector<CharPosition>& rows);
+void SaveCharEquips(const std::vector<uint32>& replaceFor, const std::vector<CharEquipSlot>& rows);
+void SaveCharAppearances(const std::vector<CharAppearance>& rows);
+void PersistCharVars(const std::vector<CharVarChange>& rows);
+auto BuildCharEquipSlots(const CCharEntity* PChar) -> std::vector<CharEquipSlot>;
+auto BuildCharAppearance(const CCharEntity* PChar) -> CharAppearance;
 // void SaveCharLinkshells(CCharEntity* PChar);     // TODO: save the character's linkshells
 void SaveMissionsList(CCharEntity* PChar);          // save the missions list
 void SaveEminenceData(CCharEntity* PChar);          // save Eminence Record (RoE) data

--- a/src/map/utils/puppetutils.h
+++ b/src/map/utils/puppetutils.h
@@ -24,6 +24,8 @@
 #include "entities/char_entity.h"
 #include "status_effect.h"
 
+class CAutomatonEntity;
+
 namespace puppetutils
 {
 

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -82,7 +82,6 @@ constexpr auto CHARACTER_SYNC_LIMIT_MAX               = 32U;
 constexpr auto CHARACTER_SYNC_DISTANCE_SWAP_THRESHOLD = 30U;
 constexpr auto CHARACTER_SYNC_PARTY_SIGNIFICANCE      = 100000U;
 constexpr auto CHARACTER_SYNC_ALLI_SIGNIFICANCE       = 10000U;
-constexpr auto PERSIST_CHECK_CHARACTERS               = 20U;
 constexpr auto INTERMEDIATE_CONTAINER_RESERVE_SIZE    = 16U;
 
 inline bool isWithinVerticalDistance(CBaseEntity* source, CBaseEntity* target)
@@ -2154,39 +2153,8 @@ auto CZoneEntities::ZoneServer(timer::time_point tick) -> Task<void>
         m_EffectCheckTime = m_EffectCheckTime + 3s > tick ? m_EffectCheckTime + 3s : tick + 3s;
     }
 
-    if (tick > m_charPersistTime && !m_charTargIds.empty())
-    {
-        m_charPersistTime = tick + 1s;
-
-        std::set<uint16>::iterator charTargIdIter = m_charTargIds.lower_bound(m_lastCharPersistTargId);
-        if (charTargIdIter == m_charTargIds.end())
-        {
-            charTargIdIter = m_charTargIds.begin();
-        }
-
-        size_t maxChecks = std::min<size_t>(m_charTargIds.size(), PERSIST_CHECK_CHARACTERS);
-
-        for (size_t i = 0; i < maxChecks; i++)
-        {
-            CCharEntity* PChar = static_cast<CCharEntity*>(m_charList[*charTargIdIter]);
-            ++charTargIdIter;
-            if (charTargIdIter == m_charTargIds.end())
-            {
-                charTargIdIter = m_charTargIds.begin();
-            }
-
-            if (PChar && PChar->PersistData(tick))
-            {
-                // We only want to persist at most 1 character per zone tick
-                break;
-            }
-        }
-        m_lastCharPersistTargId = *charTargIdIter;
-    }
-
     if (tick > m_computeTime && !m_charTargIds.empty())
     {
-        // Tick time is irregular to avoid consistently happening at the same time as char persistence
         m_computeTime = tick + 567ms;
 
         std::set<uint16>::iterator charTargIdIter = m_charTargIds.lower_bound(m_lastCharComputeTargId);

--- a/src/map/zone_entities.h
+++ b/src/map/zone_entities.h
@@ -166,9 +166,6 @@ private:
     timer::time_point m_computeTime{ timer::now() };
     uint16            m_lastCharComputeTargId{ 0 };
 
-    timer::time_point m_charPersistTime{ timer::now() };
-    uint16            m_lastCharPersistTargId{ 0 };
-
     //
     // Intermediate collections for use inside ZoneServer
     //


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This does quite a few things...

### Sweep characters for pending changes every 5s

This replaces the existing zone_entities tick-tied mechanism for Equipment and Look by a first class task on the Engine occurring every 5 seconds*.

The sweep writes on a worker, so a logout mid-write could get overwritten by an older snapshot. Every write holds one mutex, and teardown records what it wrote so the sweep skips it.

This task also collects two things that were notoriously missing on periodic saves until today: character positions and effects - no more losing your Dedication effect because the process crashed since you last zoned.

*5 seconds is absolutely arbitrary and can be tweaked as needed.

### Cleaned up persistence flags

Added position and effect flags. Remove unnecessary flag setting calls (usually calling EquipItem and then setting the flag when EquipItem itself can very well set it)

### Batched queries machinery

To support the change above, the PR includes machinery for batching updates into a single statement, this can be reused at will in the future for similar purposes. See below for rationale on why we're batching.

## Transaction and batching

You will notice I am wrapping all updates under a single transaction and batching statements as much as possible. This was all derived from running benchmarks testing the various shapes. 

The codebase today opens and closes a new transaction for each statement which, while fine and wanted for consistency purposes, introduces latency as the database has to flush pending changes to disk before returning. 

Taking the existing equipment persistence flow as an example, it would before open 18 different transactions to save what is really just one set of equipment for one character and can reasonably be batched together.

Wrapping several statements in single transaction allows the flush to only occur once, improving the overall performance.

Similarly batching many values in a single statement saves on round-trips and has real benefits.

## Benchmarks
Ran through the actual C++ machinery on my average NVME with default MariaDB settings.

Naive here means 1 TX + 1 Statement per trip

<img width="1530" height="714" alt="persist_statements" src="https://github.com/user-attachments/assets/075c3c23-e241-416d-aa1b-358821163966" />
<img width="1530" height="1224" alt="persist_sweep_time" src="https://github.com/user-attachments/assets/a6f898c7-e9e8-4471-90ca-cea285ec95db" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
