### PR TITLE
[cpp] Adds retail skill up chance weights and era skill up rates

### DIFF
--- a/scripts/tests/systems/crafting/skillup_rates.lua
+++ b/scripts/tests/systems/crafting/skillup_rates.lua
@@ -1,0 +1,109 @@
+describe('SkillUpRates', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                zone = xi.zone.SOUTHERN_SAN_DORIA,
+            })
+    end)
+
+    local tries = 1000
+
+    -- Skill up amounts follow the retail-log weight table in synthutils.cpp
+    -- Percent chance of a +0.1 through +0.5 skill up given one occurred, indexed by floor distance (recipe level - charSkill / 10).
+    local function runSkillUps(p, skillTenths, crystal, ingredient, expected)
+        xi.test.world:setSeed(1)
+
+        p:setSkillRank(xi.skill.WOODWORKING, 9)  -- rank cap 100.0 so the skill cap check never blocks
+        p:setMod(xi.mod.SYNTH_SUCCESS_RATE, 300) -- clamps success to 99% so high distances still yield samples
+        p:setMod(xi.mod.SYNTH_SPEED_WOODWORKING, 17000)
+
+        local counts = { 0, 0, 0, 0, 0 }
+        local total  = 0
+
+        for i = 1, tries do
+            if i % 200 == 0 then
+                print(string.format('iter %d: %d skill ups', i, total))
+            end
+
+            p:setSkillLevel(xi.skill.WOODWORKING, skillTenths)
+            p:addItem(crystal)
+            p:addItem(ingredient)
+
+            p.actions:craft(crystal, { ingredient })
+            xi.test.world:skipTime(15)
+
+            local gain = p:getCharSkillLevel(xi.skill.WOODWORKING) - skillTenths
+            assert(gain >= 0 and gain <= 5, string.format('impossible skill up amount %d tenths', gain))
+
+            if gain > 0 then
+                counts[gain] = counts[gain] + 1
+                total        = total + 1
+            end
+
+            p:delContainerItems(xi.inv.INVENTORY)
+        end
+
+        assert(total >= 200, string.format('only %d skill ups in %d synths, not enough samples', total, tries))
+
+        for amount = 1, 5 do
+            local expectedPercent = expected[amount] or 0
+            local observedPercent = counts[amount] * 100.0 / total
+            print(string.format('+0.%d: %d of %d (%.1f%%, expected %d%%)',
+                amount, counts[amount], total, observedPercent, expectedPercent))
+
+            if expectedPercent == 0 then
+                assert(counts[amount] == 0, string.format(
+                    '+0.%d must never occur at this distance, got %d', amount, counts[amount]))
+            else
+                local prob  = expectedPercent / 100.0
+                local mean  = total * prob
+                local sigma = math.sqrt(total * prob * (1.0 - prob))
+                local lo    = mean - 4 * sigma
+                local hi    = mean + 4 * sigma
+                assert(counts[amount] >= lo and counts[amount] <= hi, string.format(
+                    '+0.%d count %d outside 4 sigma range [%.0f, %.0f] (expected %.1f)',
+                    amount, counts[amount], lo, hi, mean))
+            end
+        end
+    end
+
+    it('distance 2 gives 85/15', function()
+        -- Willow Lumber cap 13, skill 11.0
+        runSkillUps(player, 110, xi.item.WIND_CRYSTAL, xi.item.WILLOW_LOG,
+            { [1] = 85, [2] = 15 })
+    end)
+
+    it('distance 5 gives 70/30', function()
+        -- Willow Lumber cap 13, skill 8.0
+        runSkillUps(player, 80, xi.item.WIND_CRYSTAL, xi.item.WILLOW_LOG,
+            { [1] = 70, [2] = 30 })
+    end)
+
+    it('distance 7 gives 60/40', function()
+        -- Willow Lumber cap 13, skill 6.0
+        runSkillUps(player, 60, xi.item.WIND_CRYSTAL, xi.item.WILLOW_LOG,
+            { [1] = 60, [2] = 40 })
+    end)
+
+    it('distance 10 gives 40/40/20', function()
+        -- Walnut Lumber cap 19, skill 9.0
+        runSkillUps(player, 90, xi.item.WIND_CRYSTAL, xi.item.WALNUT_LOG,
+            { [1] = 40, [2] = 40, [3] = 20 })
+    end)
+
+    it('distance 14 gives 0/40/30/20/10 and never +0.1', function()
+        -- Walnut Lumber cap 19, skill 5.0
+        runSkillUps(player, 50, xi.item.WIND_CRYSTAL, xi.item.WALNUT_LOG,
+            { [2] = 40, [3] = 30, [4] = 20, [5] = 10 })
+    end)
+
+    it('skill 60.0 and above only ever gives +0.1', function()
+        -- Lu Shangs Fishing Rod cap 70, skill 60.0: distance 10 would give 40/40/20 below level 60
+        -- That means anything above +0.1 here means the gate broke.
+        runSkillUps(player, 600, xi.item.LIGHT_CRYSTAL, xi.item.BROKEN_LU_SHANGS_FISHING_ROD,
+            { [1] = 100 })
+    end)
+end)

