### PR TITLE
[cpp] Fixes multiple mobskill check triggering over and over again

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -277,35 +277,47 @@ auto CMobController::MobSkill(int listId) -> bool
     }();
 
     auto skillList = battleutils::GetMobSkillList(resolvedListId);
+    std::erase_if(skillList,
+                  [&](const uint16 skillId)
+                  {
+                      if (battleutils::GetMobSkill(skillId) != nullptr)
+                      {
+                          return false;
+                      }
+                      ShowError("Mobskill with ID (%i) [called from skill-list ID (%i)] isn't properly defined in mob_skills.sql", skillId, resolvedListId);
+                      return true;
+                  });
     if (skillList.empty())
     {
         return false;
     }
     std::shuffle(skillList.begin(), skillList.end(), xirand::rng());
 
-    // Pick the first valid mob skill from the shuffled list.
-    const uint16 firstValidSkillId = [&]() -> uint16
+    // Lua may override the skill
+    // We used that isntead of the shuffled list
+    const auto overrideSkill = luautils::OnMobMobskillChoose(PMob, PTarget, skillList.front());
+    if (overrideSkill > 0)
     {
-        for (const auto skillId : skillList)
+        return TryMobSkill(overrideSkill, PTarget);
+    }
+
+    // Start at the top of the list after the shuffle, first one that returns 0 wins
+    for (const auto skillId : skillList)
+    {
+        if (TryMobSkill(skillId, PTarget))
         {
-            if (battleutils::GetMobSkill(skillId) != nullptr)
-            {
-                return skillId;
-            }
-            ShowError("CMobController::MobSkill -> Mobskill with ID (%i) [called from skill-list ID (%i)] isn't properly defined in mob_skills.sql", skillId, resolvedListId);
+            return true;
         }
-        return 0;
-    }();
+    }
 
-    // Lua may override the chosen skill.
-    const uint16 chosenSkillId = [&]() -> uint16
-    {
-        const auto overrideSkill = luautils::OnMobMobskillChoose(PMob, PTarget, firstValidSkillId);
-        return overrideSkill > 0 ? overrideSkill : firstValidSkillId;
-    }();
+    return false;
+}
 
-    auto* PMobSkill = battleutils::GetMobSkill(chosenSkillId);
-    if (!PMobSkill)
+// Try to use the given skill on the target
+auto CMobController::TryMobSkill(const uint16 skillId, CBattleEntity* PTarget) -> bool
+{
+    auto* PMobSkill = battleutils::GetMobSkill(skillId);
+    if (!PMobSkill || PMobSkill->isAstralFlow())
     {
         return false;
     }
@@ -322,10 +334,7 @@ auto CMobController::MobSkill(int listId) -> bool
     }
     PActionTarget = luautils::OnMobSkillTarget(PActionTarget, PMob, PMobSkill);
 
-    // NOTE: OnMobSkillReadyTime runs unconditionally so its Lua side effects still fire.
-    const auto mobSkillReadyTime = luautils::OnMobSkillReadyTime(PActionTarget, PMob, PMobSkill);
-
-    if (!PActionTarget || PMobSkill->isAstralFlow())
+    if (!PActionTarget)
     {
         return false;
     }
@@ -341,6 +350,8 @@ auto CMobController::MobSkill(int listId) -> bool
     {
         return false;
     }
+
+    const auto mobSkillReadyTime = luautils::OnMobSkillReadyTime(PActionTarget, PMob, PMobSkill);
 
     return MobSkill(PActionTarget->entityId(), PMobSkill->getID(), mobSkillReadyTime);
 }

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -49,6 +49,7 @@ public:
     virtual auto MobSkill(EntityId target, uint16 wsid, Maybe<timer::duration> castTimeOverride) -> bool;
     auto         Ability(EntityId target, uint16 abilityid) -> bool override;
     auto         MobSkill(int listId = 0) -> bool;
+    auto         TryMobSkill(uint16 skillId, CBattleEntity* PTarget) -> bool;
     auto         TryCastSpell() -> bool;
     auto         TrySpecialSkill() -> bool;
     auto         CanFollowTarget(CBattleEntity*) const -> bool;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Not too much to this. Instead of the mobskill list re-shufling EVERY single time it checks a skill in the list for the mob to use it just shuffles the list once then erases the entry if its false and then picks the next one on the list.

Old:
- Shuffle the list
- Pick a skill from that list
- If the check is false - reshuffle the entire list again
- Pick a skill from the new shuffle

New:
- Shuffle the list
- Pick a skill
- If the check is false -> erase it from the list
- Pick the next skill from the list

Scripts that force the skill being used do not change. No ordering changes, etc.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Nothing player facing here:
Go to any mob
!tp 3000
See it use an ability

If you want to test the skill check prints:
Inside bomb_toss_suicide put ` print("Checking Bomb Toss - Suicide")` inside the check
Inside bomb_toss put `print("Checking Bomb Toss")`
Inside goblin_rush put `print("Checking Goblin Rush")`
Go to any goblin, i suggest the dunes
!gotoid 17199385
Aggro it
!tp 3000 over and over again
You should see the check only print once instead of 2+ times and spamming it

<img width="948" height="768" alt="image" src="https://github.com/user-attachments/assets/9bef94f0-c3ab-4e1e-83ac-7fb3a4c1134e" />

<!-- Clear and detailed steps to test your changes here -->
