### PR TITLE
[C++] [sql] Fix Busted Dancers / Evokers Roll - Migrate some Latent effects to REGEN_DOWN & REFRESH_DOWN

### DIFF
--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -50,7 +50,7 @@ INSERT INTO `item_latents` VALUES (10737,63,10,13,64);   -- +2: Enhances "Last R
 
 -- Lunette Ring
 INSERT INTO `item_latents` VALUES (10766,29,7,56,0);   -- WEAPON_DRAWN_MP_OVER: 0 - MDEF: 7
-INSERT INTO `item_latents` VALUES (10766,369,-2,56,0); -- WEAPON_DRAWN_MP_OVER: 0 - REFRESH: -2
+INSERT INTO `item_latents` VALUES (10766,405,2,56,0); -- -2 MP/tick (while weapon is drawn)
 
 -- Mandraguard
 INSERT INTO `item_latents` VALUES (10807,370,1,26,0);    -- Regen 1/tick during Daytime
@@ -329,7 +329,7 @@ INSERT INTO `item_latents` VALUES (12717,71,5,13,6);
 -- Rune Bangles
 INSERT INTO `item_latents` VALUES (12742,1,32,56,0);     -- Rune Bangles +32 Def.
 INSERT INTO `item_latents` VALUES (12742,68,5,56,0);     -- Rune Bangles +5 Eva.
