### PR TITLE
[C++] Send General block of packet when setting hidden state

### DIFF
--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -3033,6 +3033,10 @@ void CCharEntity::tryStartNextEvent()
 
     // Set hidden status based on event data
     m_isPCHidden = currentEvent->isHidden;
+    if (m_isPCHidden)
+    {
+        updatemask |= UPDATE_HP;
+    }
 
     if (currentEvent->strings.empty())
     {


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

PR #10707 set the player to the hidden state, but never broadcast the General section, so those who already saw the character would still see them. 

## Steps to test these changes

Have two characters where you watch one leave on a transport vessel.
