### PR TITLE
[lua] TOAU Unlock Quest Audits

### DIFF
--- a/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
+++ b/scripts/quests/jeuno/The_Road_to_Aht_Urhgan.lua
@@ -13,26 +13,26 @@ quest.reward =
 
 local beginnerList =
 {
-    xi.item.DAMSELFLY_WORM,
-    xi.item.MAGICKED_SKULL,
-    xi.item.CRAB_APRON,
-    xi.item.BLOODY_ROBE,
-    xi.item.CUP_OF_DHALMEL_SALIVA,
-    xi.item.WILD_RABBIT_TAIL,
+    { xi.item.DAMSELFLY_WORM,        1 },
+    { xi.item.MAGICKED_SKULL,        1 },
+    { xi.item.CRAB_APRON,            1 },
+    { xi.item.BLOODY_ROBE,           1 },
+    { xi.item.CUP_OF_DHALMEL_SALIVA, 1 },
+    { xi.item.WILD_RABBIT_TAIL,      1 },
 }
 
 local intermediateList =
 {
-    xi.item.JADE_CRYPTEX,
-    xi.item.SILVER_ENGRAVING,
-    xi.item.THIRTEEN_KNOT_QUIPU,
+    { xi.item.JADE_CRYPTEX,        1 },
+    { xi.item.SILVER_ENGRAVING,    1 },
+    { xi.item.THIRTEEN_KNOT_QUIPU, 1 },
 }
 
 local chipList =
 {
-    xi.item.CARMINE_CHIP,
-    xi.item.CYAN_CHIP,
-    xi.item.GRAY_CHIP,
+    { xi.item.CARMINE_CHIP, 1 },
+    { xi.item.CYAN_CHIP,    1 },
+    { xi.item.GRAY_CHIP,    1 },
 }
 
 local advancedSingleList =
@@ -96,6 +96,7 @@ local function handleSelectionEventFinish(player, csid, option, npc)
     elseif option == 3 then
         if player:getGil() >= 500000 then
             player:delGil(500000)
+            player:messageSpecial(zones[xi.zone.LOWER_JEUNO].text.PAY_FAURSEL, 500000)
             quest:setVar(player, 'Prog', 2)
             quest:setMustZone(player)
             quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)
@@ -113,14 +114,37 @@ quest.sections =
 
         [xi.zone.LOWER_JEUNO] =
         {
-            ['Faursel'] = quest:progressEvent(10062),
+            ['Faursel'] =
+            {
+                onTrigger = function(player, npc)
+                    if quest:getVar(player, 'Prog') == 0 then
+                        return quest:progressEvent(10062)
+                    end
+
+                    return quest:progressEvent(10063, 0, 0, 0, 0, 0, player:getCurrentMission(xi.mission.log_id.ROV) == xi.mission.id.rov.INESCAPABLE_BINDS and 1 or 0)
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [10063] = handleEventUpdate,
+            },
 
             onEventFinish =
             {
+                -- Hearing Faursel out grants nothing. The quest is only added to the log when 10063 ends on a selection.
                 [10062] = function(player, csid, option, npc)
                     if option == 1 then
+                        quest:setVar(player, 'Prog', 1)
+                    end
+                end,
+
+                [10063] = function(player, csid, option, npc)
+                    if option == 2 or option == 3 then
                         quest:begin(player)
                     end
+
+                    handleSelectionEventFinish(player, csid, option, npc)
                 end,
             },
         },
@@ -139,9 +163,9 @@ quest.sections =
                     if
                         quest:getVar(player, 'Prog') == 1 and
                         (
-                            npcUtil.tradeHasExactly(trade, beginnerList) or
-                            npcUtil.tradeHasExactly(trade, intermediateList) or
-                            npcUtil.tradeHasExactly(trade, chipList) or
+                            npcUtil.tradeMatches(trade, beginnerList) or
+                            npcUtil.tradeMatches(trade, intermediateList) or
+                            npcUtil.tradeMatches(trade, chipList) or
                             npcUtil.tradeSetInList(trade, advancedSingleList)
                         )
                     then
@@ -152,20 +176,19 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local questProgress = quest:getVar(player, 'Prog')
                     local timePassed    = quest:getVar(player, 'Timer') <= VanadielUniqueDay() and not quest:getMustZone(player)
