### PR TITLE
[lua] ToAU Mission 3 and 4 audit

### DIFF
--- a/scripts/missions/toau/03_President_Salaheem.lua
+++ b/scripts/missions/toau/03_President_Salaheem.lua
@@ -26,6 +26,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 1 then
+                        -- TODO: This isn't necesarily true. We have proof showing that is both needed and not needed. More info is necesary.
                         if not mission:getMustZone(player) then
                             -- Trivia: There is a copy of this CS, but as a flashback, with Falzum instead of your character. CS: 3030
                             -- TODO: Maybe it's used?
@@ -45,7 +46,7 @@ mission.sections =
             {
                 [73] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 1)
-                    mission:setMustZone(player)
+                    mission:setMustZone(player) -- TODO: This isn't necesarily true. We have proof showing that is both needed and not needed. More info is necesary.
                 end,
 
                 [3020] = function(player, csid, option, npc)

--- a/scripts/missions/toau/04_Knight_of_Gold.lua
+++ b/scripts/missions/toau/04_Knight_of_Gold.lua
@@ -3,7 +3,9 @@
 -- Aht Uhrgan Mission 4
 -----------------------------------
 -- !addmission 4 3
--- Cacaroon : !pos -72.026 0.000 -82.337 50
+-- Cacaroon       : !pos -72  0  -86 50
+-- Walahra Temple : !pos  80 -0.3 22 50
+-- Teahouse       : !pos  80 -6 -117 50
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.TOAU, xi.mission.id.toau.KNIGHT_OF_GOLD)
@@ -27,7 +29,7 @@ mission.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        player:getMissionStatus(mission.areaId) == 1 and
+                        player:getMissionStatus(mission.areaId) == 2 and
                         (npcUtil.tradeMatches(trade, { { xi.item.GIL, 1000 } }) or
                         npcUtil.tradeMatches(trade, { { xi.item.IMPERIAL_BRONZE_PIECE, 1 } }))
                     then
@@ -38,12 +40,14 @@ mission.sections =
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
-                    if missionStatus == 0 then
-                        return mission:progressEvent(3035, { text_table = 0 })
-                    elseif missionStatus == 1 then
-                        return mission:progressEvent(3036, { text_table = 0 })
+                    if missionStatus <= 1 then
+                        local param6 = 0 -- Can trigger a line "weirdo with silly mask". Maybe tied to RoV?
+
+                        return mission:progressEvent(3035, 0, 0, 0, 0, 0, param6, 0, missionStatus, 0)
                     elseif missionStatus == 2 then
-                        return mission:event(3023, { text_table = 0 }):replaceDefault()
+                        return mission:event(3036, { text_table = 0 })
+                    else
+                        return mission:event(3023, { text_table = 0 })
                     end
                 end,
             },
@@ -51,7 +55,7 @@ mission.sections =
             ['Nadeey'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 3 then
+                    if player:getMissionStatus(mission.areaId) >= 3 then
                         return mission:event(3025, { text_table = 0 })
                     end
                 end,
@@ -60,45 +64,62 @@ mission.sections =
             ['Naja_Salaheem'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        return mission:progressEvent(3021, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
-                    end
+                    return mission:event(3021, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
                 end,
             },
 
             onTriggerAreaEnter =
             {
                 [4] = function(player, triggerArea)
-                    if player:getMissionStatus(mission.areaId) == 2 then
+                    if player:getMissionStatus(mission.areaId) == 3 then
                         return mission:progressEvent(3024, { text_table = 0 })
                     end
                 end,
 
                 [5] = function(player, triggerArea)
-                    if player:getMissionStatus(mission.areaId) == 3 then
-                        return mission:progressEvent(3026, { text_table = 0 })
+                    if player:getMissionStatus(mission.areaId) == 4 then
+                        local param6 = 0 -- Mention "San d'Oria's legendary sword". Maybe tied to RoV?
+
+                        return mission:progressEvent(3026, 0, 0, 0, 0, 0, param6, 0, 0, 0)
                     end
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [3026] = function(player, csid, option, npc)
+                    -- All 3 topics must be selected before you can advance
+                    local topics = utils.mask.setBit(mission:getLocalVar(player, 'Option'), option - 1, true)
+                    mission:setLocalVar(player, 'Option', topics)
+
+                    player:updateEvent(8 + topics, 1)
                 end,
             },
 
             onEventFinish =
             {
+                -- Step 2: Cacaroon trade event.
                 [3022] = function(player, csid, option, npc)
                     player:tradeComplete()
-                    player:setMissionStatus(mission.areaId, 2)
-                end,
-
-                [3024] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 3)
                 end,
 
+                -- Step 3: Zone-in event.
+                [3024] = function(player, csid, option, npc)
+                    player:setMissionStatus(mission.areaId, 4)
+                end,
+
+                -- Step 4: Zone-in event.
                 [3026] = function(player, csid, option, npc)
                     mission:complete(player)
                 end,
 
+                -- Step 1: Cacaroon trigger event.
                 [3035] = function(player, csid, option, npc)
-                    if option == 1 then
+                    if option == 0 then
                         player:setMissionStatus(mission.areaId, 1)
+                    else
+                        player:setMissionStatus(mission.areaId, 2)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Mission 3
- A zone is not required. Because of this, the 3003 event will never trigger.

Mission 4
- Naja's default event happens the entire mission.
- Cacaroon's sequence is messed up
- Nadeey needs a default text update after event 3024
- Trion has a section where you need to click through all 3 options before you can advance. The onEventUpdate fixes that.
- Split the Trion portion into a new section to make it easier to follow.

Capture: https://drive.google.com/file/d/1bnnBw31_u5LCOdFUoGnM-1vMfVK07oZ_/view?usp=drive_link
https://youtu.be/DtKYfCB130I

## Steps to test these changes

!addmission 4 2 and play through
I updated the !pos arguments to make this easier.
