### PR TITLE
[lua] Fix Parraggoh's intro event in "Beauty and the Galka"

### DIFF
--- a/scripts/quests/bastok/Beauty_and_the_Galka.lua
+++ b/scripts/quests/bastok/Beauty_and_the_Galka.lua
@@ -52,14 +52,14 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then
-                        return quest:progressEvent(6) -- Denied Cornelia's request.
+                        return quest:progressEvent(7) -- Cornelia told the player of Parraggoh's predicament.
                     end
                 end,
             },
 
             onEventFinish =
             {
-                [6] = function(player, csid, option, npc)
+                [7] = function(player, csid, option, npc)
                     if option == 0 then
                         quest:begin(player)
                     end
@@ -106,7 +106,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if player:hasKeyItem(xi.ki.PALBOROUGH_MINES_LOGS) then
-                        return quest:progressEvent(10)
+                        return quest:progressEvent(10, quest:getVar(player, 'Prog'))
                     elseif math.randomInt(1, 100) <= 50 then
                         return quest:event(8)
                     else


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Parraggoh only responds when Prog == 1, meaning the player already heard Cornelia's request from Talib and declined
- Event 6 opens "Gumbah sent you" and introduces Cornelia as new, which doesn't fit; event 7 assumes you know her and conveys the same request
- The handler renumber is required or quest:begin() stops firing
- The completion event takes the same distinction as a parameter; passing Prog selects it
- Capture is SlashTangents'

 Resolves #9482.

## Steps to test these changes
```
 !pos -14.467 6.999 55.068 234    -- Bastok Mines
 !cs 6      -- "Gumbah sent you, you say?" — introduces Cornelia as new
 !cs 7      -- "Ah, Cornelia told you of my predicament."
 !cs 10     -- "Hmm? Yes, I am Parraggoh. What? Cornelia asked you..."
 !cs 10 1   -- "Ah! You have brought me the Palborough Mines logs!"
```