### PR TITLE
[lua] Adjust Berserk / Defender in era module

### DIFF
--- a/modules/era/lua/globals/job_utils/warrior.lua
+++ b/modules/era/lua/globals/job_utils/warrior.lua
@@ -1,9 +1,30 @@
 -----------------------------------
 -- Module: Warrior Job Adjustments
 -----------------------------------
+-- https://forum.square-enix.com/ffxi/threads/44592-Oct-7-2014-%28JST%29-Version-Update (Berserk and Defender changes)
+-----------------------------------
 require('modules/module_utils')
 -----------------------------------
 local m = Module:new('era_job_utils_warrior', xi.pre(xi.expansion.ABYSSEA))
+
+-- Remove Level Scaling from Berserk
+m:addOverride('xi.job_utils.warrior.useBerserk', function(player, target, ability)
+    local power    = 25 + player:getMod(xi.mod.BERSERK_POTENCY)
+    local duration = 180 + player:getMod(xi.mod.BERSERK_DURATION)
+
+    player:addStatusEffect(xi.effect.BERSERK, { power = power, duration = duration, origin = player })
+
+    return xi.effect.BERSERK
+end)
+
+-- Remove Level Scaling from Defender
+m:addOverride('xi.job_utils.warrior.useDefender', function(player, target, ability)
+    local duration = 180 + player:getMod(xi.mod.DEFENDER_DURATION)
+
+    player:addStatusEffect(xi.effect.DEFENDER, { power = 25, duration = duration, origin = player })
+
+    return xi.effect.DEFENDER
+end)
 
 -- Warrior's Charge: Remove Triple Attack bonus
 -- TODO: find a patch note or source for this change


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Removes a out of era scaling attack / defense buff from Berserk / Defender in the era Warrior module.

## Steps to test these changes

Enable the module, observe 25% attack from Berserk at Lv99 and 25% defense from Defender at Lv99
