### PR TITLE
[sql][cpp] Adds more more detailed tracking data to audit_vendor

### DIFF
--- a/sql/audit_vendor.sql
+++ b/sql/audit_vendor.sql
@@ -15,12 +15,18 @@ CREATE TABLE IF NOT EXISTS `audit_vendor` (
   `quantity` int(10) unsigned NOT NULL DEFAULT '0',
   `seller` int(10) unsigned NOT NULL DEFAULT '0',
   `seller_name` varchar(15) DEFAULT NULL,
+  `direction` enum('sell','buy') NOT NULL DEFAULT 'sell',
+  `npcid` int(10) unsigned NOT NULL DEFAULT '0',
+  `npc_name` varchar(64) DEFAULT NULL,
+  `zoneid` smallint(5) unsigned NOT NULL DEFAULT '0',
   `baseprice` int(10) unsigned NOT NULL DEFAULT '0',
   `totalprice` int(10) unsigned NOT NULL DEFAULT '0',
+  `applied_gil` int(11) NOT NULL DEFAULT '0',
   `date` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `itemid` (`itemid`),
-  KEY `charid` (`seller`)
+  KEY `charid` (`seller`),
+  KEY `npcid` (`npcid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 AUTO_INCREMENT=1;
 
 --

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -5001,6 +5001,18 @@ void CLuaBaseEntity::createShop(uint8 size, const sol::object& arg1)
     PChar->Container->Clean();
     PChar->Container->setSize(size + 1);
 
+    // Apply the vendor ID to the actual shop container not the tempoary one
+    const auto* PVendor = [&]()
+    {
+        if (PChar->isInEvent())
+        {
+            return PChar->currentEvent->targetEntity;
+        }
+
+        return PChar->eventPreparation->targetEntity;
+    }();
+    PChar->Container->setShopVendorId(PVendor ? PVendor->id : 0);
+
     if (arg1 != sol::lua_nil && arg1.is<double>())
     {
         PChar->Container->setType(arg1.as<uint8>());

--- a/src/map/packets/c2s/0x083_shop_buy.cpp
+++ b/src/map/packets/c2s/0x083_shop_buy.cpp
@@ -21,12 +21,67 @@
 
 #include "0x083_shop_buy.h"
 
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "packets/s2c/0x01d_item_same.h"
 #include "packets/s2c/0x03f_shop_buy.h"
 #include "trade_container.h"
 #include "utils/charutils.h"
 #include "utils/itemutils.h"
+#include "utils/zoneutils.h"
+
+namespace
+{
+
+const auto auditPurchase = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint32_t quantity, uint32_t basePrice, int32_t appliedGil)
+{
+    if (settings::get<bool>("map.AUDIT_PLAYER_VENDOR"))
+    {
+        const auto* PNpc = zoneutils::GetEntity(PChar->Container->getShopVendorId(), TYPE_NPC);
+
+        const auto npcName = [PNpc]() -> std::string
+        {
+            if (PNpc)
+            {
+                return PNpc->getName();
+            }
+
+            return {};
+        }();
+
+        scheduler.postToWorkerThread(
+            [itemId,
+             quantity,
+             buyer     = PChar->id,
+             buyerName = PChar->getName(),
+             basePrice,
+             appliedGil,
+             npcId = PChar->Container->getShopVendorId(),
+             npcName,
+             zoneId = static_cast<uint16>(PChar->getZone())]()
+            {
+                const auto totalPrice = quantity * basePrice;
+
+                if (!db::preparedStmt("INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, direction, npcid, npc_name, zoneid, baseprice, totalprice, applied_gil, date) "
+                                      "VALUES (?, ?, ?, ?, 'buy', ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())",
+                                      itemId,
+                                      quantity,
+                                      buyer,
+                                      buyerName,
+                                      npcId,
+                                      npcName,
+                                      zoneId,
+                                      basePrice,
+                                      totalPrice,
+                                      appliedGil))
+                {
+                    ShowErrorFmt("Failed to log vendor purchase (item: {}, quantity: {}, buyer: {}, totalprice: {})", itemId, quantity, buyer, totalPrice);
+                }
+            });
+    }
+};
+
+} // namespace
 
 auto GP_CLI_COMMAND_SHOP_BUY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -99,7 +154,14 @@ void GP_CLI_COMMAND_SHOP_BUY::process(MapSession* PSession, CCharEntity* PChar) 
     {
         if (charutils::AddItem(PChar, LOC_INVENTORY, itemId, quantity) != ERROR_SLOTID)
         {
+            // Track the gil the player had before the transaction
+            const uint32 gilBefore = gil->getQuantity();
             charutils::UpdateItem(PChar, LOC_INVENTORY, 0, -static_cast<int32>(price * quantity));
+
+            // Audit the purchase if enabled
+            const auto appliedGil = static_cast<int32>(PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity()) - static_cast<int32>(gilBefore);
+            auditPurchase(*PSession->scheduler, PChar, itemId, quantity, price, appliedGil);
+
             ShowInfo("User '%s' purchased %u of item of ID %u [from VENDOR] ", PChar->getName(), quantity, itemId);
             PChar->pushPacket<GP_SERV_COMMAND_SHOP_BUY>(this->ShopItemIndex, quantity);
             PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);

--- a/src/map/packets/c2s/0x085_shop_sell_set.cpp
+++ b/src/map/packets/c2s/0x085_shop_sell_set.cpp
@@ -30,21 +30,52 @@
 #include "packets/s2c/0x01d_item_same.h"
 #include "trade_container.h"
 #include "utils/charutils.h"
+#include "utils/zoneutils.h"
 
 namespace
 {
 
-const auto auditSale = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint32_t quantity, uint32_t basePrice)
+const auto auditSale = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint32_t quantity, uint32_t basePrice, int32_t appliedGil)
 {
     if (settings::get<bool>("map.AUDIT_PLAYER_VENDOR"))
     {
-        scheduler.postToWorkerThread(
-            [itemId, quantity, seller = PChar->id, sellerName = PChar->getName(), basePrice]()
-            {
-                auto totalPrice = quantity * basePrice;
+        const auto* PNpc = zoneutils::GetEntity(PChar->Container->getShopVendorId(), TYPE_NPC);
 
-                const auto query = "INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, baseprice, totalprice, date) VALUES (?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())";
-                if (!db::preparedStmt(query, itemId, quantity, seller, sellerName, basePrice, totalPrice))
+        const auto npcName = [PNpc]() -> std::string
+        {
+            if (PNpc)
+            {
+                return PNpc->getName();
+            }
+
+            return {};
+        }();
+
+        scheduler.postToWorkerThread(
+            [itemId,
+             quantity,
+             seller     = PChar->id,
+             sellerName = PChar->getName(),
+             basePrice,
+             appliedGil,
+             npcId = PChar->Container->getShopVendorId(),
+             npcName,
+             zoneId = static_cast<uint16>(PChar->getZone())]()
+            {
+                const auto totalPrice = quantity * basePrice;
+
+                if (!db::preparedStmt("INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, direction, npcid, npc_name, zoneid, baseprice, totalprice, applied_gil, date) "
+                                      "VALUES (?, ?, ?, ?, 'sell', ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())",
+                                      itemId,
+                                      quantity,
+                                      seller,
+                                      sellerName,
+                                      npcId,
+                                      npcName,
+                                      zoneId,
+                                      basePrice,
+                                      totalPrice,
+                                      appliedGil))
                 {
                     ShowErrorFmt("Failed to log vendor sale (item: {}, quantity: {}, seller: {}, totalprice: {})", itemId, quantity, seller, totalPrice);
                 }
@@ -121,9 +152,14 @@ void GP_CLI_COMMAND_SHOP_SELL_SET::process(MapSession* PSession, CCharEntity* PC
         return;
     }
 
+    // Track the gil the player had before the transaction
+    const uint32 gilBefore = PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity();
     charutils::UpdateItem(PChar, LOC_INVENTORY, 0, cost);
+
+    const auto appliedGil = static_cast<int32>(PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity()) - static_cast<int32>(gilBefore);
     // TODO: Don't pass around Scheduler& through PSession
-    auditSale(*PSession->scheduler, PChar, itemId, quantity, unitPrice);
+    auditSale(*PSession->scheduler, PChar, itemId, quantity, unitPrice, appliedGil);
+
     ShowInfo("GP_CLI_COMMAND_SHOP_SELL_SET: Player '%s' sold %u of itemID %u (Total: %u gil) [to VENDOR] ", PChar->getName(), quantity, itemId, cost);
     PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(nullptr, itemId, quantity, MsgStd::Sell);
     PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);

--- a/src/map/packets/c2s/0x0aa_guild_buy.cpp
+++ b/src/map/packets/c2s/0x0aa_guild_buy.cpp
@@ -21,12 +21,77 @@
 
 #include "0x0aa_guild_buy.h"
 
+#include "common/settings.h"
 #include "entities/char_entity.h"
 #include "items/item.h"
 #include "lua/luautils.h"
 #include "packets/s2c/0x082_guild_buy.h"
 #include "utils/itemutils.h"
 #include "utils/zoneutils.h"
+
+namespace
+{
+
+const auto auditPurchase = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint8_t quantity, int32_t appliedGil)
+{
+    if (settings::get<bool>("map.AUDIT_PLAYER_VENDOR"))
+    {
+        const auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC);
+
+        const auto npcName = [PNpc]() -> std::string
+        {
+            if (PNpc)
+            {
+                return PNpc->getName();
+            }
+
+            return {};
+        }();
+
+        scheduler.postToWorkerThread(
+            [itemId,
+             quantity,
+             buyer     = PChar->id,
+             buyerName = PChar->getName(),
+             appliedGil,
+             npcId = PChar->guildShopNpc_.UniqueNo,
+             npcName,
+             zoneId = static_cast<uint16>(PChar->getZone())]()
+            {
+                // This might look ugly but the guild shop prices are roller per shop day in lua
+                // We need to derive the prices from the applied gil since the prices change
+                const auto totalPrice = static_cast<uint32>(-appliedGil);
+
+                const auto basePrice = [&]() -> uint32
+                {
+                    if (quantity > 0)
+                    {
+                        return totalPrice / quantity;
+                    }
+
+                    return 0;
+                }();
+
+                if (!db::preparedStmt("INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, direction, npcid, npc_name, zoneid, baseprice, totalprice, applied_gil, date) "
+                                      "VALUES (?, ?, ?, ?, 'buy', ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())",
+                                      itemId,
+                                      quantity,
+                                      buyer,
+                                      buyerName,
+                                      npcId,
+                                      npcName,
+                                      zoneId,
+                                      basePrice,
+                                      totalPrice,
+                                      appliedGil))
+                {
+                    ShowErrorFmt("Failed to log guild vendor purchase (item: {}, quantity: {}, buyer: {}, totalprice: {})", itemId, quantity, buyer, totalPrice);
+                }
+            });
+    }
+};
+
+} // namespace
 
 auto GP_CLI_COMMAND_GUILD_BUY::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -56,6 +121,9 @@ void GP_CLI_COMMAND_GUILD_BUY::process(MapSession* PSession, CCharEntity* PChar)
 
     if (auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC))
     {
+        // Track the gil the player had before the transaction
+        const uint32 gilBefore = PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity();
+
         // onPlayerBuy returns { itemNo, count, tradeCode }; serialize it into the 0x082 result
         // (a rejection is { 0, 0, -1 }).
         const auto result = luautils::callGlobal<sol::table>("xi.guildShops.onPlayerBuy", PChar, PNpc, this->ItemNo, quantity);
@@ -65,6 +133,14 @@ void GP_CLI_COMMAND_GUILD_BUY::process(MapSession* PSession, CCharEntity* PChar)
             const auto count     = result.get_or("count", uint8{ 0 });
             const auto tradeCode = result.get_or("tradeCode", int32{ 0 });
             PChar->pushPacket<GP_SERV_COMMAND_GUILD_BUY>(PChar, count, itemNo, static_cast<uint8>(tradeCode));
+
+            // Audit the purchase if enabled
+            const auto appliedGil = static_cast<int32>(PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity()) - static_cast<int32>(gilBefore);
+            if (tradeCode > 0 && appliedGil < 0)
+            {
+                // TODO: Don't pass around Scheduler& through PSession
+                auditPurchase(*PSession->scheduler, PChar, itemNo, static_cast<uint8>(tradeCode), appliedGil);
+            }
         }
     }
 }

--- a/src/map/packets/c2s/0x0ac_guild_sell.cpp
+++ b/src/map/packets/c2s/0x0ac_guild_sell.cpp
@@ -32,17 +32,47 @@
 namespace
 {
 
-const auto auditSale = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint32_t basePrice, uint8_t quantity)
+const auto auditSale = [](Scheduler& scheduler, CCharEntity* PChar, uint32_t itemId, uint32_t basePrice, uint8_t quantity, int32_t appliedGil)
 {
     if (settings::get<bool>("map.AUDIT_PLAYER_VENDOR"))
     {
-        scheduler.postToWorkerThread(
-            [itemId, quantity, seller = PChar->id, sellerName = PChar->getName(), basePrice]()
-            {
-                auto totalPrice = basePrice * quantity;
+        const auto* PNpc = zoneutils::GetEntity(PChar->guildShopNpc_.UniqueNo, TYPE_NPC);
 
-                const auto query = "INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, baseprice, totalprice, date) VALUES (?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())";
-                if (!db::preparedStmt(query, itemId, quantity, seller, sellerName, basePrice, totalPrice))
+        const auto npcName = [PNpc]() -> std::string
+        {
+            if (PNpc)
+            {
+                return PNpc->getName();
+            }
+
+            return {};
+        }();
+
+        scheduler.postToWorkerThread(
+            [itemId,
+             quantity,
+             seller     = PChar->id,
+             sellerName = PChar->getName(),
+             basePrice,
+             appliedGil,
+             npcId = PChar->guildShopNpc_.UniqueNo,
+             npcName,
+             zoneId = static_cast<uint16>(PChar->getZone())]()
+            {
+                const auto totalPrice = basePrice * quantity;
+
+                if (!db::preparedStmt("INSERT INTO audit_vendor(itemid, quantity, seller, seller_name, direction, npcid, npc_name, zoneid, baseprice, totalprice, applied_gil, date) "
+                                      "VALUES (?, ?, ?, ?, 'sell', ?, ?, ?, ?, ?, ?, UNIX_TIMESTAMP())",
+                                      itemId,
+                                      quantity,
+                                      seller,
+                                      sellerName,
+                                      npcId,
+                                      npcName,
+                                      zoneId,
+                                      basePrice,
+                                      totalPrice,
+                                      appliedGil))
                 {
                     ShowErrorFmt("Failed to log vendor sale (item: {}, quantity: {}, seller: {}, baseprice: {}, totalprice: {})",
                                  itemId,
@@ -96,6 +126,9 @@ void GP_CLI_COMMAND_GUILD_SELL::process(MapSession* PSession, CCharEntity* PChar
         return;
     }
 
+    // Track the gil the player had before the transaction
+    const uint32 gilBefore = PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity();
+
     const auto result = luautils::callGlobal<sol::table>("xi.guildShops.onPlayerSell", PChar, PNpc, this->ItemNo, transaction->claimed());
     if (!result.valid())
     {
@@ -128,7 +161,9 @@ void GP_CLI_COMMAND_GUILD_SELL::process(MapSession* PSession, CCharEntity* PChar
             return;
         }
 
-        auditSale(*PSession->scheduler, PChar, itemNo, price, sold);
+        // Audit the sale if enabled
+        const auto appliedGil = static_cast<int32>(PChar->getStorage(LOC_INVENTORY)->GetItem(0)->getQuantity()) - static_cast<int32>(gilBefore);
+        auditSale(*PSession->scheduler, PChar, itemNo, price, sold, appliedGil);
     }
 
     PChar->pushPacket<GP_SERV_COMMAND_GUILD_SELL>(PChar, count, itemNo, static_cast<uint8>(tradeCode));

--- a/src/map/trade_container.cpp
+++ b/src/map/trade_container.cpp
@@ -238,6 +238,16 @@ void CTradeContainer::setShopFameArea(uint8 fameArea)
     m_shopFameArea = fameArea;
 }
 
+uint32 CTradeContainer::getShopVendorId() const
+{
+    return m_shopVendorId;
+}
+
+void CTradeContainer::setShopVendorId(uint32 vendorId)
+{
+    m_shopVendorId = vendorId;
+}
+
 void CTradeContainer::unreserveUnconfirmed()
 {
     for (uint8 slotID = 0; slotID < CONTAINER_SIZE; ++slotID)
@@ -263,6 +273,7 @@ void CTradeContainer::Clean()
 {
     m_type         = 0;
     m_shopFameArea = 0xFF; // match the lua side default value
+    m_shopVendorId = 0;
     m_ItemsCount   = 0;
     m_exSize       = 0;
 

--- a/src/map/trade_container.h
+++ b/src/map/trade_container.h
@@ -51,6 +51,7 @@ public:
 
     uint8  getType() const;
     uint8  getShopFameArea() const;
+    uint32 getShopVendorId() const;
     uint8  getItemsCount() const;
     uint8  getSlotCount();     // Number of occupied cells
     uint32 getTotalQuantity(); // Total number of items (gil counts as 1)
@@ -66,6 +67,7 @@ public:
 
     void setType(uint8 type);
     void setShopFameArea(uint8 fameArea);
+    void setShopVendorId(uint32 vendorId);
     void setItemsCount(uint8 count);
     void setItem(uint8 slotID, CItem* item);
     void setRestriction(uint8 slotID, SlotRestriction restriction);
@@ -81,10 +83,11 @@ public:
     void Clean(); // we clean the container
 
 private:
-    uint8 m_type{};               // Container type (crystal type, store nation, etc.)
-    uint8 m_shopFameArea{ 0xFF }; // Fame area for shop price ranks
-    uint8 m_ItemsCount{};         // The number of items in the container (set by yourself)
-    uint8 m_exSize{};             // Can be used as a custom delineation point inside a container
+    uint8  m_type{};               // Container type (crystal type, store nation, etc.)
+    uint8  m_shopFameArea{ 0xFF }; // Fame area for shop price ranks
+    uint32 m_shopVendorId{};       // NPC the shop was opened from, for vendor auditing; 0 if unresolved
+    uint8  m_ItemsCount{};         // The number of items in the container (set by yourself)
+    uint8  m_exSize{};             // Can be used as a custom delineation point inside a container
 
     std::vector<CItem*>          m_PItem;
     std::vector<uint8>           m_slotID;

--- a/tools/migrations/061_audit_vendor_direction.py
+++ b/tools/migrations/061_audit_vendor_direction.py
@@ -1,0 +1,37 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding direction, npcid, npc_name, zoneid and applied_gil to audit_vendor"
+
+
+def check_preconditions(cur):
+    return
+
+
+def column_missing(cur, column):
+    cur.execute(f"show columns from audit_vendor where field = '{column}';")
+    return cur.fetchone() is None
+
+
+def needs_to_run(cur):
+    return column_missing(cur, "npc_name")
+
+
+def migrate(cur, db):
+    try:
+        clauses = []
+        if column_missing(cur, "direction"):
+            clauses.append("ADD COLUMN direction enum('sell','buy') NOT NULL DEFAULT 'sell' AFTER seller_name")
+        if column_missing(cur, "npcid"):
+            clauses.append("ADD COLUMN npcid int(10) unsigned NOT NULL DEFAULT 0 AFTER direction")
+            clauses.append("ADD INDEX npcid (npcid)")
+        clauses.append("ADD COLUMN npc_name varchar(64) DEFAULT NULL AFTER npcid")
+        if column_missing(cur, "zoneid"):
+            clauses.append("ADD COLUMN zoneid smallint(5) unsigned NOT NULL DEFAULT 0 AFTER npc_name")
+        if column_missing(cur, "applied_gil"):
+            clauses.append("ADD COLUMN applied_gil int(11) NOT NULL DEFAULT 0 AFTER totalprice")
+        cur.execute("ALTER TABLE audit_vendor " + ", ".join(clauses) + ";")
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
I chose to add the npc vendor ID to the cpp instead of adding more to the lua side. It seemed cleaner so we dont have more vars passed into lua than necessary since we already hit the cpp portion anyway.

Adds the following info to the audit_vendor.sql
- Direction of the transaction (sell or buy)
- npc name and npcid
- zoneid
- applied_gil column to track the data for edge cases. For instance the gil cap is 999,999,999 so if your gil is set to lets say 999,999,990 and you sell an item over 10 gil it will show the applied_gil to be -9.

Also added migration to apply new columns to existing servers. Unfortunately there is no way to populate this info with the existing table so it will show as NULL/0 for the respective columns. 

This will help server owners track gil more easily if they so please. They can do whatever backend calculations they want for more accurate gil tracking.

<img width="1297" height="72" alt="image" src="https://github.com/user-attachments/assets/5ee748b2-9893-48c6-8871-f1cff21e67a2" />

<img width="1285" height="854" alt="image" src="https://github.com/user-attachments/assets/f6cd114e-64b8-448d-b893-8659cbc845ba" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Make sure the AUDIT_PLAYER_VENDOR is set to true inside map.lua
!gotoid 17719387
Sell and buy any item you want
Look at the audit_vendor sql and see more detailed info
<!-- Clear and detailed steps to test your changes here -->
