### PR TITLE
[C++] [lua] Add equipment slot tracking to enchantment item usage, audit ring enchantments

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -6536,6 +6536,7 @@ xi.item =
     MANA_RING                           = 14651,
     PROTEAN_RING                        = 14652,
     VARIABLE_RING                       = 14653,
+    POISONA_RING                        = 14654,
     VENERER_RING                        = 14655,
     DUCAL_GUARDS_RING                   = 14657,
     BOWYER_RING                         = 14660,

--- a/scripts/items/armored_ring.lua
+++ b/scripts/items/armored_ring.lua
@@ -3,26 +3,45 @@
 -- Item: Armored Ring
 -- Item Effect: Defence +8
 -- Duration 30 Minutes
+-- https://wiki.ffo.jp/html/9580.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.ARMORED_RING) ~= nil then
-        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.ARMORED_RING)
-    end
-
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.ARMORED_RING) then
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.ARMORED_RING })
+itemObject.onItemUse = function(target, user, item, action, equipSlotID)
+    if equipSlotID then
+        local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+        if
+            effect and
+            effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+            effect:getSourceTypeParam() == xi.item.ARMORED_RING
+        then
+            effect:resetStartTime()
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, subType = equipSlotID, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.ARMORED_RING })
+        end
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.DEF, 8)
+end
+
+itemObject.onItemUnequip = function(target, item, equipSlotID)
+    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+    if
+        effect and
+        effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+        effect:getSourceTypeParam() == xi.item.ARMORED_RING
+    then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+    end
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/items/manashell_ring.lua
+++ b/scripts/items/manashell_ring.lua
@@ -2,27 +2,46 @@
 -- ID: 15782
 -- Item: Manashell Ring
 -- Item Effect: MP +9
--- Duration: 3 minutes
+-- Duration: 30 Minutes
+-- https://wiki.ffo.jp/html/9657.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
-itemObject.onItemCheck = function(target, user)
-    if target:getStatusEffectBySource(xi.effect.MAX_MP_BOOST, xi.effectSourceType.EQUIPPED_ITEM, xi.item.MANASHELL_RING) ~= nil then
-        target:delStatusEffect(xi.effect.MAX_MP_BOOST, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.MANASHELL_RING)
-    end
-
+itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.MANASHELL_RING) then
-        target:addStatusEffect(xi.effect.MAX_MP_BOOST, { duration = 180, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.MANASHELL_RING })
+itemObject.onItemUse = function(target, user, item, action, equipSlotID)
+    if equipSlotID then
+        local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+        if
+            effect and
+            effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+            effect:getSourceTypeParam() == xi.item.MANASHELL_RING
+        then
+            effect:resetStartTime()
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, subType = equipSlotID, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.MANASHELL_RING })
+        end
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.MP, 9)
+end
+
+itemObject.onItemUnequip = function(target, item, equipSlotID)
+    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+    if
+        effect and
+        effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+        effect:getSourceTypeParam() == xi.item.MANASHELL_RING
+    then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+    end
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/items/mighty_ring.lua
+++ b/scripts/items/mighty_ring.lua
@@ -3,27 +3,46 @@
 -- Item: mighty_ring
 -- Item Effect: Attack +5, Ranged Attack +5
 -- Duration: 30 Minutes
+-- https://wiki.ffo.jp/html/2278.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.MIGHTY_RING) ~= nil then
-        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.MIGHTY_RING)
-    end
-
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.MIGHTY_RING) then
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.MIGHTY_RING })
+itemObject.onItemUse = function(target, user, item, action, equipSlotID)
+    if equipSlotID then
+        local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+        if
+            effect and
+            effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+            effect:getSourceTypeParam() == xi.item.MIGHTY_RING
+        then
+            effect:resetStartTime()
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, subType = equipSlotID, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.MIGHTY_RING })
+        end
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.ATT, 5)
     effect:addMod(xi.mod.RATT, 5)
+end
+
+itemObject.onItemUnequip = function(target, item, equipSlotID)
+    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+    if
+        effect and
+        effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+        effect:getSourceTypeParam() == xi.item.MIGHTY_RING
+    then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+    end
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/items/poisona_ring.lua
+++ b/scripts/items/poisona_ring.lua
@@ -1,7 +1,8 @@
 -----------------------------------
--- ID: 4148
--- Item: Antidote
--- Item Effect: This potion remedies poison.
+-- ID: 14654
+-- Item: Poisona Ring
+-- Item Effect: Enchantment: Poisona
+-- https://wiki.ffo.jp/html/8859.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -10,9 +11,14 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target)
-    if target:hasStatusEffect(xi.effect.POISON) then
+itemObject.onItemUse = function(target, user)
+    if
+        target:hasEquipped(xi.item.POISONA_RING) and
+        target:hasStatusEffect(xi.effect.POISON)
+    then
         target:delStatusEffect(xi.effect.POISON)
+    else
+        target:messageBasic(xi.msg.basic.NO_EFFECT)
     end
 end
 

--- a/scripts/items/random_ring.lua
+++ b/scripts/items/random_ring.lua
@@ -1,30 +1,47 @@
 -----------------------------------
 -- ID: 15770
 -- Item: Random Ring
