### PR TITLE
[lua] SAM AF Quest Audits + Era Modules

### DIFF
--- a/modules/era/lua/quests/outlands/A_Thief_in_Norg.lua
+++ b/modules/era/lua/quests/outlands/A_Thief_in_Norg.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- A Thief in Norg!? (SAM AF3)
+-- Restores the JST midnight wait before Jaucribaix repairs the charred helm.
+-- The July 8, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_a_thief_in_norg'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/SAM_AF3_A_Thief_in_Norg', function(quest)
+        local norg         = quest.sections[2][xi.zone.NORG]
+        local baseThreadCS = norg.onEventFinish[162]
+
+        -- The helm is repaired at JST midnight.
+        norg.onEventFinish[162] = function(player, csid, option, npc)
+            baseThreadCS(player, csid, option, npc)
+            quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/outlands/The_Sacred_Katana.lua
+++ b/modules/era/lua/quests/outlands/The_Sacred_Katana.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- The Sacred Katana (SAM AF1)
+-- Restores the JST midnight wait before Jaucribaix offers Yomi Okuri.
+-- The July 8, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_the_sacred_katana'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/SAM_AF1_The_Sacred_Katana', function(quest)
+        local norg = quest.sections[2][xi.zone.NORG]
+
+        -- Copy of the base handler. Yomi Okuri is offered at JST midnight.
+        norg.onEventFinish[141] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:tradeComplete()
+                player:delKeyItem(xi.ki.HANDFUL_OF_CRYSTAL_SCALES)
+
+                -- Player must zone before being able to flag the next quest
+                xi.quest.setMustZone(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.YOMI_OKURI)
+                xi.quest.setVar(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.YOMI_OKURI, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)
+
+return m

--- a/modules/era/lua/quests/outlands/Yomi_Okuri.lua
+++ b/modules/era/lua/quests/outlands/Yomi_Okuri.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- Yomi Okuri (SAM AF2)
+-- Restores the JST midnight wait before Jaucribaix hands over the yomotsu hirasaka.
+-- The same wait returns before he offers A Thief in Norg!?
+-- The July 8, 2014 version update shortened both to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local moduleName = 'era_quest_yomi_okuri'
+
+if xi.module.isContentEnabled('SOA') then
+    return { name = moduleName }
+end
+
+local m = Module:new(moduleName)
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/SAM_AF2_Yomi_Okuri', function(quest)
+        local norg          = quest.sections[2][xi.zone.NORG]
+        local baseFeatherCS = norg.onEventFinish[152]
+
+        -- The hirasaka is handed over at JST midnight.
+        norg.onEventFinish[152] = function(player, csid, option, npc)
+            baseFeatherCS(player, csid, option, npc)
+            quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+        end
+
+        -- Copy of the base handler. A Thief in Norg!? is offered at JST midnight.
+        norg.onEventFinish[156] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:delKeyItem(xi.ki.FADED_YOMOTSU_HIRASAKA)
+                xi.quest.setMustZone(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.A_THIEF_IN_NORG)
+                xi.quest.setVar(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.A_THIEF_IN_NORG, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)
+
+return m

--- a/scripts/quests/outlands/SAM_AF1_The_Sacred_Katana.lua
+++ b/scripts/quests/outlands/SAM_AF1_The_Sacred_Katana.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- The Sacred Katana
+-- The Sacred Katana (SAM AF1)
 -----------------------------------
 -- Log ID: 5, Quest ID: 140
 -- Jaucribaix      : !pos 91 -7 -8 252
@@ -55,14 +55,14 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:hasKeyItem(xi.ki.HANDFUL_OF_CRYSTAL_SCALES) and
-                        npcUtil.tradeHasExactly(trade, xi.item.MUMEITO)
+                        npcUtil.tradeMatches(trade, { { xi.item.MUMEITO, 1 } })
                     then
                         return quest:progressEvent(141)
                     end
                 end,
 
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(player:findItem(17809) and 140 or 143)
+                    return quest:event(player:findItem(xi.item.MUMEITO) and 140 or 143)
                 end,
             },
 
@@ -71,7 +71,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         not player:findItem(xi.item.MUMEITO) and
-                        npcUtil.tradeHasExactly(trade, { { 'gil', 30000 } })
+                        npcUtil.tradeMatches(trade, { { xi.item.GIL, 30000 } })
                     then
                         return quest:progressEvent(145)
                     end
