### PR TITLE
[lua] BLU Quest Audits

### DIFF
--- a/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
+++ b/scripts/quests/ahtUrhgan/An_Empty_Vessel.lua
@@ -1,8 +1,12 @@
 -----------------------------------
--- An Empty Vessel
+-- An Empty Vessel (BLU Unlock)
 -----------------------------------
 -- Log ID: 6, Quest ID: 5
 -- Waoud : !pos 65 -6 -78 50
+-----------------------------------
+-- Every wait on Waoud needs a Vana'diel day change and a zone, in either order.
+-- Event 69 does not spend the day's divination.
+-- Refusing Yasfel deletes the quest. Accepting and refusing warp the player to different spots.
 -----------------------------------
 local whitegateID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 -----------------------------------
@@ -34,9 +38,10 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
-                    local lastDivination = quest:getVar(player, 'Timer')
-
-                    if lastDivination <= VanadielUniqueDay() then
+                    if
+                        not quest:getMustZone(player) and
+                        quest:getVar(player, 'Timer') <= VanadielUniqueDay()
+                    then
                         return quest:progressEvent(60, player:getGil())
                     else
                         return quest:event(63)
@@ -79,12 +84,16 @@ quest.sections =
             onEventFinish =
             {
                 [60] = function(player, csid, option, npc)
+                    quest:setLocalVar(player, 'numCorrect', 0)
+
                     if option == 50 then
                         quest:begin(player)
                         quest:setMustZone(player)
                         quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
+
+                    -- Divination completed without an offer.
                     elseif
-                        option == 1 and
+                        option == 45 and
                         player:getGil() >= 1000
                     then
                         quest:setMustZone(player)
@@ -110,11 +119,12 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     local requiredItem = quest:getVar(player, 'Option')
 
+                    -- The item is not taken. Yasfel asks for it again in Aydeewa.
                     if
                         quest:getVar(player, 'Prog') == 1 and
-                        npcUtil.tradeHasExactly(trade, requiredItemList[requiredItem])
+                        npcUtil.tradeMatches(trade, { { requiredItemList[requiredItem], 1 } })
                     then
-                        return quest:progressEvent(67, requiredItemList[requiredItem])
+                        return quest:progressEvent(67, { [6] = requiredItem })
                     end
                 end,
 
@@ -126,7 +136,7 @@ quest.sections =
                         quest:getVar(player, 'Timer') <= VanadielUniqueDay()
                     then
                         if questProgress == 0 then
-                            return quest:progressEvent(65, { [6] = quest:getVar(player, 'Option') })
+                            return quest:progressEvent(65)
                         elseif questProgress == 1 then
                             return quest:event(66, { [6] = quest:getVar(player, 'Option') })
                         elseif questProgress == 2 then
@@ -138,17 +148,13 @@ quest.sections =
                 end,
             },
 
-            onEventUpdate =
-            {
-                [65] = function(player, csid, option, npc)
-                    if option == 2 then
-                        quest:setVar(player, 'Prog', 1)
-                    end
-                end,
-            },
-
             onEventFinish =
             {
+                -- Event 65 has no menu. The hint follows on the next conversation.
+                [65] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 1)
+                end,
+
                 [67] = function(player, csid, option, npc)
                     quest:setVar(player, 'Prog', 2)
                 end,
@@ -181,17 +187,21 @@ quest.sections =
                             player:addKeyItem(xi.ki.MARK_OF_ZAHAK)
                             player:addKeyItem(xi.ki.JOB_GESTURE_BLUE_MAGE)
 
+                            -- quest:complete() wipes quest vars.
                             quest:setVar(player, 'completeEvent', 1)
                         end
-                    else
+
+                        player:setPos(148, -2, 0, 128, xi.zone.AHT_URHGAN_WHITEGATE)
+
+                    -- Player refused Yasfel.
+                    elseif option == 7 then
                         quest:setVar(player, 'Prog', 0)
                         quest:setVar(player, 'Timer', 0)
                         quest:setVar(player, 'Option', 0)
 
                         player:delQuest(quest.areaId, quest.questId)
+                        player:setPos(-17.5, -6, 39.6, 171, xi.zone.AHT_URHGAN_WHITEGATE)
                     end
