### PR TITLE
[core] Route PC to PC trades through PlayerTradeTransaction

### DIFF
--- a/scripts/specs/test/CClientEntityPairActions.lua
+++ b/scripts/specs/test/CClientEntityPairActions.lua
@@ -116,10 +116,12 @@ end
 function CClientEntityPairActions:tradeOffer(tradeIndex, invSlot, itemId, quantity)
 end
 
----Clear a trade slot.
+---Clear a trade slot. The client repeats the item it is clearing, so pass what was staged.
 ---@param tradeIndex integer Trade slot, 0..8
+---@param invSlot integer Inventory slot of the staged item
+---@param itemId xi.item Item ID
 ---@return nil
-function CClientEntityPairActions:tradeClearSlot(tradeIndex)
+function CClientEntityPairActions:tradeClearSlot(tradeIndex, invSlot, itemId)
 end
 
 ---Lock in this side's offer. Trade goes through once both sides lock.
@@ -179,6 +181,13 @@ end
 ---@nodiscard
 ---@return table<integer, GuildListEntry> list Entries keyed by item ID
 function CClientEntityPairActions:guildSellList()
+end
+
+---Buy from the currently open shop
+---@param shopSlot integer Index into the shop's item list
+---@param quantity integer Amount to buy
+---@return nil
+function CClientEntityPairActions:shopBuy(shopSlot, quantity)
 end
 
 ---Move an item between containers or split a stack

