### PR TITLE
[core] Roam/Spawn regions support

### DIFF
--- a/src/map/CMakeLists.txt
+++ b/src/map/CMakeLists.txt
@@ -134,6 +134,8 @@ set(MAP_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/recast_container.h
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/roe.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/roam_region.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/roam_region.h
     ${CMAKE_CURRENT_SOURCE_DIR}/socket.h
     ${CMAKE_CURRENT_SOURCE_DIR}/spatial_grid.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/spatial_grid.h

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -37,6 +37,7 @@
 #include "mobskill.h"
 #include "party.h"
 #include "recast_container.h"
+#include "roam_region.h"
 #include "spawn_handler.h"
 #include "status_effect_container.h"
 #include "utils/battleutils.h"
@@ -667,7 +668,7 @@ auto CMobController::ShouldCloseToTarget(const float currentDistance) -> bool
     }
 
     // Spawn leash: don't chase past the configured tether distance.
-    if (PMob->getMobMod(xi::MobMod::SpawnLeash) > 0 && distance(PMob->loc.p, PMob->m_SpawnPoint) > PMob->getMobMod(xi::MobMod::SpawnLeash))
+    if (PMob->getMobMod(xi::MobMod::SpawnLeash) > 0 && PMob->DistanceFromHome() > PMob->getMobMod(xi::MobMod::SpawnLeash))
     {
         return false;
     }
@@ -1694,9 +1695,20 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
             {
                 PMob->m_IsPathingHome = true;
 
-                if (!PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->PathTo(PMob->m_SpawnPoint))
+                // heading home means the nearest edge of the region, not the spot it happened to spawn on
+                const auto homePoint = [&]
                 {
-                    PMob->PAI->PathFind->PathInRange(PMob->m_SpawnPoint, PMob->m_maxRoamDistance, PATHFLAG_RUN);
+                    if (PMob->roamRegion())
+                    {
+                        return PMob->roamRegion()->closestPoint(PMob->loc.p);
+                    }
+
+                    return PMob->m_SpawnPoint;
+                }();
+
+                if (!PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->PathTo(homePoint))
+                {
+                    PMob->PAI->PathFind->PathInRange(homePoint, PMob->m_maxRoamDistance, PATHFLAG_RUN);
                 }
 
                 // Cap the path so we re-evaluate every few seconds instead of bee-lining home.
@@ -1791,8 +1803,7 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
                     luautils::OnMobRoamAction(PMob);
                     m_LastActionTime = m_Tick;
                 }
-                else if (!isWormSurfacing &&
-                         PMob->PAI->PathFind->RoamAround(PMob->m_SpawnPoint, PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(xi::MobMod::RoamTurns)), PMob->m_roamFlags))
+                else if (!isWormSurfacing && PMob->PAI->PathFind->RoamAround(PMob->GetRoamAnchor(), PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(xi::MobMod::RoamTurns)), PMob->m_roamFlags, PMob->roamRegion()))
                 {
                     if ((PMob->m_roamFlags & xi::RoamFlag::Stealth) != xi::RoamFlag::None)
                     {
@@ -1886,7 +1897,7 @@ void CMobController::FollowRoamPath()
         }
 
         // Snap to spawn rotation after pathing home, for mobs that must face a fixed direction.
-        if (PMob->getMobMod(xi::MobMod::RoamResetFacing) && distance(PMob->loc.p, PMob->m_SpawnPoint) <= PMob->m_maxRoamDistance)
+        if (PMob->getMobMod(xi::MobMod::RoamResetFacing) && PMob->DistanceFromHome() <= PMob->m_maxRoamDistance)
         {
             PMob->loc.p.rotation = PMob->m_SpawnPoint.rotation;
         }

--- a/src/map/ai/helpers/pathfind/path_builder.cpp
+++ b/src/map/ai/helpers/pathfind/path_builder.cpp
@@ -21,6 +21,8 @@
 
 #include <map/ai/helpers/pathfind/path_builder.h>
 
+#include <map/roam_region.h>
+
 #include <common/utils.h>
 #include <common/xirand.h>
 
@@ -87,14 +89,34 @@ auto NavPathBuilder::findPath(const position_t& start, const position_t& end) co
     return result;
 }
 