-INSERT INTO `item_latents` VALUES (12742,369,-4,56,0);   -- Rune Bangles -4MP/tic
+INSERT INTO `item_latents` VALUES (12742,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Scorpion Gauntlets
 INSERT INTO `item_latents` VALUES (12751,71,4,13,6);
@@ -1566,8 +1566,8 @@ INSERT INTO `item_latents` VALUES (15519,370,1,58,0);    -- Regen +1
 INSERT INTO `item_latents` VALUES (15520,68,7,58,0);     -- Evasion +7
 
 -- Sacrifice Torque (pet latent via item lua)
-INSERT INTO `item_latents` VALUES (15528,369,-3,21,21); -- AVATAR_IN_PARTY: 21 - REFRESH: -3
-INSERT INTO `item_latents` VALUES (15528,370,-8,21,21); -- AVATAR_IN_PARTY: 21 - REGEN:   -8
+INSERT INTO `item_latents` VALUES (15528,405,3,21,21); -- -3 MP/tick (while avatar is in party)
+INSERT INTO `item_latents` VALUES (15528,404,8,21,21); -- -8 HP/tick (while avatar is in party)
 
 -- Ace's Locket
 INSERT INTO `item_latents` VALUES (15529,291,5,0,25); -- HP_UNDER_PERCENT: 25 - COUNTER: 5
@@ -1577,7 +1577,7 @@ INSERT INTO `item_latents` VALUES (15530,368,10,10,0);   -- HP-50/Tick of TP whi
 INSERT INTO `item_latents` VALUES (15530,404,50,10,0);
 
 -- Shark Necklace
-INSERT INTO `item_latents` VALUES (15532,369,-3,56,2);   -- Has a hidden effect of draining 3 MP/tick while weapon is drawn.
+INSERT INTO `item_latents` VALUES (15532,405,3,56,2);   -- -3 MP/tick (while weapon is drawn)
 INSERT INTO `item_latents` VALUES (15532,370,1,56,2);    -- Latent Effect is triggered when the player's weapon is drawn and has more than 2 MP.
 
 -- Rajas Ring
@@ -1960,7 +1960,7 @@ INSERT INTO `item_latents` VALUES (16378,27,-1,0,75);    -- Enmity-1 when HP <75
 -- Rune Baghnakhs
 INSERT INTO `item_latents` VALUES (16408,8,7,56,0);      -- +7 STR
 INSERT INTO `item_latents` VALUES (16408,291,1,56,0);    -- +1 Counter
-INSERT INTO `item_latents` VALUES (16408,369,-4,56,0);   -- -4MP/tic
+INSERT INTO `item_latents` VALUES (16408,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Avengers
 INSERT INTO `item_latents` VALUES (16426,25,2,0,1);
@@ -1988,7 +1988,7 @@ INSERT INTO `item_latents` VALUES (16427,25,15,37,4);        -- Acc+15 Full Moon
 -- Rune Blade
 INSERT INTO `item_latents` VALUES (16563,9,5,56,0);      -- +5 DEX while drawn and MP > 0
 INSERT INTO `item_latents` VALUES (16563,287,4,56,0);    -- DMG:43 while drawn and MP > 0
-INSERT INTO `item_latents` VALUES (16563,369,-4,56,0);   -- -4MP/tic while drawn and MP > 0
+INSERT INTO `item_latents` VALUES (16563,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Perdu Sword
 INSERT INTO `item_latents` VALUES (16602,23,12,6,1000);  -- Attack+12 while TP <100%
@@ -2026,7 +2026,7 @@ INSERT INTO `item_latents` VALUES (16605,25,8,13,282);
 
 -- Rune Axe
 INSERT INTO `item_latents` VALUES (16647,23,5,56,0);     -- +5 Atk.
-INSERT INTO `item_latents` VALUES (16647,369,-3,56,0);   -- -3MP/tic
+INSERT INTO `item_latents` VALUES (16647,405,3,56,0);   -- -3 MP/tick (while weapon is drawn)
 INSERT INTO `item_latents` VALUES (16647,370,5,56,0);    -- +5HP/tic
 
 -- Arcanabane
@@ -2123,12 +2123,12 @@ INSERT INTO `item_latents` VALUES (17093,12,2,56,0);     -- +2 INT
 INSERT INTO `item_latents` VALUES (17093,13,2,56,0);     -- +2 MND
 INSERT INTO `item_latents` VALUES (17093,14,2,56,0);     -- +2 CHR
 INSERT INTO `item_latents` VALUES (17093,28,1,56,0);     -- +1 MAB
-INSERT INTO `item_latents` VALUES (17093,369,-4,56,0);   -- -4MP/tic
+INSERT INTO `item_latents` VALUES (17093,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Rune Bow
 INSERT INTO `item_latents` VALUES (17158,26,5,56,0);     -- +5 R. Acc.
 INSERT INTO `item_latents` VALUES (17158,27,-2,56,0);    -- -2 Enmity
-INSERT INTO `item_latents` VALUES (17158,369,-4,56,0);   -- -4MP/tic
+INSERT INTO `item_latents` VALUES (17158,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Arco de Velocidad
 INSERT INTO `item_latents` VALUES (17165,370,1,26,0);    -- Daytime: Regen +1HP/tick
@@ -2176,7 +2176,7 @@ INSERT INTO `item_latents` VALUES (17275,287,13,47,0);   -- DMG+13 when broken (
 -- Rune Arrow
 INSERT INTO `item_latents` VALUES (17333,10,1,56,0);     -- +1 VIT
 INSERT INTO `item_latents` VALUES (17333,24,10,56,0);    -- +10 R.Atk.
-INSERT INTO `item_latents` VALUES (17333,369,-1,56,0);   -- -1MP/tic
+INSERT INTO `item_latents` VALUES (17333,405,1,56,0);   -- -1 MP/tick (while weapon is drawn)
 
 -- Frenzy Fife
 INSERT INTO `item_latents` VALUES (17365,8,4,25,0);      -- STR+4 song/roll active
@@ -2205,7 +2205,7 @@ INSERT INTO `item_latents` VALUES (17458,71,7,44,0);  -- Citizens of San d'Oria:
 -- Rune Rod
 INSERT INTO `item_latents` VALUES (17461,23,10,56,0);    -- +10 Atk.
 INSERT INTO `item_latents` VALUES (17461,112,6,56,0);    -- +6 Healing Magic Skill
-INSERT INTO `item_latents` VALUES (17461,369,-4,56,0);   -- -4MP/tic
+INSERT INTO `item_latents` VALUES (17461,405,4,56,0);   -- -4 MP/tick (while weapon is drawn)
 
 -- Mighty Cudgel
 INSERT INTO `item_latents` VALUES (17465,12,9,28,0);     -- INT+9 on Firesday (has 1 base INT to total +9)
@@ -2580,7 +2580,7 @@ INSERT INTO `item_latents` VALUES (18075,8,2,26,2);      -- Dusk - Dawn: STR +2
 -- Rune Halberd
 INSERT INTO `item_latents` VALUES (18084,9,6,56,0);      -- +6 DEX
 INSERT INTO `item_latents` VALUES (18084,288,5,56,0);    -- +5% Dbl.Atk.
-INSERT INTO `item_latents` VALUES (18084,369,-3,56,0);   -- -3MP/tic
+INSERT INTO `item_latents` VALUES (18084,405,3,56,0);   -- -3 MP/tick (while weapon is drawn)
 
 -- Mighty Lance
 INSERT INTO `item_latents` VALUES (18091,15,15,28,0);    -- [Element: Fire]+15 on Firesday
@@ -2641,7 +2641,7 @@ INSERT INTO `item_latents` VALUES (18165,68,10,26,1);    -- Nighttime: Evasion+1
 
 -- Rune Chopper
 INSERT INTO `item_latents` VALUES (18206,25,5,56,0);     -- +5 Acc.
-INSERT INTO `item_latents` VALUES (18206,369,-3,56,0);   -- -3MP/tic
+INSERT INTO `item_latents` VALUES (18206,405,3,56,0);   -- -3 MP/tick (while weapon is drawn)
 INSERT INTO `item_latents` VALUES (18206,384,900,56,0);  -- +9% haste
 
 -- Mighty Axe
@@ -3027,7 +3027,7 @@ INSERT INTO `item_latents` VALUES (18870,287,3,40,0);    -- Dweomer Maul DMG+3 i
 
 -- Hannibal's Sword
 INSERT INTO `item_latents` VALUES (18891,368,10,56,0);       -- Regain +10
-INSERT INTO `item_latents` VALUES (18891,369,-3,56,0);       -- Refresh -3
+INSERT INTO `item_latents` VALUES (18891,405,3,56,0);       -- -3 MP/tick (while weapon is drawn)
 
 -- Chimeric Fleuret
 INSERT INTO `item_latents` VALUES (18895,288,4,13,94);       -- Double attack +4 ENFIRE
@@ -3267,7 +3267,7 @@ INSERT INTO `item_latents` VALUES (20624,287,89,6,1000); -- TP_UNDER: 1000 - DMG
 
 -- Surcoufs Jambiya +1
 INSERT INTO `item_latents` VALUES (20628,287,85,56,0);  -- WEAPON_DRAWN_MP_OVER: 0 - DMG_RATING: 85
-INSERT INTO `item_latents` VALUES (20628,369,-10,56,0); -- WEAPON_DRAWN_MP_OVER: 0 - REFRESH: -10
+INSERT INTO `item_latents` VALUES (20628,405,10,56,0); -- -10 MP/tick (while weapon is drawn)
 
 -- Eminent Scimitar
 INSERT INTO `item_latents` VALUES (20726,23,10,6,1000);      -- Att+10 TP>1000
@@ -3307,7 +3307,7 @@ INSERT INTO `item_latents` VALUES (20838,288,3,13,56);   -- Double Attack +3% if
 -- Rune Kris
 INSERT INTO `item_latents` VALUES (21558,11,5,56,0);         -- Agi+5     MP>0
 INSERT INTO `item_latents` VALUES (21558,73,5,56,0);         -- StoreTP+5 MP>0
-INSERT INTO `item_latents` VALUES (21558,369,-3,56,0);       -- Refresh-3 MP>0
+INSERT INTO `item_latents` VALUES (21558,405,3,56,0);       -- -3 MP/tick (while weapon is drawn)
 
 -- Assassin's Knife
 -- INSERT INTO `item_latents` VALUES (21573,25,10,??,0); -- Dynamis (D): Accuracy+10
@@ -3377,7 +3377,7 @@ INSERT INTO `item_latents` VALUES (21558,369,-3,56,0);       -- Refresh-3 MP>0
 
 -- Rune Algol
 INSERT INTO `item_latents` VALUES (21661,10,5,56,0);     -- Latent effect (MP>0): VIT+5
-INSERT INTO `item_latents` VALUES (21661,369,-3,56,0);   -- Drains 3 MP/tic from player (while weapon is drawn).
+INSERT INTO `item_latents` VALUES (21661,405,3,56,0);   -- -3 MP/tick (while weapon is drawn)
 INSERT INTO `item_latents` VALUES (21661,840,1,56,0);    -- Latent effect (MP>0): Weapon skill damage +1%
 
 -- Futhark Claymore
@@ -3403,7 +3403,7 @@ INSERT INTO `item_latents` VALUES (21757,288,3,13,56);   -- Double Attack +3% if
 -- Rune Scythe
 INSERT INTO `item_latents` VALUES (21817,2,10,56,0);     -- HP+10
 INSERT INTO `item_latents` VALUES (21817,165,5,56,0);    -- Critical hit rate +5
-INSERT INTO `item_latents` VALUES (21817,369,-3,56,0);   -- Drains 3 MP/tic from player
+INSERT INTO `item_latents` VALUES (21817,405,3,56,0);   -- -3 MP/tick (while weapon is drawn)
 
 -- Abyss Scythe
 -- INSERT INTO `item_latents` VALUES (21823,25,10,??,0); -- Dynamis (D): Accuracy+10

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -37,6 +37,7 @@ When a status effect is gained twice on a player. It can do one or more of the f
 #include <common/database.h>
 #include <common/types/hash_map.h>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 
@@ -2055,9 +2056,13 @@ void CStatusEffectContainer::TickRegen(timer::time_point tick)
             PChar = (CCharEntity*)m_POwner;
         }
 
-        int16 regen   = m_POwner->getMod(xi::Mod::REGEN);
+        // Regen / Refresh are clamped to 0 so that negative values don't drain HP/MP from the player.
+        // A busted Dancer(Regen) or Evoker(Refresh) carry negative values but do not cause the player to lose HP/MP.
+        // Negative values will only counteract a positive regen or refresh value.
+        // This is an abnormal way of handling this, for intentional degens, use REGEN_DOWN or REFRESH_DOWN instead.
+        int16 regen   = std::max<int16>(m_POwner->getMod(xi::Mod::REGEN), 0);
         int16 poison  = m_POwner->getMod(xi::Mod::REGEN_DOWN);
-        int16 refresh = m_POwner->getMod(xi::Mod::REFRESH) - m_POwner->getMod(xi::Mod::REFRESH_DOWN);
+        int16 refresh = std::max<int16>(m_POwner->getMod(xi::Mod::REFRESH), 0) - m_POwner->getMod(xi::Mod::REFRESH_DOWN);
         int16 regain  = m_POwner->getMod(xi::Mod::REGAIN) - m_POwner->getMod(xi::Mod::REGAIN_DOWN);
         m_POwner->addHP(regen);
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clamps Mod Regen & Mod Refresh to 0 so that Busted Dancers Roll & Evokers Roll do not incorrectly drain HP/MP from the player. A busted Dancers/Evokers roll will only counter-act a positive mod. 
Also migrated some latent effects that would be impacted by this change over to the correct REGEN_DOWN & REFRESH_DOWN mods.

@sruon Verified for me that Tacticians Roll *does* drain TP, so it already works correctly and does not share this issue. 

## Capture
https://youtu.be/11fL3OOmxYk - Busted Evoker Roll
https://youtu.be/wsB7Q7hNZbs - Busted Dancer Roll

## Steps to test these changes

!changejob COR 99
!changesjob WHM 49
Bust Dancers Roll (-3 Regen)
Observe no HP lost / tick
Cast Regen II on yourself, observe +9 HP/tick (+12 - 3)

!changesjob RDM 49
Bust Evokers Roll (-1 Refresh)
Observe no MP lost / tick
Cast Refresh on yourself, observe +2 MP/tick (+3 -1)

Try out Rune Weapons, see they still work the same 