--- a/settings/default/map.lua
+++ b/settings/default/map.lua
@@ -134,8 +134,7 @@ xi.settings.map =
     CRAFT_CHANCE_MULTIPLIER   = 1.0,
 
     -- Multiplier for skillup amounts. Using anything above 1 will break the 0.5 cap, the cap will become 0.9 (For maximum, set to 5)
-    SKILLUP_AMOUNT_MULTIPLIER = 1,
-    CRAFT_AMOUNT_MULTIPLIER   = 1,
+    SKILLUP_AMOUNT_MULTIPLIER = 1, -- This is for combat skills, not synthesis.
 
     -- Gardening Factors. DO NOT change defaults without verifiable proof that your change IS how retail does it. Myths need to be optional.
     GARDEN_DAY_MATTERS       = false,

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -42,6 +42,7 @@
 #include "zone.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 // TODO: This largely overlaps with SYNTHESIS_RESULT and could be simplified.
@@ -888,6 +889,26 @@ void handleSynthFail(CCharEntity* PChar)
     PChar->pushPacket<GP_SERV_COMMAND_COMBINE_ANS>(PChar, SynthesisResult::Failed, CCraftState::Result{ MANGLED_MESS, 0 });
 }
 
+// Percent chance of a +0.1 through +0.5 skill up given one occurred, indexed by floor distance (recipe level - charSkill / 10).
+// Derived from retail skill-up logs. Each row sums to 100.
+static constexpr std::array<std::array<uint8, 5>, 15> skillUpAmountWeights = { {
+    { 85, 15, 0, 0, 0 },   // 0 (and over-cap)
+    { 85, 15, 0, 0, 0 },   // 1
+    { 85, 15, 0, 0, 0 },   // 2
+    { 80, 20, 0, 0, 0 },   // 3
+    { 80, 20, 0, 0, 0 },   // 4
+    { 70, 30, 0, 0, 0 },   // 5
+    { 70, 30, 0, 0, 0 },   // 6
+    { 60, 40, 0, 0, 0 },   // 7
+    { 60, 40, 0, 0, 0 },   // 8
+    { 50, 40, 10, 0, 0 },  // 9
+    { 40, 40, 20, 0, 0 },  // 10
+    { 40, 40, 20, 0, 0 },  // 11
+    { 15, 45, 30, 10, 0 }, // 12
+    { 10, 40, 25, 25, 0 }, // 13
+    { 0, 40, 30, 20, 10 }, // 14+
+} };
+
 // Used in: sendSynthDone
 void doSynthSkillUp(CCharEntity* PChar)
 {
@@ -946,7 +967,18 @@ void doSynthSkillUp(CCharEntity* PChar)
         }
         else
         {
-            skillUpChance = static_cast<double>(baseDiff) * (3.0 - std::log(1.2 + static_cast<double>(charSkill) / 100.0)) / 10.0; // Original skill up equation.
+            // No data supports skill up chance scaling with the recipe level gap, so era rates are flat.
+            // This data has been taken mostly from this: https://www.bluegartr.com/threads/57123-Before-you-ask-a-stupid-crafting-question-read-this!
+            // Took the low of both ranges so 60% skillup below 50 and 25% skillup above 50.
+            // The data is not perfect but it is unfortunately the best we have for old rates.
+            if (charSkill < 500) // 0-49.9
+            {
+                skillUpChance = 0.6;
+            }
+            else // 50.0 and above
+            {
+                skillUpChance = 0.25;
+            }
         }
 
         // Apply synthesis skill gain rate modifier before synthesis fail modifier
