### PR TITLE
[module] [lua] COR AF2 Era Module

### DIFF
--- a/modules/era/lua/quests/ahturhgan/navigating_the_unfriendly_seas.lua
+++ b/modules/era/lua/quests/ahturhgan/navigating_the_unfriendly_seas.lua
@@ -1,0 +1,29 @@
+-----------------------------------
+-- Navigating the Unfriendly Seas (COR AF2)
+-- Restores the JST midnight wait before the Leypoint finishes with the hydrogauge.
+-- The June 7, 2016 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_navigating_the_unfriendly_seas', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/COR_AF2_Navigating_the_Unfriendly_Seas', function(quest)
+        local wajaom    = quest.sections[2][xi.zone.WAJAOM_WOODLANDS]
+        local baseTrade = wajaom['Leypoint'].onTrade
+
+        -- The Leypoint finishes measuring at JST midnight.
+        wajaom['Leypoint'].onTrade = function(player, npc, trade)
+            local action = baseTrade(player, npc, trade)
+            if action then
+                quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+            end
+
+            return action
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR restores the JST midnight wait for COR AF2 which was removed in the [June 7, 2016 version update](https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update).

## Steps to test these changes

Load the module. See you must wait until JST midnight instead of one minute.