--- Item Effect: Enchantment Dex + math.randomInt(1, 8)
--- Duration: 30 Mins
+-- Item Effect: Enchantment: DEX +1 to +8
+-- Duration: 30 Minutes
+-- https://wiki.ffo.jp/html/9154.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.RANDOM_RING) ~= nil then
-        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.RANDOM_RING)
-    end
-
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.RANDOM_RING) then
-        local power = math.randomInt(1, 8)
+itemObject.onItemUse = function(target, user, item, action, equipSlotID)
+    if equipSlotID then
+        local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
 
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { power = power, duration = 3600, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.RANDOM_RING })
+        if
+            effect and
+            effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+            effect:getSourceTypeParam() == xi.item.RANDOM_RING
+        then
+            effect:resetStartTime()
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { power = math.randomInt(1, 8), duration = 1800, origin = user, subType = equipSlotID, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.RANDOM_RING })
+        end
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.DEX, effect:getPower())
+end
+
+itemObject.onItemUnequip = function(target, item, equipSlotID)
+    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+    if
+        effect and
+        effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+        effect:getSourceTypeParam() == xi.item.RANDOM_RING
+    then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+    end
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/items/vision_ring.lua
+++ b/scripts/items/vision_ring.lua
@@ -3,27 +3,46 @@
 -- Item: vision_ring
 -- Item Effect: ACC+2 RACC+2
 -- Duration: 30 Minutes
+-- https://wiki.ffo.jp/html/2256.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
 
 itemObject.onItemCheck = function(target, item, caster)
-    if target:getStatusEffectBySource(xi.effect.ENCHANTMENT, xi.effectSourceType.EQUIPPED_ITEM, xi.item.VISION_RING) ~= nil then
-        target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.VISION_RING)
-    end
-
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.VISION_RING) then
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.VISION_RING })
+itemObject.onItemUse = function(target, user, item, action, equipSlotID)
+    if equipSlotID then
+        local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+        if
+            effect and
+            effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+            effect:getSourceTypeParam() == xi.item.VISION_RING
+        then
+            effect:resetStartTime()
+        else
+            target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 1800, origin = user, subType = equipSlotID, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.VISION_RING })
+        end
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
     effect:addMod(xi.mod.ACC, 2)
     effect:addMod(xi.mod.RACC, 2)
+end
+
+itemObject.onItemUnequip = function(target, item, equipSlotID)
+    local effect = target:getStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+
+    if
+        effect and
+        effect:getSourceType() == xi.effectSourceType.EQUIPPED_ITEM and
+        effect:getSourceTypeParam() == xi.item.VISION_RING
+    then
+        target:delStatusEffect(xi.effect.ENCHANTMENT, equipSlotID)
+    end
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/specs/types/Item.lua
+++ b/scripts/specs/types/Item.lua
@@ -2,8 +2,8 @@
 
 ---@class TItem
 ---@field onItemCheck? fun(target: CBaseEntity, item: CItem?, caster: CBaseEntity?): (integer?, integer?, integer?)
----@field onItemUse? fun(target: CBaseEntity, user: CBaseEntity?, item: CItem, action: CAction): integer?
----@field onItemUnequip? fun(PUser: CBaseEntity, PItem: CItem): nil
+---@field onItemUse? fun(target: CBaseEntity, user: CBaseEntity?, item: CItem, action: CAction, equipSlotID: integer?): integer?
+---@field onItemUnequip? fun(PUser: CBaseEntity, PItem: CItem, equipSlotID: integer): nil
 ---@field onItemEquip? fun(PUser: CBaseEntity, PItem: CItem): nil
 ---@field onItemAdditionalEffect? fun(attacker: CBaseEntity, target: CBaseEntity, baseAttackDamage: integer, item: CItem): (integer, integer, integer)
 ---@field onItemDrop? fun(PUser: CBaseEntity, PItem: CItem, recycleBin: boolean): nil

--- a/scripts/tests/systems/items/item_use.lua
+++ b/scripts/tests/systems/items/item_use.lua
@@ -66,4 +66,45 @@ describe('Item use', function()
         assert(midUse)
         assert(midUse:state() == xi.itemState.EQUIPPED)
     end)