--- a/scripts/tests/systems/trading/player_trade.lua
+++ b/scripts/tests/systems/trading/player_trade.lua
@@ -1,4 +1,4 @@
-describe('player trade', function()
+describe('PlayerTradeTransaction', function()
     ---@type CClientEntityPair
     local p1
     ---@type CClientEntityPair
@@ -7,26 +7,217 @@ describe('player trade', function()
     local itemA = xi.item.WIND_CRYSTAL
     local itemB = xi.item.FIRE_CRYSTAL
 
+    local function openTrade()
+        p1.actions:tradeRequest(p2)
+        p2.actions:tradeAccept()
+    end
+
+    local function findItem(player, itemId, location)
+        local item = player:findItem(itemId, location)
+        assert(item, 'item ' .. tostring(itemId) .. ' not in inventory')
+
+        return item
+    end
+
+    local function totalOf(itemId)
+        return p1:getItemCount(itemId) + p2:getItemCount(itemId)
+    end
+
     before_each(function()
         p1 = xi.test.world:spawnPlayer({ zone = xi.zone.GM_HOME })
         p2 = xi.test.world:spawnPlayer({ zone = xi.zone.GM_HOME })
+
+        -- Same position so the 6y range check passes.
         p2:setPos(p1:getXPos(), p1:getYPos(), p1:getZPos())
     end)
 
-    it('swaps one item each way', function()
+    it('staged items are InTransaction while the offer is open', function()
+        p1:addItem(itemA)
+        openTrade()
+
+        local item = findItem(p1, itemA)
+        assert(item:state() == xi.itemState.FREE, 'state before staging: ' .. tostring(item:state()))
+
+        p1.actions:tradeOffer(1, item:getSlotID(), itemA, 1)
+
+        local staged = findItem(p1, itemA)
+        assert(staged:state() == xi.itemState.IN_TRANSACTION, 'state after staging: ' .. tostring(staged:state()))
+    end)
+
+    it('a staged item cannot be equipped', function()
+        local gear = xi.item.BRONZE_DAGGER
+
+        p1:addItem(gear)
+        openTrade()
+
+        local gearSlot = findItem(p1, gear):getSlotID()
+
+        p1.actions:tradeOffer(1, gearSlot, gear, 1)
+
+        p1.actions:equipSet({ { index = gearSlot, kind = xi.slot.MAIN, container = 0 } })
+
+        assert(p1:getEquipID(xi.slot.MAIN) ~= gear, 'staged item was equipped')
+        assert(findItem(p1, gear):state() == xi.itemState.IN_TRANSACTION, 'state after equip attempt: ' .. tostring(findItem(p1, gear):state()))
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        p1.assert.no:hasItem(gear)
+        p2.assert:hasItem(gear)
+    end)
+
+    it('a received item is usable afterwards', function()
+        local gear = xi.item.BRONZE_DAGGER
+
+        p1:addItem(gear)
+        openTrade()
+
+        p1.actions:tradeOffer(1, findItem(p1, gear):getSlotID(), gear, 1)
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        local received = findItem(p2, gear)
+        assert(received:state() == xi.itemState.FREE, 'received state: ' .. tostring(received:state()))
+        assert(received:getReservedValue() == 0, 'received reserve: ' .. tostring(received:getReservedValue()))
+    end)
+
+    it('an item reserved elsewhere cannot be staged', function()
+        local gear = xi.item.BRONZE_DAGGER
+
+        p1:addItem(gear)
+
+        local item = findItem(p1, gear)
+        local slot = item:getSlotID()
+
+        -- Reproduce a pending NPC trade
+        item:setReservedValue(1)
+
+        openTrade()
+        p1.actions:tradeOffer(1, slot, gear, 1)
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(totalOf(gear) == 1, 'copies in play: ' .. tostring(totalOf(gear)))
+    end)
+
+    it('sorting skips staged stacks on either side of a merge', function()
+        p1:addItem(itemA, 5)
+        p1:addItem(itemA, 5)
+
+        local lowerSlot = findItem(p1, itemA):getSlotID()
+
+        openTrade()
+        p1.actions:tradeOffer(1, lowerSlot, itemA, 5)
+        p1.actions:sortContainer(xi.inventoryLocation.INVENTORY)
+
+        assert(totalOf(itemA) == 10, 'merge destination: ' .. tostring(totalOf(itemA)))
+
+        p1.actions:tradeClearSlot(1, lowerSlot, itemA)
+        p1.actions:tradeOffer(1, lowerSlot + 1, itemA, 5)
+        p1.actions:sortContainer(xi.inventoryLocation.INVENTORY)
+
+        assert(totalOf(itemA) == 10, 'merge source: ' .. tostring(totalOf(itemA)))
+    end)
+
+    it('a repeated Start does not disturb the open trade', function()
+        p1:addItem(itemA)
+        p2:addItem(itemA)
+
+        openTrade()
+
+        p1.actions:tradeOffer(1, findItem(p1, itemA):getSlotID(), itemA, 1)
+        p2.actions:tradeOffer(1, findItem(p2, itemA):getSlotID(), itemA, 1)
+
+        p2.actions:tradeAccept()
+
+        p1.actions:tradeCancel()
+        p2.actions:tradeCancel()
+
+        local i1 = findItem(p1, itemA)
+        local i2 = findItem(p2, itemA)
+        assert(i1:state() == xi.itemState.FREE, 'p1 item state: ' .. tostring(i1:state()))
+        assert(i2:state() == xi.itemState.FREE, 'p2 item state: ' .. tostring(i2:state()))
+    end)
+
+    it('gil only stages in slot 0 and items only in slots 1-8', function()
+        p1:setGil(5000)
+        p1:addItem(itemA)
+
+        openTrade()
+
+        p1.actions:tradeOffer(1, 0, xi.item.GIL, 1000)
+        p1.actions:tradeOffer(0, findItem(p1, itemA):getSlotID(), itemA, 1)
+
+        assert(findItem(p1, itemA):state() == xi.itemState.FREE, 'item state: ' .. tostring(findItem(p1, itemA):state()))
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(p1:getGil() == 5000, 'p1 gil: ' .. tostring(p1:getGil()))
+        p1.assert:hasItem(itemA)
+        p2.assert.no:hasItem(itemA)
+    end)
+
+    it('a rare the partner already owns cannot be staged', function()
+        local rare = xi.item.MANNEQUIN_HANDS
+
+        p1:addItem(rare)
+        p2:addItem(rare)
+
+        openTrade()
+        p1.actions:tradeOffer(1, findItem(p1, rare):getSlotID(), rare, 1)
+
+        assert(findItem(p1, rare):state() == xi.itemState.FREE, 'rare state: ' .. tostring(findItem(p1, rare):state()))
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(totalOf(rare) == 2, 'copies in play: ' .. tostring(totalOf(rare)))
+    end)
+
+    it('gil needs a free slot on the receiving side', function()
+        p1:setGil(5000)
+        p2:setGil(0)
+
+        while p2:getFreeSlotsCount(xi.inventoryLocation.INVENTORY) > 0 do
+            p2:addItem(itemA)
+        end
+
+        openTrade()
+        p1.actions:tradeOffer(0, 0, xi.item.GIL, 1000)
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(p1:getGil() == 5000, 'p1 gil: ' .. tostring(p1:getGil()))
+        assert(p2:getGil() == 0, 'p2 gil: ' .. tostring(p2:getGil()))
+    end)
+
+    it('cancelling before Make returns the item to its slot', function()
+        p1:addItem(itemA)
+        openTrade()
+
+        local origSlot = findItem(p1, itemA):getSlotID()
+
+        p1.actions:tradeOffer(1, origSlot, itemA, 1)
+        p1.actions:tradeCancel()
+
+        local restored = findItem(p1, itemA, xi.inventoryLocation.INVENTORY)
+        assert(restored:getSlotID() == origSlot, 'came back in slot ' .. tostring(restored:getSlotID()))
+        assert(restored:state() == xi.itemState.FREE, 'state after cancel: ' .. tostring(restored:state()))
+    end)
+
+    it('both sides offer and Make swaps the items', function()
         p1:addItem(itemA)
         p2:addItem(itemB)
 
-        p1.actions:tradeRequest(p2)
-        p2.actions:tradeAccept()
+        openTrade()
 
-        local p1Item = p1:findItem(itemA)
-        local p2Item = p2:findItem(itemB)
-        assert(p1Item)
-        assert(p2Item)
+        local p1Item = findItem(p1, itemA)
+        local p2Item = findItem(p2, itemB)
+        assert(p1Item and p2Item, 'expected both items present')
 
-        p1.actions:tradeOffer(0, p1Item:getSlotID(), itemA, 1)
-        p2.actions:tradeOffer(0, p2Item:getSlotID(), itemB, 1)
+        p1.actions:tradeOffer(1, p1Item:getSlotID(), itemA, 1)
+        p2.actions:tradeOffer(1, p2Item:getSlotID(), itemB, 1)
 
         p1.actions:tradeMake()
         p2.actions:tradeMake()
@@ -35,5 +226,170 @@ describe('player trade', function()
         p2.assert.no:hasItem(itemB)
         p1.assert:hasItem(itemB)
         p2.assert:hasItem(itemA)
+    end)
+
+    it('any offer change after Make invalidates acceptance', function()
+        p1:addItem(itemA)
+        p2:addItem(itemB)
+
+        openTrade()
+
+        p1.actions:tradeOffer(1, findItem(p1, itemA):getSlotID(), itemA, 1)
+        p2.actions:tradeOffer(1, findItem(p2, itemB):getSlotID(), itemB, 1)
+
+        p1.actions:tradeMake()
+        p1.actions:tradeClearSlot(1, findItem(p1, itemA):getSlotID(), itemA)
+
+        -- p2 hitting Make alone must not commit, p1's Make was cleared.
+        p2.actions:tradeMake()
+
+        p1.assert:hasItem(itemA)
+        p2.assert:hasItem(itemB)
+    end)
+
+    it('clearSlot returns the item to Free state', function()
+        p1:addItem(itemA)
+        openTrade()
+
+        local invItem = findItem(p1, itemA)
+        p1.actions:tradeOffer(1, invItem:getSlotID(), itemA, 1)
+        assert(findItem(p1, itemA):state() == xi.itemState.IN_TRANSACTION)
+
+        p1.actions:tradeClearSlot(1, invItem:getSlotID(), itemA)
+
+        local restored = findItem(p1, itemA)
+        assert(restored:state() == xi.itemState.FREE, 'state after clear: ' .. tostring(restored:state()))
+    end)
+
+    it('the same slot can be re-staged with a different quantity', function()
+        p1:addItem(itemA, 3)
+
+        openTrade()
+
+        local invItem = findItem(p1, itemA)
+        p1.actions:tradeOffer(1, invItem:getSlotID(), itemA, 1)
+        p1.actions:tradeOffer(1, invItem:getSlotID(), itemA, 2)
+
+        local staged = findItem(p1, itemA)
+        assert(staged:state() == xi.itemState.IN_TRANSACTION, 'state after re-stage: ' .. tostring(staged:state()))
+    end)
+
+    it('trade can be initiated while a player is synthing', function()
+        local crystal    = xi.item.WIND_CRYSTAL
+        local ingredient = xi.item.ARROWWOOD_LOG
+
+        p1:setSkillLevel(xi.skill.WOODWORKING, 200)
+        p1:addItem(crystal)
+        p1:addItem(ingredient)
+        p1:addItem(itemA)
+        p2:addItem(itemB)
+
+        p1.actions:craft(crystal, { ingredient })
+
+        p1.actions:tradeRequest(p2)
+        p2.actions:tradeAccept()
+
+        local p1Item = findItem(p1, itemA)
+        local p2Item = findItem(p2, itemB)
+        assert(p1Item and p2Item, 'expected both items present')
+
+        p1.actions:tradeOffer(1, p1Item:getSlotID(), itemA, 1)
+        p2.actions:tradeOffer(1, p2Item:getSlotID(), itemB, 1)
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        p1.assert:hasItem(itemB)
+        p2.assert:hasItem(itemA)
+    end)
+
+    it('gil-only trade transfers gil', function()
+        p1:setGil(5000)
+        p2:setGil(0)
+
+        openTrade()
+
+        -- Trade slot 0 is gil, and gil lives at inventory slot 0.
+        p1.actions:tradeOffer(0, 0, xi.item.GIL, 1000)
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(p1:getGil() == 4000, 'p1 gil: ' .. tostring(p1:getGil()))
+        assert(p2:getGil() == 1000, 'p2 gil: ' .. tostring(p2:getGil()))
+    end)
+
+    it('mixed gil + item trade in one direction', function()
+        p1:setGil(2000)
+        p1:addItem(itemA)
+
+        openTrade()
+
+        local p1Item = findItem(p1, itemA)
+        p1.actions:tradeOffer(0, 0, xi.item.GIL, 500)
+        p1.actions:tradeOffer(1, p1Item:getSlotID(), itemA, 1)
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        assert(p1:getGil() == 1500, 'p1 gil: ' .. tostring(p1:getGil()))
+        assert(p2:getGil() == 500, 'p2 gil: ' .. tostring(p2:getGil()))
+        p1.assert.no:hasItem(itemA)
+        p2.assert:hasItem(itemA)
+    end)
+
+    it('cancelling a gil stage leaves gil unchanged', function()
+        p1:setGil(3000)
+        openTrade()
+
+        p1.actions:tradeOffer(0, 0, xi.item.GIL, 1000)
+        p1.actions:tradeCancel()
+
+        assert(p1:getGil() == 3000, 'p1 gil: ' .. tostring(p1:getGil()))
+    end)
+
+    it('staged gil cannot be spent at a vendor', function()
+        local gear = xi.item.BRONZE_DAGGER
+
+        p1:setGil(5000)
+        p1:createShop(1)
+        p1:addShopItem(gear, 1000)
+
+        openTrade()
+        p1.actions:tradeOffer(0, 0, xi.item.GIL, 5000)
+        p1.actions:shopBuy(0, 1)
+
+        assert(p1:getGil() == 5000, 'p1 gil: ' .. tostring(p1:getGil()))
+        p1.assert.no:hasItem(gear)
+    end)
+
+    it('the server refuses a Make from out of range', function()
+        p1:addItem(itemA)
+        p2:addItem(itemB)
+
+        openTrade()
+
+        p1.actions:tradeOffer(1, findItem(p1, itemA):getSlotID(), itemA, 1)
+        p2.actions:tradeOffer(1, findItem(p2, itemB):getSlotID(), itemB, 1)
+
+        p2:setPos(p1:getXPos() + 50, p1:getYPos(), p1:getZPos())
+
+        p1.actions:tradeMake()
+        p2.actions:tradeMake()
+
+        p1.assert:hasItem(itemA)
+        p2.assert:hasItem(itemB)
+        p1.assert.no:hasItem(itemB)
+        p2.assert.no:hasItem(itemA)
+    end)
+
+    it('zoning out aborts the trade', function()
+        p1:addItem(itemA)
+        openTrade()
+
+        p1.actions:tradeOffer(1, findItem(p1, itemA):getSlotID(), itemA, 1)
+        p1:gotoZone(xi.zone.NORTHERN_SAN_DORIA)
+
+        p1.assert:hasItem(itemA)
     end)
 end)

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -78,6 +78,7 @@
 #include "items/item_furnishing.h"
 #include "items/item_usable.h"
 #include "items/item_weapon.h"
+#include "items/transactions/player_trade.h"
 #include "items/transactions/synth.h"
 #include "job_points.h"
 #include "latent_effect_container.h"
@@ -562,6 +563,32 @@ bool CCharEntity::hasAutoTargetEnabled() const
 auto CCharEntity::isCrafting() const -> bool
 {
     return animation == xi::Animation::Synth || this->activeTransaction<SynthTransaction>();
+}
+
+auto CCharEntity::tradePartner() const -> CCharEntity*
+{
+    auto* other = TradePending.resolve<CCharEntity>();
+    if (!other || other->TradePending.UniqueNo != id)
+    {
+        return nullptr;
+    }
+
+    return other;
+}
+
+auto CCharEntity::activePlayerTradeTransaction() const -> PlayerTradeTransaction*
+{
+    if (auto* local = this->activeTransaction<PlayerTradeTransaction>())
+    {
+        return local;
+    }
+    auto* other = this->tradePartner();
+    if (!other)
+    {
+        return nullptr;
+    }
+
+    return other->activeTransaction<PlayerTradeTransaction>();
 }
 
 auto CCharEntity::isFishing() const -> bool

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -64,6 +64,7 @@
 
 class CItemWeapon;
 class CTrustEntity;
+class PlayerTradeTransaction;
 
 struct jobs_t
 {
@@ -571,6 +572,12 @@ public:
     {
         transactions_.clear();
     }
+
+    // The transaction is owned by the initiator
+    auto activePlayerTradeTransaction() const -> PlayerTradeTransaction*;
+
+    // Only valid when both sides' TradePending agree
+    auto tradePartner() const -> CCharEntity*;
 
     // TODO: All member instances of EntityID_t should be Maybe<EntityID_t> to allow for them not to be set,
     //     : instead of checking for entityId.id != 0, etc.

--- a/src/map/enums/msg_std.h
+++ b/src/map/enums/msg_std.h
@@ -50,6 +50,7 @@ enum class MsgStd : uint16_t
     PollProposalParty            = 101, // Player Name's proposal to the party (cast vote with command: "/vote ?"):
     PollProposalLinkshell        = 102, // Player Name's proposal to the linkshell group (cast vote with command: "/vote ?"):
     PollProposalSystem           = 103, // Player Name's proposal to everyone (cast vote with command: "/vote ?"):
+    TradeCanceled                = 107, // Trade canceled. Either your or your target's inventory is full, or an error occurred during the transaction.
     LinkshellEquipBeforeUsing    = 108, // Equip a linkshell, pearlsack, or linkpearl before using that command.
     LinkshellKicked              = 109, // You have been kicked out of the linkshell group.
     LinkshellNoLongerExists      = 110, // That linkshell group no longer exists. This item is unusable.

--- a/src/map/items/CMakeLists.txt
+++ b/src/map/items/CMakeLists.txt
@@ -97,6 +97,8 @@ set(ITEM_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/transactions/guild_sell.h
     ${CMAKE_CURRENT_SOURCE_DIR}/transactions/item_use.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/transactions/item_use.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/transactions/player_trade.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/transactions/player_trade.h
     ${CMAKE_CURRENT_SOURCE_DIR}/transactions/synth.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/transactions/synth.h
     PARENT_SCOPE

--- a/src/map/items/transactions/player_trade.cpp
+++ b/src/map/items/transactions/player_trade.cpp
@@ -1,0 +1,492 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "player_trade.h"
+
+#include "common/logging.h"
+
+#include "entities/char_entity.h"
+#include "enums/item_flag.h"
+#include "enums/item_lockflg.h"
+#include "enums/msg_std.h"
+#include "item_container.h"
+#include "items/item.h"
+#include "packets/s2c/0x009_message.h"
+#include "packets/s2c/0x01f_item_list.h"
+#include "packets/s2c/0x022_item_trade_res.h"
+#include "packets/s2c/0x023_item_trade_list.h"
+#include "packets/s2c/0x025_item_trade_mylist.h"
+#include "utils/charutils.h"
+#include "utils/itemutils.h"
+
+#include <algorithm>
+#include <memory>
+#include <vector>
+
+namespace
+{
+
+// The client cancels on its own at this range, so this only catches one that does not
+constexpr float TradeRange = 6.0f;
+
+auto withinTradeRange(const CCharEntity* initiator, const CCharEntity* target) -> bool
+{
+    return distance(initiator->loc.p, target->loc.p) <= TradeRange && initiator->m_moghouseID == target->m_moghouseID;
+}
+
+} // namespace
+
+PlayerTradeTransaction::PlayerTradeTransaction(xi::Badge<PlayerTradeTransaction>, CCharEntity* initiator, CCharEntity* target)
+{
+    this->sides_[0].PChar = initiator;
+    this->sides_[1].PChar = target;
+}
+
+PlayerTradeTransaction::~PlayerTradeTransaction()
+{
+    this->rollbackIfOpen();
+}
+
+auto PlayerTradeTransaction::start(CCharEntity* initiator, CCharEntity* target) -> PlayerTradeTransaction*
+{
+    const bool invalidPlayers = !initiator || !target || initiator == target;
+    const bool eitherInTrade  = !invalidPlayers && (initiator->activePlayerTradeTransaction() || target->activePlayerTradeTransaction());
+    const bool outOfReach     = !invalidPlayers && !withinTradeRange(initiator, target);
+
+    if (invalidPlayers || eitherInTrade || outOfReach)
+    {
+        return nullptr;
+    }
+
+    auto transaction = std::unique_ptr<PlayerTradeTransaction>(
+        new PlayerTradeTransaction(xi::Badge<PlayerTradeTransaction>{}, initiator, target));
+    return initiator->addTransaction(std::move(transaction));
+}
+
+void PlayerTradeTransaction::cancel(CCharEntity* leaving)
+{
+    if (auto* transaction = leaving->activePlayerTradeTransaction())
+    {
+        transaction->abort(leaving);
+        return;
+    }
+
+    auto* partner = leaving->tradePartner();
+    if (!partner)
+    {
+        return;
+    }
+
+    leaving->TradePending.clean();
+    partner->TradePending.clean();
+    partner->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(leaving, GP_ITEM_TRADE_RES_KIND::Cancell);
+}
+
+auto PlayerTradeTransaction::holds(const CItem* item) const -> bool
+{
+    if (!item)
+    {
+        return false;
+    }
+
+    for (const auto& side : this->sides_)
+    {
+        for (const auto& slot : side.slots)
+        {
+            if (slot.item == item)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+auto PlayerTradeTransaction::sideOf(const CCharEntity* who) -> Side*
+{
+    if (!who)
+    {
+        return nullptr;
+    }
+
+    if (this->sides_[0].PChar == who)
+    {
+        return &this->sides_[0];
+    }
+
+    if (this->sides_[1].PChar == who)
+    {
+        return &this->sides_[1];
+    }
+
+    return nullptr;
+}
+
+auto PlayerTradeTransaction::partnerOf(const CCharEntity* who) const -> CCharEntity*
+{
+    if (this->sides_[0].PChar == who)
+    {
+        return this->sides_[1].PChar;
+    }
+
+    if (this->sides_[1].PChar == who)
+    {
+        return this->sides_[0].PChar;
+    }
+
+    return nullptr;
+}
+
+auto PlayerTradeTransaction::accept(const CCharEntity* who) -> bool
+{
+    if (auto* side = this->sideOf(who))
+    {
+        side->accepted = true;
+    }
+
+    return this->sides_[0].accepted && this->sides_[1].accepted;
+}
+
+// Runs from the destructor too, so it must not touch either character
+void PlayerTradeTransaction::releaseSlot(Slot& slot) const
+{
+    if (!slot.item)
+    {
+        return;
+    }
+
+    exitTx(slot.item);
+    slot = Slot{};
+}
+
+auto PlayerTradeTransaction::setSlot(CCharEntity* who, const uint8 transactionSlot, const uint8 inventorySlot, const uint16 expectedItemId, const uint32 qty) -> CItem*
+{
+    if (transactionSlot >= MaxSlots)
+    {
+        return nullptr;
+    }
+
+    auto* side  = this->sideOf(who);
+    auto* other = this->partnerOf(who);
+    if (!side || !other)
+    {
+        return nullptr;
+    }
+
+    // Send the packet to both sides
+    const auto pushSlotView = [&](uint8 slot, CItem* item = nullptr, uint32 viewQty = 0)
+    {
+        who->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_MYLIST>(item, slot, viewQty);
+        other->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_LIST>(item, slot, viewQty);
+    };
+
+    const auto releaseAndRestore = [&](Slot& target)
+    {
+        auto* released = target.item;
+
+        this->releaseSlot(target);
+
+        if (released)
+        {
+            who->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(released, ItemLockFlg::Normal);
+        }
+    };
+
+    // Any slot mutation invalidates both sides' Make
+    this->sides_[0].accepted = false;
+    this->sides_[1].accepted = false;
+
+    auto& slot = side->slots[transactionSlot];
+    releaseAndRestore(slot);
+
+    if (qty == 0)
+    {
+        pushSlotView(transactionSlot);
+        return nullptr;
+    }
+
+    const auto findOtherSlotStaging = [&](const uint8 fromInvSlot) -> Slot*
+    {
+        for (uint8 slotIdx = 0; slotIdx < MaxSlots; ++slotIdx)
+        {
+            if (slotIdx == transactionSlot)
+            {
+                continue;
+            }
+
+            auto& candidate = side->slots[slotIdx];
+            if (candidate.item && candidate.invSlot == fromInvSlot)
+            {
+                return &candidate;
+            }
+        }
+
+        return nullptr;
+    };
+
+    // Retail drops the earlier stage and refuses the new one when the same inv slot is staged twice
+    if (auto* alreadyStaged = findOtherSlotStaging(inventorySlot))
+    {
+        const auto stagedTxSlot = static_cast<uint8>(alreadyStaged - side->slots.data());
+
+        releaseAndRestore(*alreadyStaged);
+        pushSlotView(stagedTxSlot);
+        pushSlotView(transactionSlot);
+        return nullptr;
+    }
+
+    auto* item = who->getStorage(LOC_INVENTORY)->GetItem(inventorySlot);
+
+    const bool wrongItem     = !item || item->getID() != expectedItemId;
+    const bool exclusiveItem = item && item->hasFlag(ItemFlag::Exclusive);
+    const bool qtyExceeds    = item && qty + item->getReserve() > item->getQuantity();
+    const bool rareOnPartner = item && item->hasFlag(ItemFlag::Rare) && charutils::HasItem(other, item->getID());
+
+    if (wrongItem || exclusiveItem || qtyExceeds || rareOnPartner || !enterTx(item))
+    {
+        pushSlotView(transactionSlot);
+        return nullptr;
+    }
+
+    who->pushPacket<GP_SERV_COMMAND_ITEM_LIST>(item, ItemLockFlg::NoSelect);
+    slot = Slot{ .item = item, .invSlot = inventorySlot, .qty = qty };
+    pushSlotView(transactionSlot, item, qty);
+    return item;
+}
+
+void PlayerTradeTransaction::closeAndRemove()
+{
+    auto* initiator = this->sides_[0].PChar;
+    auto* target    = this->sides_[1].PChar;
+
+    initiator->TradePending.clean();
+    target->TradePending.clean();
+
+    this->rollbackIfOpen();
+    initiator->removeTransaction(this);
+}
+
+void PlayerTradeTransaction::abort(CCharEntity* leaving)
+{
+    if (auto* other = this->partnerOf(leaving))
+    {
+        other->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(leaving, GP_ITEM_TRADE_RES_KIND::Cancell);
+    }
+    else
+    {
+        ShowWarningFmt("PlayerTradeTransaction::abort: {} is not part of this trade", leaving->getName());
+    }
+
+    this->closeAndRemove();
+}
+
+void PlayerTradeTransaction::commitAndClose()
+{
+    auto* initiator = this->sides_[0].PChar;
+    auto* target    = this->sides_[1].PChar;
+
+    const bool ok = this->commit();
+    if (!ok)
+    {
+        ShowInfoFmt("PlayerTradeTransaction::commitAndClose: trade refused ({} <-> {})", initiator->getName(), target->getName());
+    }
+
+    const auto kind = [ok]()
+    {
+        if (ok)
+        {
+            return GP_ITEM_TRADE_RES_KIND::End;
+        }
+
+        return GP_ITEM_TRADE_RES_KIND::Cancell;
+    }();
+
+    if (!ok)
+    {
+        initiator->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::TradeCanceled);
+        target->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::TradeCanceled);
+    }
+
+    initiator->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(target, kind);
+    target->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(initiator, kind);
+
+    this->closeAndRemove();
+}
+
+auto PlayerTradeTransaction::canReceive(const Side& sender, CCharEntity* receiver) -> bool
+{
+    uint8  slotsNeeded = 0;
+    uint32 gilOffered  = 0;
+    for (const auto& slot : sender.slots)
+    {
+        if (!slot.item)
+        {
+            continue;
+        }
+
+        ++slotsNeeded;
+
+        if (slot.item->isType(ITEM_CURRENCY))
+        {
+            gilOffered += slot.qty;
+        }
+    }
+
+    if (slotsNeeded == 0)
+    {
+        return true;
+    }
+
+    if (receiver->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() < slotsNeeded)
+    {
+        return false;
+    }
+
+    // Existing gil plus the offer has to fit in one stack
+    if (gilOffered > 0)
+    {
+        const auto* receiverGil   = receiver->getStorage(LOC_INVENTORY)->GetItem(0);
+        const bool  noReceiverGil = !receiverGil;
+        const bool  wouldOverflow = !noReceiverGil &&
+                                    static_cast<uint64>(receiverGil->getQuantity()) + gilOffered > receiverGil->getStackSize();
+
+        if (noReceiverGil || wouldOverflow)
+        {
+            return false;
+        }
+    }
+
+    return std::ranges::none_of(sender.slots,
+                                [receiver](const Slot& slot)
+                                {
+                                    return slot.item && slot.item->hasFlag(ItemFlag::Rare) && charutils::HasItem(receiver, slot.item->getID());
+                                });
+}
+
+// Deliver to both sides before consuming either, so a failed delivery can be undone
+auto PlayerTradeTransaction::doCommit() -> bool
+{
+    auto* initiator = this->sides_[0].PChar;
+    auto* target    = this->sides_[1].PChar;
+
+    const bool bothAccepted   = this->sides_[0].accepted && this->sides_[1].accepted;
+    const bool partnerCanRecv = canReceive(this->sides_[0], target) && canReceive(this->sides_[1], initiator);
+    const bool stillInRange   = withinTradeRange(initiator, target);
+
+    if (!bothAccepted || !partnerCanRecv || !stillInRange)
+    {
+        return false;
+    }
+
+    struct Delivery
+    {
+        CCharEntity* receiver{};
+        uint8        invSlot{};
+        uint32       qty{};
+    };
+
+    std::vector<Delivery> delivered;
+    delivered.reserve(MaxSlots * 2);
+
+    const auto deliverSide = [&](const Side& sender, CCharEntity* receiver) -> bool
+    {
+        for (const auto& slot : sender.slots)
+        {
+            if (!slot.item)
+            {
+                continue;
+            }
+
+            // Cloned rather than spawned by id so exdata, signature and augments survive the trade
+            auto clone = xi::items::clone(*slot.item);
+            if (!clone)
+            {
+                return false;
+            }
+
+            clone->setQuantity(slot.qty);
+            clone->setReserve(0);
+
+            const uint8 deliveredSlot = charutils::AddItem(receiver, LOC_INVENTORY, std::move(clone));
+            if (deliveredSlot == ERROR_SLOTID)
+            {
+                return false;
+            }
+
+            delivered.push_back({ .receiver = receiver, .invSlot = deliveredSlot, .qty = slot.qty });
+        }
+
+        return true;
+    };
+
+    const auto undoDeliveries = [&]()
+    {
+        for (const auto& delivery : delivered)
+        {
+            charutils::UpdateItem(delivery.receiver, LOC_INVENTORY, delivery.invSlot, -static_cast<int32>(delivery.qty));
+        }
+    };
+
+    const auto consumeSide = [&](Side& sender)
+    {
+        for (auto& slot : sender.slots)
+        {
+            if (!slot.item)
+            {
+                continue;
+            }
+
+            const auto invSlot = slot.invSlot;
+            const auto qty     = slot.qty;
+            const auto itemID  = slot.item->getID();
+
+            this->releaseSlot(slot);
+
+            if (charutils::UpdateItem(sender.PChar, LOC_INVENTORY, invSlot, -static_cast<int32>(qty)) == 0)
+            {
+                ShowErrorFmt("PlayerTradeTransaction::doCommit: {} kept item {} after it was handed over", sender.PChar->getName(), itemID);
+            }
+        }
+    };
+
+    if (!deliverSide(this->sides_[0], target) || !deliverSide(this->sides_[1], initiator))
+    {
+        undoDeliveries();
+        return false;
+    }
+
+    consumeSide(this->sides_[0]);
+    consumeSide(this->sides_[1]);
+
+    return true;
+}
+
+void PlayerTradeTransaction::doRollback()
+{
+    for (auto& side : this->sides_)
+    {
+        for (auto& slot : side.slots)
+        {
+            this->releaseSlot(slot);
+        }
+    }
+}

--- a/src/map/items/transactions/player_trade.h
+++ b/src/map/items/transactions/player_trade.h
@@ -1,0 +1,91 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include "common/cbasetypes.h"
+#include "common/types/badge.h"
+#include "items/transaction.h"
+
+#include <array>
+
+class CCharEntity;
+class CItem;
+
+// The trade-slot echoes carry this in ItemNo when a slot is empty
+inline constexpr uint16 EmptyTradeSlotItemNo = 0xFFFF;
+
+class PlayerTradeTransaction : public Transaction
+{
+public:
+    static constexpr size_t MaxSlots = 9;
+    static constexpr uint8  GilSlot  = 0; // Gil is always in slot 0
+
+    // Registers on the initiator. Returns nullptr if refused, caller cleans up TradePending
+    static auto start(CCharEntity* initiator, CCharEntity* target) -> PlayerTradeTransaction*;
+
+    // Cancel for `leaving`, whether or not the transaction got as far as being created
+    static void cancel(CCharEntity* leaving);
+
+    PlayerTradeTransaction(xi::Badge<PlayerTradeTransaction>, CCharEntity* initiator, CCharEntity* target);
+    ~PlayerTradeTransaction() override;
+    DISALLOW_COPY_AND_MOVE(PlayerTradeTransaction);
+
+    auto holds(const CItem* item) const -> bool override;
+
+    // Stage or clear a slot, qty 0 releases. Clears both acceptances and pushes the packets
+    auto setSlot(CCharEntity* who, uint8 transactionSlot, uint8 inventorySlot, uint16 expectedItemId, uint32 qty) -> CItem*;
+
+    // Returns true once both sides have accepted
+    auto accept(const CCharEntity* who) -> bool;
+
+    // Both close the transaction out, leaving it destroyed
+    void abort(CCharEntity* leaving);
+    void commitAndClose();
+
+protected:
+    auto doCommit() -> bool override;
+    void doRollback() override;
+
+private:
+    struct Slot
+    {
+        CItem* item{ nullptr };
+        uint8  invSlot{ 0xFF };
+        uint32 qty{ 0 };
+    };
+
+    struct Side
+    {
+        CCharEntity*               PChar{};
+        std::array<Slot, MaxSlots> slots{};
+        bool                       accepted{};
+    };
+
+    auto sideOf(const CCharEntity* who) -> Side*;
+    auto partnerOf(const CCharEntity* who) const -> CCharEntity*;
+
+    void        releaseSlot(Slot& slot) const;
+    void        closeAndRemove();
+    static auto canReceive(const Side& sender, CCharEntity* receiver) -> bool;
+
+    std::array<Side, 2> sides_{};
+};

--- a/src/map/packets/c2s/0x032_trade_req.cpp
+++ b/src/map/packets/c2s/0x032_trade_req.cpp
@@ -23,10 +23,10 @@
 
 #include "entities/char_entity.h"
 #include "enums/msg_std.h"
+#include "items/transactions/player_trade.h"
 #include "packets/s2c/0x021_item_trade_req.h"
 #include "packets/s2c/0x022_item_trade_res.h"
 #include "packets/s2c/0x053_systemmes.h"
-#include "universal_container.h"
 #include "utils/charutils.h"
 #include "utils/jailutils.h"
 
@@ -45,76 +45,66 @@ void GP_CLI_COMMAND_TRADE_REQ::process(MapSession* PSession, CCharEntity* PChar)
         return;
     }
 
-    ShowDebug("%s initiated trade request with %s", PChar->getName(), PTarget->getName());
+    ShowDebugFmt("{} initiated trade request with {}", PChar->getName(), PTarget->getName());
 
-    // If either player is in prison don't allow the trade.
+    const auto refuse = [&](std::string_view reason)
+    {
+        ShowInfoFmt("{} -> {} trade refused: {}", PChar->getName(), PTarget->getName(), reason);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+    };
+
     if (jailutils::InPrison(PChar) || jailutils::InPrison(PTarget))
     {
-        ShowError("%s trade request with %s was blocked. They are in prison!", PChar->getName(), PTarget->getName());
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+        refuse("in prison");
         return;
     }
 
-    // If either player is crafting, don't allow the trade request.
-    // TODO: Not retail accurate but leaving it here for now.
-    if (PChar->isCrafting() || PTarget->isCrafting())
-    {
-        ShowError("%s trade request with %s was blocked. They are synthing!", PChar->getName(), PTarget->getName());
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
-
-        return;
-    }
-
-    // check /blockaid
     if (charutils::IsAidBlocked(PChar, PTarget))
     {
-        ShowDebug("%s is blocking trades", PTarget->getName());
-        // Target is blocking assistance
         PChar->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::TargetIsCurrentlyBlocking);
-        // Interaction was blocked
         PTarget->pushPacket<GP_SERV_COMMAND_SYSTEMMES>(0, 0, MsgStd::BlockedByBlockaid);
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+        refuse("blockaid");
+        return;
+    }
+
+    if (PChar->activePlayerTradeTransaction())
+    {
+        refuse("already in a trade");
         return;
     }
 
     if (PTarget->TradePending.UniqueNo == PChar->id)
     {
-        ShowDebug("%s has already sent a trade request to %s", PChar->getName(), PTarget->getName());
+        ShowDebugFmt("{} has already sent a trade request to {}", PChar->getName(), PTarget->getName());
         return;
     }
 
-    if (!PTarget->UContainer->IsContainerEmpty())
+    if (PTarget->activePlayerTradeTransaction())
     {
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
-        ShowDebug("%s's UContainer is not empty. %s cannot trade with them at this time", PTarget->getName(), PChar->getName());
+        refuse("target already in a trade");
         return;
     }
 
-    const timer::time_point currentTime     = timer::now();
-    const auto              lastTargetTrade = currentTime - PTarget->lastTradeInvite;
-    if ((PTarget->TradePending.ActIndex != 0 && lastTargetTrade < 60s) || PTarget->UContainer->GetType() == UCONTAINER_TRADE)
+    const timer::time_point currentTime           = timer::now();
+    const auto              lastTargetTrade       = currentTime - PTarget->lastTradeInvite;
+    const bool              targetHasRecentInvite = PTarget->TradePending.ActIndex != 0 && lastTargetTrade < 60s;
+
+    if (targetHasRecentInvite)
     {
-        // Can't trade with someone who's already got a pending trade before timeout
-        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+        refuse("target has a recent unanswered invite");
         return;
     }
 
     // This block usually doesn't trigger,
     // The client is generally forced to send a trade cancel packet via a cancel yes/no menu,
     // resulting in an outgoing 0x033 with 0x04 set to 0x01 for their old trade target, but sometimes the menu does not happen and a cancel is sent instead.
-    if (PChar->TradePending.UniqueNo != 0)
+    if (auto* POldTradeTarget = PChar->tradePartner())
     {
-        // Tell previous trader we don't want their business
-        auto* POldTradeTarget = static_cast<CCharEntity*>(PChar->GetEntity(PChar->TradePending.UniqueNo, TYPE_PC));
-        if (POldTradeTarget && POldTradeTarget->id == PChar->TradePending.UniqueNo)
-        {
-            POldTradeTarget->TradePending.clean();
-            PChar->TradePending.clean();
-
-            POldTradeTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
-            PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(POldTradeTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
-            return;
-        }
+        POldTradeTarget->TradePending.clean();
+        PChar->TradePending.clean();
+        POldTradeTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+        PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(POldTradeTarget, GP_ITEM_TRADE_RES_KIND::ErrYouTrade);
+        return;
     }
 
     PChar->lastTradeInvite = currentTime;

--- a/src/map/packets/c2s/0x033_trade_res.cpp
+++ b/src/map/packets/c2s/0x033_trade_res.cpp
@@ -22,20 +22,8 @@
 #include "0x033_trade_res.h"
 
 #include "entities/char_entity.h"
+#include "items/transactions/player_trade.h"
 #include "packets/s2c/0x022_item_trade_res.h"
-#include "universal_container.h"
-#include "utils/charutils.h"
-
-namespace
-{
-
-const auto cleanTradeTargets = [](CCharEntity* PChar, CCharEntity* PTarget)
-{
-    PChar->TradePending.clean();
-    PTarget->TradePending.clean();
-};
-
-} // namespace
 
 auto GP_CLI_COMMAND_TRADE_RES::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
 {
@@ -47,10 +35,8 @@ auto GP_CLI_COMMAND_TRADE_RES::validate(MapSession* PSession, const CCharEntity*
 
 void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
-
-    if (!PTarget ||
-        PTarget->TradePending.UniqueNo != PChar->id)
+    auto* PTarget = PChar->tradePartner();
+    if (!PTarget)
     {
         ShowWarningFmt("GP_CLI_COMMAND_TRADE_RES: Could not find trade targets.");
         return;
@@ -58,91 +44,46 @@ void GP_CLI_COMMAND_TRADE_RES::process(MapSession* PSession, CCharEntity* PChar)
 
     switch (static_cast<GP_CLI_COMMAND_TRADE_RES_KIND>(this->Kind))
     {
-        case GP_CLI_COMMAND_TRADE_RES_KIND::Start: // request accepted
+        case GP_CLI_COMMAND_TRADE_RES_KIND::Start:
         {
-            ShowDebug("GP_CLI_COMMAND_TRADE_RES: %s accepted trade request from %s", PTarget->getName(), PChar->getName());
-
-            // If either player universal container is NOT empty, back out of the trade.
-            if (!PChar->UContainer->IsContainerEmpty() || !PTarget->UContainer->IsContainerEmpty())
+            if (PChar->activePlayerTradeTransaction())
             {
-                ShowDebug("GP_CLI_COMMAND_TRADE_RES: UContainer is not empty");
-                cleanTradeTargets(PChar, PTarget);
-
+                // Trade is already active
                 return;
             }
 
-            // Must be within 6 yalms of each other to trade.
-            if (distance(PChar->loc.p, PTarget->loc.p) > 6 || PChar->m_moghouseID != PTarget->m_moghouseID)
+            if (!PlayerTradeTransaction::start(PChar, PTarget))
             {
-                ShowDebug("GP_CLI_COMMAND_TRADE_RES: Too far to trade");
-                cleanTradeTargets(PChar, PTarget);
-
+                ShowInfoFmt("GP_CLI_COMMAND_TRADE_RES: Start refused ({} -> {})", PChar->getName(), PTarget->getName());
+                PChar->TradePending.clean();
+                PTarget->TradePending.clean();
                 return;
             }
 
-            PChar->UContainer->SetType(UCONTAINER_TRADE);
-            PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, static_cast<GP_ITEM_TRADE_RES_KIND>(this->Kind));
-
-            PTarget->UContainer->SetType(UCONTAINER_TRADE);
-            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, static_cast<GP_ITEM_TRADE_RES_KIND>(this->Kind));
+            PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::Start);
+            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::Start);
         }
         break;
-        case GP_CLI_COMMAND_TRADE_RES_KIND::Cancell: // trade cancelled
+        case GP_CLI_COMMAND_TRADE_RES_KIND::Cancell:
         {
-            ShowDebug("GP_CLI_COMMAND_TRADE_RES: %s cancelled trade with %s", PTarget->getName(), PChar->getName());
-
-            if (PTarget->UContainer->GetType() == UCONTAINER_TRADE)
-            {
-                PTarget->UContainer->Clean();
-            }
-
-            if (PChar->UContainer->GetType() == UCONTAINER_TRADE)
-            {
-                PChar->UContainer->Clean();
-            }
-
-            cleanTradeTargets(PChar, PTarget);
-            // TODO: Verify exact sequence of packets sent here.
-            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, static_cast<GP_ITEM_TRADE_RES_KIND>(this->Kind));
+            PlayerTradeTransaction::cancel(PChar);
         }
         break;
-        case GP_CLI_COMMAND_TRADE_RES_KIND::Make: // trade accepted
+        case GP_CLI_COMMAND_TRADE_RES_KIND::Make:
         {
-            ShowDebug("GP_CLI_COMMAND_TRADE_RES: %s accepted trade with %s", PTarget->getName(), PChar->getName());
-
-            PChar->UContainer->SetLock();
-            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, static_cast<GP_ITEM_TRADE_RES_KIND>(Kind));
-
-            if (PTarget->UContainer->IsLocked())
+            // Notify the other side we're done trading
+            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::Make);
+            if (auto* transaction = PChar->activePlayerTradeTransaction(); transaction && transaction->accept(PChar))
             {
-                if (charutils::CanTrade(PChar, PTarget) && charutils::CanTrade(PTarget, PChar))
-                {
-                    charutils::DoTrade(PChar, PTarget);
-                    PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::End);
-
-                    charutils::DoTrade(PTarget, PChar);
-                    PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::End);
-                }
-                else
-                {
-                    // Failed to trade
-                    // Either players containers are full or illegal item trade attempted
-                    ShowDebug("GP_CLI_COMMAND_TRADE_RES: %s->%s trade failed (full inventory or illegal items)", PChar->getName(), PTarget->getName());
-                    PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::Cancell);
-                    PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::Cancell);
-                }
-
-                PChar->UContainer->Clean();
-                PTarget->UContainer->Clean();
-
-                cleanTradeTargets(PChar, PTarget);
+                // If both sides accepted, perform swaps and close the transaction.
+                transaction->commitAndClose();
             }
         }
         break;
         case GP_CLI_COMMAND_TRADE_RES_KIND::MakeCancell:
         {
             // XiPackets claim this can be sent by the client, but unknown in what conditions.
-            ShowDebug("GP_CLI_COMMAND_TRADE_RES: MakeCancell received from %s", PChar->getName());
+            ShowDebugFmt("GP_CLI_COMMAND_TRADE_RES: MakeCancell received from {}", PChar->getName());
         }
         break;
     }

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -23,10 +23,9 @@
 
 #include "entities/char_entity.h"
 #include "enums/msg_std.h"
