### PR TITLE
[lua] Make Water Way to Go repeatable and apply zone requirement

### DIFF
--- a/scripts/quests/windurst/Blue_Ribbon_Blues.lua
+++ b/scripts/quests/windurst/Blue_Ribbon_Blues.lua
@@ -25,7 +25,7 @@ quest.sections =
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.WATER_WAY_TO_GO) and
                 player:getFameLevel(xi.fameArea.WINDURST) >= 5 and
-                not quest:getMustZone(player)
+                not xi.quest.getMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.WATER_WAY_TO_GO)
         end,
 
         [xi.zone.WINDURST_WATERS] =

--- a/scripts/quests/windurst/Overnight_Delivery.lua
+++ b/scripts/quests/windurst/Overnight_Delivery.lua
@@ -22,7 +22,7 @@ quest.sections =
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.FOOD_FOR_THOUGHT) and
                 player:getFameLevel(xi.fameArea.WINDURST) >= 2 and
-                player:getLocalVar('Quest[2][14]mustZone') == 0
+                not xi.quest.getMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.FOOD_FOR_THOUGHT)
         end,
 
         [xi.zone.WINDURST_WATERS] =
@@ -104,10 +104,10 @@ quest.sections =
                         if vanadielHour < 6 or vanadielHour >= 18 then
                             return quest:progressEvent(141)
                         else
-                            return quest:progressEvent(144)
+                            return quest:event(144)
                         end
                     else
-                        return quest:progressEvent(142)
+                        return quest:event(142)
                     end
                 end,
             },
@@ -191,7 +191,7 @@ quest.sections =
                 [348] = function(player, csid, option, npc)
                     if quest:complete(player) then
                         player:delKeyItem(xi.ki.SMALL_BAG)
-                        player:setLocalVar('Quest[2][16]mustZone', 1)
+                        quest:setMustZone(player)
                     end
                 end,
             },
@@ -206,7 +206,10 @@ quest.sections =
         [xi.zone.MHAURA] =
         {
             ['Kotan-Purutan'] = quest:event(143):replaceDefault(),
+        },
 
+        [xi.zone.WINDURST_WATERS] =
+        {
             ['Ohbiru-Dohbiru'] =
             {
                 onTrigger = function(player, npc)
@@ -215,10 +218,7 @@ quest.sections =
                     end
                 end,
             },
-        },
 
-        [xi.zone.WINDURST_WATERS] =
-        {
             ['Kenapa-Keppa'] =
             {
                 onTrigger = function(player, npc)

--- a/scripts/quests/windurst/Water_Way_to_Go.lua
+++ b/scripts/quests/windurst/Water_Way_to_Go.lua
@@ -4,14 +4,13 @@
 -- !addquest 2 16
 -- Ohbiru-Dohbiru : !pos 23 -5 -193 238
 -- Giddeus Spring : !pos -258 -2 -249 145
--- TODO: Wikis claim that this can be repeated. However, captures don't indicate this. Needs testing/verifying.
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.WINDURST, xi.quest.id.windurst.WATER_WAY_TO_GO)
 
 quest.reward =
 {
-    fame = 16,
+    fame     = 16,
     fameArea = xi.fameArea.WINDURST,
 }
 
@@ -22,7 +21,7 @@ quest.sections =
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.OVERNIGHT_DELIVERY) and
                 player:getFameLevel(xi.fameArea.WINDURST) >= 3 and
-                not quest:getMustZone(player)
+                not xi.quest.getMustZone(player, xi.questLog.WINDURST, xi.quest.id.windurst.OVERNIGHT_DELIVERY)
         end,
 
         [xi.zone.WINDURST_WATERS] =
@@ -53,7 +52,7 @@ quest.sections =
             ['Giddeus_Spring'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.RHINOSTERY_CANTEEN) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.RHINOSTERY_CANTEEN, 1 } }) then
                         return quest:progressEvent(55)
                     end
                 end,
@@ -63,7 +62,7 @@ quest.sections =
             {
                 [55] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.item.CANTEEN_OF_GIDDEUS_WATER) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -74,7 +73,7 @@ quest.sections =
             ['Ohbiru-Dohbiru'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.CANTEEN_OF_GIDDEUS_WATER) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.CANTEEN_OF_GIDDEUS_WATER, 1 } }) then
                         return quest:progressEvent(355, 900)
                     end
                 end,
