### PR TITLE
[module] [lua] Eco-Warrior Era Modules

### DIFF
--- a/modules/era/lua/quests/bastok/eco_warrior.lua
+++ b/modules/era/lua/quests/bastok/eco_warrior.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Eco-Warrior (Bastok)
+-- Restores the level 20 restriction on the ointment.
+-- The June 25, 2015 version update raised the level cap from 20 to 25.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/47481
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_eco_warrior_bastok', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/Eco_Warrior', function(quest)
+        local gusgenMines = quest.sections[2][xi.zone.GUSGEN_MINES]
+
+        -- Copy of the base handler with the level restriction lowered to 20.
+        gusgenMines.onEventFinish[13] = function(player, csid, option, npc)
+            if option == 1 then
+                player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+                    power    = 20, -- Module change: the level restriction is 20.
+                    subPower = 1,  -- exp uses actual level and not the restricted level.
+                    origin   = player,
+                    flag     = xi.effectFlag.ON_ZONE
+                })
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/sandoria/eco_warrior.lua
+++ b/modules/era/lua/quests/sandoria/eco_warrior.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Eco-Warrior (San d'Oria)
+-- Restores the level 20 restriction on the ointment.
+-- The June 25, 2015 version update raised the level cap from 20 to 25.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/47481
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_eco_warrior_sandoria', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/sandoria/Eco_Warrior', function(quest)
+        local ordellesCaves = quest.sections[2][xi.zone.ORDELLES_CAVES]
+
+        -- Copy of the base handler with the level restriction lowered to 20.
+        ordellesCaves.onEventFinish[51] = function(player, csid, option, npc)
+            if option == 1 then
+                player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+                    power    = 20, -- Module change: the level restriction is 20.
+                    subPower = 1,  -- exp uses actual level and not the restricted level.
+                    origin   = player,
+                    flag     = xi.effectFlag.ON_ZONE
+                })
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/windurst/eco_warrior.lua
+++ b/modules/era/lua/quests/windurst/eco_warrior.lua
@@ -1,0 +1,30 @@
+-----------------------------------
+-- Eco-Warrior (Windurst)
+-- Restores the level 20 restriction on the ointment.
+-- The June 25, 2015 version update raised the level cap from 20 to 25.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/47481
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_eco_warrior_windurst', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/Eco_Warrior', function(quest)
+        local mazeOfShakhrami = quest.sections[2][xi.zone.MAZE_OF_SHAKHRAMI]
+
+        -- Copy of the base handler with the level restriction lowered to 20.
+        mazeOfShakhrami.onEventFinish[62] = function(player, csid, option, npc)
+            if option == 1 then
+                player:addStatusEffect(xi.effect.LEVEL_RESTRICTION, {
+                    power    = 20, -- Module change: the level restriction is 20.
+                    subPower = 1,  -- exp uses actual level and not the restricted level.
+                    origin   = player,
+                    flag     = xi.effectFlag.ON_ZONE
+                })
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds era modules for the eco-warrior quests to set their level cap to 20. It was raised to level 25 in the J[un 25, 2015 Version Update](https://forum.square-enix.com/ffxi/threads/47481).

## Steps to test these changes

Load the modules. Change server settings as appropriate. Do the quests. See you get synced to 20 instead of 25.