### PR TITLE
[lua] Fix New Character CS camera and when homepoint is set

### DIFF
--- a/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
+++ b/scripts/quests/hiddenQuests/New_Character_Cutscenes.lua
@@ -20,6 +20,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(-280, -12, -90, 0)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -35,7 +40,7 @@ quest.sections =
                 [0] = function(player, csid, option, npc)
                     -- Retail normally zones you for this -- but testing proved there was no difference other than NOT zoning by just calling the next event.
                     -- event 0x00 fades your screen to black and seems to wait for another event, otherwise it will never fade back in.
-                    -- TODO: research if there was some purpose to the zoning.
+                    -- I think retail uses zoning to set the "isHidden" state we use for events.
 
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
@@ -43,7 +48,7 @@ quest.sections =
                         xi.cutsceneFlag.UNKNOWN_2
                     )
 
-                    player:startEvent(7, { flags = cutsceneFlags })
+                    player:startEvent(7, { flags = cutsceneFlags, isHidden = true })
                 end,
 
                 [7] = function(player, csid, option, npc)
@@ -51,9 +56,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
                     player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
-
-                    player:setPos(-280, -12, -90, 0)
-                    player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
@@ -67,6 +69,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(-45, -0, 25, 192)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -83,9 +90,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
                     player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
-
-                    player:setPos(-45, -0, 25, 192)
-                    player:setHomePoint()
 
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
@@ -99,6 +103,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(134, 8.5, -11, 96)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -116,9 +125,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    player:setPos(134, 8.5, -11, 96)
-                    player:setHomePoint()
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.BASTOK, true))
@@ -131,6 +137,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(0, 0, -12, 192)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -149,9 +160,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    player:setPos(0, 0, -12, 192)
-                    player:setHomePoint()
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
@@ -164,6 +172,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(-100, 1, -40, 224) --cs exit
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -182,9 +195,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    player:setPos(-100, 1, -40, 224) --cs exit
-                    player:setHomePoint()
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
@@ -197,6 +207,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(-100, -8, -125, 224)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -215,9 +230,6 @@ quest.sections =
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
                     player:messageText(player, ID.text.MAP_MARKER_TUTORIAL)
 
-                    player:setPos(-100, -8, -125, 224)
-                    player:setHomePoint()
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.SANDORIA, true))
@@ -230,6 +242,14 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    -- The HP position is slightly different than the CS exit.
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setPos(-40.0, -5, 100, 64)
+                        player:setHomePoint()
+                    end
+
+                    player:setPos(-40.611, -5, 102.5, 57) -- Move back to CS exit position
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -258,11 +278,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    -- The HP position is slightly different than the CS exit.
-                    player:setPos(-40.0, -5, 100, 64)
-                    player:setHomePoint()
-                    player:setPos(-40.611, -5, 102.5, 57) -- Move back to CS exit position
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))
@@ -275,6 +290,11 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    player:setPos(30, 2, -40, 128)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setHomePoint()
+                    end
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -293,9 +313,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    player:setPos(30, 2, -40, 128)
-                    player:setHomePoint()
-
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))
@@ -308,6 +325,13 @@ quest.sections =
             onZoneIn =
             {
                 function(player, prevZone)
+                    if quest:getVar(player, 'nations') == 0 then
+                        player:setPos(-120, -5.5, 175, 48)
+                        player:setHomePoint()
+                    end
+
+                    player:setPos(-140, -7, 172, 32)
+
                     local cutsceneFlags = bit.bor(
                         xi.cutsceneFlag.UNKNOWN_1,
                         xi.cutsceneFlag.NO_PCS,
@@ -326,10 +350,6 @@ quest.sections =
                     -- If you don't get the coupon, tough luck. Retail doesn't give you a chance to get it again.
                     npcUtil.giveItem(player, xi.item.ADVENTURER_COUPON)
 
-                    player:setPos(-120, -5.5, 175, 48)
-                    player:setHomePoint()
-
-                    player:setPos(-140, -7, 172, 32)
                     quest:setVar(player, 'notSeen', 0)
                     local nationsSeen = quest:getVar(player, 'nations')
                     quest:setVar(player, 'nations', utils.mask.setBit(nationsSeen, xi.nation.WINDURST, true))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes three issues with the New Character Cutscenes.
- Sets position before the event so the camera does not mess up after. This was noticed after PR #10707 
- Homepoint should only be set on the first login, not when you swap nations later: https://youtu.be/8hMeJyNHOIQ?t=265
- Bastok Markets has two events, so the second event needs to be set as isHidden to hide the player

## Steps to test these changes

!setplayernation 0-2 to set nation
!setplayervar Test HQuest[newCharacterCS]notSeen 1 then you can !zone to the zone to check
!setplayervar Test HQuest[newCharacterCS]nations 0 if you want to test homepoints being set.
Test all 9 zones.