### PR TITLE
[module] [lua] BLU AF Quest Era Modules

### DIFF
--- a/modules/era/lua/quests/ahturhgan/beginnings.lua
+++ b/modules/era/lua/quests/ahturhgan/beginnings.lua
@@ -1,0 +1,26 @@
+-----------------------------------
+-- Beginnings (BLU AF1)
+-- Restores the JST midnight wait before Waoud offers Omens.
+-- The June 7, 2016 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_beginnings', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/BLU_AF1_Beginnings', function(quest)
+        local whitegate = quest.sections[2][xi.zone.AHT_URHGAN_WHITEGATE]
+
+        -- Copy of the base handler. Omens is offered at JST midnight.
+        whitegate.onEventFinish[707] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                xi.quest.setMustZone(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.OMENS)
+                xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.OMENS, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/ahturhgan/omens.lua
+++ b/modules/era/lua/quests/ahturhgan/omens.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Omens (BLU AF2)
+-- Restores the JST midnight wait before Waoud offers Transformations.
+-- The June 7, 2016 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_omens', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/BLU_AF2_Omens', function(quest)
+        local whitegate = quest.sections[2][xi.zone.AHT_URHGAN_WHITEGATE]
+
+        -- Copy of the base handler. Transformations is offered at JST midnight.
+        whitegate.onEventFinish[716] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:delKeyItem(xi.ki.SEALED_IMMORTAL_ENVELOPE)
+
+                xi.quest.setMustZone(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.TRANSFORMATIONS)
+                xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.TRANSFORMATIONS, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/ahturhgan/transformations.lua
+++ b/modules/era/lua/quests/ahturhgan/transformations.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Transformations (BLU AF3)
+-- Restores the JST midnight wait before Waoud offers The Beast Within.
+-- The June 7, 2016 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_transformations', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/BLU_AF3_Transformations', function(quest)
+        local alzadaal = quest.sections[2][xi.zone.ALZADAAL_UNDERSEA_RUINS]
+
+        -- Copy of the base handler. The Beast Within is offered at JST midnight.
+        alzadaal.onEventFinish[5] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.THE_BEAST_WITHIN, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a module to multiple BLU AF quests to make them have their original JST midnight waits based on [official patch notes](https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update).

## Steps to test these changes

Load the modules. See the waits are increased.