-auto NavPathBuilder::findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns) const -> Maybe<std::vector<position_t>>
+auto NavPathBuilder::findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>
 {
     const auto desiredTurnCount = static_cast<uint8_t>(xirand::GetRandomNumber<uint32>(maxTurns) + 1);
 
+    std::vector<position_t> turnPoints;
+
+    // A region samples its own points, already at the requested distance and on the mesh, and retries internally.
+    // Each turn continues from the one before it, so the mob walks across the region instead of circling its starting point.
+    if (region)
+    {
+        auto from = start;
+        for (int i = 0; i < desiredTurnCount; ++i)
+        {
+            const auto candidate = region->randomPointAt(from, maxRadius, &navMesh_);
+            if (!candidate)
+            {
+                break;
+            }
+
+            turnPoints.emplace_back(*candidate);
+            from = *candidate;
+        }
+
+        return turnPoints;
+    }
+
     // Seemingly arbitrary divisor: navmesh polys are dense enough that the query saturates regardless.
     const float maxRadiusForPolyQuery = maxRadius / 10.0f;
-
-    std::vector<position_t> turnPoints;
 
     // Allow up to 2x attempts, since findRandomPosition may return a poly outside `maxRadius`.
     const int maxAttempts = desiredTurnCount * 2;

--- a/src/map/ai/helpers/pathfind/path_builder.h
+++ b/src/map/ai/helpers/pathfind/path_builder.h
@@ -29,6 +29,8 @@
 #include <common/types/maybe.h>
 #include <vector>
 
+class RoamRegion;
+
 namespace pathfind
 {
 
@@ -42,7 +44,8 @@ public:
     auto findPath(const position_t& start, const position_t& end) const -> Maybe<PathResult>;
 
     // Pick 1..maxTurns roam destinations within `maxRadius`, or nullopt on hard navmesh failure.
-    auto findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns) const -> Maybe<std::vector<position_t>>;
+    // With a region, destinations are sampled from it instead of the disc around `start`.
+    auto findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>;
 
 private:
     NavMesh& navMesh_;

--- a/src/map/ai/helpers/pathfind/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind/pathfind.cpp
@@ -89,7 +89,7 @@ auto CPathFind::PathToImpl(const position_t& point, uint8 pathFlags) -> bool
     return found;
 }
 
-auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags) -> bool
+auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
 {
     TracyZoneScoped;
     TracyZoneString(owner_->name());
@@ -98,7 +98,7 @@ auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
 
     roamFlags_ = roamFlags;
 
-    if (FindRandomPath(point, maxRadius, maxTurns, roamFlags))
+    if (FindRandomPath(point, maxRadius, maxTurns, roamFlags, region))
     {
         return true;
     }
@@ -409,14 +409,14 @@ auto CPathFind::BuildDirectPath(const position_t& end) -> bool
     return true;
 }
 
-auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags) -> bool
+auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
 {
     TracyZoneScoped;
     TracyZoneString(owner_->name());
 
     const pathfind::NavPathBuilder builder{ navMesh() };
 
-    auto turnPoints = builder.findRoamTurnPoints(start, maxRadius, maxTurns);
+    auto turnPoints = builder.findRoamTurnPoints(start, maxRadius, maxTurns, region);
     if (!turnPoints)
     {
         // Hard navmesh failure - bail rather than partially populate the turn list.

--- a/src/map/ai/helpers/pathfind/pathfind.h
+++ b/src/map/ai/helpers/pathfind/pathfind.h
@@ -37,6 +37,7 @@
 
 class CBaseEntity;
 class NavMesh;
+class RoamRegion;
 
 namespace pathfind
 {
@@ -56,8 +57,8 @@ public:
 
     ~CPathFind();
 
-    // Walk to a random point around the given point.
-    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags = xi::RoamFlag::None) -> bool;
+    // Walk to a random point around the given point, or inside the region when the owner has one.
+    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags = xi::RoamFlag::None, const RoamRegion* region = nullptr) -> bool;
 
     // Find and walk to the given point.
     auto PathTo(const position_t& point, uint8 pathFlags = 0) -> bool;
@@ -133,7 +134,7 @@ private:
     auto BuildDirectPath(const position_t& end) -> bool;
 
     // Find a random path around the given point.
-    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags) -> bool;
+    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool;
 
     // Core of StepTo, settling `stopShort` yalms short of `pos`.
     auto StepToInternal(const position_t& pos, bool run, float stopShort) -> void;

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -42,6 +42,7 @@
 #include "packets/pet_sync.h"
 #include "packets/s2c/0x029_battle_message.h"
 #include "recast_container.h"
+#include "roam_region.h"
 #include "roe.h"
 #include "spawn_slot.h"
 #include "status_effect_container.h"
@@ -360,7 +361,47 @@ bool CMobEntity::CanRoamHome()
         return true;
     }
 
-    return distance(m_SpawnPoint, loc.p) < roam_home_distance;
+    // a mob that left its region does not walk back, it despawns and respawns somewhere inside
+    if (roamRegion_)
+    {
+        return false;
+    }
+
+    return DistanceFromHome() < roam_home_distance;
+}
+
+auto CMobEntity::GetRoamAnchor() const -> position_t
+{
+    // inside a region it wanders on from where it stands, so it covers the whole thing instead of a disc around one spot
+    if (roamRegion_)
+    {
+        return loc.p;
+    }
+
+    return m_SpawnPoint;
+}
+
+auto CMobEntity::roamRegion() const -> const RoamRegion*
+{
+    return roamRegion_;
+}
+
+void CMobEntity::setRoamRegion(const RoamRegion* region)
+{
+    roamRegion_ = region;
+
+    // a region has no leeway: its edge is the limit, so nothing outside counts as home
+    m_maxRoamDistance = 0.0f;
+}
+
+auto CMobEntity::DistanceFromHome() const -> float
+{
+    if (roamRegion_)
+    {
+        return roamRegion_->distanceOutside(loc.p);
+    }
+
+    return distance(loc.p, m_SpawnPoint);
 }
 
 bool CMobEntity::CanRoam()