+#include "items.h"
 #include "items/item_linkshell.h"
-#include "packets/s2c/0x023_item_trade_list.h"
-#include "packets/s2c/0x025_item_trade_mylist.h"
-#include "universal_container.h"
+#include "items/transactions/player_trade.h"
 
 namespace
 {
@@ -53,6 +52,31 @@ const auto auditTrade = [](Scheduler& scheduler, CCharEntity* PChar, CCharEntity
     }
 };
 
+const auto hasLinkshellEquipped = [](const CCharEntity* PChar, CItemLinkshell* POffered) -> bool
+{
+    const auto asLinkshell = [](CItemEquipment* PEquipped) -> CItemLinkshell*
+    {
+        auto* PLinkshell = reinterpret_cast<CItemLinkshell*>(PEquipped);
+        if (!PLinkshell || !PLinkshell->isType(ITEM_LINKSHELL))
+        {
+            return nullptr;
+        }
+
+        return PLinkshell;
+    };
+
+    for (const auto slot : { SLOT_LINK1, SLOT_LINK2 })
+    {
+        auto* PEquipped = asLinkshell(PChar->getEquip(slot));
+        if (PEquipped && PEquipped->GetLSID() == POffered->GetLSID())
+        {
+            return true;
+        }
+    }
+
+    return false;
+};
+
 } // namespace
 
 auto GP_CLI_COMMAND_TRADE_LIST::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
