### PR TITLE
[core] Transaction correctness in the database layer

### DIFF
--- a/src/common/database/caching_database.cpp
+++ b/src/common/database/caching_database.cpp
@@ -135,6 +135,14 @@ auto db::CachingDatabase::runWithRetry(const std::string& rawQuery, const Fn<std
                 ShowErrorFmt("{}", e.what());
                 return nullptr;
             }
+
+            // reconnect starts in autocommit, retrying would commit this statement on its own
+            if (state.inTransaction)
+            {
+                ShowErrorFmt("Connection lost mid-transaction, not retrying: {}", rawQuery);
+                ShowErrorFmt("{}", e.what());
+                return nullptr;
+            }
         }
     }
 
@@ -191,6 +199,11 @@ auto db::CachingDatabase::executeBulk(const std::string& rawQuery, const std::ve
     };
 
     return runWithRetry(rawQuery, operation);
+}
+
+void db::CachingDatabase::setInTransaction(bool value)
+{
+    getState().inTransaction = value;
 }
 
 auto db::CachingDatabase::getSchema() -> std::string

--- a/src/common/database/caching_database.h
+++ b/src/common/database/caching_database.h
@@ -43,6 +43,9 @@ struct ConnectionState
 {
     std::unique_ptr<Connection>                              connection;
     HashMap<std::string, std::unique_ptr<PreparedStatement>> statements;
+
+    // open transaction on this connection
+    bool inTransaction{ false };
 };
 
 } // namespace detail