@@ -79,7 +79,7 @@ quest.sections =
 
                 onTrigger = function(player, npc)
                     if not player:findItem(xi.item.MUMEITO) then
-                        return quest:progressEvent(144)
+                        return quest:event(144)
                     end
                 end,
             },
@@ -94,17 +94,18 @@ quest.sections =
 
                 [141] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         player:delKeyItem(xi.ki.HANDFUL_OF_CRYSTAL_SCALES)
 
                         -- Player must zone before being able to flag the next quest
-                        player:setLocalVar('Quest[5][141]mustZone', 1)
+                        xi.quest.setMustZone(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.YOMI_OKURI)
+                        xi.quest.setVar(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.YOMI_OKURI, 'Timer', GetSystemTime() + 60) -- 1 minute wait time
                     end
                 end,
 
                 [145] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.item.MUMEITO) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -123,10 +124,10 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.SACK_OF_FISH_BAIT) and
+                        npcUtil.tradeMatches(trade, { { xi.item.SACK_OF_FISH_BAIT, 1 } }) and
                         npcUtil.popFromQM(player, npc, zitahID.mob.ISONADE, { hide = 0 })
                     then
-                        player:confirmTrade()
+                        player:tradeComplete()
                         return quest:messageSpecial(zitahID.text.SENSE_OF_FOREBODING)
                     end
                 end,

--- a/scripts/quests/outlands/SAM_AF2_Yomi_Okuri.lua
+++ b/scripts/quests/outlands/SAM_AF2_Yomi_Okuri.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Yomi Okuri
+-- Yomi Okuri (SAM AF2)
 -----------------------------------
 -- Log ID: 5, Quest ID: 141
 -- Jaucribaix      : !pos 91 -7 -8 252
@@ -35,7 +35,14 @@ quest.sections =
             ['Jaucribaix'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(quest:getMustZone(player) and 142 or 146)
+                    if
+                        quest:getMustZone(player) or
+                        GetSystemTime() < quest:getVar(player, 'Timer')
+                    then
+                        return quest:event(142)
+                    end
+
+                    return quest:progressEvent(146)
                 end,
             },
 
@@ -55,84 +62,6 @@ quest.sections =
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_ACCEPTED
         end,