@@ -985,51 +1017,22 @@ void doSynthSkillUp(CCharEntity* PChar)
         //------------------------------
         // Section 4: Calculate Skill Up Amount
         //------------------------------
-        uint8 maxAllowedAmount = 1;
+        uint8 skillUpAmount = 1;
         if (charSkill < 600) // No skill ups over 0.1 happen over level 60.
         {
-            if (baseDiff >= 12)
-            {
-                maxAllowedAmount = 4;
-            }
-            else if (baseDiff >= 6)
-            {
-                maxAllowedAmount = 3;
-            }
-            else if (baseDiff >= 3)
-            {
-                maxAllowedAmount = 2;
-            }
-        }
+            const auto& weights          = skillUpAmountWeights[std::clamp<int16>(baseDiff, 0, 14)];
+            const auto  roll             = xirand::GetRandomNumber(100);
+            int32       cumulativeWeight = 0;
 
-        // TODO: More info needed for rates. This is using what was already here since the dark ages.
-        uint8 skillUpAmount = 1;
-        if (maxAllowedAmount > 1)
-        {
-            const uint8 cicles = static_cast<uint8>(maxAllowedAmount - 1);
-            double      chance = 0.0;
-
-            for (uint8 i = 1; i <= cicles; i++) // Cicle up to 3 times until cap (0.4 skill-up value) or break. The lower the maxAllowedAmount, the more likely it will break.
+            for (uint8 amount = 1; amount <= weights.size(); ++amount)
             {
-                chance = static_cast<double>(maxAllowedAmount) * 0.1;
-
-                if (chance < xirand::GetRandomNumber(1.0))
+                cumulativeWeight += weights[amount - 1];
+                if (roll < cumulativeWeight)
                 {
+                    skillUpAmount = amount;
                     break;
                 }
-
-                skillUpAmount++;
-                maxAllowedAmount--;
             }
-        }
-
-        // Settings skill amount multiplier
-        if (settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLIER") > 1)
-        {
-            // Scaled at int width: at uint8 width a large multiplier setting wraps before the cap below can catch it.
-            const int scaledAmount = skillUpAmount + skillUpAmount * settings::get<uint8>("map.CRAFT_AMOUNT_MULTIPLIER");
-
-            skillUpAmount = static_cast<uint8>(std::min(scaledAmount, 9));
         }
 
         // Cap skill gain amount if character hits the current cap


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Implements retail skill up chance data from captures and roughly 2,265 synths. https://docs.google.com/spreadsheets/d/15mD465vLHJ3qFAWCR_qU0QFP2i0KjBWHdQOnsN9kfXk/edit?gid=852003036#gid=852003036

<img width="1669" height="437" alt="image" src="https://github.com/user-attachments/assets/dc2340de-5aad-49c9-9f90-35daab964bf2" />

How the skill up rate is calculated:
We run the for loop over the weight table in order to grab the skill up amount for the weighted row. If we take distance 10 for this case its { 40, 40, 20, 0, 0 }. The roll (100) run from 0 to 99 as we have previously had issue with this before.

1) We roll the dice! (we only roll once)
2) amount = 1 -> cumulativeWeight checks 40, if it rolls < 40 we are done and we award 0.1
3) amround = 2 -> cumulativeWeight  now checks 80 (40 + 40). That roll from step 1 is now checked again - if it hits 40-79 congratulations you now have a 0.2 skill up
4) check for 3, 4, etc.


I have also made an actual test for rates here are the results. I have never made a test before. I used the `hq.lua` as an example and its almost identical other than swapping to the skilluprate table/formulas and calling the tests at the bottom

<img width="740" height="256" alt="image" src="https://github.com/user-attachments/assets/8d89d5b3-533c-4985-9c10-a8e755ccc9d9" />


- Bonus: Removes CRAFT_AMOUNT_MULTIPLIER as per the request of others

### EXTERNAL TEST
Since there is no real way to test this other than debugging it yourself I have asked our friendly AI to run a test harness with different floor distances, tiers and the result on top of the lua test just for a backup.

