### PR TITLE
[lua] Fix Various Quest Battlefield Entry Requirements

### DIFF
--- a/scripts/battlefields/Cloister_of_Frost/class_reunion.lua
+++ b/scripts/battlefields/Cloister_of_Frost/class_reunion.lua
@@ -14,13 +14,22 @@ local content = BattlefieldQuest:new({
     index            = 1,
     entryNpc         = 'IP_Entrance',
     exitNpc          = 'Ice_Protocrystal',
-    requiredItems    = { xi.item.ICE_PENDULUM },
+    requiredItems    = { xi.item.ICE_PENDULUM, keep = true },
 
     questArea     = xi.questLog.WINDURST,
     quest         = xi.quest.id.windurst.CLASS_REUNION,
     requiredVar   = 'ClassReunionProgress',
     requiredValue = 5,
 })
+
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
 
 function content:onEventFinishWin(player, csid, option, npc)
     if player:getCharVar('ClassReunionProgress') == 5 then

--- a/scripts/battlefields/Cloister_of_Gales/carbuncle_debacle.lua
+++ b/scripts/battlefields/Cloister_of_Gales/carbuncle_debacle.lua
@@ -14,13 +14,22 @@ local content = BattlefieldQuest:new({
     index            = 1,
     entryNpc         = 'WP_Entrance',
     exitNpc          = 'Wind_Protocrystal',
-    requiredItems    = { xi.item.WIND_PENDULUM },
+    requiredItems    = { xi.item.WIND_PENDULUM, keep = true }, -- Wind Pendulum is not consumed on entry, but is required to enter the battlefield.
 
     questArea     = xi.questLog.WINDURST,
     quest         = xi.quest.id.windurst.CARBUNCLE_DEBACLE,
     requiredVar   = 'CarbuncleDebacleProgress',
     requiredValue = 6,
 })
+
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
 
 function content:onEventFinishWin(player, csid, option, npc)
     if player:getCharVar('CarbuncleDebacleProgress') == 6 then

--- a/scripts/battlefields/Cloister_of_Storms/carbuncle_debacle.lua
+++ b/scripts/battlefields/Cloister_of_Storms/carbuncle_debacle.lua
@@ -14,13 +14,22 @@ local content = BattlefieldQuest:new({
     index            = 1,
     entryNpc         = 'LP_Entrance',
     exitNpc          = 'Lightning_Protocrystal',
-    requiredItems    = { xi.item.LIGHTNING_PENDULUM },
+    requiredItems    = { xi.item.LIGHTNING_PENDULUM, keep = true }, -- Lightning Pendulum is not consumed on entry, but is required to enter the battlefield.
 
     questArea     = xi.questLog.WINDURST,
     quest         = xi.quest.id.windurst.CARBUNCLE_DEBACLE,
     requiredVar   = 'CarbuncleDebacleProgress',
     requiredValue = 3,
 })
+
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
 
 function content:onEventFinishWin(player, csid, option, npc)
     if player:getCharVar('CarbuncleDebacleProgress') == 3 then

