### PR TITLE
[lua] Sets minimum shop value to 1

### DIFF
--- a/scripts/globals/shop.lua
+++ b/scripts/globals/shop.lua
@@ -74,8 +74,16 @@ end
 ---@param fameArea xi.fameArea
 ---@return integer
 xi.shop.onSellPriceCheck = function(player, itemId, fameArea)
+    local basePrice = GetReadOnlyItem(itemId):getBasePrice()
+
+    -- If the base price is 0 it should always be 0
+    if basePrice == 0 then
+        return 0
+    end
+
+    -- Floored at 1 gil so cheap items never round down to 0
     local priceRank = getPriceRank(player, fameArea)
-    return math.floor(GetReadOnlyItem(itemId):getBasePrice() * (priceRank + 389) / 400)
+    return math.max(1, math.floor(basePrice * (priceRank + 389) / 400))
 end
 
 -- send general shop dialog to player


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Something I missed on the fame re-work. Items that sell for 1+ gil should NEVER sell for 0.
Sets the minimum value to 1 gil for selling to vendors for items that have a baseSell of 1+
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!setfamelevel 0 1 
!setfamelevel 1 1 
!setfamelevel 2 1 
!additem 705 12               (arrowwood lumber has base sell 1)
!zone southern sandy
!gotoname 17719351
Sell the lumber see it be 1gil not 0 
<!-- Clear and detailed steps to test your changes here -->
