### PR TITLE
[lua] [sql] Add Terroanima Mixin to NMs missing it / Fix Offspring HP

### DIFF
--- a/scripts/zones/Promyvion-Vahzl/mobs/Ponderer.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Ponderer.lua
@@ -2,6 +2,8 @@
 -- Area: Promyvion - Vahzl
 --   NM: Ponderer
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Propagator.lua
@@ -2,7 +2,11 @@
 -- Area: Promyvion - Vahzl
 --   NM: Propagator
 -----------------------------------
-mixins = { require('scripts/mixins/families/gorger_nm') }
+mixins =
+{
+    require('scripts/mixins/families/gorger_nm'),
+    require('scripts/mixins/families/empty_terroanima'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}

--- a/scripts/zones/Promyvion-Vahzl/mobs/Solicitor.lua
+++ b/scripts/zones/Promyvion-Vahzl/mobs/Solicitor.lua
@@ -2,6 +2,8 @@
 -- Area: Promyvion - Vahzl
 --   NM: Solicitor
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Agonizer.lua
@@ -2,6 +2,8 @@
 -- Area: Spire of Vahzl
 --  Mob: Agonizer
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Spire_of_Vahzl/mobs/Contemplator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Contemplator.lua
@@ -2,6 +2,8 @@
 -- Area: Spire of Vahzl
 --  Mob: Contemplator
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Cumulator.lua
@@ -2,6 +2,8 @@
 -- Area: Spire of Vahzl
 --  Mob: Cumulator
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Spire_of_Vahzl/mobs/Ingurgitator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Ingurgitator.lua
@@ -2,7 +2,11 @@
 -- Area: Spire of Vahzl
 --  Mob: Ingurgitator
 -----------------------------------
-mixins = { require('scripts/mixins/families/gorger_nm') }
+mixins =
+{
+    require('scripts/mixins/families/gorger_nm'),
+    require('scripts/mixins/families/empty_terroanima'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}

--- a/scripts/zones/Spire_of_Vahzl/mobs/Neoingurgitator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Neoingurgitator.lua
@@ -2,6 +2,8 @@
 -- Area: Spire of Vahzl
 --  Mob: Neoingurgitator
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Procreator.lua
@@ -2,7 +2,11 @@
 -- Area: Spire of Vahzl
 --  Mob: Procreator
 -----------------------------------
-mixins = { require('scripts/mixins/families/gorger_nm') }
+mixins =
+{
+    require('scripts/mixins/families/gorger_nm'),
+    require('scripts/mixins/families/empty_terroanima'),
+}
 -----------------------------------
 ---@type TMobEntity
 local entity = {}

--- a/scripts/zones/Spire_of_Vahzl/mobs/Repiner.lua
+++ b/scripts/zones/Spire_of_Vahzl/mobs/Repiner.lua
@@ -2,6 +2,8 @@
 -- Area: Spire of Vahzl
 --  Mob: Repiner
 -----------------------------------
+mixins = { require('scripts/mixins/families/empty_terroanima') }
+-----------------------------------
 ---@type TMobEntity
 local entity = {}
 

--- a/sql/mob_groups.sql
+++ b/sql/mob_groups.sql
@@ -832,7 +832,7 @@ INSERT INTO `mob_groups` VALUES (10,0,21,'Quenchless_Seether',0,128,0,0,0,0,NULL
 
 INSERT INTO `mob_groups` VALUES (1,3172,22,'Ponderer',0,128,0,3850,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3206,22,'Propagator',0,128,0,0,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (3,2947,22,'Offspring',0,128,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2947,22,'Offspring',0,128,0,800,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,3699,22,'Solicitor',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,6651,22,'Wanderer',960,0,2192,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,6652,22,'Weeper',960,0,2636,0,0,0,NULL);
@@ -877,7 +877,7 @@ INSERT INTO `mob_groups` VALUES (40,7291,22,'Weeper',960,0,2636,0,0,0,NULL);
 
 INSERT INTO `mob_groups` VALUES (1,63,23,'Agonizer',0,128,0,5000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (2,3202,23,'Procreator',0,128,0,5000,0,0,NULL);
-INSERT INTO `mob_groups` VALUES (3,2947,23,'Offspring',0,128,0,0,0,0,NULL);
+INSERT INTO `mob_groups` VALUES (3,2947,23,'Offspring',0,128,0,800,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (4,861,23,'Cumulator',0,128,0,5000,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (5,782,23,'Contemplator',0,128,0,0,0,0,NULL);
 INSERT INTO `mob_groups` VALUES (6,2081,23,'Ingurgitator',0,128,0,0,0,0,NULL);


### PR DESCRIPTION

**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds missing Terroanima mixin to various Empty NMs in Promy Vahzl

* Sets the HP of Offspring in Promy Vahzl to 800.

## Capture
https://youtu.be/Pqe9x6WGOz0 (Offspring HP)

## Steps to test these changes

Run Vahzl, use anima, kill stuff