@@ -460,7 +501,7 @@ bool CMobEntity::CanDeaggro() const
 
 bool CMobEntity::IsFarFromHome()
 {
-    return distance(loc.p, m_SpawnPoint) > m_maxRoamDistance;
+    return DistanceFromHome() > m_maxRoamDistance;
 }
 
 bool CMobEntity::CanBeNeutral() const
@@ -714,7 +755,21 @@ void CMobEntity::Spawn()
     mobutils::CalculateMobStats(this);
     mobutils::GetAvailableSpells(this);
 
-    // spawn somewhere around my point
+    // region mobs pick a fresh spawn point every life, and m_SpawnPoint keeps it for the point-based checks
+    if (roamRegion_ && loc.zone)
+    {
+        if (const auto point = roamRegion_->randomPoint(loc.zone->navMesh()))
+        {
+            m_SpawnPoint.x = point->x;
+            m_SpawnPoint.y = point->y;
+            m_SpawnPoint.z = point->z;
+        }
+        else
+        {
+            ShowWarningFmt("Mob {} ({}): roam region has no walkable point to spawn on", name, id);
+        }
+    }
+
     loc.p = m_SpawnPoint;
 
     if ((m_roamFlags & xi::RoamFlag::Stealth) != xi::RoamFlag::None)

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -44,6 +44,7 @@ enum class MsgBasic : uint16_t;
 class CMobSpellContainer;
 class CMobSpellList;
 class CEnmityContainer;
+class RoamRegion;
 class SpawnSlot;
 
 // Per-mob spawn window in Vana'diel hours; the mob spawns only within [spawnHour, despawnHour) (wraps past midnight).
@@ -72,6 +73,11 @@ public:
 
     bool IsFarFromHome();      // check if mob is too far from spawn
     bool CanBeNeutral() const; // check if mob can have killing pause
+
+    auto DistanceFromHome() const -> float;       // how far it strayed: outside its roam region, or from its spawn point when it has none
+    auto GetRoamAnchor() const -> position_t;     // the point roaming is measured from
+    void setRoamRegion(const RoamRegion* region); // assigning a region drops m_maxRoamDistance to 0: its edge is the limit
+    auto roamRegion() const -> const RoamRegion*;
 
     bool shouldUseTPMove(uint16 tpThreshold); // return true to use a TP move, checked on on 400ms tick interval
 
@@ -242,6 +248,7 @@ private:
     static constexpr float                roam_home_distance{ 60.f };
     SpawnSlot*                            spawnSlot = nullptr;
     Maybe<SpawnWindow>                    spawnWindow_;
+    const RoamRegion*                     roamRegion_{ nullptr }; // area it spawns and roams in, owned by the zone
 };
 
 #endif