-
-                    player:setPos(148, -2, 0, 130, 50)
                 end,
             },
         },
@@ -209,11 +219,10 @@ quest.sections =
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'completeEvent') == 1 then
                         return quest:progressEvent(69)
-                    elseif quest:getVar(player, 'Timer') <= VanadielUniqueDay() then
-                        -- The timer for Divinations is reused throughout more quests, and continues to persist
-                        -- for Blue Mages when talking to Waoud (once per day).  Use this Timer to track throughout
-                        -- the remaining series.
-
+                    elseif
+                        not quest:getMustZone(player) and
+                        quest:getVar(player, 'Timer') <= VanadielUniqueDay()
+                    then
                         return quest:event(78, player:getGil())
                     else
                         return quest:event(63)
@@ -235,14 +244,12 @@ quest.sections =
                 [69] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:setVar(player, 'completeEvent', 0)
-
-                        quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
-                        xi.quest.setMustZone(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS)
                     end
                 end,
 
                 [78] = function(player, csid, option, npc)
                     if option == 1 and player:getGil() >= 1000 then
+                        quest:setMustZone(player)
                         quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
 
                         player:delGil(1000)

--- a/scripts/quests/ahtUrhgan/BLU_AF1_Beginnings.lua
+++ b/scripts/quests/ahtUrhgan/BLU_AF1_Beginnings.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Beginnings
+-- Beginnings (BLU AF1)
 -----------------------------------
 -- Log ID: 6, Quest ID: 21
 -- Waoud   : !pos 65 -6 -78 50
@@ -8,6 +8,11 @@
 -- Nahshib : !pos -274.334 -9.287 -64.255 79
 -- Nareema : !pos 518.387 -24.707 -467.297 79
 -- Waudeen : !pos 673.882 -23.995 367.604 61
+-----------------------------------
+-- Omens opens one minute after this quest completes.
+-- The June 7, 2016 version update shortened the wait from one Earth day.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
 -----------------------------------
 local whitegateID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 -----------------------------------
@@ -53,27 +58,13 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-            ['Waoud'] =
-            {
-                onTrigger = function(player, npc)
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
-
-                    if
-                        lastDivination <= VanadielUniqueDay() and
-                        not quest:getMustZone(player)
-                    then
-                        return quest:progressEvent(705)
-                    end
-                end,
-            },
+            ['Waoud'] = quest:progressEvent(705),
 
             onEventFinish =
             {
                 [705] = function(player, csid, option, npc)
                     if option == 1 then
                         quest:begin(player)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
             },
@@ -91,11 +82,9 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
-
                     if hasRequiredBrands(player) then
                         return quest:progressEvent(707)
-                    elseif lastDivination <= VanadielUniqueDay() then
+                    else
                         return quest:progressEvent(706, player:getGil())
                     end
                 end,
@@ -110,15 +99,13 @@ quest.sections =
                     then
                         player:delGil(1000)
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
 
                 [707] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS, 'Timer', VanadielUniqueDay() + 1)
                         xi.quest.setMustZone(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.OMENS)
+                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.OMENS, 'Timer', GetSystemTime() + 60) -- 1 minute wait time
                     end
                 end,
             },

--- a/scripts/quests/ahtUrhgan/BLU_AF2_Omens.lua
+++ b/scripts/quests/ahtUrhgan/BLU_AF2_Omens.lua
@@ -1,10 +1,15 @@
 -----------------------------------
--- Omens
+-- Omens (BLU AF2)
 -----------------------------------
 -- Log ID: 6, Quest ID: 22
 -- Waoud           : !pos 65 -6 -78 50
 -- Lathuya         : !pos -95.081 -6 31.638 50
 -- Aydeewa (Blank) : !pos 342.129 36.509 -24.856 68
+-----------------------------------
+-- Transformations opens one minute after this quest completes.
+-- The June 7, 2016 version update shortened the wait from one Earth day.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
 -----------------------------------
 local whitegateID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 -----------------------------------
@@ -32,14 +37,14 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
-
                     if
-                        lastDivination <= VanadielUniqueDay() and
-                        not quest:getMustZone(player)
+                        quest:getMustZone(player) or
+                        GetSystemTime() < quest:getVar(player, 'Timer')
                     then
