### PR TITLE
[module] Claimshield fixes and updates for variable timings

### DIFF
--- a/modules/custom/lua/claim_shield.lua
+++ b/modules/custom/lua/claim_shield.lua
@@ -5,166 +5,450 @@ require('modules/module_utils')
 -----------------------------------
 local m = Module:new('claim_shield')
 
-local claimshieldTime = 7500
+local claimshieldTime = 5000 -- Milliseconds.
 
--- NOTE: These names are as they are as filenames.
--- Example: Behemoth's Dominion => Behemoths_Dominion
--- Example: King Behemoth       => King_Behemoth
--- { zone name, mob name }
--- Format:
-local nmsToShield =
+-- Entries may be a mob name or { name = 'Mob_Name', time = milliseconds }.
+local shieldedEntities =
 {
-    { 'Attohwa_Chasm', 'Citipati' },
-    { 'Attohwa_Chasm', 'Tiamat' },
-    { 'Attohwa_Chasm', 'Xolotl' },
-    { 'Caedarva_Mire', 'Khimaira' },
-    { 'Castle_Oztroja', 'Mee_Deggi_the_Punisher' },
-    { 'Castle_Oztroja', 'Quu_Domi_the_Gallant' },
-    { 'FeiYin', 'Capricious_Cassie' },
-    { 'FeiYin', 'Eastern_Shadow' },
-    { 'FeiYin', 'Northern_Shadow' },
-    { 'FeiYin', 'Southern_Shadow' },
-    { 'FeiYin', 'Western_Shadow' },
-    { 'Garlaige_Citadel', 'Serket' },
-    { 'Giddeus', 'Hoo_Mjuu_the_Torrent' },
-    { 'Gustav_Tunnel', 'Bune' },
-    { 'Jugner_Forest', 'King_Arthro' },
-    { 'King_Ranperres_Tomb', 'Vrtra' },
-    { 'Labyrinth_of_Onzozo', 'Lord_of_Onzozo' },
-    { 'Lufaise_Meadows', 'Padfoot' },
-    { 'Maze_of_Shakhrami', 'Argus' },
-    { 'Maze_of_Shakhrami', 'Leech_King' },
-    { 'Mount_Zhayolm', 'Cerberus' },
-    { 'Rolanberry_Fields', 'Eldritch_Edge' },
-    { 'Rolanberry_Fields', 'Simurgh' },
-    { 'Rolanberry_Fields_[S]', 'Lamina' },
-    { 'Sauromugue_Champaign', 'Blighting_Brand' },
-    { 'Sauromugue_Champaign', 'Roc' },
-    { 'Sauromugue_Champaign_[S]', 'Hyakinthos' },
-    { 'Sea_Serpent_Grotto', 'Charybdis' },
-    { 'South_Gustaberg', 'Leaping_Lizzy' },
-    { 'Uleguerand_Range', 'Jormungand' },
-    { 'Valkurm_Dunes', 'Valkurm_Emperor' },
-    { 'Wajaom_Woodlands', 'Hydra' },
-    { 'Western_Altepa_Desert', 'King_Vinegarroon' },
+    ['Attohwa_Chasm'] =
+    {
+        'Citipati',
+        'Tiamat',
+        'Xolotl',
+    },
+
+    ['Batallia_Downs'] =
+    {
+        'Lumber_Jack',
+    },
+
+    ['Beadeaux'] =
+    {
+        'GaBhu_Unvanquished',
+    },
+
+    ['Beaucedine_Glacier'] =
+    {
+        'Nue',
+    },
+
+    ['Bibiki_Bay'] =
+    {
+        'Intulo',
+    },
+
+    ['Bostaunieux_Oubliette'] =
+    {
+        'Bloodsucker_NM',
+        'Drexerion_the_Condemned',
+        'Phanduron_the_Condemned',
+        'Sewer_Syrup',
+    },
+
+    ['Caedarva_Mire'] =
+    {
+        'Khimaira',
+    },
+
+    ['Cape_Teriggan'] =
+    {
+        'Kreutzet',
+    },
+
+    ['Castle_Oztroja'] =
+    {
+        'Mee_Deggi_the_Punisher',
+        'Quu_Domi_the_Gallant',
+        'Tzee_Xicu_the_Manifest',
+    },
+
+    ['Castle_Zvahl_Baileys'] =
+    {
+        'Duke_Haborym',
+        'Grand_Duke_Batym',
+        'Marquis_Allocen',
+        'Marquis_Amon',
+    },
+
+    ['Crawlers_Nest'] =
+    {
+        'Demonic_Tiphia',
+    },
+
+    ['Den_of_Rancor'] =
+    {
+        'Friar_Rush',
+        'Tonberry_Decapitator',
+        'Tonberry_Tracker',
+    },
+
+    ['East_Sarutabaruta'] =
+    {
+        'Spiny_Spipi',
+    },
+
+    ['Eastern_Altepa_Desert'] =
+    {
+        'Centurio_XII-I',
+    },
+
+    ['FeiYin'] =
+    {
+        'Capricious_Cassie',
+        'Eastern_Shadow',
+        'Northern_Shadow',
+        'Southern_Shadow',
+        'Western_Shadow',
+    },
+
+    ['Garlaige_Citadel'] =
+    {
+        'Serket',
+    },
+
+    ['Giddeus'] =
+    {
+        'Hoo_Mjuu_the_Torrent',
+    },
+
+    ['Gustav_Tunnel'] =
+    {
+        'Amikiri',
+        'Bune',
+    },
+
+    ['Jugner_Forest'] =
+    {
+        'King_Arthro',
+        'Panzer_Percival',
+    },
+
+    ['King_Ranperres_Tomb'] =
+    {
+        'Vrtra',
+        'Cemetery_Cherry',
+        'Spook',
+    },
+
+    ['Konschtat_Highlands'] =
+    {
+        'Steelfleece_Baldarich',
+        'Stray_Mary',
+    },
+
+    ['Korroloka_Tunnel'] =
+    {
+        'Cargo_Crab_Colin',
+    },
+
+    ['Kuftal_Tunnel'] =
+    {
+        'Amemet',
+        'Yowie',
+    },
+
+    ['La_Theine_Plateau'] =
+    {
+        'Bloodtear_Baldurf',
+    },
+
+    ['Labyrinth_of_Onzozo'] =
+    {
+        'Lord_of_Onzozo',
+        'Mysticmaker_Profblix',
+        'Ose',
+    },
+
+    ['Lufaise_Meadows'] =
+    {
+        'Padfoot',
+        'Megalobugard',
+    },
+
+    ['Maze_of_Shakhrami'] =
+    {
+        'Argus',
+        'Leech_King',
+    },
+
+    ['Misareaux_Coast'] =
+    {
+        'Upyri',
+        'Odqan',
+    },
+
+    ['Monastic_Cavern'] =
+    {
+        'Overlord_Bakgodek',
+    },
+
+    ['Mount_Zhayolm'] =
+    {
+        'Cerberus',
+    },
+
+    ['Ordelles_Caves'] =
+    {
+        'Morbolger',
+    },
+
+    ['Promyvion-Dem'] =
+    {
+        'Satiator',
+    },
+
+    ['Quicksand_Caves'] =
+    {
+        'Centurio_X-I',
+        'Sabotender_Bailarina',
+    },
+
+    ['Qulun_Dome'] =
+    {
+        'ZaDha_Adamantking',
+    },
+
+    ['Riverne-Site_A01'] =
+    {
+        'Carmine_Dobsonfly',
+    },
+
+    ['Riverne-Site_B01'] =
+    {
+        'Boroka',
+    },
+
+    ['Rolanberry_Fields'] =
+    {
+        -- 'Eldritch_Edge',
+        'Simurgh',
+    },
+
+    ['Rolanberry_Fields_[S]'] =
+    {
+        -- 'Lamina',
+    },
+
+    ['RoMaeve'] =
+    {
+        'Shikigami_Weapon',
+    },
+
+    ['Sacrarium'] =
+    {
+        'Elel',
+    },
+
+    ['Sauromugue_Champaign'] =
+    {
+        -- 'Blighting_Brand',
+        'Roc',
+    },
+
+    ['Sauromugue_Champaign_[S]'] =
+    {
+        -- 'Hyakinthos',
+    },
+
+    ['Sea_Serpent_Grotto'] =
+    {
+        'Charybdis',
+        'Fyuu_the_Seabellow',
+        'Novv_the_Whitehearted',
+        'Sea_Hog',
+    },
+
+    ['South_Gustaberg'] =
+    {
+        'Leaping_Lizzy',
+        'Carnero',
+    },
+
+    ['Temple_of_Uggalepih'] =
+    {
+        'Sozu_Sarberry',
+        'Sozu_Terberry',
+    },
+
+    ['The_Boyahda_Tree'] =
+    {
+        'Voluptuous_Vivian',
+        'Ancient_Goobbue',
+    },
+
+    ['The_Sanctuary_of_ZiTah'] =
+    {
+        'Noble_Mold',
+    },
+
+    ['The_Shrine_of_RuAvitau'] =
+    {
+        'Faust',
+        'Mother_Globe',
+    },
+
+    ['Uleguerand_Range'] =
+    {
+        'Jormungand',
+        'Bonnacon',
+    },
+
+    ['Valkurm_Dunes'] =
+    {
+        'Valkurm_Emperor',
+    },
+
+    ['VeLugannon_Palace'] =
+    {
+        'Zipacna',
+    },
+
+    ['Wajaom_Woodlands'] =
+    {
+        'Hydra',
+        'Jaded_Jody',
+        'Zoraal_Jas_Pkuucha',
+    },
+
+    ['Western_Altepa_Desert'] =
+    {
+        'King_Vinegarroon',
+    },
+
+    ['Xarcabard'] =
+    {
+        'Biast',
+    },
+
+    ['Yhoator_Jungle'] =
+    {
+        'Bright-handed_Kunberry',
+    },
+
+    ['Yuhtunga_Jungle'] =
+    {
+        'Rose_Garden',
+        'Voluptuous_Vilma',
+    },
 }
 
