### PR TITLE
Fix Moonlit Path turn-in consuming Whisper of the Moon on full inventory

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Leepe-Hoppe.lua
@@ -186,8 +186,13 @@ entity.onEventFinish = function(player, csid, option, npc)
             -- Pact as Mount
         end
 
-        -- TODO: Reward is never nil since it is initialized; however, we should't run this block
-        -- if the player chooses an item, and they don't have space in their inventory.
+        -- Item rewards fail when the player has no inventory space.  Hand the item over
+        -- first and bail out if it could not be given, so the key item is not consumed and
+        -- the turn-in can be retried.  Options 6 to 8 need no inventory space.
+        if reward ~= xi.item.NONE and not npcUtil.giveItem(player, reward) then
+            return
+        end
+
         player:addTitle(xi.title.HEIR_OF_THE_NEW_MOON)
         player:delKeyItem(xi.ki.WHISPER_OF_THE_MOON)
         player:setCharVar('MoonlitPath_date', JstMidnight())
@@ -195,10 +200,6 @@ entity.onEventFinish = function(player, csid, option, npc)
 
         if player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.THE_MOONLIT_PATH) == xi.questStatus.QUEST_ACCEPTED then
             player:completeQuest(xi.questLog.WINDURST, xi.quest.id.windurst.THE_MOONLIT_PATH)
-        end
-
-        if reward ~= 0 then
-            npcUtil.giveItem(player, reward)
         end
 
         if


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [X] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [X] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [X] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Leepe-Hoppe's turn-in ran the quest completion block unconditionally and only attempted the item reward afterwards, discarding the return value. A player with no free inventory space who chose an item reward lost the Whisper of the Moon key item and had the quest marked complete, without receiving anything.

Give the item first and return early if npcUtil.giveItem fails, so the key item is kept and the turn-in can be retried. Options 6 to 8 (gil, pact, mount whistle) need no inventory space and are unaffected.

This resolves the existing TODO and matches the already-migrated Trial_by_Fire quest, which gates completion on whether the reward was actually granted.

## Steps to test these changes
!addquest WINDURST THE_MOONLIT_PATH
!addkeyitem WHISPER_OF_THE_MOON
!additem 16448 30          -- fill inventory to zero free slots (30 being default on fresh character)
!pos 13 -9 -197 238        -- Leepe-Hoppe, Windurst Waters
Accept The Moonlit Path and obtain Whisper of the Moon. Fill inventory to zero free slots, turn in to Leepe-Hoppe, select an item reward (options 1-5).
 Before: Whisper of the Moon consumed, quest marked complete, no item received.
 After: item grant fails cleanly with the standard inventory message, key item retained, turn-in repeatable. Verified both halves on a local server — blocked with a full bag, completes normally after freeing a slot.

Verified both paths on a local server.
