### PR TITLE
[lua][cpp] Disallow respawns for spawn slots mobs when a PH dies and the NM is picked to spawn

### DIFF
--- a/scripts/globals/mobs.lua
+++ b/scripts/globals/mobs.lua
@@ -211,9 +211,17 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
         return false
     end
 
-    -- on PH death, replace PH repop with NM repop
-    -- TODO, fetch phId's spawn slot and disable respawn for all mobs in that spawn slot
-    DisallowRespawn(phId, true)
+    -- On an NMs PH death we need to disable every mob that is inside the slot so it doesnt re-roll and pop the other mob in the slot
+    local phSlotMobs = ph:getSpawnSlotMobs()
+    if #phSlotMobs == 0 then
+        phSlotMobs = { phId } -- Set the ph to the only mob in the list if it is just a single slotted mob (aka no slot)
+    end
+
+    -- Disallow the entire slot to spawn
+    for _, slotMemberId in ipairs(phSlotMobs) do
+        DisallowRespawn(slotMemberId, true)
+    end
+
     DisallowRespawn(nmId, false)
 
     -- Update mob's spawn position, if available
@@ -228,7 +236,12 @@ xi.mob.phOnDespawn = function(ph, phNmId, chance, cooldown, params)
         -- on NM death, replace NM repop with PH repop
         DisallowRespawn(nmId, true)
         if not params.doNotEnablePhSpawn then
-            DisallowRespawn(phId, false)
+            for _, slotMemberId in ipairs(phSlotMobs) do
+                if slotMemberId ~= nmId then
+                    DisallowRespawn(slotMemberId, false)
+                end
+            end
+
             local phMob = GetMobByID(phId)
             if phMob then
                 phMob:setRespawnTime(GetMobRespawnTime(phId))

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3832,6 +3832,11 @@ end
 function CBaseEntity:setRespawnTime(seconds)
 end
 
+---@nodiscard
+---@return table
+function CBaseEntity:getSpawnSlotMobs()
+end
+
 ---@param groupID integer
 ---@return nil
 function CBaseEntity:instantiateMob(groupID)

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -55,6 +55,7 @@
 #include "recast_container.h"
 #include "roe.h"
 #include "spawn_handler.h"
+#include "spawn_slot.h"
 #include "spell.h"
 #include "status_effect.h"
 #include "status_effect_container.h"
@@ -18053,6 +18054,37 @@ void CLuaBaseEntity::setRespawnTime(const uint32 seconds) const
 }
 
 /************************************************************************
+ *  Function: getSpawnSlotMobs()
+ *  Purpose : Returns a table of all the mobs that share a slot. Used for NM lottery mobs
+ *  Example : mob:getSpawnSlotMobs()
+ *  Notes   : Returns an empty table if the mob is not in a spawn slot
+ ************************************************************************/
+
+auto CLuaBaseEntity::getSpawnSlotMobs() -> sol::table
+{
+    sol::table table = lua.create_table();
+
+    if (m_PBaseEntity->objtype != TYPE_MOB)
+    {
+        ShowWarning("Attempting to get spawn slot members for invalid entity type (%s).", m_PBaseEntity->getName());
+        return table;
+    }
+
+    if (SpawnSlot* slot = static_cast<CMobEntity*>(m_PBaseEntity)->GetSpawnSlot())
+    {
+        for (const auto& entry : slot->GetEntries())
+        {
+            if (entry.mob)
+            {
+                table.add(entry.mob->id);
+            }
+        }
+    }
+
+    return table;
+}
+
+/************************************************************************
  *  Function: instantiateMob()
  *  Purpose : Used for spawning a new mob - is this for Monstrosity prep?
  *  Example : None available
@@ -21081,6 +21113,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("setSpawn", CLuaBaseEntity::setSpawn);
     SOL_REGISTER("getRespawnTime", CLuaBaseEntity::getRespawnTime);
     SOL_REGISTER("setRespawnTime", CLuaBaseEntity::setRespawnTime);
+    SOL_REGISTER("getSpawnSlotMobs", CLuaBaseEntity::getSpawnSlotMobs);
 
     SOL_REGISTER("instantiateMob", CLuaBaseEntity::instantiateMob);
 

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -875,6 +875,7 @@ public:
     void setSpawn(float x, float y, float z, const sol::object& rot);
     auto getRespawnTime() const -> uint32;
     void setRespawnTime(uint32 seconds) const;
+    auto getSpawnSlotMobs() -> sol::table;
 
     void instantiateMob(uint32 groupID);
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Finishes implementing the TODO inside phOnDespawn for spawn slots

> -- TODO, fetch phId's spawn slot and disable respawn for all mobs in that spawn slot

This was causing an issue where the spawn slotted mobs, assuming it picked a different mob in the slot, would spawn along with the NM the PH had popped.

To replicate this before the change:
Kill any mob with more than one PH that is in a slot (99% of NMs). I used Charybdis for this since it has two.
Inside the Devil_Manta lua I would set the spawn rate to 100% with a cooldown of 1 so its easier to test.
Kill the PH over and over again until it respawns with the NM when it picks the other slotted mob to spawn
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Confirm `!exec print(target:getSpawnSlotMobs())` returns the table value of the slot
<img width="853" height="1166" alt="image" src="https://github.com/user-attachments/assets/5f86b68d-66a0-4bbe-96d9-64f01da9d0cf" />

Same explanation as above: Kind of a pain in the ass to test
Kill any mob with more than one PH that is in a slot (99% of NMs). I used Charybdis for this since it has two.
Inside the Devil_Manta lua I would set the spawn rate to 100% with a cooldown of 1 so its easier to test.
Kill the PH over and over again and never see any of the slotted mobs respawn.

<!-- Clear and detailed steps to test your changes here -->