-
-        [xi.zone.NORG] =
-        {
-            ['Jaucribaix'] =
-            {
-                onTrigger = function(player, npc)
-                    local questProgress = quest:getVar(player, 'Prog')
-
-                    if questProgress <= 3 then
-                        return quest:progressEvent(player:hasKeyItem(xi.ki.YOMOTSU_FEATHER) and 152 or 147)
-                    elseif questProgress == 4 then
-                        return quest:progressEvent(player:needToZone() and 153 or 154)
-                    elseif player:hasKeyItem(xi.ki.YOMOTSU_HIRASAKA) then
-                        return quest:progressEvent(155)
-                    elseif player:hasKeyItem(xi.ki.FADED_YOMOTSU_HIRASAKA) then
-                        return quest:progressEvent(156)
-                    end
-                end,
-            },
-
-            ['Washu'] =
-            {
-                onTrade = function(player, npc, trade)
-                    if
-                        quest:getVar(player, 'Stage') == 0 and
-                        not player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST) and
-                        not player:hasKeyItem(xi.ki.YOMOTSU_FEATHER) and
-                        npcUtil.tradeHasExactly(trade, { xi.item.HECTEYES_EYE, xi.item.BASTORE_SARDINE_1, xi.item.SLICE_OF_GIANT_SHEEP_MEAT, xi.item.FROST_TURNIP })
-                    then
-                        return quest:progressEvent(150)
-                    end
-                end,
-
-                onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 1 then
-                        return quest:progressEvent(148)
-                    elseif player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST) then
-                        return quest:progressEvent(151)
-                    elseif
-                        quest:getVar(player, 'Stage') == 0 and
-                        not player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST)
-                    then
-                        return quest:progressEvent(149)
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [148] = function(player, csid, option, npc)
-                    quest:setVar(player, 'Prog', 2)
-                end,
-
-                [150] = function(player, csid, option, npc)
-                    player:confirmTrade()
-                    npcUtil.giveKeyItem(player, xi.ki.WASHUS_TASTY_WURST)
-                    quest:setVar(player, 'Prog', 3)
-                end,
-
-                [152] = function(player, csid, option, npc)
-                    player:delKeyItem(xi.ki.YOMOTSU_FEATHER)
-                    quest:setVar(player, 'Prog', 4)
-                    quest:setMustZone(player)
-                end,
-
-                [154] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.YOMOTSU_HIRASAKA)
-                    quest:setVar(player, 'Prog', 5)
-                end,
-
-                [156] = function(player, csid, option, npc)
-                    if quest:complete(player) then
-                        player:delKeyItem(xi.ki.FADED_YOMOTSU_HIRASAKA)
-                        player:setLocalVar('Quest[5][142]mustZone', 1)
-                    end
-                end,
-            },
-        },
 
         [xi.zone.LABYRINTH_OF_ONZOZO] =
         {
@@ -173,6 +102,97 @@ quest.sections =
 
                 [1] = function(player, csid, option, npc)
                     npcUtil.giveKeyItem(player, xi.ki.YOMOTSU_FEATHER)
+                end,
+            },
+        },
+
+        [xi.zone.NORG] =
+        {
+            ['Jaucribaix'] =
+            {
+                onTrigger = function(player, npc)
+                    local questProgress = quest:getVar(player, 'Prog')
+
+                    if questProgress <= 3 then
+                        if not player:hasKeyItem(xi.ki.YOMOTSU_FEATHER) then
+                            return quest:event(147)
+                        end
+
+                        return quest:progressEvent(152)
+                    elseif questProgress == 4 then
+                        if
+                            quest:getMustZone(player) or
+                            GetSystemTime() < quest:getVar(player, 'Wait')
+                        then
+                            return quest:event(153)
+                        end
+
+                        return quest:progressEvent(154)
+                    elseif player:hasKeyItem(xi.ki.YOMOTSU_HIRASAKA) then
+                        return quest:event(155)
+                    elseif player:hasKeyItem(xi.ki.FADED_YOMOTSU_HIRASAKA) then
+                        return quest:progressEvent(156)
+                    end
+                end,
+            },
+
+            ['Washu'] =
+            {
+                onTrade = function(player, npc, trade)
+                    if
+                        quest:getVar(player, 'Stage') == 0 and
+                        not player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST) and
+                        not player:hasKeyItem(xi.ki.YOMOTSU_FEATHER) and
+                        npcUtil.tradeMatches(trade, { { xi.item.HECTEYES_EYE, 1 }, { xi.item.BASTORE_SARDINE_1, 1 }, { xi.item.SLICE_OF_GIANT_SHEEP_MEAT, 1 }, { xi.item.FROST_TURNIP, 1 } })
+                    then
+                        return quest:progressEvent(150)
+                    end
+                end,
+
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 1 then
+                        return quest:progressEvent(148)
+                    elseif player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST) then
+                        return quest:event(151)
+                    elseif
+                        quest:getVar(player, 'Stage') == 0 and
+                        not player:hasKeyItem(xi.ki.WASHUS_TASTY_WURST)
+                    then
+                        return quest:event(149)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [148] = function(player, csid, option, npc)
+                    quest:setVar(player, 'Prog', 2)
+                end,
+
+                [150] = function(player, csid, option, npc)
+                    player:tradeComplete()
+                    npcUtil.giveKeyItem(player, xi.ki.WASHUS_TASTY_WURST)
+                    quest:setVar(player, 'Prog', 3)
+                end,
+
+                [152] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.YOMOTSU_FEATHER)
+                    quest:setVar(player, 'Prog', 4)
+                    quest:setMustZone(player)
+                    quest:setVar(player, 'Wait', GetSystemTime() + 60) -- 1 minute wait time
+                end,
+
+                [154] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.YOMOTSU_HIRASAKA)
+                    quest:setVar(player, 'Prog', 5)
+                end,
+
+                [156] = function(player, csid, option, npc)
+                    if quest:complete(player) then
+                        player:delKeyItem(xi.ki.FADED_YOMOTSU_HIRASAKA)
+                        xi.quest.setMustZone(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.A_THIEF_IN_NORG)
+                        xi.quest.setVar(player, xi.questLog.OUTLANDS, xi.quest.id.outlands.A_THIEF_IN_NORG, 'Timer', GetSystemTime() + 60) -- 1 minute wait time
+                    end
                 end,
             },
         },

