### PR TITLE
[core] Make AI state changes safe from inside a running state

### DIFF
--- a/scripts/tests/systems/combat/state_reentrancy.lua
+++ b/scripts/tests/systems/combat/state_reentrancy.lua
@@ -1,0 +1,110 @@
+-- Coverage for lua re-entering the AI state machine from inside a state.
+--
+-- Original bugs:
+--   * (UAF -> crash) a stun from a mob's own TP move interrupted the CMobSkillState whose Update() was still running, freeing it mid-resolution.
+--   * a state entered from within Cleanup() was popped straight back off, so the stun never applied and the finished state was cleaned up over and over.
+--   * PAI->Reset() dropped the attack state without its Cleanup, leaving the mob engaged with nothing to swing: TP moves kept firing, auto-attacks did not.
+
+describe('AI state re-entrancy', function()
+    ---@type CClientEntityPair
+    local player
+
+    ---@type CTestEntity
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ level = 1, zone = xi.zone.BEAUCEDINE_GLACIER_S })
+        mob    = player.entities:moveTo('Ruszor')
+        mob:respawn()
+        player:setUnkillable(true)
+    end)
+
+    after_each(function()
+        for _, name in ipairs({ 'TEST_WS_EXIT', 'TEST_WS_USE', 'TEST_DISENGAGE' }) do
+            mob:removeListener(name)
+        end
+    end)
+
+    -- Ticks the mob a second at a time, collecting the states it passes through and whether it landed a hit (the player is healed back up so every swing shows).
+    local function run(seconds)
+        local seen = {}
+        local hits = 0
+        for _ = 1, seconds do
+            local hp = player:getHP()
+            xi.test.world:tickEntity(mob)
+            xi.test.world:skipTime(1)
+            if player:getHP() ~= hp then
+                hits = hits + 1
+            end
+
+            player:setHP(player:getMaxHP())
+            seen[mob:getCurrentAction()] = true
+        end
+
+        return seen, hits
+    end
+
+    local function engage()
+        mob:addEnmity(player, 100, 100)
+        run(3)
+        assert(mob:getCurrentAction() == xi.action.category.BASIC_ATTACK, 'precondition: mob is engaged and attacking')
+    end
+
+    it('does not tear out a TP move that stuns its own user', function()
+        engage()
+
+        local exits = {}
+        mob:addListener('WEAPONSKILL_STATE_EXIT', 'TEST_WS_EXIT', function(_, _, completed)
+            table.insert(exits, completed)
+        end)
+
+        local resolved = false
+        mob:addListener('WEAPONSKILL_USE', 'TEST_WS_USE', function(mobArg)
+            resolved = true
+            mobArg:stun(3000)
+        end)
+
+        mob:setTP(3000)
+        mob:useMobAbility(xi.mobSkill.AQUA_BLAST, player, 2000)
+
+        local seen = run(10)
+
+        assert(resolved, 'the TP move should have resolved')
+        assert(#exits == 1, 'the mob skill state should retire exactly once')
+        assert(exits[1] == true, 'the skill resolved, so it must not report an interrupt')
+        assert(seen[xi.action.category.SLEEP], 'the stun should have parked the mob inactive')
+        assert(mob:getCurrentAction() == xi.action.category.BASIC_ATTACK, 'mob should be back to attacking')
+    end)
+
+    it('applies a stun asked for from a DISENGAGE listener', function()
+        engage()
+
+        local disengages = 0
+        mob:addListener('DISENGAGE', 'TEST_DISENGAGE', function(mobArg)
+            disengages = disengages + 1
+            mobArg:stun(3000)
+        end)
+
+        mob:disengage()
+        xi.test.world:tickEntity(mob)
+        xi.test.world:skipTime(1)
+
+        assert(disengages == 1, 'the disengage handler ran ' .. disengages .. ' times, expected once')
+        assert(mob:getCurrentAction() == xi.action.category.SLEEP, 'the stun asked for during Cleanup should have applied')
+    end)
+
+    it('lets a mob re-engage after resetAI', function()
+        engage()
+
+        mob:resetAI()
+
+        assert(not mob:isEngaged(), 'resetAI dropped the attack state, so the mob must not still look engaged')
+        assert(mob:getCurrentAction() == xi.action.category.ROAMING, 'resetAI should leave the mob idle')
+
+        mob:addEnmity(player, 100, 100)
+        local _, hits = run(12)
+
+        assert(mob:getCurrentAction() == xi.action.category.BASIC_ATTACK, 'mob should have re-engaged')
+        assert(hits > 0, 'mob should be swinging again')
+    end)
+end)

--- a/scripts/tests/systems/spawn_handler.lua
+++ b/scripts/tests/systems/spawn_handler.lua
@@ -15,6 +15,20 @@ describe('Spawn Handler', function()
             mob.assert:isSpawned()
         end)
 