@@ -60,101 +84,36 @@ auto GP_CLI_COMMAND_TRADE_LIST::validate(MapSession* PSession, const CCharEntity
     return PacketValidator(PChar)
         .blockedBy({ BlockedState::InEvent, BlockedState::Monstrosity })
         .mustNotEqual(PChar->TradePending.UniqueNo, 0, "No trade target")
-        .range("TradeIndex", this->TradeIndex, 0, 8);
+        .range("TradeIndex", this->TradeIndex, 0, 8)
+        .custom([&](PacketValidator& v)
+                {
+                    v.mustEqual(this->ItemNo == static_cast<uint16>(ITEMID::GIL),
+                                this->TradeIndex == PlayerTradeTransaction::GilSlot,
+                                "Gil belongs in the gil trade slot");
+                });
 }
 
 void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar) const
 {
-    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
-
-    if (!PTarget ||
-        PChar->id != PTarget->TradePending.UniqueNo)
+    auto* PTarget     = PChar->tradePartner();
+    auto* transaction = PChar->activePlayerTradeTransaction();
+    if (!PTarget || !transaction)
     {
-        ShowWarningFmt("GP_CLI_COMMAND_TRADE_LIST: Could not find trade targets.");
+        ShowWarningFmt("GP_CLI_COMMAND_TRADE_LIST: no active player trade for {}", PChar->getName());
         return;
     }
 
-    // If updating a filled slot, remove the pending item.
-    if (!PChar->UContainer->IsSlotEmpty(this->TradeIndex))
+    // Must have the relevant linkshell equipping to offer a pearl
+    auto* POffered = PChar->getStorage(LOC_INVENTORY)->GetItem(this->ItemIndex);
+    if (this->ItemNum > 0 && POffered && POffered->isType(ITEM_LINKSHELL) && !hasLinkshellEquipped(PChar, static_cast<CItemLinkshell*>(POffered)))
     {
-        CItem* PCurrentSlotItem = PChar->UContainer->GetItem(this->TradeIndex);
-        if (this->ItemNum != 0)
-        {
-            ShowError("GP_CLI_COMMAND_TRADE_LIST: Player %s trying to update trade quantity of a RESERVED item! [Item: %i | Trade Slot: %i] ",
-                      PChar->getName(),
-                      PCurrentSlotItem->getID(),
-                      this->TradeIndex);
-        }
-
-        PCurrentSlotItem->setReserve(0);
-        PChar->UContainer->ClearSlot(this->TradeIndex);
-    }
-
-    CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(this->ItemIndex);
-
-    // Validate that the item exists in sufficient quantity, is not reserved, and is not an EX item.
-    if (!PItem ||
-        PItem->getID() != this->ItemNo ||
-        PItem->hasFlag(ItemFlag::Exclusive) ||
-        this->ItemNum + PItem->getReserve() > PItem->getQuantity() ||
-        PItem->isSubType(ITEM_LOCKED))
-    {
-        ShowErrorFmt("GP_CLI_COMMAND_TRADE_LIST: {} trying to add an invalid item/quantity [Item: {} | Trade Slot: {}] ",
-                     PChar->getName(),
-                     this->ItemNo,
-                     this->TradeIndex);
+        PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::LinkshellEquipBeforeUsing);
         return;
     }
 