--- a/src/map/roam_region.cpp
+++ b/src/map/roam_region.cpp
@@ -1,0 +1,320 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "roam_region.h"
+
+#include "navmesh/navmesh.h"
+
+#include <common/tracy.h>
+#include <common/xirand.h>
+
+// Detour for the vector math only
+#include <DetourCommon.h>
+
+#include <mapbox/earcut.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numbers>
+#include <ranges>
+
+// earcut wants 2D points
+namespace mapbox::util
+{
+
+template <>
+struct nth<0, Vector3>
+{
+    static auto get(const Vector3& vertex) -> float
+    {
+        return vertex.x;
+    }
+};
+
+template <>
+struct nth<1, Vector3>
+{
+    static auto get(const Vector3& vertex) -> float
+    {
+        return vertex.z;
+    }
+};
+
+} // namespace mapbox::util
+
+namespace
+{
+
+// samples a roam query takes before giving up on finding a walkable point
+constexpr uint8 kSampleAttempts = 8;
+
+// the load-time check runs once, so it can try much harder before writing a region off
+constexpr uint8 kValidationSamples = 64;
+
+// how far a snap may move a point before it counts as a different point
+constexpr float kSnapTolerance = 2.5f;
+
+// how far short of the target a walk may stop and still count as reaching it
+constexpr float kShortfallTolerance = 2.5f;
+
+// the only place the triangulator is named. it returns a flat triangle list indexing the rings concatenated in order
+auto triangulate(const std::vector<RoamRegion::Ring>& rings) -> std::vector<uint32>
+{
+    return mapbox::earcut<uint32>(rings);
+}
+
+auto signedArea(const Vector3& a, const Vector3& b, const Vector3& c) -> float
+{
+    return (b.x - a.x) * (c.z - a.z) - (c.x - a.x) * (b.z - a.z);
+}
+
+} // namespace
+
+RoamRegion::RoamRegion(const Ring& outer, const std::vector<Ring>& holes)
+{
+    // earcut takes the outer ring first, then the holes
+    std::vector<Ring> rings;
+    rings.reserve(holes.size() + 1);
+    rings.push_back(outer);
+    rings.insert(rings.end(), holes.begin(), holes.end());
+
+    const auto indices = triangulate(rings);
+
+    // indices address the rings as one flat vertex run, in ring order
+    const auto vertices = rings | std::views::join | std::ranges::to<Ring>();
+    if (vertices.empty())
+    {
+        return;
+    }
+
+    // keep a running area total so sampling can pick a triangle by its share of the region
+    float areaSum = 0.0f;
+
+    triangles_.reserve(indices.size() / 3);
+    for (size_t i = 0; i + 2 < indices.size(); i += 3)
+    {
+        const auto& a = vertices[indices[i]];
+        const auto& b = vertices[indices[i + 1]];
+        const auto& c = vertices[indices[i + 2]];
+
+        areaSum += std::abs(signedArea(a, b, c)) * 0.5f;
+        triangles_.push_back({ .a = a, .b = b, .c = c, .areaSum = areaSum });
+    }
+
+    // the box every query checks before touching the triangles
+    boundsX_ = std::ranges::minmax(vertices | std::views::transform(&Vector3::x));
+    boundsZ_ = std::ranges::minmax(vertices | std::views::transform(&Vector3::z));
+}
+
+auto RoamRegion::contains(const float x, const float z) const -> bool
+{
+    TracyZoneScoped;
+
+    // cheap reject before walking the triangle list
+    if (x < boundsX_.min || x > boundsX_.max || z < boundsZ_.min || z > boundsZ_.max)
+    {
+        return false;
+    }
+
+    const Vector3 point{ .x = x, .y = 0.0f, .z = z };
+
+    // inside the region means inside any one of its triangles
+    return std::ranges::any_of(triangles_,
+                               [&](const Triangle& triangle)
+                               {
+                                   const auto ab = signedArea(triangle.a, triangle.b, point);
+                                   const auto bc = signedArea(triangle.b, triangle.c, point);
+                                   const auto ca = signedArea(triangle.c, triangle.a, point);
+
+                                   // winding is whatever the ring was authored with, so accept either sign as long as it agrees
+                                   return (ab >= 0.0f && bc >= 0.0f && ca >= 0.0f) || (ab <= 0.0f && bc <= 0.0f && ca <= 0.0f);
+                               });
+}
+
+auto RoamRegion::hasWalkableSurface(const NavMesh& navMesh) const -> bool
+{
+    return randomPoint(&navMesh, kValidationSamples).has_value();
+}
+
+auto RoamRegion::closestPoint(const position_t& position) const -> position_t
+{
+    TracyZoneScoped;
+
+    // already inside, so the position is its own answer
+    if (triangles_.empty() || contains(position.x, position.z))
+    {
+        return position;
+    }
+
+    // this scans the edges the triangulation added too, which is harmless: from outside, a boundary edge is always hit before any of them
+    auto closest         = position;
+    auto closestDistance = std::numeric_limits<float>::max();
+    auto consider        = [&](const Vector3& a, const Vector3& b)
+    {
+        float      t        = 0.0f;
+        const auto distance = dtDistancePtSegSqr2D(&position.x, &a.x, &b.x, t);
+        if (distance < closestDistance)
+        {
+            closestDistance = distance;
+            dtVlerp(&closest.x, &a.x, &b.x, t);
+        }
+    };
+
+    // three edges per triangle, nearest one wins
+    for (const auto& triangle : triangles_)
+    {
+        consider(triangle.a, triangle.b);
+        consider(triangle.b, triangle.c);
+        consider(triangle.c, triangle.a);
+    }
+
+    return closest;
+}
+
+auto RoamRegion::distanceOutside(const position_t& position) const -> float
+{
+    const auto closest = closestPoint(position);
+
+    return std::hypot(closest.x - position.x, closest.z - position.z);
+}
+
+auto RoamRegion::samplePoint() const -> position_t
+{
+    // area-weighted, so every square yalm is equally likely however the triangles were cut
+    const auto  pick     = xirand::GetRandomNumber(0.0f, triangles_.back().areaSum);
+    const auto& triangle = *std::ranges::lower_bound(triangles_, pick, {}, &Triangle::areaSum);
+
+    // two barycentric weights, folded back over the diagonal when they overshoot the triangle
+    auto u = xirand::GetRandomNumber(0.0f, 1.0f);
+    auto v = xirand::GetRandomNumber(0.0f, 1.0f);
+    if (u + v > 1.0f)
+    {
+        u = 1.0f - u;
+        v = 1.0f - v;
+    }
+
+    // mix the corners by those weights, y included
+    const auto& a = triangle.a;
+    const auto& b = triangle.b;
+    const auto& c = triangle.c;
+
+    position_t point;
+    point.x = a.x + u * (b.x - a.x) + v * (c.x - a.x);
+    point.y = a.y + u * (b.y - a.y) + v * (c.y - a.y);
+    point.z = a.z + u * (b.z - a.z) + v * (c.z - a.z);
+
+    return point;
+}
+
+auto RoamRegion::acceptPoint(const position_t& point, const NavMesh* navMesh) const -> Maybe<position_t>
+{
+    // no mesh to check against, so the geometry has the final say
+    if (!navMesh)
+    {
+        return point;
+    }
+
+    // take the mesh height over the authored one. if the snap has to travel to get there, the point was never walkable
+    const auto snapped = navMesh->findClosestValidPoint(point);
+    if (!snapped)
+    {
+        return std::nullopt;
+    }
+
+    // it landed too far from where we asked, so it is not the point we sampled
+    if (std::abs(snapped->x - point.x) > kSnapTolerance || std::abs(snapped->z - point.z) > kSnapTolerance)
+    {
+        return std::nullopt;
+    }
+
+    return snapped;
+}
+
+auto RoamRegion::randomPoint(const NavMesh* navMesh, const uint8 attempts) const -> Maybe<position_t>
+{
+    TracyZoneScoped;
+
+    if (triangles_.empty())
+    {
+        return std::nullopt;
+    }
+
+    // sample until one of them survives the mesh check
+    for (uint8 attempt = 0; attempt < attempts; ++attempt)
+    {
+        if (const auto point = acceptPoint(samplePoint(), navMesh))
+        {
+            return point;
+        }
+    }
+
+    return std::nullopt;
+}
+
+auto RoamRegion::randomPointAt(const position_t& from, float distance, const NavMesh* navMesh) const -> Maybe<position_t>
+{
+    TracyZoneScoped;
+
+    if (triangles_.empty())
+    {
+        return std::nullopt;
+    }
+
+    for (uint8 attempt = 0; attempt < kSampleAttempts; ++attempt)
+    {
+        // a random direction, `distance` away
+        const auto angle = xirand::GetRandomNumber(0.0f, 2.0f * std::numbers::pi_v<float>);
+
+        position_t target;
+        target.x = from.x + std::cos(angle) * distance;
+        target.y = from.y;
+        target.z = from.z + std::sin(angle) * distance;
+
+        // that direction left the region, so try another
+        if (!contains(target.x, target.z))
+        {
+            continue;
+        }
+
+        if (!navMesh)
+        {
+            return target;
+        }
+
+        // walk the surface rather than teleport: it stops at the first wall in the way, so nothing lands across geometry
+        position_t reached;
+        if (!navMesh->moveAlongSurface(from, target, reached))
+        {
+            continue;
+        }
+
+        // something blocked the way well short of the target
+        if (std::abs(reached.x - target.x) > kShortfallTolerance || std::abs(reached.z - target.z) > kShortfallTolerance)
+        {
+            continue;
+        }
+
+        return reached;
+    }
+
+    return std::nullopt;
+}

