### PR TITLE
[lua] Adjust Ziryu Roam Range

### DIFF
--- a/scripts/zones/Riverne-Site_A01/mobs/Ziryu.lua
+++ b/scripts/zones/Riverne-Site_A01/mobs/Ziryu.lua
@@ -44,7 +44,7 @@ end
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 30)
-    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 500)
+    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 10)
     mob:setMobMod(xi.mobMod.ROAM_RATE, 10)
     mob:setRoamFlags(xi.roamFlag.WORM)
 end

--- a/scripts/zones/Riverne-Site_B01/mobs/Ziryu.lua
+++ b/scripts/zones/Riverne-Site_B01/mobs/Ziryu.lua
@@ -9,7 +9,7 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.CHARMABLE, 1)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 30)
-    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 500)
+    mob:setMobMod(xi.mobMod.ROAM_DISTANCE, 10)
     mob:setMobMod(xi.mobMod.ROAM_RATE, 10)
     mob:setRoamFlags(xi.roamFlag.WORM)
 end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reduces the roam range of Ziryu in Ouryu + BV2 to fix some navmesh issues with them being able to pick a position far outside of the arena. 

## Steps to test these changes

Run BV2, see worms don't escape
