### PR TITLE
[lua] Open the Rampart Gates for mounted players in the [S] areas

### DIFF
--- a/scripts/zones/Batallia_Downs_[S]/IDs.lua
+++ b/scripts/zones/Batallia_Downs_[S]/IDs.lua
@@ -76,6 +76,7 @@ zones[xi.zone.BATALLIA_DOWNS_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Myllue_RK'), -- San, Bas, Win, Flag +4, CA
+        RAMPART_GATE_OFFSET = GetFirstID('_2c1'),
     },
 }
 

--- a/scripts/zones/Batallia_Downs_[S]/Zone.lua
+++ b/scripts/zones/Batallia_Downs_[S]/Zone.lua
@@ -1,10 +1,27 @@
 -----------------------------------
 -- Zone: Batallia_Downs_[S] (84)
 -----------------------------------
+local ID = zones[xi.zone.BATALLIA_DOWNS_S]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
+local rampartTable =
+{
+    [1] = ID.npc.RAMPART_GATE_OFFSET,
+    [2] = ID.npc.RAMPART_GATE_OFFSET + 1,
+    [3] = ID.npc.RAMPART_GATE_OFFSET + 2,
+    [4] = ID.npc.RAMPART_GATE_OFFSET + 3,
+    [5] = ID.npc.RAMPART_GATE_OFFSET + 4,
+}
+
 zoneObject.onInitialize = function(zone)
+    zone:registerCylindricalTriggerArea(1, 321.762, -194.744, 15)
+    zone:registerCylindricalTriggerArea(2, 327.975, -118.794, 15)
+    zone:registerCylindricalTriggerArea(3,   0.000, -170.000, 15)
+    zone:registerCylindricalTriggerArea(4, 156.000,  100.000, 15)
+    zone:registerCylindricalTriggerArea(5,  -2.059,  225.000, 15)
+
     xi.voidwalker.zoneOnInit(zone)
     xi.darkixion.zoneOnInit(zone)
 end
@@ -28,6 +45,14 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
+    if not player:hasStatusEffect(xi.effect.MOUNTED) then
+        return
+    end
+
+    local gate = GetNPCByID(rampartTable[triggerArea])
+    if gate then
+        gate:openDoor(9)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/IDs.lua
@@ -72,6 +72,7 @@ zones[xi.zone.ROLANBERRY_FIELDS_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Hedioste_RK'), -- San, Bas, Win, Flag +4, CA
+        RAMPART_GATE_OFFSET = GetFirstID('_2j1'),
     },
 }
 

--- a/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
@@ -1,10 +1,27 @@
 -----------------------------------
 -- Zone: Rolanberry_Fields_[S] (91)
 -----------------------------------
+local ID = zones[xi.zone.ROLANBERRY_FIELDS_S]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
+local rampartTable =
+{
+    [1] = ID.npc.RAMPART_GATE_OFFSET,
+    [2] = ID.npc.RAMPART_GATE_OFFSET + 4,
+    [3] = ID.npc.RAMPART_GATE_OFFSET + 5,
+    [4] = ID.npc.RAMPART_GATE_OFFSET + 6,
+    [5] = ID.npc.RAMPART_GATE_OFFSET + 7,
+}
+
 zoneObject.onInitialize = function(zone)
+    zone:registerCylindricalTriggerArea(1, 188.943, 435.986, 15)
+    zone:registerCylindricalTriggerArea(2, -43.426, 335.406, 15)
+    zone:registerCylindricalTriggerArea(3,   1.749, 240.000, 15)
+    zone:registerCylindricalTriggerArea(4, 226.946, 287.264, 15)
+    zone:registerCylindricalTriggerArea(5, 460.000, -80.000, 15)
+
     xi.voidwalker.zoneOnInit(zone)
     xi.darkixion.zoneOnInit(zone)
 end
@@ -28,6 +45,14 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
+    if not player:hasStatusEffect(xi.effect.MOUNTED) then
+        return
+    end
+
+    local gate = GetNPCByID(rampartTable[triggerArea])
+    if gate then
+        gate:openDoor(9)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)

--- a/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/IDs.lua
@@ -71,6 +71,7 @@ zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S] =
     npc =
     {
         CAMPAIGN_NPC_OFFSET = GetFirstID('Alreage_RK'), -- San, Bas, Win, Flag +4, CA
+        RAMPART_GATE_OFFSET = GetFirstID('_2q2'),
     },
 }
 

--- a/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
@@ -1,10 +1,23 @@
 -----------------------------------
 -- Zone: Sauromugue_Champaign_[S] (98)
 -----------------------------------
+local ID = zones[xi.zone.SAUROMUGUE_CHAMPAIGN_S]
+-----------------------------------
 ---@type TZone
 local zoneObject = {}
 
+local rampartTable =
+{
+    [1] = ID.npc.RAMPART_GATE_OFFSET,
+    [2] = ID.npc.RAMPART_GATE_OFFSET + 1,
+    [3] = ID.npc.RAMPART_GATE_OFFSET + 2,
+}
+
 zoneObject.onInitialize = function(zone)
+    zone:registerCylindricalTriggerArea(1, -358.799, 334.000, 15)
+    zone:registerCylindricalTriggerArea(2,   39.999, 180.000, 15)
+    zone:registerCylindricalTriggerArea(3,  -48.696, -48.697, 15)
+
     xi.voidwalker.zoneOnInit(zone)
 end
 
@@ -23,6 +36,14 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)
+    if not player:hasStatusEffect(xi.effect.MOUNTED) then
+        return
+    end
+
+    local gate = GetNPCByID(rampartTable[triggerArea])
+    if gate then
+        gate:openDoor(9)
+    end
 end
 
 zoneObject.onEventUpdate = function(player, csid, option, npc)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Rampart Gates and Doors in Batallia Downs [S], Rolanberry Fields [S] and Sauromugue Champaign [S] now open on their own when a mounted player rides up to them.

Each gate gets a cylindrical trigger area, and entering one while mounted calls `openDoor()`.

The values come from siknoz's capture (https://youtu.be/FFVdm38aqYA) on issue #31:
- **15 yalm radius.** Large, but it has to be — the gate takes a couple of seconds to swing, and at chocobo speed that is about how long 15 yalms takes. It finishes opening as you reach it rather than in your face.
- **9 second timer.** At **1:48** in the capture the gate closes on the rider while he is standing on the threshold, so it is on a timer. Riding out of range and back in reopens it.
That 1:48 also answers the concern raised on the issue about a gate closing in a second player's face: retail closes it in the first player's face, so the timer is the accurate behavior rather than a shortcut.

One thing I left alone: clicking a door goes through `CTriggerState`, which closes it after a hardcoded 7 seconds, so on a click these gates still shut at 7 rather than 9. That is existing behavior for every door in the game, so it felt out of scope here.

## Steps to test these changes

`!mount` for a chocobo, then in any of the three zones:

```
!pos 1.749 14.100 240.000 91        -- Rolanberry Fields [S]
!pos 0.000 -10.831 -170.000 84      -- Batallia Downs [S]
!pos 39.999 22.799 180.000 98       -- Sauromugue Champaign [S]
```

Ride 20 yalms clear of the gate and approach:

- Mounted, it opens as you get near and shuts again after 9 seconds, even if you stay put.
- Ride out of range and back and it reopens.
- On foot it stays shut, and clicking it still works as before.

All 13 gates across the three zones were checked in-game.