@@ -86,7 +85,7 @@ quest.sections =
                     then
                         return quest:progressEvent(354)
                     else
-                        return quest:progressEvent(353)
+                        return quest:event(353)
                     end
                 end,
             },
@@ -99,10 +98,9 @@ quest.sections =
 
                 [355] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         -- Note: Message display for gil reward is handled by the event
                         player:addGil(900)
-                        player:setLocalVar('Quest[2][17]mustZone', 1)
                         quest:setMustZone(player)
                     end
                 end,
@@ -110,15 +108,98 @@ quest.sections =
         },
     },
 
+    -- Quest complete section.
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_COMPLETED and
-                quest:getMustZone(player)
+            return status == xi.questStatus.QUEST_COMPLETED
         end,
+
+        [xi.zone.GIDDEUS] =
+        {
+            ['Giddeus_Spring'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        quest:getVar(player, 'Prog') == 1 and
+                        npcUtil.tradeMatches(trade, { { xi.item.RHINOSTERY_CANTEEN, 1 } })
+                    then
+                        return quest:progressEvent(55)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [55] = function(player, csid, option, npc)
+                    if npcUtil.giveItem(player, xi.item.CANTEEN_OF_GIDDEUS_WATER) then
+                        player:tradeComplete()
+                    end
+                end,
+            },
+        },
 
         [xi.zone.WINDURST_WATERS] =
         {
-            ['Ohbiru-Dohbiru'] = quest:progressEvent(356, 0, xi.item.CANTEEN_OF_GIDDEUS_WATER)
+            ['Ohbiru-Dohbiru'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if npcUtil.tradeMatches(trade, { { xi.item.CANTEEN_OF_GIDDEUS_WATER, 1 } }) then
+                        return quest:progressEvent(355, 900)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    -- Default after completing without zoning.
+                    if quest:getMustZone(player) then
+                        return quest:event(356, 0, xi.item.CANTEEN_OF_GIDDEUS_WATER)
+                    end
+
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    -- Re-start quest.
+                    if questProgress == 0 then
+                        if player:getFameLevel(xi.fameArea.WINDURST) < 5 then
+                            return quest:progressEvent(352, 0, xi.item.CANTEEN_OF_GIDDEUS_WATER)
+                        end
+
+                    -- Quest re-started.
+                    elseif questProgress == 1 then
+                        if
+                            not player:findItem(xi.item.RHINOSTERY_CANTEEN) and
+                            not player:findItem(xi.item.CANTEEN_OF_GIDDEUS_WATER)
+                        then
+                            return quest:progressEvent(354)
+                        else
+                            return quest:event(353)
+                        end
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [352] = function(player, csid, option, npc)
+                    if
+                        option == 0 and
+                        npcUtil.giveItem(player, xi.item.RHINOSTERY_CANTEEN)
+                    then
+                        quest:begin(player)
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+
+                [354] = function(player, csid, option, npc)
+                    npcUtil.giveItem(player, xi.item.RHINOSTERY_CANTEEN)
+                end,
+
+                [355] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:tradeComplete()
+                        player:addGil(900)
+                        quest:setMustZone(player)
+                    end
+                end,
+            },
         },
     },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Fixes zone requirements for Water Way to Go.
- Allows repeat for Water Way to Go. Must be below fame 5 in Windurst AND not on the Say it with Flowers quest.
- Fixes optional dialog in Overnight Delivery.

Big thank you to Val for tracking down it's fame 5+ that stops the repeat.
<img width="790" height="1002" alt="image" src="https://github.com/user-attachments/assets/d36fbe06-d065-47be-aed0-70befccb2c4d" />

Thank you to Siknoz for the capture: https://1drv.ms/u/c/87e665e10555c452/EdBu0k17CtdDtJkQvhThchMB_c2e5UpFY_XQcug-bah3cA?e=Pu0w37

JP wiki for the flowers quest blocking: https://wiki.ffo.jp/html/10407.html (We also tested this on retail, just don't have a capture).

## Steps to test these changes

Run through the 3 quests in order, making sure you can (or can not) repeat Water Way to Go.
Overnight Delivery -> Water Way to Go -> Blue Ribbon Blues

