### PR TITLE
[lua] Update ToAU 5 - 11

### DIFF
--- a/scripts/missions/toau/05_Confessions_of_Royalty.lua
+++ b/scripts/missions/toau/05_Confessions_of_Royalty.lua
@@ -54,7 +54,12 @@ mission.sections =
 
             ['Nadeey'] = mission:event(3025, { text_table = 0 }),
 
-            ['Naja_Salaheem'] = mission:event(3021, { text_table = 0 }),
+            ['Naja_Salaheem'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:event(3021, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
+                end,
+            },
         },
 
         [xi.zone.CHATEAU_DORAGUILLE] =

--- a/scripts/missions/toau/06_Easterly_Winds.lua
+++ b/scripts/missions/toau/06_Easterly_Winds.lua
@@ -20,6 +20,20 @@ mission.sections =
             return currentMission == mission.missionId
         end,
 
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Cacaroon'] = mission:event(3023, { text_table = 0 }),
+
+            ['Nadeey'] = mission:event(3025, { text_table = 0 }),
+
+            ['Naja_Salaheem'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:event(3021, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
+                end,
+            },
+        },
+
         [xi.zone.CHATEAU_DORAGUILLE] =
         {
             ['Halver'] =

--- a/scripts/missions/toau/07_Westerly_Winds.lua
+++ b/scripts/missions/toau/07_Westerly_Winds.lua
@@ -23,10 +23,30 @@ mission.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
+            ['Cacaroon'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(3023, { text_table = 0 })
+                    end
+                end,
+            },
+
+            ['Nadeey'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(3025, { text_table = 0 })
+                    end
+                end,
+            },
+
             ['Naja_Salaheem'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
+                    if player:getMissionStatus(mission.areaId) == 0 then
+                        return mission:event(3021, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
+                    else
                         return mission:progressEvent(3028, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0, 0)
                     end
                 end,
@@ -64,7 +84,7 @@ mission.sections =
                 [3028] = function(player, csid, option, npc)
                     if mission:complete(player) then
                         player:delKeyItem(xi.ki.RAILLEFALS_NOTE)
-                        player:setLocalVar('Mission[4][7]mustZone', 1)
+                        xi.mission.setMustZone(player, xi.mission.log_id.TOAU, xi.mission.id.toau.A_MERCENARY_LIFE)
                     end
                 end,
             },

--- a/scripts/missions/toau/08_A_Mercenary_Life.lua
+++ b/scripts/missions/toau/08_A_Mercenary_Life.lua
@@ -24,12 +24,18 @@ mission.sections =
             ['Naja_Salaheem'] =
             {
                 onTrigger = function(player, npc)
+                    -- Option cycles between 2 and either a 1 or a 0.
                     local dialog = mission:getVar(player, 'Option')
-                    if dialog == 0 then
-                        mission:setVar(player, 'Option', 1)
+                    if dialog == 2 then
+                        -- Condition for Naja being friendly is unknown.
+                        -- My character was a BLU with no mercenary rank and got friendly alt dialog.
+                        local altOption = 0 -- 1 -> Friendly. 0 -> Not.
+                        dialog = altOption
                     else
-                        mission:setVar(player, 'Option', 0)
+                        dialog = 2
                     end
+
+                    mission:setVar(player, 'Option', dialog)
 
                     return mission:event(3029, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, dialog, 0)
                 end,
@@ -50,30 +56,18 @@ mission.sections =
             onTriggerAreaEnter =
             {
                 [3] = function(player, triggerArea)
-                    return mission:progressEvent(3050, 3, 3, 3, 3, 3, 3, 3, 3, 0)
+                    return mission:progressEvent(3050, 0, 1, 0, 0, 0, 0, 0, 0, 0)
                 end,
             },
 
             onEventUpdate =
             {
                 [3050] = function(player, csid, option, npc)
-                    local dialogStatus = mission:getLocalVar(player, 'Dialog')
+                    -- Both topics must be selected before you can advance.
+                    local dialogStatus = utils.mask.setBit(mission:getLocalVar(player, 'Dialog'), option - 1, true)
+                    mission:setLocalVar(player, 'Dialog', dialogStatus)
 
-                    if option == 1 then
-                        if dialogStatus == 0 then
-                            mission:setLocalVar(player, 'Dialog', 1)
-                            player:updateEvent(1, 0, 0, 0, 0, 0, 0, 0)
-                        else
-                            player:updateEvent(3, 0, 0, 0, 0, 0, 0, 0)
-                        end
-                    elseif option == 2 then
-                        if dialogStatus == 0 then
-                            mission:setLocalVar(player, 'Dialog', 1)
-                            player:updateEvent(2, 0, 0, 0, 0, 0, 0, 0)
-                        else
-                            player:updateEvent(3, 0, 0, 0, 0, 0, 0, 0)
-                        end
-                    end
+                    player:updateEvent(dialogStatus, 1, 0, 0, 0, 0, 0, 0)
                 end,
             },
 

--- a/scripts/missions/toau/09_Undersea_Scouting.lua
+++ b/scripts/missions/toau/09_Undersea_Scouting.lua
@@ -26,12 +26,9 @@ mission.sections =
             ['Naja_Salaheem'] =
             {
                 onTrigger = function(player, npc)
-                    local dialog = mission:getVar(player, 'Option')
-                    if dialog == 0 then
-                        mission:setVar(player, 'Option', 1)
-                    else
-                        mission:setVar(player, 'Option', 0)
-                    end
+                    -- Order goes 1 -> 0 -> 1 -> 0 ...
+                    local dialog = mission:getVar(player, 'Option') == 0 and 1 or 0
+                    mission:setVar(player, 'Option', dialog)
 
                     return mission:event(3051, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, dialog, 0)
                 end,
@@ -43,7 +40,9 @@ mission.sections =
             onTriggerAreaEnter =
             {
                 [23] = function(player, triggerArea)
-                    return mission:progressEvent(1, xi.besieged.getMercenaryRank(player))
+                    local param3 = 0 -- Mentions, "Hey, it's you!" Maybe tied to PUP?
+
+                    return mission:progressEvent(1, xi.besieged.getMercenaryRank(player), param3)
                 end,
             },
 

--- a/scripts/missions/toau/10_Astral_Waves.lua
+++ b/scripts/missions/toau/10_Astral_Waves.lua
@@ -10,7 +10,6 @@ local mission = Mission:new(xi.mission.log_id.TOAU, xi.mission.id.toau.ASTRAL_WA
 
 mission.reward =
 {
-    keyItem     = xi.ki.ASTRAL_COMPASS,
     nextMission = { xi.mission.log_id.TOAU, xi.mission.id.toau.IMPERIAL_SCHEMES },
 }
 
@@ -34,7 +33,7 @@ mission.sections =
             {
                 [3052] = function(player, csid, option, npc)
                     if option == 1 then
-                        player:updateEvent(1, 1, 0, 0, 0, 0, 0, 0)
+                        player:updateEvent(xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, 0)
                     end
                 end,
             },
@@ -43,8 +42,8 @@ mission.sections =
             {
                 [3052] = function(player, csid, option, npc)
                     if mission:complete(player) then
-                        player:setCharVar('Mission[4][10]Timer', VanadielUniqueDay() + 1)
-                        player:setLocalVar('Mission[4][10]mustZone', 1)
+                        xi.mission.setVar(player, xi.mission.log_id.TOAU, xi.mission.id.toau.IMPERIAL_SCHEMES, 'Timer', VanadielUniqueDay() + 1)
+                        xi.mission.setMustZone(player, xi.mission.log_id.TOAU, xi.mission.id.toau.IMPERIAL_SCHEMES)
                     end
                 end,
             },

--- a/scripts/missions/toau/11_Imperial_Schemes.lua
+++ b/scripts/missions/toau/11_Imperial_Schemes.lua
@@ -25,12 +25,18 @@ mission.sections =
             ['Naja_Salaheem'] =
             {
                 onTrigger = function(player, npc)
-                    local dialog = mission:getVar(player, 'Option') + 1 -- Captured values 1 and 2
-                    if dialog == 1 then
-                        mission:setVar(player, 'Option', 1)
+                    -- Option cycles between 2 and either a 1 or a 0.
+                    local dialog = mission:getVar(player, 'Option')
+                    if dialog == 2 then
+                        -- Condition for Naja being friendly is unknown.
+                        -- My character was a BLU with no mercenary rank and got friendly alt dialog.
+                        local altOption = 0 -- 1 -> Friendly. 0 -> Not.
+                        dialog = altOption
                     else
-                        mission:setVar(player, 'Option', 0)
+                        dialog = 2
                     end
+
+                    mission:setVar(player, 'Option', dialog)
 
                     return mission:event(3053, xi.besieged.getMercenaryRank(player), 1, 0, 0, 0, 0, 0, dialog, 0)
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There are some minor text changes for ToAU mission 5 - 11.
- Added default text for Cacaroon, Nadeey, and Naja Salaheem. The text stops right after Trion leaves for home (Mission 7).
- Updated setLocalVar calls with the xi.mission enums
- Removed the KI granted in mission 10; it's already granted in mission 9
- Fixed a small text bug with event 3052 in mission 10

There are two instances where the capture I had differed from what was coded for alternating text with Naja. Mission 8 and Mission 11.

Naja seems to alternate 2 -> 0 -> 2 -> 0.... (my capture) OR  2 -> 1 -> 2 -> 1 .... (what was coded in mission 11) where 0 is the meaner text and 1 is the nicer text.
I had 2 captures that showed what I coded for mission 8 (mine and Jimmayus's https://www.dropbox.com/s/jtmgwmz24h041zd/Aht%20Urghan%20Mission%208-10%20%2B%20nyzul%20staging%20point%20acquisition.rar?dl=0)
I only had my capture for mission 11.
I couldn't find the original capture that coded the 2 -> 1 ->2 -> 1. 1 is the nicer text. I'm guessing it might be dependent on current rank points towards ranking up? I went with the meaner version that I saw in my capture.

Text for 0
"Hoho, the Private First Class is back. Just who d'ya think you are, waitin' around for the world to come to you?"
"We've got no place for sluggards here. Get your head outta the clouds and get to work!"

Text for 1
"Good boy. Keep gettin' those jobs done."
 "Salaheem's Sentinels are known for quality, precision, and speed. So get out there and prrrove your worth!"

My capture: https://drive.google.com/file/d/1bnnBw31_u5LCOdFUoGnM-1vMfVK07oZ_/view?usp=drive_link
https://youtu.be/DtKYfCB130I

## Steps to test these changes

Add mission 5 and play through all the missions. Test changing your rank to make sure text works on event 3052.