+        it('does not inherit queued actions from its previous life', function()
+            local mob = player.entities:moveTo('Forest_Funguar')
+
+            -- deadline well past the despawn, so the only way it can leave the queue is the respawn dropping it
+            mob:queue(60000, function()
+            end)
+
+            assert(not mob:actionQueueEmpty(), 'precondition: the action is queued')
+
+            mob:respawn()
+
+            assert(mob:actionQueueEmpty(), 'a queued action outlived the respawn')
+        end)
+
         it('does not respawn a mob before its timer expires', function()
             local mob = player.entities:moveTo('Forest_Funguar')
             player:claimAndKillMob(mob)

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -462,6 +462,10 @@ void CAIContainer::Reset()
         m_stateStack.pop();
     }
 
+    // drop the queues too, or an action from the previous life fires on the next spawn.
+    ClearActionQueue();
+    ClearTimerQueue();
+
     // no Cleanup ran, so clear the engaged flags by hand. Internal_Engage skips anything that still looks engaged, leaving it with nothing to swing with.
     if (auto* battle = dynamic_cast<CBattleEntity*>(PEntity); battle && battle->animation == xi::Animation::Attack)
     {

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -405,6 +405,17 @@ void CAIContainer::resumeNextState()
     }
 }
 
+void CAIContainer::finishCurrentState(const timer::time_point tick)
+{
+    auto finished = std::move(m_currentState);
+    resumeNextState();
+
+    if (finished)
+    {
+        finished->Cleanup(tick);
+    }
+}
+
 auto CAIContainer::CanChangeState() const -> bool
 {
     return !GetCurrentState() || GetCurrentState()->CanChangeState();
@@ -505,19 +516,16 @@ auto CAIContainer::Tick(const timer::time_point tick) -> Task<void>
 
         CState* running = m_currentState.get();
 
-        if (running->DoUpdate(tick))
-        {
-            // A state can enter a successor during its own update (e.g. petskill
-            // re-engages), which becomes current. Only retire the state we actually ran.
-            if (running == m_currentState.get())
-            {
-                running->Cleanup(tick);
-                resumeNextState();
-            }
-        }
-        else // Not finished: leave it current and stop.
+        if (!running->DoUpdate(tick)) // Not finished: leave it current and stop.
         {
             break;
+        }
+
+        // A state can enter a successor during its own update (e.g. petskill
+        // re-engages), which becomes current. Only retire the state we actually ran.
+        if (running == m_currentState.get())
+        {
+            finishCurrentState(tick);
         }
     }
 
@@ -546,8 +554,7 @@ void CAIContainer::ClearStateStack()
 {
     while (m_currentState)
     {
-        m_currentState->Cleanup(timer::now());
-        resumeNextState();
+        finishCurrentState(timer::now());
     }
 }
 
@@ -555,8 +562,7 @@ void CAIContainer::InterruptStates()
 {
     while (m_currentState && m_currentState->CanInterrupt())
     {
-        m_currentState->Cleanup(timer::now());
-        resumeNextState();
+        finishCurrentState(timer::now());
     }
 }
 
@@ -650,8 +656,7 @@ void CAIContainer::CheckCompletedStates()
 {
     while (m_currentState && m_currentState->IsCompleted())
     {
-        m_currentState->Cleanup(timer::now());
-        resumeNextState();
+        finishCurrentState(timer::now());
     }
 }
 

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -394,11 +394,9 @@ auto CAIContainer::enterState(std::unique_ptr<CState> next) -> bool
 void CAIContainer::resumeNextState()
 {
     // The current state is finished; resume the one suspended beneath it, or go idle.
-    if (m_stateStack.empty())
-    {
-        m_currentState.reset();
-    }
-    else
+    retire(std::move(m_currentState));
+
+    if (!m_stateStack.empty())
     {
         m_currentState = std::move(m_stateStack.top());
         m_stateStack.pop();
@@ -413,6 +411,15 @@ void CAIContainer::finishCurrentState(const timer::time_point tick)
     if (finished)
     {
         finished->Cleanup(tick);
+        retire(std::move(finished));
+    }
+}
+
+void CAIContainer::retire(std::unique_ptr<CState> state)
+{
+    if (state)
+    {
+        m_retiredStates.push_back(std::move(state));
     }
 }
 
@@ -448,9 +455,10 @@ void CAIContainer::Reset()
         Controller->Reset();
     }
 
-    m_currentState.reset();
+    retire(std::move(m_currentState));
     while (!m_stateStack.empty())
     {
+        retire(std::move(m_stateStack.top()));
         m_stateStack.pop();
     }
 
@@ -496,9 +504,8 @@ auto CAIContainer::Tick(const timer::time_point tick) -> Task<void>
     }
 
     //
-    // The current state is held in m_currentState (not on the stack) while it runs, so a
-    // re-entrant change can't free the object we're executing in. Entering a state only
-    // suspends the current one beneath it, never frees it.
+    // The current state is held in m_currentState (not on the stack) while it runs, and finished states sit in m_retiredStates until the end of the tick.
+    // A re-entrant change can suspend or retire the state we are executing in, but never free it.
     //
 
     // The guard is a backstop against
@@ -542,6 +549,9 @@ auto CAIContainer::Tick(const timer::time_point tick) -> Task<void>
 
     PEntity->PostTick();
 
+    // nothing is executing now, so the states retired this tick can go.
+    m_retiredStates.clear();
+
     co_return;
 }
 
