### PR TITLE
[lua] [sql] Sickle Slash crit fix and Ghrah adjustment

### DIFF
--- a/scripts/actions/mobskills/big_scissors.lua
+++ b/scripts/actions/mobskills/big_scissors.lua
@@ -20,8 +20,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
-    params.canCrit          = true
-    params.criticalChance   = { 1.00, 1.00, 1.00 }
+    params.canCrit        = true
+    params.criticalChance = { 1.00, 1.00, 1.00 }
 
     -- TODO: Nightmare Crab - Ignores shadows
 

--- a/scripts/actions/mobskills/core_meltdown.lua
+++ b/scripts/actions/mobskills/core_meltdown.lua
@@ -9,8 +9,6 @@ local mobskillObject = {}
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
     if mob:isMobType(xi.mobType.NOTORIOUS) then
         return 1
-    elseif mob:getAnimationSub() ~= 0 then -- Form check (Must be ball form)
-        return 1
     elseif mob:getHPP() > 30 then -- Can only be used under 30% HP
         return 1
     elseif math.randomInt(1, 100) >= 34 then -- Less of a chance to happen than other skills.

--- a/scripts/actions/mobskills/sickle_slash_ghrah.lua
+++ b/scripts/actions/mobskills/sickle_slash_ghrah.lua
@@ -1,13 +1,20 @@
 -----------------------------------
 -- Sickle Slash
--- Family: Spider
--- Description: Deals critical damage. Attack multiplier varies with TP.
+-- Family: Ghrah
+-- Description: Deals heavy damage.  Attack multiplier varies with TP.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    return 0
+    if
+        mob:getFamily() == xi.mobFamily.GHRAH and -- TODO: Set proper skill lists for Ghrah.
+        mob:getAnimationSub() ~= 2
+    then
+        return 1
+    else
+        return 0
+    end
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
@@ -19,9 +26,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.attackType       = xi.attackType.PHYSICAL
     params.damageType       = xi.damageType.BLUNT
     params.shadowBehavior   = xi.mobskills.shadowBehavior.NUMSHADOWS_1
-    params.attackMultiplier = { 0.5, 1.5, 2.5 }
-    params.canCrit          = true
-    params.criticalChance   = { 1.0, 1.0, 1.0 }
+    params.attackMultiplier = { 1.5, 2.0, 2.5 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/mixins/families/ghrah.lua
+++ b/scripts/mixins/families/ghrah.lua
@@ -216,6 +216,7 @@ g_mixins.families.ghrah = function(ghrahMob)
         local skin = math.randomInt(1161, 1168)
         mob:setModelId(skin)
         mob:setAnimationSub(0)
+        mob:setMagicCastingEnabled(false)
         mob:setAggressive(false)
         mob:setLocalVar('changeTime', GetSystemTime() + math.randomInt(40, 60)) -- Stagger first change
         mob:setLocalVar('targetForm', getTargetForm(mob))
@@ -237,10 +238,18 @@ g_mixins.families.ghrah = function(ghrahMob)
         handleFormChange(mob)
     end)
 
+    ghrahMob:addListener('ENGAGE', 'GHRAH_ENGAGE', function(mob)
+        mob:setMagicCastingEnabled(true) -- Enable casting when engaging
+    end)
+
     ghrahMob:addListener('COMBAT_TICK', 'GHRAH_COMBAT', function(mob)
         if not xi.combat.behavior.isEntityBusy(mob) then
             handleFormChange(mob)
         end
+    end)
+
+    ghrahMob:addListener('DISENGAGE', 'GHRAH_DISENGAGE', function(mob)
+        mob:setMagicCastingEnabled(false) -- Disable casting when idle
     end)
 end
 