--- a/scripts/quests/outlands/SAM_AF3_A_Thief_in_Norg.lua
+++ b/scripts/quests/outlands/SAM_AF3_A_Thief_in_Norg.lua
@@ -1,5 +1,5 @@
 -----------------------------------
--- Yomi Okuri
+-- A Thief in Norg!? (SAM AF3)
 -----------------------------------
 -- Log ID: 5, Quest ID: 142
 -- Jaucribaix      : !pos 91 -7 -8 252
@@ -35,7 +35,14 @@ quest.sections =
             ['Jaucribaix'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(quest:getMustZone(player) and 157 or 158)
+                    if
+                        quest:getMustZone(player) or
+                        GetSystemTime() < quest:getVar(player, 'Timer')
+                    then
+                        return quest:event(157)
+                    end
+
+                    return quest:progressEvent(158)
                 end,
             },
 
@@ -85,9 +92,9 @@ quest.sections =
                     if questProgress == 2 then
                         return quest:progressEvent(301)
                     elseif questProgress == 3 then
-                        return quest:progressEvent(303)
+                        return quest:event(303)
                     elseif questProgress >= 4 then
-                        return quest:progressEvent(302)
+                        return quest:event(302)
                     end
                 end,
             },
@@ -107,7 +114,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         player:hasKeyItem(xi.ki.CHARRED_HELM) and
-                        npcUtil.tradeHasExactly(trade, xi.item.SPOOL_OF_GOLD_THREAD)
+                        npcUtil.tradeMatches(trade, { { xi.item.SPOOL_OF_GOLD_THREAD, 1 } })
                     then
                         return quest:progressEvent(162)
                     end
@@ -117,17 +124,28 @@ quest.sections =
                     local questProgress = quest:getVar(player, 'Prog')
 
                     if questProgress <= 4 then
-                        return quest:progressEvent(159)
+                        return quest:event(159)
                     elseif questProgress == 5 then
                         return quest:progressEvent(166)
                     elseif questProgress == 6 then
-                        return quest:progressEvent(player:findItem(xi.item.BANISHING_CHARM) and 167 or 168)
+                        if player:findItem(xi.item.BANISHING_CHARM) then
+                            return quest:event(167)
+                        end
+
+                        return quest:progressEvent(168)
                     elseif questProgress == 7 then
                         return quest:progressEvent(160)
                     elseif questProgress == 8 then
-                        return quest:progressEvent(161)
+                        return quest:event(161)
                     elseif questProgress == 9 then
-                        return quest:progressEvent(quest:getMustZone(player) and 163 or 164)
+                        if
+                            quest:getMustZone(player) or
+                            GetSystemTime() < quest:getVar(player, 'Wait')
+                        then
+                            return quest:event(163)
+                        end
+
+                        return quest:progressEvent(164)
                     end
                 end,
             },
@@ -139,10 +157,11 @@ quest.sections =
                 end,
 
                 [162] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     player:delKeyItem(xi.ki.CHARRED_HELM)
                     quest:setVar(player, 'Prog', 9)
                     quest:setMustZone(player)
+                    quest:setVar(player, 'Wait', GetSystemTime() + 60) -- 1 minute wait time
                 end,
 
                 [164] = function(player, csid, option, npc)
@@ -171,9 +190,9 @@ quest.sections =
                     if questProgress == 1 then
                         return quest:progressEvent(304)
                     elseif questProgress == 2 then
-                        return quest:progressEvent(305)
+                        return quest:event(305)
                     elseif questProgress >= 3 then
-                        return quest:progressEvent(306)
+                        return quest:event(306)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR does two things:

1. Audits SAM AF quests to fix a few issues including enforcing zone switching, enforcing wait timers, updating wait timers to the lowered 1 minute retail timer per the [July 2014 version update](https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update), and fixing items getting stuck after a trade.

3. Creates era modules for the SAM AF quests to restore the original JST midnight waits in place of the updated shortened retail waits.

## Steps to test these changes

Do all the SAM AF quests and see that items aren't locked, zoning is enforced, and timers are too. Then enable the modules and see all the same except JST midnight waits are present like era.