### PR TITLE
[lua] Fix untargetable caskets and early despawns

### DIFF
--- a/scripts/globals/caskets.lua
+++ b/scripts/globals/caskets.lua
@@ -90,52 +90,6 @@ local casketInfo =
 }
 
 -----------------------------------
--- Desc: Helper function for making it easier to read time between spawns.
--- TODO: Simplify and deprecate this function, as its only used in timeElapsedCheck
------------------------------------
-local function convertTime(rawTime)
-    local rawSeconds = tonumber(rawTime)
-    local timeTable  = { '', '', '' }
-
-    timeTable[1] = string.format('%02.f', math.floor(rawSeconds / 3600))
-    timeTable[2] = string.format('%02.f', math.floor(rawSeconds / 60 - timeTable[1] * 60))
-    timeTable[3] = string.format('%02.f', math.floor(rawSeconds - timeTable[1] * 3600 - timeTable[2] * 60))
-
-    return timeTable
-end
-
------------------------------------
--- Desc: Check for time elapsed since last spawned
--- NOTE: will NOT allow a spawn if time since last spanwed is under 5 mins.
------------------------------------
-local function timeElapsedCheck(npc)
-    local spawnTime = GetSystemTime() + 360000 -- Default time in case no var set.
-    local timeTable = { 0, 0, 0 }              -- Hours, Minutes, Seconds.
-
-    if npc == nil then
-        return false
-    end
-
-    if npc:getLocalVar('[caskets]SPAWNTIME') then
-        spawnTime = npc:getLocalVar('[caskets]SPAWNTIME')
-    end
-
-    local lastSpawned = GetSystemTime() - spawnTime
-
-    timeTable = convertTime(lastSpawned)
-
-    if
-        tonumber(timeTable[1]) >= 01 or
-        tonumber(timeTable[1]) < 01 and
-        tonumber(timeTable[2]) >= 05
-    then
-        return true
-    end
-
-    return false
-end
-
------------------------------------
 -- Desc: Grabs an id for a casket if one is available if not, no casket will spawn.
 -----------------------------------
 local function getCasketID(mob)
@@ -151,15 +105,16 @@ local function getCasketID(mob)
     local baseChestId = caskets[1]:getID()
     local chestId     = 0
 
+    -- retail reuses a casket id as soon as its previous chest is gone
     for i = baseChestId, baseChestId + 15 do
-        if timeElapsedCheck(GetNPCByID(i)) then
-            if
-                GetNPCByID(i):getLocalVar('[caskets]SPAWNSTATUS') == casketInfo.spawnStatus.DESPAWNED or
-                GetNPCByID(i):getLocalVar('[caskets]SPAWNSTATUS') == 0
-            then
-                chestId = i
-                break
-            end
+        local casket = GetNPCByID(i)
+
+        if
+            casket ~= nil and
+            casket:getLocalVar('[caskets]SPAWNSTATUS') == casketInfo.spawnStatus.DESPAWNED
+        then
+            chestId = i
+            break
         end
     end
 
@@ -222,9 +177,18 @@ end
 -- Desc: Despawn a chest and reset its local var's
 -----------------------------------
 local function removeChest(npc)
-    npc:setAnimationSub(0, false)
-    npc:setStatus(xi.status.DISAPPEAR)
-    npc:resetLocalVars()
+    -- Clear the initially queued despawn timer, else it may occur on an unrelated relocated spawn.
+    npc:clearTimerQueue()
+
+    npc:setUntargetable(true)
+    npc:entityAnimationPacket(xi.animationString.STATUS_DISAPPEAR)
+
+    -- Vars are kept until the entity is gone so the slot can't be reused mid fade out.
+    npc:timer(2000, function(despawningNpc)
+        despawningNpc:setAnimationSub(0, false)
+        despawningNpc:setStatus(xi.status.DISAPPEAR)
+        despawningNpc:resetLocalVars()
+    end)
 end
 
 -----------------------------------
@@ -275,6 +239,8 @@ local function setCasketData(player, x, y, z, r, npc, partyID, mobLvl)
     npc:setLocalVar('[caskets]SPAWNTIME', GetSystemTime())
     npc:setPos(x, y, z, r)
     npc:setStatus(xi.status.NORMAL)
+    npc:setUntargetable(false)
+    npc:hideName(false)
     npc:entityAnimationPacket(xi.animationString.STATUS_VISIBLE)
     npc:setModelId(chestStyle)
     sendChestDropMessage(player)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
- Closes #11097 - a recent update capture changed the database flags the lua was implicitly relying on. This PR sets them explicitly on spawn.
- Fixes a long standing **unreported issue** of caskets despawning too early. The solution is to clear the timer when the chest despawns as that can occur outside of said timer when emptying the casket.
- Gets rid of the (non-working) 5 minutes cooldown business, I have hundreds of captures showing same ID caskets respawning within 182 seconds.
- Produce the correct despawn sequence (kesu then actual despawn 2s later)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
