### PR TITLE
[module] [lua] Mog Safe Quest Fixes + Modules

### DIFF
--- a/modules/era/lua/quests/otherareas/give_a_moogle_a_break.lua
+++ b/modules/era/lua/quests/otherareas/give_a_moogle_a_break.lua
@@ -1,0 +1,42 @@
+-----------------------------------
+-- Give a Moogle a Break
+-- Restores the conquest tally wait before the Moogle offers the quest.
+-- Restores the JST midnight wait before the Moogle hands over the reward.
+-- The July 8, 2014 version update shortened both waits to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_give_a_moogle_a_break', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Give_a_Moogle_a_Break', function(quest)
+        -- Copy of the base check. The quest is offered at the next conquest tally.
+        quest.sections[1].check = function(player, status, vars)
+            local bedPlacedTime = quest:getVar(player, 'bedPlacedTime')
+
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                xi.moghouse.inMogHouseInHomeNation(player) and
+                player:getFameLevel(player:getNation()) >= 3 and
+                quest:getLocalVar(player, 'mustZone') == 0 and
+                quest:getLocalVar(player, 'questSeen') == 0 and
+                bedPlacedTime ~= 0 and
+                bedPlacedTime < NextConquestTally() - utils.days(7) -- Module change
+        end
+
+        -- Every Mog House zone shares one section table. A wrapper would run the base handler once per zone.
+        for _, zoneId in ipairs(xi.moghouse.moghouseZones) do
+            local section = quest.sections[2][zoneId]
+
+            -- Copy of the base handler. The reward is handed over at JST midnight.
+            section.onEventFinish[30007] = function(player, csid, option, npc)
+                player:tradeComplete()
+                quest:setVar(player, 'Prog', 1)
+                quest:setVar(player, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/otherareas/moogles_in_the_wild.lua
+++ b/modules/era/lua/quests/otherareas/moogles_in_the_wild.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- Moogles in the Wild
+-- Restores the conquest tally wait before the Moogle offers the quest.
+-- Restores the JST midnight wait before the Moogle hands over the reward.
+-- The July 8, 2014 version update shortened both waits to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_moogles_in_the_wild', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Moogles_in_the_Wild', function(quest)
+        -- Copy of the base check. The quest is offered at the next conquest tally.
+        quest.sections[1].check = function(player, status, vars)
+            local bedPlacedTime = quest:getVar(player, 'bedPlacedTime')
+
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC) and
+                xi.moghouse.inMogHouseInHomeNation(player) and
+                player:getFameLevel(player:getNation()) >= 7 and
+                quest:getLocalVar(player, 'mustZone') == 0 and
+                quest:getLocalVar(player, 'questSeen') == 0 and
+                bedPlacedTime ~= 0 and
+                bedPlacedTime < NextConquestTally() - utils.days(7) -- Module change
+        end
+
+        -- Every Mog House zone shares one section table. A wrapper would run the base handler once per zone.
+        for _, zoneId in ipairs(xi.moghouse.moghouseZones) do
+            local section = quest.sections[2][zoneId]
+
+            -- Copy of the base handler. The reward is handed over at JST midnight.
+            section.onEventFinish[30015] = function(player, csid, option, npc)
+                player:tradeComplete()
+                quest:setVar(player, 'Prog', 1)
+                quest:setVar(player, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/otherareas/the_moogles_picnic.lua
+++ b/modules/era/lua/quests/otherareas/the_moogles_picnic.lua
@@ -1,0 +1,43 @@
+-----------------------------------
+-- The Moogle's Picnic!
+-- Restores the conquest tally wait before the Moogle offers the quest.
+-- Restores the JST midnight wait before the Moogle hands over the reward.
+-- The July 8, 2014 version update shortened both waits to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_moogles_picnic', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/The_Moogles_Picnic', function(quest)
+        -- Copy of the base check. The quest is offered at the next conquest tally.
+        quest.sections[1].check = function(player, status, vars)
+            local bedPlacedTime = quest:getVar(player, 'bedPlacedTime')
+
+            return status == xi.questStatus.QUEST_AVAILABLE and
+                player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK) and
+                xi.moghouse.inMogHouseInHomeNation(player) and
+                player:getFameLevel(player:getNation()) >= 5 and
+                quest:getLocalVar(player, 'mustZone') == 0 and
+                quest:getLocalVar(player, 'questSeen') == 0 and
+                bedPlacedTime ~= 0 and
+                bedPlacedTime < NextConquestTally() - utils.days(7) -- Module change
+        end
+
+        -- Every Mog House zone shares one section table. A wrapper would run the base handler once per zone.
+        for _, zoneId in ipairs(xi.moghouse.moghouseZones) do
+            local section = quest.sections[2][zoneId]
+
+            -- Copy of the base handler. The reward is handed over at JST midnight.
+            section.onEventFinish[30011] = function(player, csid, option, npc)
+                player:tradeComplete()
+                quest:setVar(player, 'Prog', 1)
+                quest:setVar(player, 'Timer', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/scripts/items/bronze_bed.lua
+++ b/scripts/items/bronze_bed.lua
@@ -7,13 +7,13 @@ local itemObject = {}
 
 itemObject.onFurniturePlaced = function(player)
     if player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK) == xi.questStatus.QUEST_AVAILABLE then
