### PR TITLE
[Conquest] Fix impossible to meet bit condition and minor cleanup of the conquest messaging

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1834,49 +1834,68 @@ end
 -- Helper method for sendConquestTallyUpdateMessage and sendConquestTallyEndMessage
 xi.conquest.sendBalanceOfPowerMessage = function(player, messageBase, ranking, isConquestAlliance)
     local offset = 0
-    if bit.band(ranking, 0x03) == 0x01 then
-        offset = offset + 7 -- 7
-        if bit.band(ranking, 0x30) == 0x10 then
-            offset = offset + 1 -- 8
-            if bit.band(ranking, 0x0C) == 0x0C then
-                offset = offset + 1 -- 9
+
+    -- Get specific nation masks, which translates to the concrete nation ranking.
+    local rankingSandoria = bit.rshift(bit.band(ranking, 0x03), 0) -- Bits 1 and 2.
+    local rankingBastok   = bit.rshift(bit.band(ranking, 0x0C), 2) -- Bits 3 and 4.
+    local rankingWindurst = bit.rshift(bit.band(ranking, 0x30), 4) -- Bits 5 and 6.
+
+    -- Sandoria in first place.
+    if rankingSandoria == 1 then
+        offset = offset + 7         -- Global balance of power: 1st: San d'Oria 2nd: Windurst 3rd: Bastok
+
+        -- Windurst also in 1st place.
+        if rankingWindurst == 1 then
+            offset = offset + 1     -- All three nations are tied for first place.
+            if rankingBastok == 3 then
+                offset = offset + 1 -- Global balance of power: 1st: San d'Oria and Windurst (tie) 3rd: Bastok
             end
-        elseif bit.band(ranking, 0x0C) == 0x08 then
-            offset = offset + 3 -- 10
-            if bit.band(ranking, 0x30) == 0x30 then
-                offset = offset + 1 -- 11
+        -- Bastok in 2nd place.
+        elseif rankingBastok == 2 then
+            offset = offset + 3     -- Global balance of power: 1st: San d'Oria 2nd: Bastok and Windurst (tie)
+            if rankingWindurst == 3 then
+                offset = offset + 1 -- Global balance of power: 1st: San d'Oria 2nd: Bastok 3rd: Windurst
             end
-        elseif bit.band(ranking, 0x0C) == 0x04 then
-            offset = offset + 6 -- 13
+        -- Bastok also in 1st place.
+        elseif rankingBastok == 1 then
+            offset = offset + 6     -- Global balance of power: 1st: San d'Oria and Bastok (tie) 3rd: Windurst
         end
-    elseif bit.band(ranking, 0x0C) == 0x04 then
-        offset = offset + 15 -- 15
-        if bit.band(ranking, 0x30) == 0x02 then
-            offset = offset + 3 -- 18
-            if bit.band(ranking, 0x03) == 0x03 then
-                offset = offset + 1 -- 19
+
+    -- Bastok in first place.
+    elseif rankingBastok == 1 then
+        offset = offset + 15        -- Global balance of power: 1st: Bastok 2nd: San d'Oria 3rd: Windurst
+        -- Windurst in 2nd place.
+        if rankingWindurst == 2 then
+            offset = offset + 3     -- Global balance of power: 1st: Bastok 2nd: San d'Oria and Windurst (tie)
+            if rankingSandoria == 3 then
+                offset = offset + 1 -- Global balance of power: 1st: Bastok 2nd: Windurst 3rd: San d'Oria
             end
-        elseif bit.band(ranking, 0x30) == 0x10 then
-            offset = offset + 6 -- 21
+        -- Windurst also in 1st place.
+        elseif rankingWindurst == 1 then
+            offset = offset + 6     -- Global balance of power: 1st: Bastok and Windurst (tie) 3rd: San d'Oria
         end
-    elseif bit.band(ranking, 0x30) == 0x10 then
-        offset = offset + 23 -- 23
-        if bit.band(ranking, 0x0C) == 0x08 then
-            offset = offset + 3 -- 26
-            if bit.band(ranking, 0x30) == 0x30 then
-                offset = offset + 1 -- 27
+
+    -- Windurst in first place.
+    elseif rankingWindurst == 1 then
+        offset = offset + 23        -- Global balance of power: 1st: Windurst 2nd: San d'Oria 3rd: Bastok
+        -- Bastok in 2nd place.
+        if rankingBastok == 2 then
+            offset = offset + 3     -- Global balance of power: 1st: Windurst 2nd: San d'Oria and Bastok (tie)
+            if rankingSandoria == 3 then
+                offset = offset + 1 -- Global balance of power: 1st: Windurst 2nd: Bastok 3rd: San d'Oria
             end
         end
     end
 
     player:messageText(player, messageBase + offset, 5) -- Global balance of power:
 
+    -- If theres an alliance, it's between the 2 last nations. We use the nation in first place to determine it.
     if isConquestAlliance then
-        if bit.band(ranking, 0x03) == 0x01 then
+        if rankingSandoria == 1 then
             player:messageText(player, messageBase + 50, 5) -- Bastok and Windurst have formed an alliance.
-        elseif bit.band(ranking, 0x0C) == 0x04 then
+        elseif rankingBastok == 1 then
             player:messageText(player, messageBase + 51, 5) -- San d'Oria and Windurst have formed an alliance.
-        elseif bit.band(ranking, 0x30) == 0x10 then
+        elseif rankingWindurst == 1 then
             player:messageText(player, messageBase + 52, 5) -- San d'Oria and Bastok have formed an alliance.
         end
     end


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`bit.band(ranking, 0x30) == 0x02` can never be true. Assuming typo of 0x20, an actually possible result.

Thats how started. This whole thing was unreadable. So I rewrote it, of course.
- Fixes the original impossible condition.
- Fixes a case of dead code.
- Rewrote it to use nation rankings directly:
  - The bitmask is a 6 bit mask divided in 3 pairs, with each pair belonging to a nation.
  - Each pair is the actual ranking of the nation. So if we store the ranking, we dont have to do incomprehensible bit operations on every step.
- Actually paste the message returned instead of a fucking meaningless number, because i already know how to do basic math.

## Steps to test these changes

None. If something breaks I dont care.
