### PR TITLE
Build: keep clang-tidy off Catch2's sources, follow CPM_SOURCE_CACHE when filtering clang-tidy warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,8 @@ message(STATUS "TRACY_ENABLE: ${TRACY_ENABLE}")
 
 add_subdirectory(ext)
 
+# After add_subdirectory(ext) so third-party targets never inherit CMAKE_CXX_CLANG_TIDY.
+# Dependencies pulled in later have to be wrapped in suspend_clang_tidy()/resume_clang_tidy().
 include(ClangTidy)
 include(Fuzzing)
 

--- a/cmake/ClangTidy.cmake
+++ b/cmake/ClangTidy.cmake
@@ -31,3 +31,16 @@ if(ENABLE_CLANG_TIDY)
   #unset(clang_tidy_sha1)
 
 endif(ENABLE_CLANG_TIDY)
+
+# Third-party code pulled in after this file is included inherits CMAKE_CXX_CLANG_TIDY, and
+# clang-tidy then analyses it against the dependency's own .clang-tidy instead of ours.
+# Bracket those CPMAddPackage/add_subdirectory calls with these.
+macro(suspend_clang_tidy)
+  set(SUSPENDED_CXX_CLANG_TIDY "${CMAKE_CXX_CLANG_TIDY}")
+  unset(CMAKE_CXX_CLANG_TIDY)
+endmacro()
+
+macro(resume_clang_tidy)
+  set(CMAKE_CXX_CLANG_TIDY "${SUSPENDED_CXX_CLANG_TIDY}")
+  unset(SUSPENDED_CXX_CLANG_TIDY)
+endmacro()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(reporters)
 
 # Catch2 hosts the C++ unit tests that run during xi_test startup, before the
 # Lua test engine boots (see main.cpp).
+suspend_clang_tidy()
 CPMAddPackage(
     NAME Catch2
     GITHUB_REPOSITORY catchorg/Catch2
@@ -12,6 +13,7 @@ CPMAddPackage(
         "CATCH_INSTALL_DOCS OFF"
         "CATCH_INSTALL_EXTRAS OFF"
 ) # defines: Catch2::Catch2
+resume_clang_tidy()
 
 set(SOURCES
     ${COMMON_SOURCES}

--- a/tools/ci/summarize_clang_tidy.py
+++ b/tools/ci/summarize_clang_tidy.py
@@ -1,11 +1,24 @@
+import os
 import re
 import sys
 from collections import defaultdict
 
 
+def third_party_markers():
+    # CPM checks dependencies out under the build tree unless CPM_SOURCE_CACHE points
+    # somewhere else, which CI does so the sources survive between runs.
+    markers = ["_deps/"]
+    source_cache = os.environ.get("CPM_SOURCE_CACHE")
+    if source_cache:
+        markers.append(source_cache.replace(os.sep, "/").rstrip("/") + "/")
+
+    return markers
+
+
 def parse_tidy_log(log_content):
     warning_regex = re.compile(r"^(/.+?):(\d+):(\d+):\s+warning:\s+(.*)$")
     warnings_by_file = defaultdict(list)
+    markers = third_party_markers()
     lines = log_content.splitlines()
 
     i = 0
@@ -19,8 +32,7 @@ def parse_tidy_log(log_content):
 
         file_path, line_num, col_num, message = match.groups()
 
-        # Filter '_deps' output
-        if "_deps/" in file_path:
+        if any(marker in file_path for marker in markers):
             i += 1
             continue
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Build: keep clang-tidy off Catch2's sources
CI: follow CPM_SOURCE_CACHE when filtering clang-tidy warnings 

Hopefully fixes CI
