### PR TITLE
[lua] [sql] Implement Minotaur's Mortal Ray

### DIFF
--- a/scripts/actions/mobskills/mortal_ray_minotaur.lua
+++ b/scripts/actions/mobskills/mortal_ray_minotaur.lua
@@ -1,0 +1,19 @@
+-----------------------------------
+-- Mortal Ray
+-- Description: Inflicts Doom upon an enemy.
+-- Type: Magical (Dark)
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobGazeMove(mob, target, xi.effect.DOOM, 10, 3, 35))
+
+    return xi.effect.DOOM
+end
+
+return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -373,6 +373,8 @@ xi.mobSkill =
 
     BLANK_GAZE                    =  586,
 
+    MORTAL_RAY_MINOTAUR           =  589,
+
     BOMB_TOSS_1                   =  591,
 
     BERSERK_BOMB_BIG              =  593, -- Big Bomb / Friars Lantern

--- a/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
+++ b/scripts/zones/Phomiuna_Aqueducts/mobs/Minotaur.lua
@@ -58,4 +58,18 @@ entity.onMobFight = function(mob, target)
     end
 end
 
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local tpTable =
+    {
+        xi.mobSkill.TRICLIP_1,
+        xi.mobSkill.BACK_SWISH_1,
+        xi.mobSkill.MOW_1,
+        xi.mobSkill.FRIGHTFUL_ROAR_1,
+        xi.mobSkill.UNBLESSED_ARMOR,
+        xi.mobSkill.MORTAL_RAY_MINOTAUR,
+    }
+
+    return tpTable[math.randomInt(1, #tpTable)]
+end
+
 return entity

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -617,7 +617,7 @@ INSERT INTO `mob_skills` VALUES (584,328,'uppercut',0,0.0,7.0,2000,1500,4,0,0,2,
 INSERT INTO `mob_skills` VALUES (586,330,'blank_gaze',4,0.0,7.0,2000,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (587,331,'antiphase',1,0.0,15.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (588,398,'death_trap',1,0.0,30.0,2000,2000,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (589,333,'mortal_ray',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (589,855,'mortal_ray_minotaur',0,0.0,15.0,2900,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (590,334,'goblin_rush',0,0.0,6.0,2966,800,4,0,0,1,0,0,0);
 INSERT INTO `mob_skills` VALUES (591,335,'bomb_toss',2,0.0,13.5,2916,4000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (592,336,'bomb_toss_suicide',1,0.0,13.5,4683,4000,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implement's Minotaur's missing version of Mortal Ray that counts down faster than normal.

Thank to @Valentine-PHX for the cap.

<img width="1543" height="953" alt="image" src="https://github.com/user-attachments/assets/251874a9-848a-440e-b3f3-bd1af28aa777" />


## Steps to test these changes

!tp 3000 Minotaur
