### PR TITLE
[core] No seals from NMs or in Lumoria. Proper seal types per level ranges.

### DIFF
--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -1055,8 +1055,8 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     if (!getMobMod(xi::MobMod::NoDrops) && validZone && charutils::CheckMob(m_HiPCLvl, this) > EMobDifficulty::TooWeak && getMobMod(xi::MobMod::ExpBonus) > -100)
     {
         // Check for seal drops
-        // Only one type of seal can drop per mob
-        if (xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Seal))
+        // Only one type of seal can drop per mob, and notorious monsters never drop them
+        if ((m_Type & xi::MobType::Notorious) == xi::MobType::Normal && xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Seal))
         {
             const auto seals = GetEligibleSeals();
             AddItemToPool(seals[xirand::GetRandomNumber(seals.size())]);

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -819,22 +819,39 @@ void CMobEntity::DistributeRewards()
 }
 
 // Return the list of seals that can drop based on the mob's level.
+// Each tier is exclusive, a mob only rolls between the seals of its own tier.
 // Rules:
 // - Mob  < 50: Beastmen's Seal
 // - Mob >= 50: Beastmen's Seal, Kindred's Seal
-// - Mob >= 70: Beastmen's Seal, Kindred's Seal, Kindred's Crest
-// - Mob >= 80: Beastmen's Seal, Kindred's Seal, Kindred's Crest, High Kindred's Crest
-// If Abyssea is not enabled, pool is limited to Beastmen's Seal and Kindred's Seal.
-auto CMobEntity::GetEligibleSeals() -> std::vector<uint16>
+// - Mob >= 70: Kindred's Seal, Kindred's Crest
+// - Mob >= 80: Kindred's Crest, High Kindred's Crest
+// - Mob >= 100: Kindred's Crest, High Kindred's Crest, Sacred Kindred's Crest
+auto CMobEntity::GetEligibleSeals() const -> std::vector<uint16>
 {
-    if (GetMLevel() >= 80 && luautils::IsContentEnabled("ABYSSEA"))
+    // Using Abyssea being enabled as a marker for """era""" servers to return the old bands.
+    if (!luautils::IsContentEnabled("ABYSSEA"))
     {
-        return { BEASTMENS_SEAL, KINDREDS_SEAL, KINDREDS_CREST, HIGH_KINDREDS_CREST };
+        if (GetMLevel() >= 50)
+        {
+            return { BEASTMENS_SEAL, KINDREDS_SEAL };
+        }
+
+        return { BEASTMENS_SEAL };
     }
 
-    if (GetMLevel() >= 70 && luautils::IsContentEnabled("ABYSSEA"))
+    if (GetMLevel() >= 100)
     {
-        return { BEASTMENS_SEAL, KINDREDS_SEAL, KINDREDS_CREST };
+        return { KINDREDS_CREST, HIGH_KINDREDS_CREST, SACRED_KINDREDS_CREST };
+    }
+
+    if (GetMLevel() >= 80)
+    {
+        return { KINDREDS_CREST, HIGH_KINDREDS_CREST };
+    }
+
+    if (GetMLevel() >= 70)
+    {
+        return { KINDREDS_SEAL, KINDREDS_CREST };
     }
 
     if (GetMLevel() >= 50)
@@ -1054,9 +1071,12 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     // Check if mob can drop seals -- mobmod to disable drops, zone type isnt battlefield/dynamis, mob is stronger than Too Weak, or mobmod for EXP bonus is -100 or lower (-100% exp)
     if (!getMobMod(xi::MobMod::NoDrops) && validZone && charutils::CheckMob(m_HiPCLvl, this) > EMobDifficulty::TooWeak && getMobMod(xi::MobMod::ExpBonus) > -100)
     {
+        // Seals, geodes and avatarites do not drop from notorious monsters. Crystals still do.
+        const bool isNotorious = (m_Type & xi::MobType::Notorious) != xi::MobType::Normal;
+
         // Check for seal drops
-        // Only one type of seal can drop per mob, and notorious monsters never drop them
-        if ((m_Type & xi::MobType::Notorious) == xi::MobType::Normal && xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Seal))
+        // Only one type of seal can drop per mob
+        if (!isNotorious && xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Seal))
         {
             const auto seals = GetEligibleSeals();
             AddItemToPool(seals[xirand::GetRandomNumber(seals.size())]);
@@ -1065,7 +1085,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
 
         // Check for geode/avatarites drops
         // Only one type of geode can drop per mob
-        if (xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Geode))
+        if (!isNotorious && xirand::GetRandomNumber(100) < 20 && CanAddSpecial(LootRecastID::Geode))
         {
             if (const auto geodes = GetEligibleGeodes(); !geodes.empty())
             {

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -1049,7 +1049,7 @@ void CMobEntity::DropItems(CCharEntity* PChar)
     }
 
     xi::ZoneType zoneType  = zoneutils::GetZone(PChar->getZone())->GetTypeMask();
-    bool         validZone = !((this->m_Type & xi::MobType::Battlefield) != xi::MobType::Normal) && !((zoneType & xi::ZoneType::Dynamis) != xi::ZoneType::Unknown);
+    bool         validZone = !((this->m_Type & xi::MobType::Battlefield) != xi::MobType::Normal) && !((zoneType & xi::ZoneType::Dynamis) != xi::ZoneType::Unknown) && loc.zone->GetRegionID() != REGION_TYPE::LUMORIA;
 
     // Check if mob can drop seals -- mobmod to disable drops, zone type isnt battlefield/dynamis, mob is stronger than Too Weak, or mobmod for EXP bonus is -100 or lower (-100% exp)
     if (!getMobMod(xi::MobMod::NoDrops) && validZone && charutils::CheckMob(m_HiPCLvl, this) > EMobDifficulty::TooWeak && getMobMod(xi::MobMod::ExpBonus) > -100)

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -97,7 +97,7 @@ public:
     bool CanDropGil();    // mob has gil to drop
     bool CanStealGil();   // can steal gil from mob
     void ResetGilPurse(); // reset total gil held
-    auto GetEligibleSeals() -> std::vector<uint16>;
+    auto GetEligibleSeals() const -> std::vector<uint16>;
     auto GetEligibleGeodes() const -> std::vector<uint16>;
 
     void setMobMod(xi::MobMod type, int16 value);

--- a/src/map/items.h
+++ b/src/map/items.h
@@ -74,6 +74,7 @@ enum ITEMID : uint16
     EVOLITH                        = 2783,
     KINDREDS_CREST                 = 2955,
     HIGH_KINDREDS_CREST            = 2956,
+    SACRED_KINDREDS_CREST          = 2957,
     MOKUJIN                        = 2970,
     INOSHISHINOFUDA                = 2971,
     SHIKANOFUDA                    = 2972,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Handful of changes:

### No seals/geodes in Lumoria

This is documented on the japanese wiki and briefly retested

> However, [monsters](https://wiki-ffo-jp.translate.goog/html/30.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) in [the ](https://wiki-ffo-jp.translate.goog/html/231.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[Lumoria](https://wiki-ffo-jp.translate.goog/html/266.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) region do not drop it

https://wiki-ffo-jp.translate.goog/html/530.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp

### No seals/geodes from NMs

This isn't documented but we haven't been able to find any such instance in our collective logs

### Correct seals per range
Up until now LSB was adding each seal believed to be eligible to the returned set. 
The japanese wiki clearly documents them as exclusive ranges (and my parsed logs concur)

> [An item that](https://wiki-ffo-jp.translate.goog/html/493.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) occasionally drops from [monsters ](https://wiki-ffo-jp.translate.goog/html/575.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[that](https://wiki-ffo-jp.translate.goog/html/30.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) grant [experience points from ](https://wiki-ffo-jp.translate.goog/html/476.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[Lv](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 1 to [Lv](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 69

> [An item that](https://wiki-ffo-jp.translate.goog/html/493.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) occasionally [drops](https://wiki-ffo-jp.translate.goog/html/575.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) when defeating [monsters](https://wiki-ffo-jp.translate.goog/html/30.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) that grant [experience points between ](https://wiki-ffo-jp.translate.goog/html/476.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[Lv](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 50 and [Lv](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 79.

> [The type of ](https://wiki-ffo-jp.translate.goog/html/30077.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[seal ](https://wiki-ffo-jp.translate.goog/html/3905.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[dropped](https://wiki-ffo-jp.translate.goog/html/575.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) is determined by [the monster](https://wiki-ffo-jp.translate.goog/html/30.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 's level . Below [Lv 50, only ](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[Beastman seals](https://wiki-ffo-jp.translate.goog/html/530.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) are dropped ; from [Lv](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) 50 and above , there is [a](https://wiki-ffo-jp.translate.goog/html/30.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) choice between [Beastman](https://wiki-ffo-jp.translate.goog/html/530.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) / [Beast God seals](https://wiki-ffo-jp.translate.goog/html/531.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) ; above [Lv 70, there is a choice between ](https://wiki-ffo-jp.translate.goog/html/345.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)[Beast God](https://wiki-ffo-jp.translate.goog/html/531.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) / [Demon seals](https://wiki-ffo-jp.translate.goog/html/21129.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) ; and above Lv 80, there is a choice between [Demon](https://wiki-ffo-jp.translate.goog/html/21129.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) / [Demon King seals . Level 100 and above](https://wiki-ffo-jp.translate.goog/html/22307.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)

Note that they claim the last threshold is level 90 on one page and 100 on another. My logs say it is 100.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