**Roll range (`GetRandomNumber(100)`), 100M draws:** rolls span 0-99 inclusive
(hit counts: roll 0 = 999509, roll 99 = 1000335, outside 0-99 = 0), uniform
(per-value share min 0.9969% / expected 1.0000% / max 1.0019%). No off-by-one:
100 outcomes carved by cumulative `roll < threshold` gives exact percentages.

**Amount distribution per floor distance.** Exact = every roll 0-99 enumerated
through the selection loop (no sampling). Observed = 10M full RNG samples.

| Floor dist | Tier | Expected % | Exact % | Observed % | Result |
|-----------:|-----:|-----------:|--------:|-----------:|:-------|
| 0 | +0.1 | 85 | 85 | 84.989 | MATCH |
| 0 | +0.2 | 15 | 15 | 15.011 | MATCH |
| 0 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 0 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 0 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 1 | +0.1 | 85 | 85 | 85.011 | MATCH |
| 1 | +0.2 | 15 | 15 | 14.989 | MATCH |
| 1 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 1 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 1 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 2 | +0.1 | 85 | 85 | 84.990 | MATCH |
| 2 | +0.2 | 15 | 15 | 15.010 | MATCH |
| 2 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 2 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 2 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 3 | +0.1 | 80 | 80 | 80.017 | MATCH |
| 3 | +0.2 | 20 | 20 | 19.983 | MATCH |
| 3 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 3 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 3 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 4 | +0.1 | 80 | 80 | 80.006 | MATCH |
| 4 | +0.2 | 20 | 20 | 19.994 | MATCH |
| 4 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 4 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 4 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 5 | +0.1 | 70 | 70 | 70.015 | MATCH |
| 5 | +0.2 | 30 | 30 | 29.985 | MATCH |
| 5 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 5 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 5 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 6 | +0.1 | 70 | 70 | 69.992 | MATCH |
| 6 | +0.2 | 30 | 30 | 30.008 | MATCH |
| 6 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 6 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 6 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 7 | +0.1 | 60 | 60 | 60.017 | MATCH |
| 7 | +0.2 | 40 | 40 | 39.983 | MATCH |
| 7 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 7 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 7 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 8 | +0.1 | 60 | 60 | 60.017 | MATCH |
| 8 | +0.2 | 40 | 40 | 39.983 | MATCH |
| 8 | +0.3 | 0 | 0 | 0.000 | MATCH |
| 8 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 8 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 9 | +0.1 | 50 | 50 | 50.030 | MATCH |
| 9 | +0.2 | 40 | 40 | 39.991 | MATCH |
| 9 | +0.3 | 10 | 10 | 9.979 | MATCH |
| 9 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 9 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 10 | +0.1 | 40 | 40 | 39.996 | MATCH |
| 10 | +0.2 | 40 | 40 | 39.989 | MATCH |
| 10 | +0.3 | 20 | 20 | 20.015 | MATCH |
| 10 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 10 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 11 | +0.1 | 40 | 40 | 39.995 | MATCH |
| 11 | +0.2 | 40 | 40 | 40.007 | MATCH |
| 11 | +0.3 | 20 | 20 | 19.998 | MATCH |
| 11 | +0.4 | 0 | 0 | 0.000 | MATCH |
| 11 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 12 | +0.1 | 15 | 15 | 15.000 | MATCH |
| 12 | +0.2 | 45 | 45 | 44.993 | MATCH |
| 12 | +0.3 | 30 | 30 | 29.995 | MATCH |
| 12 | +0.4 | 10 | 10 | 10.012 | MATCH |
| 12 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 13 | +0.1 | 10 | 10 | 10.006 | MATCH |
| 13 | +0.2 | 40 | 40 | 39.977 | MATCH |
| 13 | +0.3 | 25 | 25 | 25.021 | MATCH |
| 13 | +0.4 | 25 | 25 | 24.996 | MATCH |
| 13 | +0.5 | 0 | 0 | 0.000 | MATCH |
| 14+ | +0.1 | 0 | 0 | 0.000 | MATCH |
| 14+ | +0.2 | 40 | 40 | 40.025 | MATCH |
| 14+ | +0.3 | 30 | 30 | 29.976 | MATCH |
| 14+ | +0.4 | 20 | 20 | 19.997 | MATCH |
| 14+ | +0.5 | 10 | 10 | 10.001 | MATCH |

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Craft a lot. Track your skill up rates...see they match
<!-- Clear and detailed steps to test your changes here -->
