### PR TITLE
[lua] 75 Era Silent Oil / Prism Powder Duration Modules

### DIFF
--- a/modules/era/lua/items/flask_of_deodorizer.lua
+++ b/modules/era/lua/items/flask_of_deodorizer.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Restores the random Deodorize duration (1 minute 30 seconds to 6 minutes).
+-- Changed December 7th, 2010 : https://www.playonline.com/pcd/verup/ff11/detail/6024/detail.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_deodorizer_duration'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.items.flask_of_deodorizer.onItemUse', function(target, user)
+    if not target:hasStatusEffect(xi.effect.DEODORIZE) then
+        target:addStatusEffect(xi.effect.DEODORIZE, { power = 1, duration = math.random(90, 360), origin = user, tick = 10 })
+    else
+        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    end
+end)
+
+return m

--- a/modules/era/lua/items/pinch_of_prism_powder.lua
+++ b/modules/era/lua/items/pinch_of_prism_powder.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Restores the random Invisible duration (1 minute 30 seconds to 6 minutes).
+-- Changed December 7th, 2010 : https://www.playonline.com/pcd/verup/ff11/detail/6024/detail.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_prism_powder_duration'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.items.pinch_of_prism_powder.onItemUse', function(target, user)
+    if target:hasStatusEffect(xi.effect.INVISIBLE) then
+        target:delStatusEffect(xi.effect.INVISIBLE)
+    end
+
+    target:addStatusEffect(xi.effect.INVISIBLE, { power = 1, duration = math.floor(math.random(90, 360) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
+end)
+
+return m

--- a/modules/era/lua/items/pinch_of_rainbow_powder.lua
+++ b/modules/era/lua/items/pinch_of_rainbow_powder.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Restores the fixed 3 minute Invisible duration.
+-- Changed December 7th, 2010 : https://www.playonline.com/pcd/verup/ff11/detail/6024/detail.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_rainbow_powder_duration'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.items.pinch_of_rainbow_powder.onItemUse', function(target, user)
+    if target:hasStatusEffect(xi.effect.INVISIBLE) then
+        target:delStatusEffect(xi.effect.INVISIBLE)
+    end
+
+    target:addStatusEffect(xi.effect.INVISIBLE, { power = 1, duration = math.floor(180 * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
+end)
+
+return m

--- a/modules/era/lua/items/pot_of_silent_oil.lua
+++ b/modules/era/lua/items/pot_of_silent_oil.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Restores the random Sneak duration (1 minute 30 seconds to 6 minutes).
+-- Changed December 7th, 2010 : https://www.playonline.com/pcd/verup/ff11/detail/6024/detail.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_silent_oil_duration'
+
+if xi.module.isContentEnabled('ABYSSEA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.items.pot_of_silent_oil.onItemUse', function(target, user)
+    if not target:hasStatusEffect(xi.effect.SNEAK) then
+        target:addStatusEffect(xi.effect.SNEAK, { power = 1, duration = math.floor(math.random(90, 360) * xi.settings.main.SNEAK_INVIS_DURATION_MULTIPLIER), origin = user, tick = 10 })
+    end
+end)
+
+return m


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds modules for the old randomized durations on Silent/Invis/Deodorize items. 

## Steps to test these changes

Enable the modules, use them. 