### PR TITLE
[lua] Fix inventory-full check blocking gil and spell rewards in avatar trials

### DIFF
--- a/scripts/zones/Mhaura/npcs/Ripapa.lua
+++ b/scripts/zones/Mhaura/npcs/Ripapa.lua
@@ -101,7 +101,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.ELDER_BRANCH
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Mhaura/npcs/Ripapa.lua
+++ b/scripts/zones/Mhaura/npcs/Ripapa.lua
@@ -101,7 +101,10 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.ELDER_BRANCH
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
+        if
+            player:getFreeSlotsCount() == 0 and
+            (option < 5 or option > 6)
+        then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Norg/npcs/Edal-Tahdal.lua
+++ b/scripts/zones/Norg/npcs/Edal-Tahdal.lua
@@ -78,7 +78,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.EYE_OF_NEPT
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Norg/npcs/Edal-Tahdal.lua
+++ b/scripts/zones/Norg/npcs/Edal-Tahdal.lua
@@ -78,7 +78,10 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.EYE_OF_NEPT
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
+        if
+            player:getFreeSlotsCount() == 0 and
+            (option < 5 or option > 6)
+        then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
@@ -98,7 +98,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.BOTTLE_OF_RUST_B_GONE  -- Rust 'B' Gone
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
+++ b/scripts/zones/Northern_San_dOria/npcs/Gulmama.lua
@@ -98,7 +98,10 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.BOTTLE_OF_RUST_B_GONE  -- Rust 'B' Gone
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
+        if
+            player:getFreeSlotsCount() == 0 and
+            (option < 5 or option > 6)
+        then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Rabao/npcs/Agado-Pugado.lua
+++ b/scripts/zones/Rabao/npcs/Agado-Pugado.lua
@@ -104,7 +104,7 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.BOTTLE_OF_BUBBLY_WATER
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then
+        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then

--- a/scripts/zones/Rabao/npcs/Agado-Pugado.lua
+++ b/scripts/zones/Rabao/npcs/Agado-Pugado.lua
@@ -104,7 +104,10 @@ entity.onEventFinish = function(player, csid, option, npc)
             item = xi.item.BOTTLE_OF_BUBBLY_WATER
         end
 
-        if player:getFreeSlotsCount() == 0 and (option ~= 5 and option ~= 6) then
+        if
+            player:getFreeSlotsCount() == 0 and
+            (option < 5 or option > 6)
+        then
             player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, item)
         else
             if option == 5 then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The four un-migrated Trial NPCs guard their reward handling with:

   ```lua  
if player:getFreeSlotsCount() == 0 and (option ~= 5 or option ~= 6) then 
```

The parenthesised check is always true, so the guard applies to every option. With a full inventory, both gil and pact rewards are refused and the player receives nothing. The quest is not completed and the Whisper key item is not consumed. The error message renders with a blank item name.

Use `and` so the inventory check applies only to the item rewards, which matches the already-migrated Trial_by_Fire and Trial_by_Earth.

Affects Trial by Ice (Gulmama), Wind (Agado-Pugado), Lightning (Ripapa) and Water (Edal-Tahdal).

## Steps to test these changes
```
 !addquest OUTLANDS TRIAL_BY_WIND
 !addkeyitem WHISPER_OF_GALES
 !additem 16448 30          -- fill inventory to zero free slots
 !pos -17 7 -10 247         -- Agado-Pugado, Rabao
```
 Talk to Agado-Pugado and select a reward.
 Before: options 5 (10,000 gil) and 6 (Garuda) are both refused with You cannot obtain the . — blank item name — no reward given, quest not completed, Whisper of Gales not consumed.
 After: both are granted and the quest completes normally on a full inventory.

 Verified in-client on Trial by Wind; the other three NPCs are character-identical.