--- Find the position of a target entity in a table,
--- only if they have matching ids
-local tableFindPosByID = function(t, target)
-    for index, entity in ipairs(t) do
-        if entity:getID() == target:getID() then
-            return index
-        end
-    end
-
-    return nil
-end
-
--- Using entity ids: dedupe a table in-place
-local dedupeByID = function(t)
-    local seen = {}
-    for index, entity in ipairs(t) do
-        if seen[entity:getID()] then
-            table.remove(t, index)
-        else
-            seen[entity:getID()] = true
-        end
-    end
-end
-
--- Called when the claimshield period ends
-local timerFunc = function(mob)
-    local enmityList = mob:getEnmityList()
-
-    -- Filter so that pets will only count as a single entry along
-    -- with their masters
-    local entries = {}
-    for _, v in pairs(enmityList) do
-        local entity = v['entity']
-        local master = entity:getMaster()
-        if
-            not entity:isPC() and
-            master and
-            master:isPC()
-        then
-            table.insert(entries, master)
-        else
-            table.insert(entries, entity)
-        end
-    end
-
-    -- Remove duplicates from entries table caused by pets or other shenanigans
-    dedupeByID(entries)
-
-    local numEntries = #entries
-
-    mob:setMobMod(xi.mobMod.CLAIM_TYPE, xi.claimType.EXCLUSIVE)
-    mob:setUnkillable(false)
-    mob:setCallForHelpBlocked(false)
-
-    mob:resetAI()
-    mob:setHP(mob:getMaxHP())
-    mob:delStatusEffectsByFlag(0xFFFF) -- Delete all effects with all flags
-
-    -- Select a winner
-    local claimWinner = utils.randomEntry(entries)
-    if claimWinner then
-        mob:updateClaim(claimWinner)
-
-        -- Message winner and their party/alliance that they've won
-        local alliance = claimWinner:getAlliance()
-        for _, member in pairs(alliance) do
-            local str = string.format('Your group has won the lottery for %s! (out of %i players)', mob:getPacketName(), numEntries)
-            if #alliance == 1 then
-                str = string.format('You have won the lottery for %s! (out of %i players)', mob:getPacketName(), numEntries)
-            end
-
-            member:printToPlayer(str, xi.msg.channel.SYSTEM_3, '')
-
-            -- Remove from entries table
-            local pos = tableFindPosByID(entries, member)
-            if pos then
-                table.remove(entries, pos)
-            end
-        end
-
-        -- Everyone left in the entries table isn't part of the winning group, message them and
-        -- clear them from the enmity list
-        for _, member in pairs(entries) do
-            local str = string.format('Your group was not successful in the lottery for %s. (out of %i players)', mob:getPacketName(), numEntries)
-            if #alliance == 1 then
-                str = string.format('Your were not successful in the lottery for %s. (out of %i players)', mob:getPacketName(), numEntries)
-            end
-
-            member:printToPlayer(str, xi.msg.channel.SYSTEM_3, '')
-            mob:clearEnmityForEntity(member)
-        end
-    end
-end
-
--- Called on entity onMobSpawn, sets up timerFunc
-local listenerFunc = function(mob)
-    print(string.format('Applying Claimshield to %s for %ims', mob:getPacketName(), claimshieldTime))
-
+-- Adds claim shield and sets the mob up to collect entries.
+local startClaimShield = function(mob, shieldTime)
     mob:setMobMod(xi.mobMod.CLAIM_TYPE, xi.claimType.UNCLAIMABLE)
     mob:setUnkillable(true)
     mob:setCallForHelpBlocked(true)
