### PR TITLE
[lua] Various Quest Level Corrections

### DIFF
--- a/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
+++ b/scripts/quests/otherAreas/An_Explorers_Footsteps.lua
@@ -97,7 +97,8 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:getMainLvl() >= 10 -- Level requirement added in the March 8, 2007 update: https://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
         end,
 
         [xi.zone.SELBINA] =

--- a/scripts/quests/sandoria/The_Rumor.lua
+++ b/scripts/quests/sandoria/The_Rumor.lua
@@ -21,7 +21,7 @@ quest.sections =
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:getFameLevel(xi.fameArea.SANDORIA) >= 3 and
-                player:getMainLvl() >= 10
+                player:getMainLvl() >= 5 -- Level requirement added in the March 8, 2007 update: https://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
         end,
 
         [xi.zone.BOSTAUNIEUX_OUBLIETTE] =

--- a/scripts/quests/windurst/Making_the_Grade.lua
+++ b/scripts/quests/windurst/Making_the_Grade.lua
@@ -23,7 +23,8 @@ quest.sections =
             return status == xi.questStatus.QUEST_AVAILABLE and
                 player:hasCompletedQuest(xi.questLog.WINDURST, xi.quest.id.windurst.TEACHERS_PET) and
                 player:getQuestStatus(xi.questLog.WINDURST, xi.quest.id.windurst.LET_SLEEPING_DOGS_LIE) ~= xi.questStatus.QUEST_ACCEPTED and
-                player:getFameLevel(xi.fameArea.WINDURST) >= 3
+                player:getFameLevel(xi.fameArea.WINDURST) >= 3 and
+                player:getMainLvl() >= 10 -- Level requirement added in the March 8, 2007 update: https://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html
         end,
 
         [xi.zone.WINDURST_WATERS] =

--- a/scripts/zones/Selbina/DefaultActions.lua
+++ b/scripts/zones/Selbina/DefaultActions.lua
@@ -1,6 +1,7 @@
 -- local ID = zones[xi.zone.SELBINA]
 
 return {
+    ['Abelard']      = { event = 1130 },
     ['Battal']       = { event = 1102 },
     ['Elfriede']     = { event = 25 },
     ['Devean']       = { event = 124 },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR corrects a handful of quests that either had incorrect level requirements or were missing level requirements. In the [March 2007 version update](https://www.playonline.com/pcd/update/ff11us/20070308c2bbd1/detail.html), multiple quests had level requirements added to them. These requirements still exist on retail [per captures](https://youtu.be/iowvTWqwksE) from a few days ago. Many quests already had the correct level requirements, but this PR makes the following corrections:


| Quest | Before | After |
|---|---|---|
| The Rumor | Lv10 | Lv5 |
| Making the Grade | none | Lv10 |
| An Explorer's Footsteps | none | Lv10 |

The other quests from the patch notes (Intermediate Teamwork, Healing the Land, Altana's Sorrow, Curses Foiled A-Golem, Acting in Good Faith, Know One's Onions, Stop Your Whining, Secret of the Damp Scroll, The Sahagin's Stash, It's Not Your Vault) already have the correct requirements and were not touched.

## Steps to test these changes

Do the quests. See they have the above level requirements per retail and JP wiki.
