### PR TITLE
[core] Roam on spawn, increase neutral time

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -49,6 +49,9 @@ namespace
 // Distance walked toward spawn per roam-home tick before re-evaluating.
 constexpr float kRoamHomeStepDistance = 10.0f;
 
+// A mob notices nobody for this long after spawning or losing its target.
+constexpr auto kNeutralDuration = 15s;
+
 } // namespace
 
 CMobController::CMobController(CMobEntity* PEntity)
@@ -1662,8 +1665,8 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
         co_return;
     }
 
-    // Don't aggro for ~10s after disengaging.
-    PMob->m_neutral = PMob->CanBeNeutral() && m_Tick <= m_NeutralTime + 10s;
+    // Don't aggro for a moment after disengaging.
+    PMob->m_neutral = m_Tick <= m_NeutralTime + kNeutralDuration;
 
     // If we already have a roam path going, just keep walking it.
     if (PMob->PAI->PathFind->IsFollowingPath())

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -463,11 +463,6 @@ bool CMobEntity::IsFarFromHome()
     return distance(loc.p, m_SpawnPoint) > m_maxRoamDistance;
 }
 
-bool CMobEntity::CanBeNeutral() const
-{
-    return !((m_Type & xi::MobType::Notorious) != xi::MobType::Normal);
-}
-
 bool CMobEntity::shouldUseTPMove(uint16 tpThreshold)
 {
     const auto& MobSkillList = battleutils::GetMobSkillList(getMobMod(xi::MobMod::SkillList));

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -741,6 +741,12 @@ void CMobEntity::Spawn()
     {
         SetDespawnTime(std::chrono::seconds(getMobMod(xi::MobMod::IdleDespawn)));
     }
+
+    // Roam immediately on spawn
+    if (CanRoam() && PAI->PathFind->RoamAround(m_SpawnPoint, GetRoamDistance(), static_cast<uint8>(getMobMod(xi::MobMod::RoamTurns)), m_roamFlags))
+    {
+        PAI->PathFind->FollowPath(timer::now());
+    }
 }
 
 void CMobEntity::OnWeaponSkillFinished(CWeaponSkillState& state, action_t& action)

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -70,8 +70,7 @@ public:
     auto getEntityFlags() const -> xi::EntityFlags;   // Returns the current value in m_flags
     void setEntityFlags(xi::EntityFlags EntityFlags); // Change the current value in m_flags
 
-    bool IsFarFromHome();      // check if mob is too far from spawn
-    bool CanBeNeutral() const; // check if mob can have killing pause
+    bool IsFarFromHome(); // check if mob is too far from spawn
 
     bool shouldUseTPMove(uint16 tpThreshold); // return true to use a TP move, checked on on 400ms tick interval
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
2 small changes for retail accuracy™:
- Spawn mobs already roaming
- Increase neutral time during which mobs cannot aggro or link from 10s to 15s - and apply it to NMs

2 videos from @ThrisStraizo show how it works on retail:
https://www.youtube.com/watch?v=eKuo_MyMWoI
https://youtu.be/EJ9-pWHjg8k

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
