### PR TITLE
[lua] Fix 'onlyInitiator' key item handling in battlefield framework

### DIFF
--- a/scripts/battlefields/Jade_Sepulcher/Shadows_of_the_Mind.lua
+++ b/scripts/battlefields/Jade_Sepulcher/Shadows_of_the_Mind.lua
@@ -14,7 +14,7 @@ local content = Battlefield:new({
     index            = 1,
     entryNpc         = '_1v0',
     exitNpcs         = { '_1v1', '_1v2', '_1v3' },
-    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content.groups = {

--- a/scripts/battlefields/Jade_Sepulcher/making_a_mockery.lua
+++ b/scripts/battlefields/Jade_Sepulcher/making_a_mockery.lua
@@ -15,7 +15,7 @@ local content = Battlefield:new({
     index            = 0,
     entryNpc         = '_1v0',
     exitNpcs         = { '_1v1', '_1v2', '_1v3' },
-    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content:addEssentialMobs({ 'Mocking_Colibri' })

--- a/scripts/battlefields/Navukgo_Execution_Chamber/happy_caster.lua
+++ b/scripts/battlefields/Navukgo_Execution_Chamber/happy_caster.lua
@@ -14,7 +14,7 @@ local content = Battlefield:new({
     index            = 1,
     entryNpc         = '_1s0',
     exitNpcs         = { '_1s1', '_1s2', '_1s3' },
-    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content:addEssentialMobs({ 'Two-faced_Flan' })

--- a/scripts/battlefields/Navukgo_Execution_Chamber/tough_nut_to_crack.lua
+++ b/scripts/battlefields/Navukgo_Execution_Chamber/tough_nut_to_crack.lua
@@ -15,7 +15,7 @@ local content = Battlefield:new({
     index            = 0,
     entryNpc         = '_1s0',
     exitNpcs         = { '_1s1', '_1s2', '_1s3' },
-    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content:addEssentialMobs({ 'Watch_Wamoura' })

--- a/scripts/battlefields/Talacca_Cove/call_to_arms.lua
+++ b/scripts/battlefields/Talacca_Cove/call_to_arms.lua
@@ -15,7 +15,7 @@ local content = Battlefield:new({
     index            = 0,
     entryNpc         = '_1l0',
     exitNpcs         = { '_1l1', '_1l2', '_1l3' },
-    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.CONFIDENTIAL_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content.groups = {

--- a/scripts/battlefields/Talacca_Cove/compliments_to_the_chef.lua
+++ b/scripts/battlefields/Talacca_Cove/compliments_to_the_chef.lua
@@ -14,7 +14,7 @@ local content = Battlefield:new({
     index            = 1,
     entryNpc         = '_1l0',
     exitNpcs         = { '_1l1', '_1l2', '_1l3' },
-    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, message = ID.text.IMPERIAL_ORDER_BREAKS },
+    requiredKeyItems = { xi.ki.SECRET_IMPERIAL_ORDER, onlyInitiator = true, message = ID.text.IMPERIAL_ORDER_BREAKS },
 })
 
 content:addEssentialMobs({ 'Angler_Orobon' })

--- a/scripts/globals/battlefield.lua
+++ b/scripts/globals/battlefield.lua
@@ -406,7 +406,8 @@ end
 --  - delayToExit: Amount of time to wait before exiting the battlefield. Defaults to 5 seconds. (optional)
 --  - requiredItems: Items required to be traded to enter the battlefield.
 --                   Needs to be in the format of { itemid, quantity, useMessage = ID.text.*, wearMessage = ID.text.*, wornMessage = ID.text.* }. (optional)
---  - requiredKeyItems: Key items required to be able to enter the battlefield - these are removed upon entry unless 'keep = true' (optional)
+--  - requiredKeyItems: Key items required to be able to enter the battlefield - these are removed upon entry unless 'keep = true'.
+--                      Set 'onlyInitiator' to true to only require the initiator of the battlefield to have the key item. (optional)
 --  - title: Title given to players upon victory (optional)
 --  - grantXP: Amount of XP to grant upon victory (optional)
 --  - grantXPLockout: If true, players can only receive the grantXP once per day, resetting at JST midnight. (optional)
@@ -587,27 +588,38 @@ function Battlefield:checkRequirements(player, npc, isRegistrant, trade)
         return false
     end
 
-    for _, keyItem in ipairs(self.requiredKeyItems) do
-        if type(keyItem) == 'table' then
+    -- Everyone must hold the required key items by default.
+    -- Note : Key items are not consumed here, only checked, consumption is handled in onBattlefieldEnter
+    local needsKeyItems = true
 
-            -- Only need one from the group
-            local hasAny = false
+    -- Battlefields flagged 'onlyInitiator' only require them from the battlefield initiator to enter.
+    if self.requiredKeyItems.onlyInitiator then
+        needsKeyItems = isRegistrant
+    end
 
-            for _, subitem in ipairs(keyItem) do
-                if player:hasKeyItem(subitem) then
-                    hasAny = true
+    if needsKeyItems then
+        for _, keyItem in ipairs(self.requiredKeyItems) do
+            if type(keyItem) == 'table' then
 
-                    break
+                -- Some battlefields may be entered with one of several key items. (e.g. Requiem of Sin)
+                local hasAnyKeyItem = false
+
+                for _, subitem in ipairs(keyItem) do
+                    if player:hasKeyItem(subitem) then
+                        hasAnyKeyItem = true
+
+                        break
+                    end
                 end
-            end
 
-            if not hasAny then
-                return false
-            end
+                if not hasAnyKeyItem then
+                    return false
+                end
 
-        else
-            if not player:hasKeyItem(keyItem) then
-                return false
+            else
+                if not player:hasKeyItem(keyItem) then
+                    return false
+                end
             end
         end
     end
@@ -1077,6 +1089,8 @@ function Battlefield:onBattlefieldEnter(player, battlefield)
 
     local initiatorId, _ = battlefield:getInitiator()
 
+    -- Handle key item consumption. Runs for every player that enters the battlefield.
+    -- If onlyInitiator is true, then only the player that registered the battlefield will have their key item consumed.
     if
         #self.requiredKeyItems > 0 and
         (not self.requiredKeyItems.onlyInitiator or player:getID() == initiatorId)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

While looking into a bug report about key item handling for ISNMs I discovered the battlefield framework partially supported it but not in both spots where key items were checked. When 'onlyInitiator' was set to true, it still required everyone to have the key item to enter, but it only consumed it from it the battlefield initiator. This means if you were to, for instance, run a ISNM with a group of 6 people, one of your members would become ineligible to participate every run. 

This PR fixes the key item check by honoring 'onlyInitiator' in both the key item check to enter and on battlefield enter itself, where the key item is actually consumed. 

## Steps to test these changes

Get two accounts, have one of them with a ISNM KI, and the other without - see you can enter the ISNM on both characters 
Enter again, this time with both characters having the KI, and see its only consumed from the initiator. 
