### PR TITLE
[lua][module] Homepoint and WHM AF NPC location adjustments

### DIFF
--- a/modules/era/sql/abyssea/mob_spawn_points.sql
+++ b/modules/era/sql/abyssea/mob_spawn_points.sql
@@ -1,0 +1,7 @@
+-----------------------------------
+-- Module: Abyssea Mob Spawn Points Adjustments
+-----------------------------------
+
+-- WHM AF Quest "Piejue's Decision" ??? and mob spawn relocated
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/09/2011)
+UPDATE `mob_spawn_points` SET `pos_x` = 173.643, `pos_y` = -24.536, `pos_z` = -81.385 WHERE `mobname` = 'Altedour_I_Tavnazia'; -- Fei'Yin

--- a/modules/era/sql/abyssea/npc_list.sql
+++ b/modules/era/sql/abyssea/npc_list.sql
@@ -1,0 +1,7 @@
+-----------------------------------
+-- Module: Abyssea NPC List Adjustments
+-----------------------------------
+
+-- WHM AF Quest "Piejue's Decision" ??? relocated
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/09/2011)
+UPDATE `npc_list` SET `pos_x` = 173.143, `pos_y` = -24.016, `pos_z` = -81.385 WHERE `name` = 'qm1' AND (`npcid` & 0xFFF000) >> 12 = 204; -- Fei'Yin

--- a/modules/era/sql/rov/npc_list.sql
+++ b/modules/era/sql/rov/npc_list.sql
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Module: RoV NPC List Adjustments
+-----------------------------------
+
+-- Revert home point relocations
+-- Source: https://forum.square-enix.com/ffxi/threads/49065-Nov-10-2015-%28JST%29-Version-Update
+UPDATE `npc_list` SET `pos_x` = -293.791, `pos_y` = -10.000, `pos_z` = -102.539 WHERE `name` = 'HomePoint#1' AND (`npcid` & 0xFFF000) >> 12 = 235; -- Bastok Markets
+UPDATE `npc_list` SET `pos_x` =   53.645, `pos_y` =   7.500, `pos_z` =  -28.682 WHERE `name` = 'HomePoint#1' AND (`npcid` & 0xFFF000) >> 12 = 236; -- Port Bastok
+UPDATE `npc_list` SET `pos_x` =  -66.077, `pos_y` =   4.000, `pos_z` = -104.948 WHERE `name` = 'HomePoint#1' AND (`npcid` & 0xFFF000) >> 12 = 232; -- Port San d'Oria
+UPDATE `npc_list` SET `pos_x` =  -67.980, `pos_y` =  -4.000, `pos_z` =  110.675 WHERE `name` = 'HomePoint#1' AND (`npcid` & 0xFFF000) >> 12 = 240; -- Port Windurst


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Module to relocate several city home points to their pre-RoV locations
- Reverts ??? related to WHM AF quest in Fei'yin to its pre-Abyssea location

## Steps to test these changes

- Load RoV and Abyssea modules
- See NPCs in their correct in era locations