-    // If item count is zero remove from container
-    if (this->ItemNum == 0)
+    if (const auto* PItem = transaction->setSlot(PChar, this->TradeIndex, this->ItemIndex, this->ItemNo, this->ItemNum))
     {
-        ShowInfo("GP_CLI_COMMAND_TRADE_LIST: %s->%s trade updating trade slot id %d with item %s, quantity 0", PChar->getName(), PTarget->getName(), this->TradeIndex, PItem->getName());
-        PItem->setReserve(0);
-        PChar->UContainer->SetItem(this->TradeIndex, nullptr);
+        // TODO: Don't pass around Scheduler& through PSession
+        auditTrade(*PSession->scheduler, PChar, PTarget, PItem, this->ItemNum);
     }
-
-    if (PItem->isType(ITEM_LINKSHELL))
-    {
-        const auto asLinkshell = [](CItemEquipment* PEquipped) -> CItemLinkshell*
-        {
-            auto* PLinkshell = reinterpret_cast<CItemLinkshell*>(PEquipped);
-            return (PLinkshell && PLinkshell->isType(ITEM_LINKSHELL)) ? PLinkshell : nullptr;
-        };
-
-        auto* PItemLinkshell  = static_cast<CItemLinkshell*>(PItem);
-        auto* PItemLinkshell1 = asLinkshell(PChar->getEquip(SLOT_LINK1));
-        auto* PItemLinkshell2 = asLinkshell(PChar->getEquip(SLOT_LINK2));
-        if ((!PItemLinkshell1 && !PItemLinkshell2) || ((!PItemLinkshell1 || PItemLinkshell1->GetLSID() != PItemLinkshell->GetLSID()) &&
-                                                       (!PItemLinkshell2 || PItemLinkshell2->GetLSID() != PItemLinkshell->GetLSID())))
-        {
-            PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::LinkshellEquipBeforeUsing);
-            PItem->setReserve(0);
-            PChar->UContainer->SetItem(this->TradeIndex, nullptr);
-        }
-        else
-        {
-            ShowInfo("GP_CLI_COMMAND_TRADE_LIST: %s->%s trade updating trade slot id %d with item %s, quantity %d", PChar->getName(), PTarget->getName(), this->TradeIndex, PItem->getName(), this->ItemNum);
-            PItem->setReserve(this->ItemNum + PItem->getReserve());
-            PChar->UContainer->SetItem(this->TradeIndex, PItem);
-        }
-    }
-    else
-    {
-        ShowInfo("GP_CLI_COMMAND_TRADE_LIST: %s->%s trade updating trade slot id %d with item %s, quantity %d", PChar->getName(), PTarget->getName(), this->TradeIndex, PItem->getName(), this->ItemNum);
-        PItem->setReserve(this->ItemNum + PItem->getReserve());
-        PChar->UContainer->SetItem(this->TradeIndex, PItem);
-    }
-
-    // TODO: Don't pass around Scheduler& through PSession
-    auditTrade(*PSession->scheduler, PChar, PTarget, PItem, this->ItemNum);
-
-    ShowDebug("GP_CLI_COMMAND_TRADE_LIST: %s->%s trade pushing packet to %s", PChar->getName(), PTarget->getName(), PChar->getName());
-    PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_MYLIST>(PItem, this->TradeIndex);
-
-    ShowDebug("GP_CLI_COMMAND_TRADE_LIST: %s->%s trade pushing packet to %s", PChar->getName(), PTarget->getName(), PTarget->getName());
-    PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_LIST>(PItem, this->TradeIndex);
-
-    PChar->UContainer->UnLock();
-    PTarget->UContainer->UnLock();
 }

