### PR TITLE
[lua] Self Destruct chance

### DIFF
--- a/scripts/actions/mobskills/self-destruct_bomb.lua
+++ b/scripts/actions/mobskills/self-destruct_bomb.lua
@@ -7,6 +7,10 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if math.randomInt(1, 100) > 50 then -- A bomb will have a 25% chance to use Self-Destruct
+        return 1
+    end
+
     return 0
 end
 

--- a/scripts/actions/mobskills/self-destruct_bomb_big.lua
+++ b/scripts/actions/mobskills/self-destruct_bomb_big.lua
@@ -9,13 +9,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if
-        mob:isMobType(xi.mobType.NOTORIOUS) or -- TODO: Set skill list
-        mob:getHPP() >= 90
-    then
-        return 1
-    end
-
     return 0
 end
 

--- a/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
+++ b/scripts/zones/Ifrits_Cauldron/mobs/Magma.lua
@@ -29,7 +29,7 @@ entity.onMobMobskillChoose = function(mob, target, skillId)
         xi.mobSkill.BERSERK_BOMB,
     }
 
-    if mob:getHPP() < 10 then
+    if mob:getHPP() <= 10 then
         table.insert(skillList, xi.mobSkill.SELF_DESTRUCT_BOMB)
     end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts the chance for regular bombs to explode to around 25%.

I ultimately testing only letting bombs tp above 25%, under 25%, and all the time, and they all looked about the same.
Ultimately the chance was between 25-30%, ending with 171 berserks and 65 self destructs.

I have set the chance to return at 66%, and because of how math works, that ultimately means they will choose self destruct around 25% of the time.

I removed the HP requirement from grow bombs as I know that's bullshit from testing, and removed the NM blocker as that is already handled in the grow bomb mixin.

https://www.dropbox.com/scl/fo/z650rc7kepgjz4ui89obp/APBJpLrSukfyqy-1j14GgnQ?rlkey=2hr7tfc928aei6wvu5c1bvobx&st=tx1grsco&dl=0

## Steps to test these changes

!tp 3000 some bombs.