--- a/src/map/roam_region.h
+++ b/src/map/roam_region.h
@@ -1,0 +1,78 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#pragma once
+
+#include <common/mmo.h>
+#include <common/types/maybe.h>
+
+#include <map/ximesh/vector3.h>
+
+#include <algorithm>
+#include <vector>
+
+class NavMesh;
+
+// An area a mob is allowed to roam in: an outer ring plus any number of holes.
+// Triangulated in the XZ plane up front, so picking a point is a weighted pick over triangles instead of guessing inside the bounding box until something sticks.
+// The rings are drawn by hand and only approximate the walkable floor, so queries take a navmesh and only return points it agrees with.
+class RoamRegion
+{
+public:
+    using Ring = std::vector<Vector3>;
+
+    RoamRegion(const Ring& outer, const std::vector<Ring>& holes);
+
+    auto contains(float x, float z) const -> bool;
+
+    // whether any of the region sits on the navmesh at all. one that misses it entirely would fail silently at runtime
+    auto hasWalkableSurface(const NavMesh& navMesh) const -> bool;
+
+    // uniform random point anywhere in the region, giving up after `attempts` samples find nothing walkable
+    auto randomPoint(const NavMesh* navMesh = nullptr, uint8 attempts = 8) const -> Maybe<position_t>;
+
+    // random point `distance` units from `from`, still in the region and reachable without leaving the walkable surface
+    auto randomPointAt(const position_t& from, float distance, const NavMesh* navMesh = nullptr) const -> Maybe<position_t>;
+
+    // nearest point of the region to `position`, or `position` itself when it is already inside
+    auto closestPoint(const position_t& position) const -> position_t;
+
+    // how far outside the region `position` is in the XZ plane, or zero when it is inside
+    auto distanceOutside(const position_t& position) const -> float;
+
+private:
+    struct Triangle
+    {
+        Vector3 a;
+        Vector3 b;
+        Vector3 c;
+        float   areaSum; // running total of triangle areas, for the weighted pick
+    };
+
+    auto samplePoint() const -> position_t;
+    auto acceptPoint(const position_t& point, const NavMesh* navMesh) const -> Maybe<position_t>;
+
+    std::vector<Triangle> triangles_;
+
+    // rejects a position before it walks the triangles
+    std::ranges::minmax_result<float> boundsX_{};
+    std::ranges::minmax_result<float> boundsZ_{};
+};

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -37,6 +37,7 @@
 #include "map_networking.h"
 #include "mob_spell_list.h"
 #include "mobutils.h"