-                        return quest:progressEvent(710)
+                        return
                     end
+
+                    return quest:progressEvent(710)
                 end,
             },
 
@@ -47,8 +52,6 @@ quest.sections =
             {
                 [710] = function(player, csid, option, npc)
                     quest:begin(player)
-
-                    xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS, 'Timer', VanadielUniqueDay() + 1)
                 end,
             },
         },
@@ -65,16 +68,13 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     local questProgress = quest:getVar(player, 'Prog')
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
 
                     if questProgress == 1 then
                         return quest:progressEvent(712)
-                    elseif lastDivination <= VanadielUniqueDay() then
-                        if questProgress == 0 then
-                            return quest:progressEvent(711, player:getGil())
-                        elseif questProgress == 2 then
-                            return quest:progressEvent(713, player:getGil())
-                        end
+                    elseif questProgress == 0 then
+                        return quest:progressEvent(711, player:getGil())
+                    elseif questProgress == 2 then
+                        return quest:progressEvent(713, player:getGil())
                     end
                 end,
             },
@@ -103,8 +103,6 @@ quest.sections =
                     then
                         player:delGil(1000)
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
 
@@ -120,8 +118,6 @@ quest.sections =
                     then
                         player:delGil(1000)
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
 
@@ -133,23 +129,8 @@ quest.sections =
                     if quest:complete(player) then
                         player:delKeyItem(xi.ki.SEALED_IMMORTAL_ENVELOPE)
 
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer', VanadielUniqueDay() + 1)
                         xi.quest.setMustZone(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.TRANSFORMATIONS)
-                    end
-                end,
-            },
-        },
-
-        [xi.zone.NAVUKGO_EXECUTION_CHAMBER] =
-        {
-            onEventFinish =
-            {
-                [32001] = function(player, csid, option, npc)
-                    if
-                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.OMENS and
-                        quest:getVar(player, 'Prog') == 0
-                    then
-                        quest:setVar(player, 'Prog', 1)
+                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.TRANSFORMATIONS, 'Timer', GetSystemTime() + 60) -- 1 minute wait time
                     end
                 end,
             },
@@ -173,6 +154,21 @@ quest.sections =
                 end,
             },
         },
+
+        [xi.zone.NAVUKGO_EXECUTION_CHAMBER] =
+        {
+            onEventFinish =
+            {
+                [32001] = function(player, csid, option, npc)
+                    if
+                        player:getLocalVar('battlefieldWin') == xi.battlefield.id.OMENS and
+                        quest:getVar(player, 'Prog') == 0
+                    then
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+            },
+        },
     },
 
     {
@@ -182,7 +178,7 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
-            ['Lathuya'] = quest:event(718):replaceDefault(),
+            ['Lathuya'] = quest:event(771):replaceDefault(),
         },
     },
 }

--- a/scripts/quests/ahtUrhgan/BLU_AF3_Transformations.lua
+++ b/scripts/quests/ahtUrhgan/BLU_AF3_Transformations.lua
@@ -1,10 +1,15 @@
 -----------------------------------
--- Transformations
+-- Transformations (BLU AF3)
 -----------------------------------
 -- Log ID: 6, Quest ID: 23
 -- Waoud              : !pos 65 -6 -78 50
 -- Imperial Whitegate : !pos 152 -2 0 50
 -- Alzadaal (Blank)   : !pos -529.704 0 649.682 72
+-----------------------------------
+-- The Beast Within opens one minute after this quest completes.
+-- The June 7, 2016 version update shortened the wait from one Earth day.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
 -----------------------------------
 local alzadaalID  = zones[xi.zone.ALZADAAL_UNDERSEA_RUINS]
 local whitegateID = zones[xi.zone.AHT_URHGAN_WHITEGATE]
@@ -33,17 +38,17 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
-
                     if
-                        lastDivination <= VanadielUniqueDay() and
-                        not quest:getMustZone(player)
+                        quest:getMustZone(player) or
+                        GetSystemTime() < quest:getVar(player, 'Timer')
                     then
-                        if quest:getVar(player, 'Prog') == 0 then
-                            return quest:progressEvent(720, player:getGil())
-                        else
-                            return quest:progressEvent(721, player:getGil())
-                        end
+                        return
+                    end
+
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(720, player:getGil())
+                    else
+                        return quest:progressEvent(721, player:getGil())
                     end
                 end,
             },