--- a/src/map/packets/c2s/0x03a_item_stack.cpp
+++ b/src/map/packets/c2s/0x03a_item_stack.cpp
@@ -56,6 +56,7 @@ void GP_CLI_COMMAND_ITEM_STACK::process(MapSession* PSession, CCharEntity* PChar
         // Skip items that are invalid, locked, reserved or already meeting stack size.
         if (!PItem ||
             PItem->getReserve() > 0 ||
+            PItem->isBusy() ||
             PItem->isSubType(ITEM_LOCKED) ||
             PItem->getQuantity() >= PItem->getStackSize())
         {
@@ -70,6 +71,7 @@ void GP_CLI_COMMAND_ITEM_STACK::process(MapSession* PSession, CCharEntity* PChar
             if (!PItem2 ||
                 PItem2->getID() != PItem->getID() ||
                 PItem2->getReserve() > 0 ||
+                PItem2->isBusy() ||
                 PItem2->isSubType(ITEM_LOCKED) ||
                 PItem2->getQuantity() >= PItem2->getStackSize())
             {

--- a/src/map/packets/c2s/0x083_shop_buy.cpp
+++ b/src/map/packets/c2s/0x083_shop_buy.cpp
@@ -89,7 +89,7 @@ void GP_CLI_COMMAND_SHOP_BUY::process(MapSession* PSession, CCharEntity* PChar) 
 
     const CItem* gil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
 
-    if (!gil || !gil->isType(ITEM_CURRENCY) || gil->getReserve() != 0)
+    if (!gil || !gil->isType(ITEM_CURRENCY) || gil->getReserve() != 0 || gil->isBusy())
     {
         ShowError("User '%s' has invalid gil", PChar->getName());
         return;

--- a/src/map/packets/c2s/0x096_combine_ask.cpp
+++ b/src/map/packets/c2s/0x096_combine_ask.cpp
@@ -93,40 +93,12 @@ void GP_CLI_COMMAND_COMBINE_ASK::process(MapSession* PSession, CCharEntity* PCha
         return;
     }
 
-    // NOTE: This section is intended to be temporary to ensure that duping shenanigans aren't possible.
-    // It should be replaced by something more robust or more stateful as soon as is reasonable
-    auto* PTarget = PChar->TradePending.resolve<CCharEntity>();
-
-    // Clear pending trades on synthesis start
-    if (PTarget)
-    {
-        PChar->TradePending.clean();
-        PTarget->TradePending.clean();
-    }
-
-    // Clears out trade session and blocks synthesis at any point in trade process after accepting
-    // trade request.
     if (PChar->UContainer->GetType() != UCONTAINER_EMPTY)
     {
-        if (PTarget)
-        {
-            ShowDebug("%s trade request with %s was canceled because %s tried to craft.",
-                      PChar->getName(),
-                      PTarget->getName(),
-                      PChar->getName());
-
-            PTarget->TradePending.clean();
-            PTarget->UContainer->Clean();
-            PTarget->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PChar, GP_ITEM_TRADE_RES_KIND::Cancell);
-            PChar->pushPacket<GP_SERV_COMMAND_ITEM_TRADE_RES>(PTarget, GP_ITEM_TRADE_RES_KIND::Cancell);
-        }
-
         PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(MsgStd::CannotBeProcessed);
-        PChar->TradePending.clean();
         PChar->UContainer->Clean();
         return;
     }
-    // End temporary additions
 
     const auto* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(this->CrystalIdx);
     if (!PItem ||

--- a/src/map/packets/s2c/0x023_item_trade_list.cpp
+++ b/src/map/packets/s2c/0x023_item_trade_list.cpp
@@ -23,17 +23,23 @@
 
 #include "common/utils.h"
 #include "items/item_linkshell.h"
+#include "items/transactions/player_trade.h"
 #include "utils/itemutils.h"
 
-GP_SERV_COMMAND_ITEM_TRADE_LIST::GP_SERV_COMMAND_ITEM_TRADE_LIST(CItem* PItem, const uint8 slotId)
+GP_SERV_COMMAND_ITEM_TRADE_LIST::GP_SERV_COMMAND_ITEM_TRADE_LIST(CItem* PItem, const uint8 slotId, const uint32 qty)
 {
     auto& packet = this->data();
 
-    const uint32 amount = PItem->getReserve();
-
-    packet.ItemNum    = amount;
-    packet.ItemNo     = amount == 0 ? 0 : PItem->getID();
+    packet.ItemNum    = qty;
     packet.TradeIndex = slotId;
+
+    if (PItem == nullptr || qty == 0)
+    {
+        packet.ItemNo = EmptyTradeSlotItemNo;
+        return;
+    }
+
+    packet.ItemNo = PItem->getID();
 
     if (PItem->isSubType(ITEM_CHARGED))
     {

--- a/src/map/packets/s2c/0x023_item_trade_list.h
+++ b/src/map/packets/s2c/0x023_item_trade_list.h
@@ -43,5 +43,5 @@ public:
         uint8_t  Attr[24];         // PS2: Attr
     };
 
-    GP_SERV_COMMAND_ITEM_TRADE_LIST(CItem* PItem, uint8 slotId);
+    GP_SERV_COMMAND_ITEM_TRADE_LIST(CItem* PItem, uint8 slotId, uint32 qty);
 };

--- a/src/map/packets/s2c/0x025_item_trade_mylist.cpp
+++ b/src/map/packets/s2c/0x025_item_trade_mylist.cpp
@@ -21,16 +21,22 @@
 
 #include "0x025_item_trade_mylist.h"
 
+#include "items/transactions/player_trade.h"
 #include "utils/itemutils.h"
 
-GP_SERV_COMMAND_ITEM_TRADE_MYLIST::GP_SERV_COMMAND_ITEM_TRADE_MYLIST(const CItem* PItem, const uint8 slot)
+GP_SERV_COMMAND_ITEM_TRADE_MYLIST::GP_SERV_COMMAND_ITEM_TRADE_MYLIST(const CItem* PItem, const uint8 slot, const uint32 qty)
 {
     auto& packet = this->data();
 
-    const uint32 amount = PItem->getReserve();
-
-    packet.ItemNum    = amount == 0 ? 0 : amount;
-    packet.ItemNo     = amount == 0 ? 0 : PItem->getID();
     packet.TradeIndex = slot;
-    packet.ItemIndex  = amount == 0 ? 0 : PItem->getSlotID();
+
+    if (PItem == nullptr || qty == 0)
+    {
+        packet.ItemNo = EmptyTradeSlotItemNo;
+        return;
+    }
+
+    packet.ItemNum   = qty;
+    packet.ItemNo    = PItem->getID();
+    packet.ItemIndex = PItem->getSlotID();
 }

--- a/src/map/packets/s2c/0x025_item_trade_mylist.h
+++ b/src/map/packets/s2c/0x025_item_trade_mylist.h
@@ -41,5 +41,5 @@ public:
         uint8_t  ItemIndex;  // PS2: ItemIndex
     };
 
-    GP_SERV_COMMAND_ITEM_TRADE_MYLIST(const CItem* PItem, uint8 slot);
+    GP_SERV_COMMAND_ITEM_TRADE_MYLIST(const CItem* PItem, uint8 slot, uint32 qty);
 };

--- a/src/map/utils/auctionutils.cpp
+++ b/src/map/utils/auctionutils.cpp
@@ -141,7 +141,7 @@ void auctionutils::ProofOfPurchase(CCharEntity* PChar, GP_AUC_PARAM_LOT param)
 
     CItem* PItem = PChar->getStorage(LOC_INVENTORY)->GetItem(param.ItemWorkIndex);
 
-    if (PItem && !(PItem->isSubType(ITEM_LOCKED)) && PItem->getReserve() == 0 && !PItem->hasFlag(ItemFlag::NoAuction) && PItem->getQuantity() >= param.ItemStacks)
+    if (PItem && !(PItem->isSubType(ITEM_LOCKED)) && PItem->getReserve() == 0 && !PItem->isBusy() && !PItem->hasFlag(ItemFlag::NoAuction) && PItem->getQuantity() >= param.ItemStacks)
     {
         if (isPartiallyUsed(PItem))
         {
@@ -168,7 +168,7 @@ void auctionutils::ProofOfPurchase(CCharEntity* PChar, GP_AUC_PARAM_LOT param)
         auctionFee = std::clamp<uint32>(auctionFee, 0, settings::get<uint32>("map.AH_MAX_FEE"));
 
         const auto PGil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
-        if (PGil->getQuantity() < auctionFee || PGil->getReserve() > 0)
+        if (PGil->getQuantity() < auctionFee || PGil->getReserve() > 0 || PGil->isBusy())
         {
             PChar->pushPacket<GP_SERV_COMMAND_AUC>(GP_CLI_COMMAND_AUC_COMMAND::LotIn, 197, 0, 0, 0, 0); // Not enough gil to pay fee
             return;
@@ -248,7 +248,7 @@ auto auctionutils::PurchasingItems(CCharEntity* PChar, GP_AUC_PARAM_BID param) -
             }
             const CItem* gil = PChar->getStorage(LOC_INVENTORY)->GetItem(0);
 
-            if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= param.BidPrice && gil->getReserve() == 0)
+            if (gil != nullptr && gil->isType(ITEM_CURRENCY) && gil->getQuantity() >= param.BidPrice && gil->getReserve() == 0 && !gil->isBusy())
             {
                 const auto rset = db::preparedStmt("UPDATE auction_house SET buyer_name = ?, sale = ?, sell_date = ? WHERE itemid = ? AND buyer_name IS NULL "
                                                    "AND stack = ? AND price <= ? ORDER BY price LIMIT 1",

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -100,6 +100,7 @@
 #include "blueutils.h"
 #include "charutils.h"
 #include "enums/item_lockflg.h"
+#include "items/transactions/player_trade.h"
 #include "items/transactions/synth.h"
 #include "itemutils.h"
 #include "job_points.h"
@@ -2027,78 +2028,6 @@ void DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity,
         ShowInfo("Player %s DROPPING itemID: %s (%u) quantity: %u", PChar->getName(), xi::items::lookup(ItemID)->getName(), ItemID, quantity);
         PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(nullptr, ItemID, quantity, MsgStd::ThrowAway);
         PChar->pushPacket<GP_SERV_COMMAND_ITEM_SAME>(PChar);
-    }
-}
-
-/************************************************************************
- *                                                                       *
- *  Check the possibility of trade between characters                    *
- *                                                                       *
- ************************************************************************/
-
-bool CanTrade(CCharEntity* PChar, CCharEntity* PTarget)
-{
-    if (PChar->m_PMonstrosity != nullptr || PTarget->m_PMonstrosity != nullptr)
-    {
-        return false;
-    }
-
-    if (PTarget->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() < PChar->UContainer->GetItemsCount())
-    {
-        ShowDebug("Unable to trade, %s doesn't have enough inventory space", PTarget->getName());
-        return false;
-    }
-
-    for (uint8 slotid = 0; slotid <= 8; ++slotid)
-    {
-        CItem* PItem = PChar->UContainer->GetItem(slotid);
-
-        if (PItem != nullptr && PItem->hasFlag(ItemFlag::Rare))
-        {
-            if (HasItem(PTarget, PItem->getID()))
-            {
-                ShowDebug("Unable to trade, %s has the rare item already (%s)", PTarget->getName(), PItem->getName());
-                return false;
-            }
-        }
-    }
-
-    return true;
-}
-
-/************************************************************************
- *                                                                       *
- *  Do the exchange between characters                                   *
- *                                                                       *
- ************************************************************************/
-
-void DoTrade(CCharEntity* PChar, CCharEntity* PTarget)
-{
-    ShowDebug("%s->%s trade item movement started", PChar->getName(), PTarget->getName());
-    for (uint8 slotid = 0; slotid <= 8; ++slotid)
-    {
-        CItem* PItem = PChar->UContainer->GetItem(slotid);
-
-        if (PItem != nullptr)
-        {
-            if (PItem->getStackSize() == 1 && PItem->getReserve() == 1)
-            {
-                auto PNewItem = xi::items::clone(*PItem);
-                ShowDebug("Adding %s to %s inventory stacksize 1", PNewItem->getName(), PTarget->getName());
-                PNewItem->setReserve(0);
-                AddItem(PTarget, LOC_INVENTORY, std::move(PNewItem));
-            }
-            else
-            {
-                ShowDebug("Adding %s to %s inventory", PItem->getName(), PTarget->getName());
-                AddItem(PTarget, LOC_INVENTORY, PItem->getID(), PItem->getReserve());
-            }
-            ShowDebug("Removing %s from %s's inventory", PItem->getName(), PChar->getName());
-            auto amount = PItem->getReserve();
-            PItem->setReserve(0);
-            UpdateItem(PChar, LOC_INVENTORY, PItem->getSlotID(), (int32)(0 - amount));
-            PChar->UContainer->ClearSlot(slotid);
-        }
     }
 }
 
@@ -7754,6 +7683,11 @@ void removeCharFromZone(CCharEntity* PChar)
     if (PChar->PSession)
     {
         PChar->PSession->blowfish.status = BLOWFISH_PENDING_ZONE;
+    }
+
+    if (auto* tradeTransaction = PChar->activePlayerTradeTransaction())
+    {
+        tradeTransaction->abort(PChar);
     }
 
     PChar->TradePending.clean();

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -123,9 +123,6 @@ void  BuildingCharAbilityTable(CCharEntity* PChar);
 void  BuildingCharTraitsTable(CCharEntity* PChar);
 void  BuildingCharPetAbilityTable(CCharEntity* PChar, CPetEntity* PPet, uint32 PetID);
 
-void DoTrade(CCharEntity* PChar, CCharEntity* PTarget);
-bool CanTrade(CCharEntity* PChar, CCharEntity* PTarget);
-
 void   CheckWeaponSkill(CCharEntity* PChar, uint8 skill);
 bool   HasItem(CCharEntity* PChar, uint16 ItemID, IncludeRecycleBin includeRecycleBin = IncludeRecycleBin::Yes);
 uint32 getItemCount(CCharEntity* PChar, uint16 ItemID);

--- a/src/map/utils/dboxutils.cpp
+++ b/src/map/utils/dboxutils.cpp
@@ -132,7 +132,7 @@ void dboxutils::AddItemsToBeSent(CCharEntity* PChar, GP_CLI_COMMAND_PBX_BOXNO Bo
         return;
     }
 
-    if (PItem->getQuantity() < ItemStacks || PItem->getReserve() > 0 || PItem->isSubType(ITEM_LOCKED))
+    if (PItem->getQuantity() < ItemStacks || PItem->getReserve() > 0 || PItem->isBusy() || PItem->isSubType(ITEM_LOCKED))
     {
         ShowWarningFmt("DBOX: {} attempted to send insufficient/reserved/locked {}: {} ({})", PChar->getName(), ItemStacks, PItem->getName(), PItem->getID());
         return;

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.cpp
@@ -50,6 +50,7 @@
 #include "map/packets/c2s/0x053_lockstyle.h"
 #include "map/packets/c2s/0x06e_group_solicit_req.h"
 #include "map/packets/c2s/0x074_group_solicit_res.h"
+#include "map/packets/c2s/0x083_shop_buy.h"
 #include "map/packets/c2s/0x096_combine_ask.h"
 #include "map/packets/c2s/0x0aa_guild_buy.h"
 #include "map/packets/c2s/0x0ab_guild_buylist.h"
@@ -364,6 +365,24 @@ auto CLuaClientEntityPairActions::guildSellList() const -> sol::table
 }
 
 /************************************************************************
+ *  Function: shopBuy()
+ *  Purpose : Emits packet 0x083 to buy from the currently open shop.
+ *  Example : p1.actions:shopBuy(0, 1)
+ ************************************************************************/
+
+void CLuaClientEntityPairActions::shopBuy(uint16 shopSlot, uint32 quantity) const
+{
+    const auto packet      = parent_->packets().createPacket<GP_CLI_COMMAND_SHOP_BUY>();
+    auto*      buy         = packet->as<GP_CLI_COMMAND_SHOP_BUY>();
+    buy->ItemNum           = quantity;
+    buy->ShopNo            = 0;
+    buy->ShopItemIndex     = shopSlot;
+    buy->PropertyItemIndex = 0;
+
+    parent_->packets().sendBasicPacket(*packet);
+}
+
+/************************************************************************
  *  Function: inviteToParty()
  *  Purpose : Emits packet to invite a PC.
  *  Example : player.actions:inviteToParty(player2)
@@ -568,13 +587,13 @@ void CLuaClientEntityPairActions::tradeOffer(uint8 tradeIndex, uint8 invSlot, ui
  *  Example : p1.actions:tradeClearSlot(0)
  ************************************************************************/
 
-void CLuaClientEntityPairActions::tradeClearSlot(uint8 tradeIndex) const
+void CLuaClientEntityPairActions::tradeClearSlot(uint8 tradeIndex, uint8 invSlot, uint16 itemId) const
 {
     const auto packet = parent_->packets().createPacket<GP_CLI_COMMAND_TRADE_LIST>();
     auto*      data   = packet->as<GP_CLI_COMMAND_TRADE_LIST>();
     data->TradeIndex  = tradeIndex;
-    data->ItemIndex   = 0;
-    data->ItemNo      = 0;
+    data->ItemIndex   = invSlot;
+    data->ItemNo      = itemId;
     data->ItemNum     = 0;
 
     parent_->packets().sendBasicPacket(*packet);
@@ -1018,6 +1037,7 @@ void CLuaClientEntityPairActions::Register()
     SOL_REGISTER("guildSell", CLuaClientEntityPairActions::guildSell);
     SOL_REGISTER("guildBuyList", CLuaClientEntityPairActions::guildBuyList);
     SOL_REGISTER("guildSellList", CLuaClientEntityPairActions::guildSellList);
+    SOL_REGISTER("shopBuy", CLuaClientEntityPairActions::shopBuy);
     SOL_REGISTER("inviteToParty", CLuaClientEntityPairActions::inviteToParty);
     SOL_REGISTER("formAlliance", CLuaClientEntityPairActions::formAlliance);
     SOL_REGISTER("acceptPartyInvite", CLuaClientEntityPairActions::acceptPartyInvite);

--- a/src/test/lua/helpers/lua_client_entity_pair_actions.h
+++ b/src/test/lua/helpers/lua_client_entity_pair_actions.h
@@ -52,7 +52,7 @@ public:
     void tradeRequest(CLuaBaseEntity* target) const;
     void tradeAccept() const;
     void tradeOffer(uint8 tradeIndex, uint8 invSlot, uint16 itemId, uint32 quantity) const;
-    void tradeClearSlot(uint8 tradeIndex) const;
+    void tradeClearSlot(uint8 tradeIndex, uint8 invSlot, uint16 itemId) const;
     void tradeMake() const;
     void tradeCancel() const;
     void acceptRaise() const;
@@ -63,6 +63,8 @@ public:
     void guildSell(uint16 itemId, uint8 quantity) const;
     auto guildBuyList() const -> sol::table;
     auto guildSellList() const -> sol::table;
+
+    void shopBuy(uint16 shopSlot, uint32 quantity) const;
 
     void moveItem(uint8 srcContainer, uint8 srcSlot, uint8 dstContainer, uint32 quantity, sol::optional<uint8> dstSlot) const;
     void sortContainer(uint8 container) const;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Route all player to player trades through the Transaction framework.

This does change a few things to align with retail:
- Can't stage a Rare item if partner already owns it
- Proper error messages on inventory full
- A couple more paths are checked for injections

## Steps to test these changes
Includes a comprehensive set of tests

<!-- Clear and detailed steps to test your changes here -->
