### PR TITLE
[lua] [sql] Test your Mite Improvements

### DIFF
--- a/scripts/actions/mobskills/viscid_secretion.lua
+++ b/scripts/actions/mobskills/viscid_secretion.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Viscid Secretion
+-- Reduces the attack speed and movement speed of enemies within a fan-shaped area originating from the caster.
+-- Applies a 25% haste effect to the caster.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    if not mob:hasStatusEffect(xi.effect.HASTE) then
+        mob:addStatusEffect(xi.effect.HASTE, { power = 2500, duration = 90, origin = mob })
+    end
+
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW,   power = 5000, duration = 120, tier = 8 },
+        [2] = { effectId = xi.effect.WEIGHT, power =   50, duration = 120           },
+    }
+
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
+end
+
+return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -215,7 +215,9 @@ xi.mobSkill =
     BIONIC_BOOST                  =  359,
     FLYING_HIP_PRESS              =  360,
     EARTH_SHOCK                   =  361,
+    DOUBLE_CLAW_1                 =  362,
 
+    SPINNING_TOP_1                =  365,
     TAIL_BLOW_1                   =  366,
     FIREBALL_1                    =  367,
     BLOCKHEAD_1                   =  368,
@@ -858,7 +860,7 @@ xi.mobSkill =
     PLASMA_CHARGE                 = 1358,
     CHTHONIAN_RAY                 = 1359,
     APOCALYPTIC_RAY               = 1360,
-
+    VISCID_SECRETION              = 1361,
     WILD_GINSENG                  = 1362,
     HUNGRY_CRUNCH                 = 1363,
 

--- a/scripts/zones/The_Shrouded_Maw/mobs/Pasuk.lua
+++ b/scripts/zones/The_Shrouded_Maw/mobs/Pasuk.lua
@@ -1,11 +1,35 @@
 -----------------------------------
 -- Area: The Shrouded Maw
 -- ENM Test Your Mite
---  Mob: Pasuk
+-- Mob: Pasuk
 -----------------------------------
 
 ---@type TMobEntity
 local entity = {}
+
+local function vanish(mob, target)
+    mob:setLocalVar('warping', 1)
+    mob:setAutoAttackEnabled(false)
+    mob:setMagicCastingEnabled(false)
+    mob:setMobAbilityEnabled(false)
+    mob:entityAnimationPacket(xi.animationString.STATUS_DISAPPEAR)
+    mob:setBaseSpeed(0)
+    mob:timer(1000, function(mobArg)
+        local warpPosition = utils.getNearPosition(target:getPos(), math.randomInt(2, 4), math.randomFloat(0, 2 * math.pi))
+        mobArg:setPos(warpPosition.x, warpPosition.y, warpPosition.z)
+        mobArg:lookAt(target:getPos())
+    end)
+end
+
+local function appear(mob)
+    mob:setLocalVar('warping', 0)
+    mob:entityAnimationPacket(xi.animationString.STATUS_VISIBLE)
+    mob:setStatus(xi.status.UPDATE)
+    mob:setAutoAttackEnabled(true)
+    mob:setMagicCastingEnabled(true)
+    mob:setMobAbilityEnabled(true)
+    mob:setBaseSpeed(45)
+end
 
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.BIND)
@@ -14,8 +38,42 @@ entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
 end
 
+entity.onMobSpawn = function(mob)
+    mob:setBaseSpeed(45)
+    mob:setLocalVar('warping', 0)
+end
+
+entity.onMobFight = function(mob, target)
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
+    if mob:getLocalVar('warping') == 1 then
+        return
+    end
+
+    -- If Pasuk loses LoS of the target, they will vanish and warp to their targets position.
+    if not mob:canSee(target) then
+        vanish(mob, target)
+        mob:timer(1500, function(mobArg)
+            appear(mobArg)
+        end)
+    end
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skills =
+    {
+        xi.mobSkill.SPINNING_TOP_1,
+        xi.mobSkill.DOUBLE_CLAW_1,
+        xi.mobSkill.VISCID_SECRETION
+    }
+
+    return skills[math.randomInt(1, #skills)]
+end
+
 entity.onAdditionalEffect = function(mob, target, damage)
-    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TP_DRAIN, { chance = 25, power = math.randomInt(200, 250) })
+    return xi.mob.onAddEffect(mob, target, damage, xi.mob.ae.TP_DRAIN, { chance = 100, power = math.randomInt(70, 250) }) -- TODO: Might be based off of dINT, needs more captures.
 end
 
 return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -390,10 +390,10 @@ INSERT INTO `mob_skills` VALUES (358,826,'heavy_whisk',4,0.0,7.0,2000,1500,4,0,0
 INSERT INTO `mob_skills` VALUES (359,827,'bionic_boost',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (360,828,'flying_hip_press',1,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (361,829,'earth_shock',1,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (362,830,'double_claw',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (362,830,'double_claw',0,0.0,7.0,2000,800,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (363,831,'grapple',4,0.0,12.5,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (364,832,'filamented_hold',4,0.0,12.5,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (365,833,'spinning_top',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (365,833,'spinning_top',1,0.0,15.0,2000,800,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (366,110,'tail_blow',0,0.0,7.0,2183,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (367,111,'fireball',2,0.0,11.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (368,112,'blockhead',0,0.0,7.0,1633,1000,4,0,0,1,0,0,0);
@@ -1389,7 +1389,7 @@ INSERT INTO `mob_skills` VALUES (1357,1008,'tidal_dive',1,0.0,15.0,5500,1000,4,0
 INSERT INTO `mob_skills` VALUES (1358,1009,'plasma_charge',0,0.0,7.0,2833,1000,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1359,855,'chthonian_ray',4,0.0,25.0,2000,2800,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1360,855,'apocalyptic_ray',4,0.0,10.0,2000,2800,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1361,1105,'viscid_secretion',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1361,832,'viscid_secretion',4,0.0,12.5,2000,1300,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1362,37,'wild_ginseng',0,0.0,7.0,2000,2600,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1363,822,'hungry_crunch',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1364,848,'mighty_snort',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds teleporting mechanic to Pasuk which is triggered when they lose LoS of their target - they briefly fade away before reappearing next to the their target.

* Adds Viscid Secretion, a TP move specific to Pasuk that applies a powerful 50% Slow & 50% Gravity on top of providing a 25% Haste buff to the user.

* Adjusts the frequency of their TP Drain to 100%, based on new captures. 

## Capture
https://youtu.be/C4CLGAE8ud8 (Teleport mechanic on display in this capture)
[Test_your_Mite_2026-8-8_11_59.zip](https://github.com/user-attachments/files/30861565/Test_your_Mite_2026-8-8_11_59.zip)

## Steps to test these changes

Run Test your Mite in the Shrouded Maw. 
