### PR TITLE
[core] No cooldown on bad crafting recipe

### DIFF
--- a/src/map/packets/c2s/0x033_trade_res.cpp
+++ b/src/map/packets/c2s/0x033_trade_res.cpp
@@ -50,7 +50,6 @@ void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar)
     auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     if (!PTarget ||
-        PChar->TradePending.UniqueNo != PTarget->id ||
         PTarget->TradePending.UniqueNo != PChar->id)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_RES: Could not find trade targets.");

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -68,7 +68,6 @@ void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar
     auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     if (!PTarget ||
-        PTarget->id != PChar->TradePending.UniqueNo ||
         PChar->id != PTarget->TradePending.UniqueNo)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_LIST: Could not find trade targets.");

--- a/src/map/packets/c2s/0x096_combine_ask.cpp
+++ b/src/map/packets/c2s/0x096_combine_ask.cpp
@@ -98,7 +98,7 @@ void GP_CLI_COMMAND_COMBINE_ASK::process(MapSession* PSession, CCharEntity* PCha
     auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
 
     // Clear pending trades on synthesis start
-    if (PTarget && PChar->TradePending.UniqueNo == PTarget->id)
+    if (PTarget)
     {
         PChar->TradePending.clean();
         PTarget->TradePending.clean();

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -1106,8 +1106,6 @@ void doSynthSkillUp(CCharEntity* PChar)
  ************************/
 void startSynth(CCharEntity* PChar, const SynthOffer& offer)
 {
-    PChar->m_LastSynthTime = timer::now();
-
     if (!resolveRecipe(PChar, offer))
     {
         return;
@@ -1120,6 +1118,8 @@ void startSynth(CCharEntity* PChar, const SynthOffer& offer)
         PChar->pushPacket<GP_SERV_COMMAND_COMBINE_ANS>(PChar, SynthesisResult::CancelBadRecipe);
         return;
     }
+
+    PChar->m_LastSynthTime = timer::now();
 
     const auto effect = crystalProps(offer.crystal.itemId).effect;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moving the timestamp after all checks are performed so that you're not penalized for inputting a bad recipe which retail doesn't do.

Also dropped a few unnecessary checks on trades since resolve() provides a strong guarantee upfront.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
