### PR TITLE
Tests: Fix flaky tests in Qufim Island

### DIFF
--- a/scripts/specs/test/CTestEntity.lua
+++ b/scripts/specs/test/CTestEntity.lua
@@ -26,3 +26,11 @@ end
 ---@return nil
 function CTestEntity:despawn()
 end
+
+---Collapse a mob's spawn level range so its stats are deterministic across runs.
+---Will raise an error if called on non-mob entities or if the range is invalid.
+---@param minLevel integer The minimum level to roll
+---@param maxLevel integer The maximum level to roll
+---@return nil
+function CTestEntity:setLevelRange(minLevel, maxLevel)
+end

--- a/scripts/tests/packets/s2c/0x028_battle2/base.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/base.lua
@@ -128,7 +128,10 @@ describe('BATTLE2', function()
                 zone  = xi.zone.QUFIM_ISLAND,
             })
 
+        -- The Clipper spawns at level 28 or 29, so its stats, and the packet values below,
+        -- depend on the shared RNG stream. Pin the level.
         mob = player.entities:moveTo(17293357)
+        mob:setLevelRange(28, 28)
         mob:respawn()
         mob.assert:isAlive()
     end)

--- a/scripts/tests/systems/spells/blue_correlation.lua
+++ b/scripts/tests/systems/spells/blue_correlation.lua
@@ -31,7 +31,10 @@ describe('Blue Magic monster correlation', function()
         player:addSpell(xi.magic.spell.FOOT_KICK)
         player.actions:setBlueSpells({ xi.magic.spell.FOOT_KICK })
 
+        -- The Clipper spawns at level 28 or 29, so its VIT, its DEF, and the damage below all
+        -- depend on the shared RNG stream. Pin the level.
         mob = player.entities:moveTo(17293357)
+        mob:setLevelRange(28, 28)
         mob:respawn()
         mob.assert:isAlive()
     end)

--- a/src/test/lua/lua_test_entity.cpp
+++ b/src/test/lua/lua_test_entity.cpp
@@ -105,6 +105,34 @@ void CLuaTestEntity::respawn() const
 }
 
 /************************************************************************
+ *  Function: setLevelRange()
+ *  Purpose : Fix the level a mob rolls when it spawns
+ *  Example : mob:setLevelRange(28, 28)
+ *  Notes   : Spawn() draws the level from [minLevel, maxLevel], so a mob with a
+ *          : range gets different stats depending on the shared RNG stream.
+ *          : Collapse the range to pin the stats.
+ ************************************************************************/
+void CLuaTestEntity::setLevelRange(const uint8 minLevel, const uint8 maxLevel) const
+{
+    auto* mob = dynamic_cast<CMobEntity*>(m_PBaseEntity);
+    if (!mob)
+    {
+        TestError("setLevelRange() can only be called on mob entities, not on {}",
+                  static_cast<uint8>(m_PBaseEntity->objtype));
+        return;
+    }
+
+    if (minLevel == 0 || maxLevel < minLevel)
+    {
+        TestError("setLevelRange({}, {}) is not a valid level range for {}", minLevel, maxLevel, mob->getName());
+        return;
+    }
+
+    mob->m_minLevel = minLevel;
+    mob->m_maxLevel = maxLevel;
+}
+
+/************************************************************************
  *  Function: assert_()
  *  Purpose : Get assertion helper for this entity
  *  Example : entity.assert:isAlive()
@@ -120,5 +148,6 @@ void CLuaTestEntity::Register()
     SOL_REGISTER("setEntity", CLuaTestEntity::setEntity);
     SOL_REGISTER("despawn", CLuaTestEntity::despawn);
     SOL_REGISTER("respawn", CLuaTestEntity::respawn);
+    SOL_REGISTER("setLevelRange", CLuaTestEntity::setLevelRange);
     SOL_READONLY("assert", CLuaTestEntity::assert_);
 }

--- a/src/test/lua/lua_test_entity.h
+++ b/src/test/lua/lua_test_entity.h
@@ -35,6 +35,7 @@ public:
     virtual void setEntity(CBaseEntity* entity);
     void         despawn() const;
     void         respawn() const;
+    void         setLevelRange(uint8 minLevel, uint8 maxLevel) const;
     auto         assert_() -> CLuaTestEntityAssertions;
 
     static void Register();


### PR DESCRIPTION
The Clipper these suites share spawns at level 28 or 29, so its stats, and the damage they assert, depended on the shared RNG stream.

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Came up while I was working on other stuff.