-    mob:stun(claimshieldTime)
-
-    mob:timer(claimshieldTime, timerFunc)
+    mob:stun(shieldTime)
 end
 
--- Main entrypoint of each override
-local overrideFunc = function(mob)
-    mob:addListener('SPAWN', string.format('%s_CS_SPAWN', mob:getPacketName()), listenerFunc)
+-- Collects all unique entries from the mobs enmity list and returns them as a table.
+local collectEntries = function(mob)
+    local entries     = {}
+    local seenPlayers = {}
 
-    -- Call original onMobInitialize
-    super(mob)
+    for _, enmityEntry in pairs(mob:getEnmityList()) do
+        local entity = enmityEntry.entity
+        local player = entity:isPC() and entity or entity:getMaster()
+
+        if player and player:isPC() then
+            local playerId = player:getID()
+            if not seenPlayers[playerId] then
+                seenPlayers[playerId] = true
+                entries[#entries + 1] = player
+            end
+        end
+    end
+
+    return entries
 end
 
--- NOTE: At the time we iterate over these entries, the Lua zone and mob objects won't be ready,
---     : so we deal with everything as strings for now.
-for _, entry in pairs(nmsToShield) do
-    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobInitialize', entry[1], entry[2]), overrideFunc)
+-- Removes claim shield.
+local endClaimShield = function(mob)
+    mob:setUnkillable(false)
+    mob:setCallForHelpBlocked(false)
+    mob:setHP(mob:getMaxHP())
+
+    local mobId = mob:getID()
+    for _, effect in ipairs(mob:getStatusEffects()) do
+        if effect:getOriginID() ~= mobId then
+            mob:delStatusEffectSilent(effect:getEffectType())
+        end
+    end
+end
+
+-- Selects a winner, awards claim, notifies entrants, and clears enmity for losing entrants.
+local resolveLottery = function(mob, entries)
+    mob:setMobMod(xi.mobMod.CLAIM_TYPE, xi.claimType.EXCLUSIVE)
+
+    for _, enmityEntry in pairs(mob:getEnmityList()) do
+        local entity = enmityEntry.entity
+        if entity then
+            if not entity:isPC() then
+                entity:disengage()
+            end
+
+            mob:resetEnmity(entity)
+        end
+    end
+
+    mob:resetAI()
+    mob:disengage()
+
+    local entrantCount = #entries
+    local claimWinner  = utils.randomEntry(entries)
+    if not claimWinner then
+        return
+    end
+
+    local alliance       = claimWinner:getAlliance()
+    local winningMembers = {}
+    local winnerPrefix   = #alliance == 1 and 'You have' or 'Your group has'
+    local winnerMessage  = string.format('%s won the lottery for %s! (out of %i players)', winnerPrefix, mob:getPacketName(), entrantCount)
+
+    for _, member in pairs(alliance) do
+        winningMembers[member:getID()] = true
+    end
+
+    mob:updateClaim(claimWinner)
+    mob:addEnmity(claimWinner, 1, 1)
+
+    for _, member in pairs(alliance) do
+        member:printToPlayer(winnerMessage, xi.msg.channel.SYSTEM_3, '')
+    end
+
+    for _, entrant in ipairs(entries) do
+        if not winningMembers[entrant:getID()] then
+            local loserAlliance = entrant:getAlliance()
+            local loserPrefix   = #loserAlliance == 1 and 'You were' or 'Your group was'
+            local loserMessage  = string.format('%s not successful in the lottery for %s. (out of %i players)', loserPrefix, mob:getPacketName(), entrantCount)
+            entrant:printToPlayer(loserMessage, xi.msg.channel.SYSTEM_3, '')
+        end
+    end
+end
+
+-- Adds Claim Shield listener on spawn.
+local addClaimshield = function(mob, shieldTime)
+    mob:addListener('SPAWN', string.format('%s_CS_SPAWN', mob:getPacketName()), function(mobArg)
+        print(string.format('Applying Claimshield to %s for %ims', mobArg:getPacketName(), shieldTime))
+        mob:setPriorityRender(true) -- Make sure the mob is visible to all players
+        startClaimShield(mobArg, shieldTime)
+
+        mobArg:timer(shieldTime, function(mobArgTwo)
+            local entries = collectEntries(mobArgTwo)
+
+            endClaimShield(mobArgTwo)
+            resolveLottery(mobArgTwo, entries)
+        end)
+    end)
+end
+
+for zoneName, entities in pairs(shieldedEntities) do
+    for _, entity in ipairs(entities) do
+        local mobName    = type(entity) == 'table' and entity.name or entity
+        local shieldTime = type(entity) == 'table' and entity.time or claimshieldTime
+
+        m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobInitialize', zoneName, mobName), function(mob)
+            addClaimshield(mob, shieldTime)
+            super(mob)
+        end)
+    end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
From original PR description on all changes:.

Adds / Updates the claim shield module.

- Uses a zone based table built as an array, making it easy to add future NMs if needed.
- Default claim shield duration is 5000 ms, but has support to override if needed.
Example : { name = 'Tiamat', time = 10000 }.
- Duplicate ID check runs one time at the end of claimshield and iterates through the list once, returns one clean table of valid entries.
- Adds priority rendering for the mob so all players can see it regardless of population
- Fixes an issue where the mob would get stuck in an animation state and would no longer auto-attack
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Enable the module in the init
!gotoid 17101197
!spawnmob 17101197
stun it when it spawns
See it claims to you and hit you
<!-- Clear and detailed steps to test your changes here -->