+#include "roam_region.h"
 #include "spawn_handler.h"
 #include "spawn_slot.h"
 #include "zone_instance.h"
@@ -401,6 +402,136 @@ auto LoadNPCList(Scheduler& scheduler, const std::vector<xi::ZoneId>& zoneIds) -
  *                                                                       *
  ************************************************************************/
 
+// Temporary addition to exercise roam region code until the YAML loader is wired
+void LoadRoamRegions(CZone* PZone)
+{
+    if (PZone->GetID() != xi::ZoneId::WestRonfaure)
+    {
+        return;
+    }
+
+    const RoamRegion::Ring outer{
+        { -299.00f, -43.22f, 177.00f },
+        { -299.00f, -45.26f, 191.00f },
+        { -281.00f, -49.83f, 199.00f },
+        { -257.00f, -49.26f, 225.00f },
+        { -217.00f, -55.12f, 229.00f },
+        { -215.00f, -59.15f, 241.00f },
+        { -207.00f, -59.17f, 241.00f },
+        { -201.00f, -58.53f, 233.00f },
+        { -171.93f, -57.62f, 226.23f },
+        { -145.00f, -55.31f, 213.00f },
+        { -137.00f, -57.16f, 207.00f },
+        { -123.12f, -60.66f, 208.73f },
+        { -123.12f, -60.67f, 206.94f },
+        { -122.37f, -60.64f, 206.94f },
+        { -122.37f, -60.64f, 206.19f },
+        { -122.27f, -60.64f, 206.94f },
+        { -121.52f, -60.64f, 206.94f },
+        { -121.52f, -60.62f, 208.93f },
+        { -121.00f, -60.61f, 209.00f },
+        { -115.00f, -60.78f, 221.00f },
+        { -103.00f, -60.83f, 227.00f },
+        { -89.00f, -60.63f, 215.00f },
+        { -71.00f, -60.66f, 213.00f },
+        { -53.00f, -60.87f, 211.00f },
+        { -49.00f, -60.71f, 205.00f },
+        { -43.00f, -60.26f, 205.00f },
+        { -39.00f, -59.55f, 197.00f },
+        { -37.00f, -50.84f, 115.00f },
+        { -85.00f, -51.92f, 111.00f },
+        { -93.00f, -51.68f, 129.00f },
+        { -101.00f, -51.19f, 147.00f },
+        { -124.95f, -51.31f, 150.55f },
+        { -124.96f, -51.31f, 150.61f },
+        { -124.99f, -51.31f, 150.80f },
+        { -125.00f, -51.33f, 151.00f },
+        { -128.00f, -51.35f, 151.00f },
+        { -141.00f, -52.10f, 152.93f },
+        { -141.00f, -52.10f, 153.00f },
+        { -141.50f, -52.10f, 153.00f },
+        { -155.00f, -51.21f, 155.00f },
+        { -181.00f, -52.23f, 187.00f },
+        { -197.00f, -51.58f, 191.00f },
+        { -211.00f, -51.64f, 189.00f },
+        { -229.00f, -53.22f, 179.00f },
+        { -235.00f, -51.06f, 171.00f },
+        { -235.00f, -50.82f, 155.00f },
+        { -245.00f, -50.66f, 153.00f },
+        { -255.00f, -48.14f, 143.00f },
+        { -273.00f, -42.35f, 143.00f },
+        { -277.00f, -41.74f, 151.00f },
+        { -291.00f, -40.61f, 157.00f },
+        { -293.00f, -42.15f, 171.00f },
+    };
+
+    const std::vector<RoamRegion::Ring> holes{
+        {
+            { -108.75f, -60.56f, 195.14f },
+            { -108.00f, -60.56f, 195.14f },
+            { -108.00f, -60.52f, 194.39f },
+            { -99.80f, -60.77f, 194.39f },
+            { -99.76f, -60.83f, 195.09f },
+            { -99.76f, -60.77f, 194.34f },
+            { -91.56f, -59.54f, 194.34f },
+            { -91.53f, -60.66f, 195.09f },
+            { -91.53f, -59.54f, 194.35f },
+            { -83.33f, -60.19f, 194.35f },
+            { -83.33f, -60.45f, 195.10f },
+            { -82.58f, -60.44f, 195.20f },
+            { -83.33f, -60.45f, 195.20f },
+            { -83.33f, -60.45f, 195.95f },
+            { -91.53f, -60.66f, 195.95f },
+            { -91.56f, -60.66f, 195.20f },
+            { -91.56f, -60.66f, 195.94f },
+            { -99.76f, -60.83f, 195.94f },
+            { -99.80f, -60.83f, 195.24f },
+            { -99.80f, -60.83f, 195.99f },
+            { -108.00f, -60.56f, 195.99f },
+            { -108.00f, -60.56f, 195.24f },
+        },
+        {
+            { -119.81f, -60.57f, 199.16f },
+            { -118.87f, -60.55f, 198.18f },
+            { -114.85f, -60.55f, 199.51f },
+            { -114.55f, -60.55f, 200.77f },
+            { -117.13f, -60.60f, 203.21f },
+            { -117.64f, -60.57f, 202.67f },
+            { -118.34f, -60.57f, 202.94f },
+        },
+        {
+            { -123.39f, -60.00f, 201.45f },
+            { -122.31f, -60.00f, 201.59f },
+            { -122.08f, -60.00f, 197.02f },
+            { -118.17f, -60.00f, 197.27f },
+            { -116.56f, -60.00f, 196.95f },
+            { -115.31f, -59.74f, 195.09f },
+            { -123.27f, -59.74f, 194.98f },
+        },
+    };
+
+    const auto* region = PZone->addRoamRegion("e_46", RoamRegion(outer, holes));
+
+    if (!region->hasWalkableSurface(*PZone->navMesh()))
+    {
+        ShowWarningFmt("LoadRoamRegions: e_46 does not sit on the navmesh of zone {}", static_cast<uint16>(PZone->GetID()));
+    }
+
+    // Assign the 12 mobs to the region
+    for (uint32 mobId = 17186862; mobId <= 17186872; ++mobId)
+    {
+        if (auto* PMob = dynamic_cast<CMobEntity*>(GetEntity(mobId, TYPE_MOB)))
+        {
+            PMob->setRoamRegion(region);
+        }
+    }
+
+    if (auto* PMob = dynamic_cast<CMobEntity*>(GetEntity(17186875, TYPE_MOB)))
+    {
+        PMob->setRoamRegion(region);
+    }
+}
+
 auto LoadMOBList(Scheduler& scheduler, const std::vector<xi::ZoneId>& zoneIds) -> Task<void>
 {
     TracyZoneScoped;
@@ -635,6 +766,8 @@ auto LoadMOBList(Scheduler& scheduler, const std::vector<xi::ZoneId>& zoneIds) -
         zoneIds,
         [](CZone* PZone)
         {
+            LoadRoamRegions(PZone);
+
             PZone->ForEachMob(
                 [](CMobEntity* PMob)
                 {

--- a/src/map/zone.cpp
+++ b/src/map/zone.cpp
@@ -56,6 +56,7 @@ constexpr std::uint16_t WeatherCycle = 2160;
 #include "nominate_manager.h"
 #include "party.h"
 #include "recast_container.h"
+#include "roam_region.h"
 #include "spawn_handler.h"
 #include "status_effect_container.h"
 #include "treasure_pool.h"
@@ -587,6 +588,29 @@ auto CZone::navMesh() const -> NavMesh*
 auto CZone::xiMesh() const -> XiMesh*
 {
     return xiMesh_.get();
+}
+
+auto CZone::roamRegion(const std::string& name) const -> const RoamRegion*
+{
+    const auto region = roamRegions_.find(name);
+    if (region == roamRegions_.end())
+    {
+        return nullptr;
+    }
+
+    return region->second.get();
+}
+
+auto CZone::addRoamRegion(std::string name, RoamRegion region) -> const RoamRegion*
+{
+    // A duplicate name keeps the region already in place: replacing it would dangle every mob pointing at it.
+    const auto [entry, added] = roamRegions_.try_emplace(std::move(name), std::make_unique<RoamRegion>(std::move(region)));
+    if (!added)
+    {
+        ShowWarningFmt("Zone {}: duplicate roam region {}, ignoring it", m_zoneName, entry->first);
+    }
+
+    return entry->second.get();
 }
 
 void CZone::LoadXiMesh()

--- a/src/map/zone.h
+++ b/src/map/zone.h
@@ -60,6 +60,7 @@
 #include "data/enums/zone_type.h"
 class XiMesh;
 class NavMesh;
+class RoamRegion;
 class SpawnHandler;
 
 #define MAX_ZONEID 300
@@ -337,6 +338,9 @@ public:
     auto navMesh() const -> NavMesh*;
     auto xiMesh() const -> XiMesh*;
 
+    auto roamRegion(const std::string& name) const -> const RoamRegion*;
+    auto addRoamRegion(std::string name, RoamRegion region) -> const RoamRegion*;
+
     auto LoadNavMesh() -> Task<void>;
     void RebuildNavMesh(const NavMeshConfig& config = {});
 
@@ -364,6 +368,8 @@ private:
 
     std::unique_ptr<NavMesh> navMesh_;
     std::unique_ptr<XiMesh>  xiMesh_;
+
+    FlatHashMap<std::string, std::unique_ptr<RoamRegion>> roamRegions_;
 
     xi::ZoneId     m_zoneID;
     xi::ZoneType   m_zoneType;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(xi_test
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/merits_dataset_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/entity_list_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/rng_runtime_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/roam_region_tests.cpp
     ${resource})
 add_dependencies(xi_test data_schema_generate)
 

--- a/src/test/tests/roam_region_tests.cpp
+++ b/src/test/tests/roam_region_tests.cpp
@@ -1,0 +1,116 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+#include "map/roam_region.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+
+namespace
+{
+
+// 100x100 square with a 20x20 hole punched in the middle.
+auto squareWithHole() -> RoamRegion
+{
+    const RoamRegion::Ring outer{ { 0.0f, -10.0f, 0.0f }, { 100.0f, -10.0f, 0.0f }, { 100.0f, -10.0f, 100.0f }, { 0.0f, -10.0f, 100.0f } };
+    const RoamRegion::Ring hole{ { 40.0f, -10.0f, 40.0f }, { 60.0f, -10.0f, 40.0f }, { 60.0f, -10.0f, 60.0f }, { 40.0f, -10.0f, 60.0f } };
+
+    return RoamRegion(outer, { hole });
+}
+
+} // namespace
+
+TEST_CASE("RoamRegion contains respects holes and bounds", "[roam_region]")
+{
+    const auto region = squareWithHole();
+
+    CHECK(region.contains(5.0f, 5.0f));
+    CHECK(region.contains(99.0f, 99.0f));
+    CHECK_FALSE(region.contains(50.0f, 50.0f));
+    CHECK_FALSE(region.contains(-1.0f, 50.0f));
+    CHECK_FALSE(region.contains(50.0f, 101.0f));
+}
+
+TEST_CASE("RoamRegion measures how far outside a position is", "[roam_region]")
+{
+    const auto region = squareWithHole();
+
+    // inside: the position is its own closest point
+    const position_t inside{ 10.0f, -10.0f, 10.0f, 0, 0 };
+    CHECK(region.distanceOutside(inside) == 0.0f);
+    CHECK(region.closestPoint(inside).x == inside.x);
+    CHECK(region.closestPoint(inside).z == inside.z);
+
+    // past the west wall: nearest point is on the wall, straight back in
+    const position_t west{ -10.0f, -10.0f, 50.0f, 0, 0 };
+    CHECK(std::abs(region.distanceOutside(west) - 10.0f) < 0.01f);
+    CHECK(std::abs(region.closestPoint(west).x - 0.0f) < 0.01f);
+    CHECK(std::abs(region.closestPoint(west).z - 50.0f) < 0.01f);
+
+    // in the hole: the region is all around, nearest wall is 10 away
+    const position_t inHole{ 50.0f, -10.0f, 50.0f, 0, 0 };
+    CHECK(std::abs(region.distanceOutside(inHole) - 10.0f) < 0.01f);
+    CHECK(region.contains(region.closestPoint(inHole).x, region.closestPoint(inHole).z));
+}
+
+TEST_CASE("RoamRegion samples land inside the region", "[roam_region]")
+{
+    const auto region = squareWithHole();
+
+    for (int i = 0; i < 5000; ++i)
+    {
+        const auto point = region.randomPoint();
+
+        REQUIRE(point.has_value());
+        REQUIRE(region.contains(point->x, point->z));
+    }
+}
+
+TEST_CASE("RoamRegion ring queries hold their distance", "[roam_region]")
+{
+    const auto       region = squareWithHole();
+    const position_t from{ 50.0f, -10.0f, 10.0f, 0, 0 };
+
+    int hits = 0;
+    for (int i = 0; i < 5000; ++i)
+    {
+        const auto point = region.randomPointAt(from, 20.0f);
+        if (!point)
+        {
+            continue;
+        }
+
+        REQUIRE(std::abs(std::hypot(point->x - from.x, point->z - from.z) - 20.0f) < 0.01f);
+        REQUIRE(region.contains(point->x, point->z));
+        ++hits;
+    }
+
+    CHECK(hits > 0);
+}
+
+TEST_CASE("RoamRegion with no geometry hands out nothing", "[roam_region]")
+{
+    const RoamRegion region({}, {});
+
+    CHECK_FALSE(region.randomPoint().has_value());
+    CHECK_FALSE(region.randomPointAt({}, 10.0f).has_value());
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Wrap a polygon with optional holes into a dedicated RoamRegion class owned by CZone and shared by all mobs who reside in said region.

- On each spawn pick a random point inside it
- Roam destinations are sampled from it, chaining off from last
- Deaggro outside of it triggers despawn (NMs will still walk back to the closest edge but nothing in this branch tests it)
- Assigning a region lowers the roam tolerance to 0 - testing by @montijin has shown it to be pretty strict but we may revisit
- Mobs without regions behave the same as they do today

Triangulation backed by mapbox/earcut which I had already included before. Swapping is just 2 lines to change.
Weak dependency on Detour for math purposes.

Temporarily hardcodes a single region in West Ronfaure so code paths can be exercised until we get the actual data in.
<img width="1641" height="1356" alt="Screenshot 2026-08-16 155919" src="https://github.com/user-attachments/assets/0c802eef-ac71-4126-9cb0-0be2672544b2" />

## Steps to test these changes
Kill mobs in WRonfaure, watch them respawn far away.

<!-- Clear and detailed steps to test your changes here -->