@@ -52,6 +55,8 @@ class CachingDatabase : public Database
 public:
     auto execute(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
     auto executeBulk(const std::string& query, const std::vector<BoundValue>& params) -> std::unique_ptr<ResultSet> override;
+
+    void setInTransaction(bool value) override;
 
     auto getSchema() -> std::string override;
     auto getVersion() -> std::string override;

--- a/src/common/database/database.cpp
+++ b/src/common/database/database.cpp
@@ -361,48 +361,40 @@ auto db::transaction(const Fn<void() const>& transactionFn) -> bool
 {
     TracyZoneScoped;
 
-    const bool wasAutoCommitOn = db::getAutoCommit();
-
-    if (db::setAutoCommit(false) && db::transactionStart())
+    if (!db::transactionStart())
     {
-        // covers COMMIT/ROLLBACK too
-        db::getDatabase().setInTransaction(true);
-        const auto transactionScope = xi::finally<Fn<void()>>(
-            []() -> void
-            {
-                db::getDatabase().setInTransaction(false);
-            });
-
-        try
-        {
-            transactionFn();
-
-            if (!db::transactionCommit())
-            {
-                ShowCritical("Transaction failed: COMMIT failed, rolling back!");
-
-                db::transactionRollback();
-                db::setAutoCommit(wasAutoCommitOn);
-                return false;
-            }
-        }
-        catch (const std::exception& e)
-        {
-            ShowCritical("Transaction failed: Rolling back!");
-            ShowCritical("Transaction failed: %s", e.what());
-
-            db::transactionRollback();
-            db::setAutoCommit(wasAutoCommitOn);
-            return false;
-        }
-    }
-    else
-    {
-        db::setAutoCommit(wasAutoCommitOn);
         return false;
     }
 
-    db::setAutoCommit(wasAutoCommitOn);
+    // covers COMMIT/ROLLBACK too
+    db::getDatabase().setInTransaction(true);
+    const auto transactionScope = xi::finally<Fn<void()>>(
+        []() -> void
+        {
+            db::getDatabase().setInTransaction(false);
+        });
+
+    try
+    {
+        transactionFn();
+    }
+    catch (const std::exception& e)
+    {
+        ShowCritical("Transaction failed: Rolling back!");
+        ShowCritical("Transaction failed: %s", e.what());
+
+        db::transactionRollback();
+        return false;
+    }
+
+    if (!db::transactionCommit())
+    {
+        ShowCritical("Transaction failed: COMMIT failed, rolling back!");
+
+        db::transactionRollback();
+        return false;
+    }
+
     return true;
 }
 

--- a/src/common/database/database.cpp
+++ b/src/common/database/database.cpp
@@ -365,7 +365,15 @@ auto db::transaction(const Fn<void() const>& transactionFn) -> bool
         try
         {
             transactionFn();
-            db::transactionCommit();
+
+            if (!db::transactionCommit())
+            {
+                ShowCritical("Transaction failed: COMMIT failed, rolling back!");
+
+                db::transactionRollback();
+                db::setAutoCommit(wasAutoCommitOn);
+                return false;
+            }
         }
         catch (const std::exception& e)
         {

--- a/src/common/database/database.cpp
+++ b/src/common/database/database.cpp
@@ -26,6 +26,9 @@
 #include <common/logging.h>
 #include <common/macros.h>
 #include <common/utils.h>
+#include <common/xi.h>
+
+#include <common/types/fn.h>
 
 #include <common/types/hash_map.h>
 
@@ -362,6 +365,14 @@ auto db::transaction(const Fn<void() const>& transactionFn) -> bool
 
     if (db::setAutoCommit(false) && db::transactionStart())
     {
+        // covers COMMIT/ROLLBACK too
+        db::getDatabase().setInTransaction(true);
+        const auto transactionScope = xi::finally<Fn<void()>>(
+            []() -> void
+            {
+                db::getDatabase().setInTransaction(false);
+            });
+
         try
         {
             transactionFn();

--- a/src/common/database/database.h
+++ b/src/common/database/database.h
@@ -33,6 +33,7 @@
 #include <fmt/format.h>
 
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -91,6 +92,9 @@ auto preparedStmt(Scheduler& scheduler, const std::string& rawQuery, Args&&... a
 //
 // `project` turns one row into a tuple of values, one per placeholder, and every row must yield the same types.
 // Numeric columns only.
+//
+// Throws if the statement fails.
+// Call it inside db::transaction, which turns the throw into a rollback.
 template <typename T, typename ProjectFn>
 void executeBulk(const std::string& query, const std::vector<T>& rows, ProjectFn project);
 
@@ -165,7 +169,10 @@ void executeBulk(const std::string& query, const std::vector<T>& rows, ProjectFn
             project(row));
     }
 
-    getDatabase().executeBulk(query, params);
+    if (!getDatabase().executeBulk(query, params))
+    {
+        throw std::runtime_error(fmt::format("bulk statement failed after {} rows: {}", rows.size(), query));
+    }
 }
 
 template <typename... Args>

--- a/src/common/database/database.h
+++ b/src/common/database/database.h
@@ -67,6 +67,11 @@ public:
 
     // The version of the database driver, ie. MariaDB Connector/C++ 1.0.3.
     virtual auto getDriverVersion() -> std::string = 0;
+
+    // suppresses the reconnect-and-retry path while a transaction is open
+    virtual void setInTransaction(bool)
+    {
+    }
 };
 
 // Get the active database backend.

--- a/src/common/database/database.h
+++ b/src/common/database/database.h
@@ -127,10 +127,9 @@ auto enableTimers() -> void;
 
 // Execute a transaction with the given transaction function.
 //
-// Will handle maintenance of the autocommit state and rollback the transaction if the transaction
-// function throws. Otherwise will commit the transaction on successful completion of the function.
+// Rolls back if the transaction function throws, otherwise commits.
 //
-// Returns true if the transaction was successful and committed or false if it was rolled back.
+// Returns true only if the COMMIT itself succeeded.
 auto transaction(const Fn<void() const>& transactionFn) -> bool;
 
 auto getTableColumnNames(const std::string& tableName) -> std::vector<std::string>;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5959,13 +5959,22 @@ void SaveCharPositions(const std::vector<CharPosition>& rows)
 {
     TracyZoneScoped;
 
-    // not an upsert: `chars` has a BEFORE INSERT trigger that fires even on update
-    db::executeBulk(
-        "UPDATE chars SET pos_rot = ?, pos_x = ?, pos_y = ?, pos_z = ?, boundary = ? WHERE charid = ?",
-        rows,
-        [](const CharPosition& row)
+    if (rows.empty())
+    {
+        return;
+    }
+
+    db::transaction(
+        [&]()
         {
-            return std::make_tuple(row.rotation, row.x, row.y, row.z, row.boundary, row.charid);
+            // not an upsert: `chars` has a BEFORE INSERT trigger that fires even on update
+            db::executeBulk(
+                "UPDATE chars SET pos_rot = ?, pos_x = ?, pos_y = ?, pos_z = ?, boundary = ? WHERE charid = ?",
+                rows,
+                [](const CharPosition& row)
+                {
+                    return std::make_tuple(row.rotation, row.x, row.y, row.z, row.boundary, row.charid);
+                });
         });
 }
 

--- a/src/world/ipc_server.cpp
+++ b/src/world/ipc_server.cpp
@@ -123,8 +123,8 @@ auto IPCServer::getIPPsForParty(uint32 partyId) -> std::vector<IPP>
 
     // TODO: Simplify query now that there's alliance versions?
     const auto query = "SELECT server_addr, server_port, MIN(charid) FROM accounts_sessions JOIN accounts_parties USING (charid) "
-                       "WHERE IF (allianceid <> 0, allianceid = (SELECT MAX(allianceid) FROM accounts_parties WHERE partyid = ?), "
-                       "partyid = ?) GROUP BY server_addr, server_port";
+                       "WHERE (allianceid <> 0 AND allianceid = (SELECT MAX(allianceid) FROM accounts_parties WHERE partyid = ?)) "
+                       "OR (allianceid = 0 AND partyid = ?) GROUP BY server_addr, server_port";
 
     const auto rset = db::preparedStmt(query, partyId, partyId);
     if (rset && rset->rowsCount())


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Handful of light tweaks

- Wraps a batch query I forgot to put in a transaction
- executeBulk throws if failed so that rollback occurs
- Ensure COMMIT actually succeeds before returning
- Disable automatic retry on lost connections while in a transaction - everything submitted up to that point is automatically rolled back and continuing middle of the transaction without resending the whole thing is worse than backing out
- Dropped the auto-commit dance from db::transaction - it's already done transparently database side and shaves 3 trips per TX
- Tweaks a query to make it use one of the recently created index - IF() in a query forces full table scans

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
