### PR TITLE
[core] Stop status effects reverting to their original duration and power on zone

### DIFF
--- a/scripts/tests/systems/effects/zone_persistence.lua
+++ b/scripts/tests/systems/effects/zone_persistence.lua
@@ -1,0 +1,47 @@
+-- Zoning in clears the pending-persist flag, so anything that changes afterwards has to re-flag the character or the next zone reloads the stale row.
+describe('Status effect persistence across zoning', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.WAR,
+                level = 75,
+                zone  = xi.zone.SOUTHERN_SAN_DORIA,
+            })
+
+        -- char_effects rows outlive the test, and a leftover effect dirties the flag for us
+        player:delStatusEffect(xi.effect.PROTECT)
+        player:delStatusEffect(xi.effect.DEDICATION)
+    end)
+
+    it('carries the remaining duration, not the original', function()
+        player:addStatusEffect(xi.effect.PROTECT, { power = 50, duration = 1800, origin = player })
+        player:gotoZone(xi.zone.EAST_RONFAURE)
+
+        xi.test.world:skipTime(600)
+        player:gotoZone(xi.zone.SOUTHERN_SAN_DORIA)
+
+        local protect = player:getStatusEffect(xi.effect.PROTECT)
+        assert(protect ~= nil, 'Protect should survive zoning')
+
+        local remaining = protect:getTimeRemaining() / 1000
+        assert(remaining > 1100 and remaining <= 1200,
+            'expected ~1200s left after 600s elapsed, got ' .. tostring(remaining))
+    end)
+
+    it('carries a subPower changed after the effect was gained', function()
+        player:addStatusEffect(xi.effect.DEDICATION, { power = 30, subPower = 2500, duration = 3600, origin = player })
+        player:gotoZone(xi.zone.EAST_RONFAURE)
+
+        player:getStatusEffect(xi.effect.DEDICATION):setSubPower(1200)
+        xi.test.world:skipTime(600)
+        player:gotoZone(xi.zone.SOUTHERN_SAN_DORIA)
+
+        local dedication = player:getStatusEffect(xi.effect.DEDICATION)
+        assert(dedication ~= nil, 'Dedication should survive zoning')
+        assert(dedication:getSubPower() == 1200,
+            'expected the spent cap to persist, got ' .. tostring(dedication:getSubPower()))
+    end)
+end)

--- a/src/map/persist_batch.cpp
+++ b/src/map/persist_batch.cpp
@@ -130,6 +130,9 @@ void persist::flush(CCharEntity* PChar, const IsLogout logout)
 
     PChar->StatusEffectContainer->DropEffectsForTransition(logout);
 
+    // durations tick down without anything flagging the character, so rewrite them on the way out
+    PChar->setPersist(CharPersist::Effects);
+
     PersistBatch batch;
     batch.add(PChar, logout);
 

--- a/src/map/status_effect.cpp
+++ b/src/map/status_effect.cpp
@@ -21,6 +21,7 @@
 
 #include "status_effect.h"
 #include "entities/battle_entity.h"
+#include "entities/char_entity.h"
 
 #include "status_effect_container.h"
 #include <utility>
@@ -75,6 +76,14 @@ auto CStatusEffect::GetName() const -> const std::string&
 auto CStatusEffect::SetOwner(CBattleEntity* owner) -> void
 {
     owner_ = owner;
+}
+
+auto CStatusEffect::MarkPersistDirty() const -> void
+{
+    if (owner_ != nullptr && owner_->objtype == TYPE_PC)
+    {
+        static_cast<CCharEntity*>(owner_)->setPersist(CharPersist::Effects);
+    }
 }
 
 auto CStatusEffect::GetStatusID() const -> xi::StatusEffect
@@ -170,16 +179,19 @@ auto CStatusEffect::GetStartTime() const -> timer::time_point
 auto CStatusEffect::SetEffectFlags(xi::StatusEffectFlag flags) -> void
 {
     flags_ = flags;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::AddEffectFlag(xi::StatusEffectFlag flag) -> void
 {
     flags_ |= flag;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::DelEffectFlag(xi::StatusEffectFlag flag) -> void
 {
     flags_ &= ~flag;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::HasEffectFlag(xi::StatusEffectFlag flag) const -> bool
@@ -196,6 +208,7 @@ auto CStatusEffect::SetIcon(uint16 icon) -> void
     }
 
     icon_ = icon;
+    MarkPersistDirty();
     owner_->StatusEffectContainer->UpdateStatusIcons();
 }
 
@@ -214,11 +227,13 @@ auto CStatusEffect::SetSource(uint16 sourceType, uint32 sourceTypeParam) -> void
 {
     sourceType_      = sourceType;
     sourceTypeParam_ = sourceTypeParam;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetOriginID(uint32 originID) -> void
 {
     originID_ = originID;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetEffectType(uint16 type) -> void
@@ -234,32 +249,38 @@ auto CStatusEffect::SetEffectSlot(uint8 slot) -> void
 auto CStatusEffect::SetPower(uint16 power) -> void
 {
     power_ = power;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetSubPower(uint16 subPower) -> void
 {
     subPower_ = subPower;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetTier(uint16 tier) -> void
 {
     tier_ = tier;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetDuration(timer::duration duration) -> void
 {
     duration_ = duration;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetStartTime(timer::time_point startTime) -> void
 {
     tickCount_ = 0;
     startTime_ = startTime;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::SetTickTime(timer::duration tick) -> void
 {
     tickTime_ = tick;
+    MarkPersistDirty();
 }
 
 auto CStatusEffect::IncrementElapsedTickCount() -> void

--- a/src/map/status_effect.h
+++ b/src/map/status_effect.h
@@ -111,6 +111,9 @@ public:
     auto isDeleted() const -> bool;
 
 private:
+    // flags the owner for persistence after a change to a column we write to char_effects
+    auto MarkPersistDirty() const -> void;
+
     CBattleEntity* owner_{ nullptr };
 
     std::vector<CModifier> modList_;          // List of modifiers

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3100,6 +3100,11 @@ bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker)
     {
         PDefender->setModifier(modShadow, --Shadow);
 
+        if (PDefender->objtype == TYPE_PC)
+        {
+            static_cast<CCharEntity*>(PDefender)->setPersist(CharPersist::Effects);
+        }
+
         if (Shadow == 0)
         {
             switch (modShadow)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Fixes 2 things I missed in the original implementation:
- Persist changes to buffs whose subpower has changed (Dedication, Stoneskin among others) during the periodic sweep
- Write updated changes on zone out

Closes #11143 

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
