### PR TITLE
[module] [lua] Apoc Nigh Quest Chain Modules

### DIFF
--- a/modules/era/lua/quests/jeuno/Apocalypse_Nigh.lua
+++ b/modules/era/lua/quests/jeuno/Apocalypse_Nigh.lua
@@ -1,0 +1,74 @@
+-----------------------------------
+-- Apocalypse Nigh
+-- Restores the JST midnight waits before this quest can be started and after the Empyreal Paradox battlefield is cleared.
+-- The wait for Gilgamesh's reward cutscene in Norg is not tied to Aldo's cutscene.
+-- The wait after the battlefield was left alone until the November 10, 2021 version update shortened it to one Vana'diel day.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/58770
+-- Source: https://wiki.ffo.jp/html/7291.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_apocalypse_nigh'
+
+if xi.module.isContentEnabled('TVR') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Apocalypse_Nigh', function(quest)
+        local empyrealParadox = quest.sections[2][xi.zone.EMPYREAL_PARADOX]
+        local norg            = quest.sections[2][xi.zone.NORG]
+
+        -- Copy of the base check with the timer compared as a timestamp.
+        quest.sections[1].check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.SHADOWS_OF_THE_DEPARTED) and
+                GetSystemTime() >= vars.Timer and -- Module change: this quest opens at JST midnight.
+                not quest:getMustZone(player)
+        end
+
+        -- Copy of the base handler with the one Vana'diel day wait extended to JST midnight.
+        empyrealParadox.onEventFinish[32001] = function(player, csid, option, npc)
+            if
+                player:getLocalVar('battlefieldWin') == xi.battlefield.id.APOCALYPSE_NIGH and
+                quest:getVar(player, 'Prog') == 3
+            then
+                quest:setVar(player, 'Prog', 4)
+                quest:setVar(player, 'Timer', JstMidnight()) -- Module change: the wait runs to JST midnight.
+            end
+        end
+
+        -- Copy of the base handler with the timer compared as a timestamp.
+        norg['_700'].onTrigger = function(player, npc)
+            if
+                quest:getVar(player, 'Prog') == 5 and
+                GetSystemTime() < quest:getVar(player, 'Timer') -- Module change: Gilgamesh is unavailable until JST midnight.
+            then
+                return quest:progressEvent(235)
+            end
+        end
+
+        -- Copy of the base handler with the timer compared as a timestamp.
+        norg['Gilgamesh'].onTrigger = function(player, npc)
+            if
+                GetSystemTime() >= quest:getVar(player, 'Timer') and -- Module change: Gilgamesh waits until JST midnight.
+                not quest:getMustZone(player)
+            then
+                local questProgress = quest:getVar(player, 'Prog')
+
+                if questProgress == 5 then
+                    return quest:progressEvent(232, 252, 6)
+                elseif questProgress == 6 then
+                    return quest:progressEvent(234, 252)
+                end
+            end
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/jeuno/Shadows_of_the_Departed.lua
+++ b/modules/era/lua/quests/jeuno/Shadows_of_the_Departed.lua
@@ -1,0 +1,51 @@
+-----------------------------------
+-- Shadows of the Departed
+-- Restores the JST midnight waits before this quest can be started and before Apocalypse Nigh can be started.
+-- Prishe's trust was added on February 18, 2014, and the follow-up patch on February 20 changed both waits to a Vana'diel date change.
+-- That patch was never documented; the date comes from the JP quest wiki.
+-----------------------------------
+-- Source: https://wiki.ffo.jp/html/5557.html
+-- Source: https://wiki.ffo.jp/html/7291.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_shadows_of_the_departed'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Shadows_of_the_Departed', function(quest)
+        local ruludeGardens = quest.sections[2][xi.zone.RULUDE_GARDENS]
+
+        -- Copy of the base check with the timer compared as a timestamp.
+        quest.sections[1].check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.STORMS_OF_FATE) and
+                player:getCurrentMission(xi.mission.log_id.ZILART) == xi.mission.id.zilart.AWAKENING and
+                player:getMissionStatus(xi.mission.log_id.ZILART) == 3 and
+                GetSystemTime() >= vars.Timer -- Module change: this quest opens at JST midnight.
+        end
+
+        -- Copy of the base handler with the one Vana'diel day wait extended to JST midnight.
+        ruludeGardens.onEventFinish[162] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                for keyItemId = xi.ki.PROMYVION_HOLLA_SLIVER, xi.ki.PROMYVION_HOLLA_SLIVER + 2 do
+                    player:delKeyItem(keyItemId)
+                end
+
+                player:messageSpecial(zones[xi.zone.RULUDE_GARDENS].text.YOU_HAND_THE_THREE_SLIVERS)
+
+                xi.quest.setVar(player, xi.questLog.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH, 'Timer', JstMidnight()) -- Module change: Apocalypse Nigh opens at JST midnight.
+                xi.quest.setMustZone(player, xi.questLog.JEUNO, xi.quest.id.jeuno.APOCALYPSE_NIGH)
+            end
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/jeuno/Storms_of_Fate.lua
+++ b/modules/era/lua/quests/jeuno/Storms_of_Fate.lua
@@ -1,0 +1,34 @@
+-----------------------------------
+-- Storms of Fate
+-- Restores the JST midnight wait before Shadows of the Departed can be started.
+-- Prishe's trust was added on February 18, 2014, and the follow-up patch on February 20 changed the wait to a Vana'diel date change.
+-- That patch was never documented; the date comes from the JP quest wiki.
+-----------------------------------
+-- Source: https://wiki.ffo.jp/html/5557.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_storms_of_fate'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Storms_of_Fate', function(quest)
+        local ruludeGardens = quest.sections[2][xi.zone.RULUDE_GARDENS]
+
+        -- Copy of the base handler with the one Vana'diel day wait extended to JST midnight.
+        ruludeGardens.onEventFinish[143] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                xi.quest.setVar(player, xi.questLog.JEUNO, xi.quest.id.jeuno.SHADOWS_OF_THE_DEPARTED, 'Timer', JstMidnight()) -- Module change: Shadows of the Departed opens at JST midnight.
+            end
+        end
+    end)
+end)
+
+return m

