### PR TITLE
[module] [lua] Inside the Belly Era Module

### DIFF
--- a/modules/era/lua/quests/otherareas/inside_the_belly.lua
+++ b/modules/era/lua/quests/otherareas/inside_the_belly.lua
@@ -1,0 +1,179 @@
+-----------------------------------
+-- Inside the Belly
+-- Restores Zaldon's trade list to the era of the newest enabled expansion.
+-- The quest launched with 18 fish. Version updates from 2009-11-10 onward grew the list.
+-- Each batch is gated on when the trade option was added, not on when its fish was implemented.
+--
+-- Source: https://www.playonline.com/pcd/verup/ff11/detail/5053/detail.html
+-- Source: https://wiki.ffo.jp/html/1338.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_inside_the_belly',
+    xi.pre(xi.expansion.WOTG) or
+    xi.pre(xi.expansion.ABYSSEA) or
+    xi.pre(xi.expansion.SOA) or
+    xi.pre(xi.expansion.ROV))
+
+local tradeBatches =
+{
+    -- Added 2009-11-10 and 2010-03-23.
+    {
+        blocked = xi.pre(xi.expansion.WOTG),
+        items =
+        {
+            xi.item.BLADEFISH_1,
+            xi.item.GAVIAL_FISH,
+            xi.item.VEYDAL_WRASSE_1,
+            xi.item.MORINABALIGI,
+            xi.item.TURNABALIGI,
+            xi.item.KALKANBALIGI,
+            xi.item.PTERYGOTUS,
+            xi.item.GERROTHORAX,
+            xi.item.PIRARUCU,
+            xi.item.MEGALODON,
+            xi.item.YAYINBALIGI,
+            xi.item.LAKERDA,
+            xi.item.KILICBALIGI,
+            xi.item.MONKE_ONKE_1,
+            xi.item.AHTAPOT,
+            xi.item.ARMORED_PISCES,
+            xi.item.MOLA_MOLA,
+        },
+    },
+
+    -- Added 2010-09-09 and 2010-12-07.
+    {
+        blocked = xi.pre(xi.expansion.ABYSSEA),
+        items =
+        {
+            xi.item.GUGRU_TUNA_1,
+            xi.item.ISTAVRIT_1,
+            xi.item.GIGANT_OCTOPUS_1,
+            xi.item.THREE_EYED_FISH_1,
+            xi.item.GIGANT_SQUID,
+            xi.item.RHINOCHIMERA_1,
+            xi.item.GRIMMONITE,
+            xi.item.TITANIC_SAWFISH,
+            xi.item.PELAZOEA,
+            xi.item.DORADO_GAR,
+            xi.item.CROCODILOS,
+        },
+    },
+
+    -- Added 2012-07-24, between Abyssea and SoA.
+    {
+        blocked = xi.pre(xi.expansion.SOA),
+        items =
+        {
+            xi.item.ABAIA,
+            xi.item.MATSYA,
+        },
+    },
+
+    -- Added 2015-06-25 and 2015-11-10.
+    {
+        blocked = xi.pre(xi.expansion.ROV),
+        items =
+        {
+            xi.item.SORYU,
+            xi.item.SEKIRYU,
+            xi.item.HAKURYU,
+            xi.item.FAR_EAST_PUFFER,
+        },
+    },
+}
+
+local blockedFish = {}
+for _, batch in ipairs(tradeBatches) do
+    if batch.blocked then
+        for _, itemId in ipairs(batch.items) do
+            blockedFish[itemId] = true
+        end
+    end
+end
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Inside_the_Belly', function(quest)
+        -- Sections 2 and 3 take the fish trades (quest accepted and quest completed).
+        for _, sectionIdx in ipairs({ 2, 3 }) do
+            local zaldon      = quest.sections[sectionIdx][xi.zone.SELBINA]['Zaldon']
+            local baseOnTrade = zaldon.onTrade
+
+            -- A blocked fish returns nothing. Zaldon plays his default dialogue and the fish is kept.
+            zaldon.onTrade = function(player, npc, trade)
+                for itemSlot = 0, trade:getSlotCount() - 1 do
+                    if blockedFish[trade:getItemId(itemSlot)] then
+                        return
+                    end
+                end
+
+                return baseOnTrade(player, npc, trade)
+            end
+
+            -- The stock hint lists name only original and 2009-batch fish.
+            -- Events 163, 164, and 165 render a fixed count of names (5, 2+4, 2+6). An empty slot prints a blank name.
+            if xi.pre(xi.expansion.WOTG) then
+                zaldon.onTrigger = function(player, npc)
+                    local fishingSkill = xi.crafting.getTotalSkill(player, xi.skill.FISHING)
+
+                    local tier = 4
+
+                    if fishingSkill < 40 then
+                        tier = 1
+                    elseif fishingSkill < 50 then
+                        tier = 2
+                    elseif fishingSkill < 75 then
+                        tier = 3
+                    end
+
+                    local csTier =
+                    {
+                        {
+                            162,
+                            xi.item.GIANT_CATFISH_1,
+                            xi.item.DARK_BASS_1,
+                            xi.item.OGRE_EEL_1,
+                            xi.item.ZAFMLUG_BASS,
+                        },
+
+                        {
+                            163,
+                            xi.item.ZAFMLUG_BASS,
+                            xi.item.GIANT_DONKO_1,
+                            xi.item.BHEFHEL_MARLIN_1,
+                            xi.item.JUNGLE_CATFISH,
+                            xi.item.SILVER_SHARK,
+                        },
+
+                        {
+                            164,
+                            xi.item.JUNGLE_CATFISH,
+                            xi.item.EMPEROR_FISH,
+                            xi.item.SILVER_SHARK,
+                            xi.item.TAKITARO,
+                            xi.item.SEA_ZOMBIE,
+                            xi.item.GIANT_CHIRAI,
+                        },
+
+                        {
+                            165,
+                            xi.item.TAKITARO,
+                            xi.item.SEA_ZOMBIE,
+                            xi.item.TITANICTUS,
+                            xi.item.CAVE_CHERAX,
+                            xi.item.TRICORN,
+                            xi.item.RYUGU_TITAN,
+                            xi.item.LIK,
+                            xi.item.GUGRUSAURUS,
+                        },
+                    }
+
+                    return quest:event(unpack(csTier[tier]))
+                end
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds a module for the quest "Inside the Belly" that will pick up your desired server settings and only let players trade fish that were acceptable Inside the Belly trade targets in that era. For example, if you enable TOAU but nothing beyond, Zaldon will only take the original 18 fish as acceptable trades. If you enable WOTG, he will pick up the original 18 plus the additional acceptable trade targets added during the WOTG era. This is because some fish which existed when the quest was implemented were later added as trades in future eras. Below is a chart demonstrating how it works:

| Setting | Trade additions unlocked | Fish |
|---|---|---|
| always available | Original quest list | Giant Catfish, Dark Bass, Ogre Eel, Zafmlug Bass, Giant Donko, Bhefhel Marlin, Silver Shark, Jungle Catfish, Emperor Fish, Titanictus, Takitaro, Giant Chirai, Ryugu Titan, Tricorn, Sea Zombie, Cave Cherax, Lik, Gugrusaurus |
| `ENABLE_WOTG` | 2009-11-10 and 2010-03-23 | Bladefish, Gavial Fish, Veydal Wrasse, Morinabaligi, Turnabaligi, Kalkanbaligi, Pterygotus, Gerrothorax, Pirarucu, Megalodon, Yayinbaligi, Lakerda, Kilicbaligi, Monke-Onke, Ahtapot, Armored Pisces, Mola Mola |
| `ENABLE_ABYSSEA` | 2010-09-09 and 2010-12-07 | Gugru Tuna, Istavrit, Gigant Octopus, Three-eyed Fish, Gigant Squid, Rhinochimera, Grimmonite, Titanic Sawfish, Pelazoea, Dorado Gar, Crocodilos |
| `ENABLE_SOA` | 2012-07-24 | Abaia, Matsya |
| `ENABLE_ROV` | 2015-06-25 and 2015-11-10 | Soryu, Sekiryu, Hakuryu, Far East Puffer |

Additionally, this module also edits what the client prints as hints for acceptable trade targets. This means Zaldon will not suggest out of era fish as acceptable trades depending on what your server settings are.

<img width="1121" height="39" alt="image" src="https://github.com/user-attachments/assets/940deb11-5137-48c7-9c77-779943c3965a" />

**Sources:**

**Sources**

https://wiki.ffo.jp/html/1338.html
http://www.playonline.com/pcd/verup/ff11/detail/5053/detail.html
http://www.playonline.com/pcd/verup/ff11/detail/5334/detail.html
http://www.playonline.com/pcd/verup/ff11/detail/5833/detail.html
http://www.playonline.com/pcd/verup/ff11/detail/6024/detail.html
http://forum.square-enix.com/ffxi/threads/25811
https://forum.square-enix.com/ffxi/threads/47480
https://forum.square-enix.com/ffxi/threads/49065
https://wiki.ffo.jp/html/22243.html
https://wiki.ffo.jp/html/19739.html
https://wiki.ffo.jp/html/21170.html
https://wiki.ffo.jp/html/22368.html
https://wiki.ffo.jp/html/27203.html
https://wiki.ffo.jp/html/34936.html

## Steps to test these changes

Enable the module and set your desired server settings. See Zaldon only takes certain trades depending on what era the server is running.