+
+    it('ring enchantments stack', function()
+        assert(player:addItem(xi.item.ARMORED_RING))
+        assert(player:addItem(xi.item.ARMORED_RING))
+
+        local armoredRings = player:findItems(xi.item.ARMORED_RING, xi.inv.INVENTORY)
+        assert(#armoredRings == 2)
+
+        local defense = player:getMod(xi.mod.DEF)
+
+        player.actions:equipSet({
+            { index = armoredRings[1]:getSlotID(), kind = xi.slot.RING1, container = xi.inv.INVENTORY },
+            { index = armoredRings[2]:getSlotID(), kind = xi.slot.RING2, container = xi.inv.INVENTORY },
+        })
+
+        -- Wait for the enchanted items to become usable
+        xi.test.world:skipTime(31)
+
+        -- Each ring carries a base DEF+1 alongside the DEF+8 it grants when used
+        assert(player:getMod(xi.mod.DEF) == defense + 2, 'both rings give their base defense')
+
+        local function useRing(ring)
+            player.actions:useItem(player, ring:getSlotID(), xi.inv.INVENTORY)
+            xi.test.world:skipTime(4)
+            xi.test.world:tick()
+        end
+
+        useRing(armoredRings[1])
+        assert(player:getMod(xi.mod.DEF) == defense + 10, 'first ring grants its enchantment')
+
+        useRing(armoredRings[2])
+        assert(player:getMod(xi.mod.DEF) == defense + 18, 'second ring stacks its own enchantment')
+
+        player:unequipItem(xi.slot.RING1)
+        assert(player:getMod(xi.mod.DEF) == defense + 9, 'unequipped ring loses its enchantment')
+        assert(player:countEffect(xi.effect.ENCHANTMENT) == 1, 'worn ring keeps its enchantment')
+
+        player:unequipItem(xi.slot.RING2)
+        assert(player:getMod(xi.mod.DEF) == defense, 'unequipping both rings restores original defense')
+        assert(player:countEffect(xi.effect.ENCHANTMENT) == 0, 'unequipping both rings removes enchantments')
+    end)
 end)

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -3035,7 +3035,21 @@ int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem, action_t
         charutils::RemoveInvisible(PChar);
     }
 
-    auto result = onItemUse(PTarget, PUser, PItem, action);
+    // If the item being used is equipped, pass the equipment slot to the Lua script.
+    sol::object equipSlotID = sol::lua_nil;
+    if (const auto* PChar = dynamic_cast<CCharEntity*>(PUser))
+    {
+        for (uint8 slotID = SLOT_MAIN; slotID <= SLOT_BACK; ++slotID)
+        {
+            if (PChar->getEquip(static_cast<SLOTTYPE>(slotID)) == PItem)
+            {
+                equipSlotID = sol::make_object(lua, slotID);
+                break;
+            }
+        }
+    }
+
+    auto result = onItemUse(PTarget, PUser, PItem, action, equipSlotID);
     if (!result.valid())
     {
         sol::error err = result;
@@ -3089,7 +3103,7 @@ void OnItemEquip(CBaseEntity* PUser, CItem* PItem)
     }
 }
 
-void OnItemUnequip(CBaseEntity* PUser, CItem* PItem)
+void OnItemUnequip(CBaseEntity* PUser, CItem* PItem, uint8 equipSlotID)
 {
     TracyZoneScoped;
 
@@ -3101,7 +3115,7 @@ void OnItemUnequip(CBaseEntity* PUser, CItem* PItem)
         return;
     }
 
-    auto result = onItemUnequip(PUser, PItem);
+    auto result = onItemUnequip(PUser, PItem, equipSlotID);
     if (!result.valid())
     {
         sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -321,7 +321,7 @@ int32 OnItemUse(CBaseEntity* PUser, CBaseEntity* PTarget, CItem* PItem, action_t
 auto  OnItemCheck(CBaseEntity* PTarget, CItem* PItem, CBaseEntity* PCaster = nullptr) -> std::tuple<int32, int32, int32>;
 void  OnItemDrop(CBaseEntity* PUser, CItem* PItem, IsRecycleBin recycleBin = IsRecycleBin::No);
 void  OnItemEquip(CBaseEntity* PUser, CItem* PItem);
-void  OnItemUnequip(CBaseEntity* PUser, CItem* PItem);
+void  OnItemUnequip(CBaseEntity* PUser, CItem* PItem, uint8 equipSlotID);
 void  CheckForGearSet(CBaseEntity* PTarget);
 
 int32 OnMagicCastingCheck(CBaseEntity* PChar, CBaseEntity* PTarget, CSpell* PSpell);

--- a/src/map/status_effect_container.cpp
+++ b/src/map/status_effect_container.cpp
@@ -1524,7 +1524,7 @@ auto CStatusEffectContainer::SetEffectParams(CStatusEffect* StatusEffect) -> voi
 
     // Is an effect from a usable item not caught above.
     // Known use cases: Enchantments without an effect source.
-    else
+    else if (name.empty())
     {
         const CItem* Ptem = xi::items::lookup(subType);
         if (Ptem != nullptr && subType > 0)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -2311,7 +2311,7 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
             break;
         }
 
-        luautils::OnItemUnequip(PChar, PItem);
+        luautils::OnItemUnequip(PChar, PItem, equipSlotID);
 
         PChar->inventorySyncState().queueEquipChange(LOC_INVENTORY, 0, static_cast<SLOTTYPE>(equipSlotID), PItem, Equipping::No);
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Sets up onItemUse and onItemUnequip to pass the equipment slot so that enchantments in the ring/earring slots stack and remove their effects properly. Also closes an edge case where a subType in the item effect could unintentionally be fed as a itemID (which is part of the reason this didn't work correctly to begin with)

Test included.

## Steps to test these changes

!additem Armored Ring x2
/checkparam yourself
note defense
equip them both, see items stack
remove one, see one enchantment leave + lose 9 defense (1+ 8 from the enchantment)
remove the other
