### PR TITLE
[lua] ROTZ Tales' Beginning Implementation

### DIFF
--- a/scripts/missions/rotz/01_The_New_Frontier.lua
+++ b/scripts/missions/rotz/01_The_New_Frontier.lua
@@ -6,6 +6,11 @@
 -- !addmission 3 0
 -- !setrank <name> 6
 -- Norg : !zone 252
+-- Tales' Beginning : !pos -25.784 1.097 -40.953 252
+-----------------------------------
+-- Zoning in at rank 6 plays event 1 as a short notice with a choice to watch the cutscene now or later.
+-- Later reveals the Tales' Beginning at H-9 (event 293), which replays event 1 as the full cutscene.
+-- The [ROZ]TalesBeginning charVar feeds the postponed-storyline bits in the mission log packet.
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.ZILART, xi.mission.id.zilart.THE_NEW_FRONTIER)
@@ -26,14 +31,61 @@ mission.sections =
 
         [xi.zone.NORG] =
         {
-            onZoneIn = function(player, prevZone)
-                return 1
+            ['Tales_Beginning'] =
+            {
+                onTrigger = function(player, npc)
+                    return mission:progressEvent(293, 0, 0, 838927106, 157421318, 0, 4457218, 292556943, 0)
+                end,
+            },
+
+            afterZoneIn = function(player)
+                local norgID = zones[xi.zone.NORG]
+
+                if player:getCharVar('[ROZ]TalesBeginning') == 0 then
+                    return mission:progressEvent(1, 5, 0, 1751, 292583557, 1615226948, 424215298, 21487749, 8262)
+                else
+                    player:enableEntities({ norgID.npc.TALES_BEGINNING, norgID.npc.TALES_BEGINNING - 1 })
+                end
             end,
+
+            onEventUpdate =
+            {
+                [1] = function(player, csid, option, npc)
+                    if player:getCharVar('[ROZ]TalesBeginning') == 0 then
+                        -- The reply picks the short notice over the full cutscene.
+                        player:updateEvent(79, VanadielTime(), 0, 0, 0, utils.MAX_UINT32, 9044486, 0)
+                    else
+                        -- The reply picks the full cutscene.
+                        player:updateEvent(65, 0, 838927106, 1, 0, 4457218, 292556943, 0)
+                    end
+                end,
+            },
 
             onEventFinish =
             {
                 [1] = function(player, csid, option, npc)
-                    mission:complete(player)
+                    -- Maybe later. The storyline is postponed until started at the Tales' Beginning.
+                    if option == 0 and player:getCharVar('[ROZ]TalesBeginning') == 0 then
+                        local norgID = zones[xi.zone.NORG]
+
+                        player:setCharVar('[ROZ]TalesBeginning', 1)
+                        player:sendPartialMissionLog(xi.mission.log_id.ZILART, false)
+                        player:enableEntities({ norgID.npc.TALES_BEGINNING, norgID.npc.TALES_BEGINNING - 1 })
+                    -- The full cutscene played, at once (option 1) or from the Tales' Beginning.
+                    elseif option == 1 or option == 0 then
+                        if player:getCharVar('[ROZ]TalesBeginning') > 0 then
+                            player:setCharVar('[ROZ]TalesBeginning', 0)
+                            player:enableEntities({})
+                        end
+
+                        mission:complete(player)
+                    end
+                end,
+
+                [293] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:startEvent(1, 252, 0, 838927106, 1, 0, 4457218, 292556943, 0)
+                    end
                 end,
             },
         },

--- a/scripts/tests/missions/rotz.lua
+++ b/scripts/tests/missions/rotz.lua
@@ -14,7 +14,24 @@ describe('Rise of the Zilart', function()
 
             -- After defeating the Shadow Lord and gaining rank 6, head to Norg for a cut-scene.
             player:gotoZone(xi.zone.NORG)
+            player.events:expect({ eventId = 1, finishOption = 1 }) -- Yes (View cutscene).
+            player.assert:hasKI(xi.ki.MAP_OF_NORG)
+            player.assert:hasMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.WELCOME_TNORG)
+        end)
+
+        it('should complete ZM1 after postponing it to the Tales\' Beginning', function()
+            player:addMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.THE_NEW_FRONTIER)
+            player:setRank(6)
+
+            -- Choosing "Maybe later" postpones the storyline instead of completing it.
+            player:gotoZone(xi.zone.NORG)
+            player.events:expect({ eventId = 1, finishOption = 0 }) -- Maybe later.
+            player.assert:hasMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.THE_NEW_FRONTIER)
+
+            -- Examine the Tales' Beginning at H-9 to start the storyline.
+            player.entities:gotoAndTrigger('Tales_Beginning', { eventId = 293, finishOption = 1 })
             player.events:expect({ eventId = 1 })
+            player.assert:hasKI(xi.ki.MAP_OF_NORG)
             player.assert:hasMission(xi.mission.log_id.ZILART, xi.mission.id.zilart.WELCOME_TNORG)
         end)
 

--- a/scripts/zones/Norg/IDs.lua
+++ b/scripts/zones/Norg/IDs.lua
@@ -54,6 +54,7 @@ zones[xi.zone.NORG] =
     },
     npc =
     {
+        TALES_BEGINNING = GetFirstID('Tales_Beginning'), -- ZM1 mission script uses this
     },
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implements the Tales' Beginning for Rise of the Zilart Missions based on retail captures.

## Steps to test these changes

Set yourself to Rank 6 and add ZM 1. Zone into Norg. See the option to skip CS and watch it later. See that the Tales' Beginning spawns in Norg.

## Captures

Valentine

https://www.youtube.com/watch?v=pnPE_tlHqUs

https://drive.google.com/file/d/1mwYl9kNdMW4m1NtRg5ihMpM5RxALRPid/view?usp=sharing