-        player:setCharVar('Quest[4][100]bedPlacedTime', GetSystemTime())
-        player:setLocalVar('Quest[4][100]mustZone', 1)
+        xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK, 'bedPlacedTime', GetSystemTime())
+        xi.quest.setLocalVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK, 'mustZone', 1)
     end
 end
 
 itemObject.onFurnitureRemoved = function(player)
-    player:setCharVar('Quest[4][100]bedPlacedTime', 0)
+    xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK, 'bedPlacedTime', 0)
 end
 
 return itemObject

--- a/scripts/items/mahogany_bed.lua
+++ b/scripts/items/mahogany_bed.lua
@@ -7,13 +7,13 @@ local itemObject = {}
 
 itemObject.onFurniturePlaced = function(player)
     if player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC) == xi.questStatus.QUEST_AVAILABLE then
-        player:setCharVar('Quest[4][101]bedPlacedTime', GetSystemTime())
-        player:setLocalVar('Quest[4][101]mustZone', 1)
+        xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC, 'bedPlacedTime', GetSystemTime())
+        xi.quest.setLocalVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC, 'mustZone', 1)
     end
 end
 
 itemObject.onFurnitureRemoved = function(player)
-    player:setCharVar('Quest[4][101]bedPlacedTime', 0)
+    xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC, 'bedPlacedTime', 0)
 end
 
 return itemObject

--- a/scripts/items/nobles_bed.lua
+++ b/scripts/items/nobles_bed.lua
@@ -7,13 +7,13 @@ local itemObject = {}
 
 itemObject.onFurniturePlaced = function(player)
     if player:getQuestStatus(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.MOOGLES_IN_THE_WILD) == xi.questStatus.QUEST_AVAILABLE then
-        player:setCharVar('Quest[4][102]bedPlacedTime', GetSystemTime())
-        player:setLocalVar('Quest[4][102]mustZone', 1)
+        xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.MOOGLES_IN_THE_WILD, 'bedPlacedTime', GetSystemTime())
+        xi.quest.setLocalVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.MOOGLES_IN_THE_WILD, 'mustZone', 1)
     end
 end
 
 itemObject.onFurnitureRemoved = function(player)
-    player:setCharVar('Quest[4][102]bedPlacedTime', 0)
+    xi.quest.setVar(player, xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.MOOGLES_IN_THE_WILD, 'bedPlacedTime', 0)
 end
 
 return itemObject

--- a/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
+++ b/scripts/quests/otherAreas/Give_a_Moogle_a_Break.lua
@@ -12,7 +12,7 @@ quest.reward =
     title = xi.title.MOGS_KIND_MASTER,
 }
 
--- Since there are so many zones with interactions:
+-- Every Mog House zone shares one section table.
 quest.sections = {}
 
 quest.sections[1] =
@@ -23,7 +23,7 @@ quest.sections[1] =
         return status == xi.questStatus.QUEST_AVAILABLE and
             xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 3 and
-            not quest:getMustZone(player) and
+            quest:getLocalVar(player, 'mustZone') == 0 and
             quest:getLocalVar(player, 'questSeen') == 0 and
             bedPlacedTime ~= 0 and
             GetSystemTime() > bedPlacedTime + 60