-                    local onRovMission  = player:getCurrentMission(xi.mission.log_id.ROV) == xi.mission.id.rov.INESCAPABLE_BINDS and 1 or 0
 
-                    -- Initial Quest Dialogues
-                    if questProgress == 0 then
-                        return quest:progressEvent(10063, 0, 0, 0, 0, 0, onRovMission)
-                    elseif questProgress == 1 then
-                        return quest:progressEvent(10064, 0, 0, 0, 0, 0, onRovMission)
+                    -- No decision yet. Faursel reads the lists again.
+                    -- Prog 0: accepted back when 10062 granted the quest.
+                    if questProgress == 0 or questProgress == 1 then
+                        return quest:progressEvent(10064, 0, 0, 0, 0, 0, player:getCurrentMission(xi.mission.log_id.ROV) == xi.mission.id.rov.INESCAPABLE_BINDS and 1 or 0)
 
                     -- Purchased the Boarding Permit
                     elseif questProgress == 2 then
                         if timePassed then
-                            return quest:progressEvent(10067)
+                            -- Capture: the parameters 10067 starts with. Zeros end the cutscene before the fade to black.
+                            return quest:progressEvent(10067, 15, 1, 3, -1, 541, 540, 0, 99)
                         else
-                            return quest:progressEvent(10066)
+                            return quest:event(10066) -- No refunds. Come back tomorrow.
                         end
 
                     -- Traded Items for Boarding Permit
@@ -173,7 +196,7 @@ quest.sections =
                         if timePassed then
                             return quest:progressEvent(10070)
                         else
-                            return quest:progressEvent(10072)
+                            return quest:event(10072) -- Come back tomorrow.
                         end
 
                     -- Purchased Permit, and has returned from Wajaom Woodlands
@@ -185,13 +208,18 @@ quest.sections =
 
             onEventUpdate =
             {
-                [10063] = handleEventUpdate,
                 [10064] = handleEventUpdate,
+
+                -- Capture: the reply to the option 30 update. The cutscene shows the key items and holds the black screen for the warp.
+                [10067] = function(player, csid, option, npc)
+                    if option == 30 then
+                        player:updateEvent(79, 1, 0, 34, 910, 540, 99, 99)
+                    end
+                end,
             },
 
             onEventFinish =
             {
-                [10063] = handleSelectionEventFinish,
                 [10064] = handleSelectionEventFinish,
 
                 [10067] = function(player, csid, option, npc)
@@ -204,7 +232,7 @@ quest.sections =
                 end,
 
                 [10069] = function(player, csid, option, npc)
-                    player:confirmTrade()
+                    player:tradeComplete()
                     quest:setMustZone(player)
                     quest:setVar(player, 'Prog', 3)
                     quest:setVar(player, 'Timer', VanadielUniqueDay() + 1)

--- a/scripts/zones/Lower_Jeuno/IDs.lua
+++ b/scripts/zones/Lower_Jeuno/IDs.lua
@@ -55,6 +55,7 @@ zones[xi.zone.LOWER_JEUNO] =
         YIN_POCANAKHU_GET_LOST        = 8023,  -- Hey, what are you tryin' to pull? Get lost!
         MERTAIRE_RING                 = 8071,  -- So, what did you do with that ring? Maybe it's valuable. I'd ask a collector if I were you. Of course, he might just say it's worthless...
         CONQUEST                      = 8083,  -- You've earned conquest points!
+        PAY_FAURSEL                   = 9587,  -- You pay Faursel <number> gil!
         NO_KEY                        = 9933,  -- You do not have a usable key in your possession.
         RETRIEVE_DIALOG_ID            = 10213, -- You retrieve <item> from the porter moogle's care.
         WAYPOINT_EXAMINE              = 10374, -- An enigmatic contrivance hovers in silence...


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits the quest "The Road to Aht Urghan" against retail [captures.](https://www.youtube.com/watch?v=qcDA9A2HLhg) It does the following things:

- The quest is now properly granted at the end of a specific event based on retail captures (it was being granted too early before).
- Adds missing text saying you pay Faursel 500k if you choose to do so.
- Adds retail parameters to some events and as a result makes the teleportation event when you buy the pass look just like retail instead of briefly showing your character in lower Jeuno even after seeing a cutscene of your character in Wajaom.
- Demotes some dialogue options and converts some trade interactions based on modern LSB conventions.

## Steps to test these changes

Become a Tenshodo Member and do the quest. See it is more accurate now and still works.