@@ -560,7 +570,8 @@ void CAIContainer::ClearStateStack()
 
 void CAIContainer::InterruptStates()
 {
-    while (m_currentState && m_currentState->CanInterrupt())
+    // a state running its own Update is left alone - tearing it out would free it under its own frame. whatever wanted the interrupt stacks above it instead.
+    while (m_currentState && !m_currentState->isExecuting() && m_currentState->CanInterrupt())
     {
         finishCurrentState(timer::now());
     }

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -442,6 +442,14 @@ void CAIContainer::Reset()
     {
         m_stateStack.pop();
     }
+
+    // no Cleanup ran, so clear the engaged flags by hand. Internal_Engage skips anything that still looks engaged, leaving it with nothing to swing with.
+    if (auto* battle = dynamic_cast<CBattleEntity*>(PEntity); battle && battle->animation == xi::Animation::Attack)
+    {
+        battle->animation = xi::Animation::None;
+        battle->setBattleTarget(std::nullopt);
+        battle->updatemask |= UPDATE_HP;
+    }
 }
 
 auto CAIContainer::Tick(const timer::time_point tick) -> Task<void>

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -153,6 +153,9 @@ private:
     // Finish with the current state and resume the one suspended beneath it (or go idle).
     void resumeNextState();
 
+    // swap in the state beneath before Cleanup, so anything Cleanup enters stacks on the resumed state instead of being popped right back off.
+    void finishCurrentState(timer::time_point tick);
+
     auto stateCount() const -> size_t;
 
     // The state the entity is currently in (null == idle). It lives here rather than on

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <stack>
+#include <vector>
 
 #include "ai/controllers/controller.h"
 #include "entities/base_entity.h"
@@ -156,6 +157,9 @@ private:
     // swap in the state beneath before Cleanup, so anything Cleanup enters stacks on the resumed state instead of being popped right back off.
     void finishCurrentState(timer::time_point tick);
 
+    // park a finished state until the end of the tick; its Update/Cleanup frame may still be live further up the call stack.
+    void retire(std::unique_ptr<CState> state);
+
     auto stateCount() const -> size_t;
 
     // The state the entity is currently in (null == idle). It lives here rather than on
@@ -163,6 +167,9 @@ private:
     // holds the states suspended beneath it.
     std::unique_ptr<CState>             m_currentState;
     std::stack<std::unique_ptr<CState>> m_stateStack;
+
+    // retired states, freed at the end of Tick().
+    std::vector<std::unique_ptr<CState>> m_retiredStates;
 
     CAIActionQueue ActionQueue;
 };

--- a/src/map/ai/states/state.cpp
+++ b/src/map/ai/states/state.cpp
@@ -20,6 +20,7 @@
 */
 
 #include "state.h"
+#include "common/xi.h"
 #include "entities/base_entity.h"
 
 void CState::TryInterrupt(CBattleEntity* PAttacker)
@@ -96,7 +97,19 @@ auto CState::GetErrorMsg() const -> std::unique_ptr<CBasicPacket>
 auto CState::DoUpdate(const timer::time_point tick) -> bool
 {
     UpdateTarget(target_);
+
+    m_executing       = true;
+    const auto onExit = xi::finally([this]()
+                                    {
+                                        m_executing = false;
+                                    });
+
     return Update(tick);
+}
+
+auto CState::isExecuting() const -> bool
+{
+    return m_executing;
 }
 
 auto CState::IsCompleted() const -> bool

--- a/src/map/ai/states/state.h
+++ b/src/map/ai/states/state.h
@@ -86,6 +86,9 @@ public:
 
     auto DoUpdate(timer::time_point tick) -> bool;
 
+    // true while this state's own Update is running. Interrupting it there would free it under its own frame.
+    auto isExecuting() const -> bool;
+
     // try interrupt (on hit)
     virtual void TryInterrupt(CBattleEntity* PAttacker);
 
@@ -119,5 +122,6 @@ protected:
 private:
     EntityId          target_{};
     bool              m_completed{ false };
+    bool              m_executing{ false };
     timer::time_point m_entryTime{ timer::now() };
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
More hacks for the orphan crushing machine.

### Bug 1: Clear the engaged flags when resetting AI

Reset() throws the state stack away without running Cleanup, so nothing clears the engaged animation. 

The mob still looks engaged, Internal_Engage won't hand it a new attack state, and it carries on using TP moves while never swinging again. 

### Bug 2: Resume the next AI state before running Cleanup

Cleanup ran before the finished state was swapped out, so anything a lua handler started got popped straight back off.

Dark Ixion's onMobDisengage stun loops until the tick's iteration guard trips and doesnt apply.

### Bug 3: Don't free an AI state from inside its own update

A mob stunning itself from its own TP move goes CInactiveState::init -> InterruptStates, which frees the state that's still mid-Update. Resolution carries on inside the dead object and crashes as soon as it reads back the mobskill it just took down with it..

Finished states now sit in m_retiredStates until the end of the tick, and InterruptStates leaves the running one alone.

## Steps to test these changes
Tests included.

<!-- Clear and detailed steps to test your changes here -->