@@ -65,7 +65,7 @@ local questAccepted =
     ['Moogle'] =
     {
         onTrade = function(player, npc, trade)
-            if npcUtil.tradeHasExactly(trade, { xi.item.POWER_BOW, xi.item.BEETLE_RING }) then
+            if npcUtil.tradeMatches(trade, { { xi.item.POWER_BOW, 1 }, { xi.item.BEETLE_RING, 1 } }) then
                 return quest:progressEvent(30007)
             end
         end,
@@ -96,7 +96,7 @@ local questAccepted =
         end,
 
         [30007] = function(player, csid, option, npc)
-            player:confirmTrade()
+            player:tradeComplete()
             quest:setVar(player, 'Prog', 1)
             quest:setVar(player, 'Timer', GetSystemTime() + 60)
         end,

--- a/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
+++ b/scripts/quests/otherAreas/Moogles_in_the_Wild.lua
@@ -12,7 +12,7 @@ quest.reward =
     title = xi.title.MOGS_LOVING_MASTER,
 }
 
--- Since there are so many zones with interactions:
+-- Every Mog House zone shares one section table.
 quest.sections = {}
 
 quest.sections[1] =
@@ -24,7 +24,7 @@ quest.sections[1] =
             player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.THE_MOOGLE_PICNIC) and
             xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 7 and
-            not quest:getMustZone(player) and
+            quest:getLocalVar(player, 'mustZone') == 0 and
             quest:getLocalVar(player, 'questSeen') == 0 and
             bedPlacedTime ~= 0 and
             GetSystemTime() > bedPlacedTime + 60
@@ -66,7 +66,7 @@ local questAccepted =
     ['Moogle'] =
     {
         onTrade = function(player, npc, trade)
-            if npcUtil.tradeHasExactly(trade, { xi.item.RAPTOR_MANTLE, xi.item.WOOL_HAT }) then
+            if npcUtil.tradeMatches(trade, { { xi.item.RAPTOR_MANTLE, 1 }, { xi.item.WOOL_HAT, 1 } }) then
                 return quest:progressEvent(30015)
             end
         end,
@@ -97,7 +97,7 @@ local questAccepted =
         end,
 
         [30015] = function(player, csid, option, npc)
-            player:confirmTrade()
+            player:tradeComplete()
             quest:setVar(player, 'Prog', 1)
             quest:setVar(player, 'Timer', GetSystemTime() + 60)
         end,

--- a/scripts/quests/otherAreas/The_Moogles_Picnic.lua
+++ b/scripts/quests/otherAreas/The_Moogles_Picnic.lua
@@ -12,7 +12,7 @@ quest.reward =
     title = xi.title.MOGS_EXCEPTIONALLY_KIND_MASTER,
 }
 
--- Since there are so many zones with interactions:
+-- Every Mog House zone shares one section table.
 quest.sections = {}
 
 quest.sections[1] =
@@ -24,7 +24,7 @@ quest.sections[1] =
             player:hasCompletedQuest(xi.questLog.OTHER_AREAS, xi.quest.id.otherAreas.GIVE_A_MOOGLE_A_BREAK) and
             xi.moghouse.inMogHouseInHomeNation(player) and
             player:getFameLevel(player:getNation()) >= 5 and
-            not quest:getMustZone(player) and
+            quest:getLocalVar(player, 'mustZone') == 0 and
             quest:getLocalVar(player, 'questSeen') == 0 and
             bedPlacedTime ~= 0 and
             GetSystemTime() > bedPlacedTime + 60
@@ -66,7 +66,7 @@ local questAccepted =
     ['Moogle'] =
     {
         onTrade = function(player, npc, trade)
-            if npcUtil.tradeHasExactly(trade, { xi.item.SHRIMP_LURE, xi.item.STICK_OF_SELBINA_BUTTER }) then
+            if npcUtil.tradeMatches(trade, { { xi.item.SHRIMP_LURE, 1 }, { xi.item.STICK_OF_SELBINA_BUTTER, 1 } }) then
                 return quest:progressEvent(30011)
             end
         end,
@@ -97,7 +97,7 @@ local questAccepted =
         end,
 
         [30011] = function(player, csid, option, npc)
-            player:confirmTrade()
+            player:tradeComplete()
             quest:setVar(player, 'Prog', 1)
             quest:setVar(player, 'Timer', GetSystemTime() + 60)
         end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes a few outdated pieces of code with the mog safe expansion quests and adds era modules restoring the JST midnight and Conquest Tally waits. The timers were changed in the [July 8, 2014 version update](https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update).

## Steps to test these changes

Do the quests without the module on and see you can chain them because retail wait times are only 60 seconds. Then turn on the modules and see your wait times are much longer.