--- a/scripts/battlefields/Cloister_of_Tremors/puppet_master.lua
+++ b/scripts/battlefields/Cloister_of_Tremors/puppet_master.lua
@@ -23,6 +23,15 @@ local content = BattlefieldQuest:new({
     quest     = xi.quest.id.windurst.THE_PUPPET_MASTER,
 })
 
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
+
 content.groups =
 {
     {

--- a/scripts/battlefields/Ghelsba_Outpost/holy_crest.lua
+++ b/scripts/battlefields/Ghelsba_Outpost/holy_crest.lua
@@ -18,7 +18,14 @@ local content = BattlefieldQuest:new({
     quest         = xi.quest.id.sandoria.THE_HOLY_CREST,
 })
 
+-- Players must be on the quest with the key item or have completed the quest to enter the battlefield.
 function content:entryRequirement(player, npc, isRegistrant, trade)
+    local questStatus = player:getQuestStatus(xi.questLog.SANDORIA, xi.quest.id.sandoria.THE_HOLY_CREST)
+
+    if questStatus == xi.questStatus.QUEST_COMPLETED then
+        return true
+    end
+
     return player:hasKeyItem(xi.ki.DRAGON_CURSE_REMEDY)
 end
 

--- a/scripts/battlefields/LaLoff_Amphitheater/divine_might.lua
+++ b/scripts/battlefields/LaLoff_Amphitheater/divine_might.lua
@@ -19,9 +19,10 @@ local content = Battlefield:new({
     requiredItems = { xi.item.ARK_PENTASPHERE, wearMessage = laLoffID.text.THE_SEAL_FADES, wornMessage = { laLoffID.text.INK_HAS_FADED, xi.item.ARK_PENTASPHERE } },
 })
 
+-- Players must be on the quest or have completed the quest to enter the battlefield.
 function content:entryRequirement(player, npc, isRegistrant, trade)
-    return player:getQuestStatus(xi.questLog.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT) == xi.questStatus.QUEST_ACCEPTED or
-        player:getQuestStatus(xi.questLog.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT) == xi.questStatus.QUEST_ACCEPTED
+    return player:getQuestStatus(xi.questLog.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT) >= xi.questStatus.QUEST_ACCEPTED or
+        player:getQuestStatus(xi.questLog.OUTLANDS, xi.quest.id.outlands.DIVINE_MIGHT_REPEAT) >= xi.questStatus.QUEST_ACCEPTED
 end
 
 content.groups =

--- a/scripts/battlefields/Talacca_Cove/puppetmaster_blues.lua
+++ b/scripts/battlefields/Talacca_Cove/puppetmaster_blues.lua
@@ -16,8 +16,17 @@ local content = BattlefieldQuest:new({
     exitNpcs         = { '_1l1', '_1l2', '_1l3' },
     questArea        = xi.questLog.AHT_URHGAN,
     quest            = xi.quest.id.ahtUrhgan.PUPPETMASTER_BLUES,
-    requiredKeyItems = { xi.ki.TOGGLE_SWITCH, xi.ki.VALKENGS_MEMORY_CHIP },
+    requiredKeyItems = { xi.ki.TOGGLE_SWITCH, xi.ki.VALKENGS_MEMORY_CHIP, keep = true }, -- Key items are not consumed on entry, but are required to enter the battlefield.
 })
+
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
 
 content.groups =
 {

--- a/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
+++ b/scripts/battlefields/Waughroon_Shrine/thief_in_norg.lua
@@ -14,13 +14,22 @@ local content = BattlefieldQuest:new({
     index            = 4,
     entryNpc         = 'BC_Entrance',
     exitNpc          = 'Burning_Circle',
-    requiredItems    = { xi.item.BANISHING_CHARM },
+    requiredItems    = { xi.item.BANISHING_CHARM, keep = true }, -- Banishing Charm is not consumed on entry, but is required to enter the battlefield.
 
     questArea     = xi.questLog.OUTLANDS,
     quest         = xi.quest.id.outlands.A_THIEF_IN_NORG,
     requiredVar   = 'Quest[5][142]Prog',
     requiredValue = 6,
 })
+
+-- Only the battlefield registrant needs to have the required item and quest state to initiate the battlefield.
+function content:checkRequirements(player, npc, isRegistrant, trade)
+    if isRegistrant then
+        return BattlefieldQuest.checkRequirements(self, player, npc, isRegistrant, trade)
+    end
+
+    return self:isValidEntry(player, npc)
+end
 
 content.groups =
 {


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

As a follow-up to yesterdays PR, this one relaxes and augments some requirements to enter certain quest related battlefields. 

Many of these battlefields were checking quest state in their requirements, which is correct, but it was also enforcing those requirements on everyone trying to help. 

* A Thief in Norg, Class Reuinion, Carbuncle Debacle, Puppetmaster Blues & Puppet Master - Only the person on the quest needs the required item and quest state to initiate the battlefield, and the items are not consumed on entry incase of a loss and can be repeated. The check requirements override allows other players to help with the quest. 

* For Holy Crest and Divine Might players must be on or have completed the quest in order to participate.

## Sources
https://www.bg-wiki.com/ffxi/A_Thief_in_Norg!%3F - Denotes "You can throw away the Banishing Charm after the battlefield"
https://www.bg-wiki.com/ffxi/The_Holy_Crest - Denotes "Only players who are on or have completed the quest may partcipate"
https://ffxiclopedia.fandom.com/wiki/Puppetmaster_Blues - Puppetmaster Blues - Denotes "You keep the two key items incase of a failure" - They are consumed on victory which @ThrisStraizo already coded.
https://www.bg-wiki.com/ffxi/Class_Reunion - Denotes you may toss the Ice Pendulum after completing the quest. 
https://www.bg-wiki.com/ffxi/Carbuncle_Debacle - Denotes you may toss the Lightning Pendulum and Lightning Pendulum after completing the quest.
Divine Might - @sruon and @normalname33 (Tao) and I tested this one a while back, and players who were not on the quest but had completed it before we able to help. 

## Steps to test these changes

Test "A Thief in Norg"

Requires 2 characters

On your 1st character

!addquest outlands 142
!setquestvar <YourCharName> 5 142 Prog 6
!additem 1166
!pos -345 104 -260 144

Invite a 2nd character, enter the battlefield and see that the 2nd character is able to help. 