### PR TITLE
[lua] Implement Alzadaal Entry with Remnants Permits

### DIFF
--- a/scripts/zones/Bhaflau_Thickets/npcs/Hamta-Iramta.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/Hamta-Iramta.lua
@@ -33,6 +33,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(135)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(135)
         else
             player:startEvent(134)
         end

--- a/scripts/zones/Bhaflau_Thickets/npcs/Kamih_Mapokhalam.lua
+++ b/scripts/zones/Bhaflau_Thickets/npcs/Kamih_Mapokhalam.lua
@@ -34,6 +34,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(121)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(121)
         else
             player:startEvent(120)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/Kwadaaf.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Kwadaaf.lua
@@ -24,6 +24,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(223)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(223)
         else
             player:startEvent(222)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/Nasheefa.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Nasheefa.lua
@@ -26,6 +26,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(183)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(183)
         else
             player:startEvent(182)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/Nuimahn.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Nuimahn.lua
@@ -26,6 +26,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then -- entering
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(203)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(203)
         else
             player:startEvent(202)
         end

--- a/scripts/zones/Caedarva_Mire/npcs/Tyamah.lua
+++ b/scripts/zones/Caedarva_Mire/npcs/Tyamah.lua
@@ -26,6 +26,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(163)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(163)
         else
             player:startEvent(162)
         end

--- a/scripts/zones/Mount_Zhayolm/npcs/Bapokk.lua
+++ b/scripts/zones/Mount_Zhayolm/npcs/Bapokk.lua
@@ -26,6 +26,9 @@ entity.onTrigger = function(player, npc)
         if player:hasKeyItem(xi.ki.CAPTAIN_WILDCAT_BADGE) then -- Zhayolm -> Ruins
             player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.CAPTAIN_WILDCAT_BADGE)
             player:startEvent(163)
+        elseif player:hasKeyItem(xi.ki.REMNANTS_PERMIT) then
+            player:messageSpecial(ID.text.YOU_HAVE_A_BADGE, xi.ki.REMNANTS_PERMIT)
+            player:startEvent(163)
         else
             player:startEvent(162)
         end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds free access to Alzadaal when in possession of a Remnants Permit.

## Capture
Captain event takes priority as shown by @ThrisStraizo capture.
<img width="1082" height="430" alt="image" src="https://github.com/user-attachments/assets/7c442adb-4fb7-46cd-982f-d17d0c6571cb" />

Entry with the Remnants Permit
<img width="1479" height="220" alt="image" src="https://github.com/user-attachments/assets/971c939f-5681-4f3d-8887-06fb87b54621" />

## Steps to test these changes

!pos -459.942 -20.048 -4.999 52
!addkeyitem Remnants_Permit
Talk to Hamta
<img width="424" height="153" alt="image" src="https://github.com/user-attachments/assets/7a5386eb-41e7-4611-a15a-83b409532d89" />