--- a/scripts/zones/Kuftal_Tunnel/mobs/Arachne.lua
+++ b/scripts/zones/Kuftal_Tunnel/mobs/Arachne.lua
@@ -76,6 +76,7 @@ end
 
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+    mob:setMod(xi.mod.STORETP, 125)
 end
 
 entity.onMobDeath = function(mob, player, optParams)

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1472,9 +1472,9 @@ INSERT INTO `mob_skills` VALUES (1438,94,'blood_pact',0,0.0,7.0,2000,0,1,0,0,0,0
 INSERT INTO `mob_skills` VALUES (1441,1065,'actinic_burst',1,0.0,10.0,2300,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1442,1066,'core_meltdown',1,0.0,15.0,4233,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1443,1061,'hexidiscs',4,0.0,7.0,3750,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1444,1062,'vorpal_blade',0,0.0,7.0,2000,3333,4,0,0,0,0,0,0); -- Only used in human form
+INSERT INTO `mob_skills` VALUES (1444,1062,'vorpal_blade',0,0.0,7.0,3333,1000,4,0,0,0,0,0,0); -- Only used in human form
 INSERT INTO `mob_skills` VALUES (1445,1063,'damnation_dive',4,0.0,10.0,3166,2000,4,0,0,0,0,0,0); -- Only used in bird form.
-INSERT INTO `mob_skills` VALUES (1446,1064,'sickle_slash',0,0.0,7.0,1800,1000,4,0,0,0,0,0,0); -- Only used in spider form.
+INSERT INTO `mob_skills` VALUES (1446,1064,'sickle_slash_ghrah',0,0.0,7.0,1800,1000,4,0,0,0,0,0,0); -- Only used in spider form.
 INSERT INTO `mob_skills` VALUES (1447,1070,'vertical_cleave',0,0.0,7.0,2866,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1448,1071,'efflorescent_foetor',4,0.0,10.0,2866,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1449,1072,'stupor_spores',1,0.0,10.0,2400,1000,4,0,0,0,0,0,0);
@@ -1492,7 +1492,7 @@ INSERT INTO `mob_skills` VALUES (1460,847,'auto_attack_geush',0,0.0,7.0,2000,0,4
 -- INSERT INTO `mob_skills` VALUES (1461,1059,'shield_bash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1462,1060,'shield_bash',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1463,1074,'reactor_cool',0,0.0,7.0,3666,1000,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1464,1075,'optic_induration_charge',0,0.0,7.0,3266,0,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1464,1075,'optic_induration_charge',0,0.0,7.0,5000,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1465,1076,'optic_induration',4,0.0,15.0,1500,800,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1466,1077,'static_filament',4,0.0,10.0,4616,2000,4,0,0,0,0,0,0); -- bar form only
 INSERT INTO `mob_skills` VALUES (1467,1078,'decayed_filament',1,0.0,8.0,5333,2000,4,0,0,0,0,0,0); -- bar form only


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts sickle slash to always crit.  In testing, Ghrah sickle slash never crits, so the ability is fundamentally different.
The damage variability of Sickle Slash comes from the attack modifier it seems, as it always crits.

<img width="507" height="63" alt="image" src="https://github.com/user-attachments/assets/84133bfb-e7ce-4859-a1df-0131fc6c3872" />
<img width="483" height="81" alt="image" src="https://github.com/user-attachments/assets/dfe4cf77-1a1e-4f19-92af-150d1ec2c6c3" />
<img width="486" height="68" alt="image" src="https://github.com/user-attachments/assets/3b9fa6c1-dc66-410a-92d4-6a7d082b0200" />

The scaling that I've added seems to match as far as I can tell.

https://www.dropbox.com/scl/fo/ptt6gorcjukqhcji4w5hy/ANX1AGTdi7YFsXYcL0WrCKs?rlkey=04sbwng2ntl8ef2b5e36ge3bk&st=cjlvv3pv&dl=0

When using Arachne to test, I realized I forgot to add the 125 STP from my original cap.  Oops.

https://youtu.be/Da4KlkqJy5M

This PR also prevents ghrahs from casting out of combat, because they don't.
This also removes the animation sub restriction from core meltdown, as I have confirmed ghrahs can use it in any form; Human, Spider or Bird, and it didn't even take me that long to confirm because they use the ability often enough.

This also adjusts the optic induration charge time lockout to match that of retail.

(Also fixes the indenting on Big Scissors, don't kill me)

## Steps to test these changes

Watch some ghrahs, !tp 3000 some stuff 
