### PR TITLE
[lua] Fix rampart gate lookup in the [S] areas

### DIFF
--- a/scripts/zones/Batallia_Downs_[S]/Zone.lua
+++ b/scripts/zones/Batallia_Downs_[S]/Zone.lua
@@ -18,9 +18,9 @@ local rampartTable =
 zoneObject.onInitialize = function(zone)
     zone:registerCylindricalTriggerArea(1, 321.762, -194.744, 15)
     zone:registerCylindricalTriggerArea(2, 327.975, -118.794, 15)
-    zone:registerCylindricalTriggerArea(3,   0.000, -170.000, 15)
-    zone:registerCylindricalTriggerArea(4, 156.000,  100.000, 15)
-    zone:registerCylindricalTriggerArea(5,  -2.059,  225.000, 15)
+    zone:registerCylindricalTriggerArea(3, 156.000,  100.000, 15)
+    zone:registerCylindricalTriggerArea(4,  -2.059,  225.000, 15)
+    zone:registerCylindricalTriggerArea(5,   0.000, -170.000, 15)
 
     xi.voidwalker.zoneOnInit(zone)
     xi.darkixion.zoneOnInit(zone)
@@ -49,7 +49,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         return
     end
 
-    local gate = GetNPCByID(rampartTable[triggerArea])
+    local gate = GetNPCByID(rampartTable[triggerArea:getTriggerAreaID()])
     if gate then
         gate:openDoor(9)
     end

--- a/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
+++ b/scripts/zones/Rolanberry_Fields_[S]/Zone.lua
@@ -49,7 +49,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         return
     end
 
-    local gate = GetNPCByID(rampartTable[triggerArea])
+    local gate = GetNPCByID(rampartTable[triggerArea:getTriggerAreaID()])
     if gate then
         gate:openDoor(9)
     end

--- a/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
+++ b/scripts/zones/Sauromugue_Champaign_[S]/Zone.lua
@@ -40,7 +40,7 @@ zoneObject.onTriggerAreaEnter = function(player, triggerArea)
         return
     end
 
-    local gate = GetNPCByID(rampartTable[triggerArea])
+    local gate = GetNPCByID(rampartTable[triggerArea:getTriggerAreaID()])
     if gate then
         gate:openDoor(9)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes two bugs from #11127.

onTriggerAreaEnter passes the trigger area object, so it needs getTriggerAreaID(); and Batallia's gate ids aren't sequential, so the offsets mapped to the wrong gates. No gate opened before these changes in the 3 zones, all open after.

## Steps to test these changes
Rolanberry:
- !pos -43.426 13.268 335.406 91
- !mount
 Ride more than 15 yalms away from gate and return.

Same in Sauromugue:
- !pos -48.696 4.868 -48.697 98

And Batallia: 
- !pos 161.183 0.468 91.111 84