--- a/scripts/quests/jeuno/Apocalypse_Nigh.lua
+++ b/scripts/quests/jeuno/Apocalypse_Nigh.lua
@@ -162,6 +162,7 @@ quest.sections =
                         quest:getVar(player, 'Prog') == 3
                     then
                         quest:setVar(player, 'Prog', 4)
+                        quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
             },
@@ -189,7 +190,6 @@ quest.sections =
             {
                 [10057] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 5)
-                    quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
                 end,
             },
         },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR does the following things:

**1. Storms of Fate** - adds a module restoring the JST midnight wait which was seemingly removed in 2014 when Prishe's trust was added, [per JP wiki](https://wiki.ffo.jp/html/5557.html).

**2. Shadows of the Departed** - adds a module restoring the JST midnight wait which was seemingly removed in 2014 when Prishe's trust was added, [per JP wiki](https://wiki.ffo.jp/html/5557.html).

**3. Apocalypse Nigh** - adds a module restoring the JST midnight wait which was removed [per official patch notes in 2021](https://forum.square-enix.com/ffxi/threads/58770). After research on this quest, I also came to the conclusion per captures (and BG and JP wiki) that the wait for the quest triggers upon battlefield completion and not upon speaking to Aldo afterward, as it was previously coded. Accordingly, I made that adjustment to the quest itself.

## Steps to test these changes

Enable the modules and adjust your server settings appropriately. Flag Storms of Fate, run it to completion. See you must wait until JST midnight. Do the same for both Shadows of the Departed and Apocalypse Nigh.

## Captures

KnowOne

Apocalypse Nigh
https://youtu.be/U3kF4oTRw0Q
https://www.dropbox.com/s/t7j4s6ia5cbi9i4/Apocalypse%20Nigh.rar?dl=0

Siknoz

Quest - Jeuno - Apocalypse Nigh - Testing on Multiple Jobs
https://youtu.be/uz10WAsMfVA
https://www.dropbox.com/scl/fi/e82e7d6hbg7cxyn7wdebj/Quest-Jeuno-Apocalypse-Nigh-Testing-on-Multiple-Jobs.zip?rlkey=cf8vts9tdfd3psvs0r7mf35qy&dl=0