@@ -68,7 +73,6 @@ quest.sections =
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
 
                         quest:setVar(player, 'Prog', 1)
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
 
@@ -79,8 +83,6 @@ quest.sections =
                     then
                         player:delGil(1000)
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
 
@@ -102,11 +104,7 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
-                    local lastDivination = xi.quest.getVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.AN_EMPTY_VESSEL, 'Timer')
-
-                    if lastDivination <= VanadielUniqueDay() then
-                        return quest:progressEvent(723, player:getGil())
-                    end
+                    return quest:progressEvent(723, player:getGil())
                 end,
             },
 
@@ -119,8 +117,6 @@ quest.sections =
                     then
                         player:delGil(1000)
                         player:messageSpecial(whitegateID.text.PAY_DIVINATION)
-
-                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.BEGINNINGS, 'Timer', VanadielUniqueDay() + 1)
                     end
                 end,
             },
@@ -183,7 +179,9 @@ quest.sections =
                 end,
 
                 [5] = function(player, csid, option, npc)
-                    quest:complete(player)
+                    if quest:complete(player) then
+                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_BEAST_WITHIN, 'Timer', GetSystemTime() + 60) -- 1 minute wait time
+                    end
                 end,
             },
         },

--- a/scripts/quests/ahtUrhgan/BLU_LB_The_Beast_Within.lua
+++ b/scripts/quests/ahtUrhgan/BLU_LB_The_Beast_Within.lua
@@ -1,8 +1,13 @@
 -----------------------------------
--- The Beast Within
+-- The Beast Within (BLU LB)
 -----------------------------------
 -- Log ID: 6, Quest ID: 40
 -- Waoud: !pos 65 -6 -78 50
+-----------------------------------
+-- Opens one minute after Transformations completes.
+-- The June 7, 2016 version update shortened the wait from one Earth day.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
 -----------------------------------
 local whitegateID     = zones[xi.zone.AHT_URHGAN_WHITEGATE]
 local jadeSepulcherID = zones[xi.zone.JADE_SEPULCHER]
@@ -30,6 +35,10 @@ quest.sections =
             ['Waoud'] =
             {
                 onTrigger = function(player, npc)
+                    if GetSystemTime() < quest:getVar(player, 'Timer') then
+                        return
+                    end
+
                     return quest:progressEvent(760)
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR does multiple things for the BLU unlock quest and AF quest lines against retail captures:

**An Empty Vessel (BLU Job Unlock)**

- Waoud now charges 1000 gil when you fail his questions, and won't read for you again until the next game day. It used to be free and instantly repeatable.
- The reading now needs all ten answers right in one sitting. Correct answers used to carry over, so five right twice was enough.
- Waoud now moves the quest on after taking back his request. It used to stall there and could not be finished.
- Waoud now names the right item when you hand it to him.
- Yasfel now drops you where retail drops you when you turn him down, not where accepting does.
- Waoud now reads again straight after the Raubahn scene, instead of making you wait a day.
- Waoud now needs both a new game day and a zone before he reads again. The day alone used to be enough.
- Waoud now leaves the item in your bag when he doesn't take it. It used to get locked.

**BLU AF Quests**

- Only An Empty Vessel now uses the once-a-day reading. Beginnings, Omens and Transformations no longer share that timer, so paying for a hint can't delay a reading, and a reading can't delay a quest.
- Waoud now starts Beginnings as soon as you qualify. He used to offer a fortune instead until you left the zone and came back.
- Beginnings no longer sets a timer that nothing checks.
- Lathuya now plays the line retail plays after Omens.
- Each file header now names the job and artifact number.

## Steps to test these changes

Start the BLU unlock quest and see all of the above. Then do all of the AF quests and see the same.

## Captures

- [An Empty Vessel](https://youtu.be/XP4-UOwoDtY)
- [Beginnings](https://youtu.be/oU9Fshj0Rn8)
- [Omens](https://youtu.be/5yV8lNafGOg)
- [Transformations](https://youtu.be/QLWYp9LPu-U)
- [The Beast Within](https://youtu.be/JfXqw_h2KNw)