### PR TITLE
[lua] [yaml] [sql] IxDrk spell list, dragur/wamoura ecosystem fixes, some item fixes

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -4228,6 +4228,9 @@ ecosystems:
           draugar:
             id: 416
             attributes:
+              mods:
+                mdef:      20
+                udmgmagic: -1250
               stats:
                 vit: d
                 agi: d
@@ -4725,6 +4728,8 @@ ecosystems:
             id: 471
             attributes:
               element: fire
+              mods:
+                dmgphys: -1250
               stats:
                 str: e
                 dex: e

--- a/scripts/items/rotten_quiver.lua
+++ b/scripts/items/rotten_quiver.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- ID: 4196
 -- Rotten Quiver
--- When used, you will obtain 18 Old Arrows
+-- When used, you will obtain one partial stack of Old Arrows
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -11,7 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target)
-    npcUtil.giveItem(target, { { xi.item.OLD_ARROW, 99 } })
+    npcUtil.giveItem(target, { { xi.item.OLD_ARROW, math.randomInt(10, 20) } })
 end
 
 return itemObject

--- a/scripts/items/rusty_bolt_case.lua
+++ b/scripts/items/rusty_bolt_case.lua
@@ -1,6 +1,7 @@
 -----------------------------------
 -- ID: 4197
 -- rusty_bolt_case
+-- When used, you will obtain one partial stack of Rusty Bolts
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -10,7 +11,7 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target)
-    npcUtil.giveItem(target, { { xi.item.RUSTY_BOLT, 99 } })-- 99x rusty_bolt
+    npcUtil.giveItem(target, { { xi.item.RUSTY_BOLT, math.randomInt(10, 20) } })
 end
 
 return itemObject

--- a/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
+++ b/scripts/zones/The_Garden_of_RuHmet/mobs/Ixaern_DRK.lua
@@ -109,6 +109,31 @@ entity.onMobSpawn = function(mob)
     })
 end
 
+entity.onMobSpellChoose = function(mob, target, spellId)
+    local spellList =
+    {
+        [ 1] = { xi.magic.spell.FIRE_II,     target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 2] = { xi.magic.spell.BLIZZARD_II, target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 3] = { xi.magic.spell.AERO_II,     target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 4] = { xi.magic.spell.STONE_III,   target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 5] = { xi.magic.spell.THUNDER_II,  target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 6] = { xi.magic.spell.WATER_III,   target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+        [ 7] = { xi.magic.spell.POISON,      target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.POISON,   0, 100 },
+        [ 8] = { xi.magic.spell.BIO_II,      target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.BIO,      4, 100 },
+        [ 9] = { xi.magic.spell.STUN,        target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.STUN,     0, 100 },
+        [10] = { xi.magic.spell.ABSORB_STR,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.STR_DOWN, 0, 100 },
+        [11] = { xi.magic.spell.ABSORB_DEX,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.DEX_DOWN, 0, 100 },
+        [12] = { xi.magic.spell.ABSORB_VIT,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.VIT_DOWN, 0, 100 },
+        [13] = { xi.magic.spell.ABSORB_AGI,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.AGI_DOWN, 0, 100 },
+        [14] = { xi.magic.spell.ABSORB_INT,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.INT_DOWN, 0, 100 },
+        [15] = { xi.magic.spell.ABSORB_MND,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.MND_DOWN, 0, 100 },
+        [16] = { xi.magic.spell.ABSORB_CHR,  target, false, xi.action.type.ENFEEBLING_TARGET, xi.effect.CHR_DOWN, 0, 100 },
+        [17] = { xi.magic.spell.ABSORB_TP,   target, false, xi.action.type.DAMAGE_TARGET,     nil,                0, 100 },
+    }
+
+    return xi.combat.behavior.chooseAction(mob, target, nil, spellList)
+end
+
 entity.onMobDespawn = function(mob)
     mob:setLocalVar('AERN_RERAISES', 0)
 end

--- a/sql/item_mods_pet.sql
+++ b/sql/item_mods_pet.sql
@@ -207,7 +207,7 @@ INSERT INTO `item_mods_pet` VALUES (12649,370,1,2); -- Wyvern - REGEN: 1
 INSERT INTO `item_mods_pet` VALUES (12650,27,-2,1); -- Avatar - ENMITY: -2
 
 -- Drachen Finger Gauntlets
-INSERT INTO `item_mods_pet` VALUES (13974,25,5,2); -- Wyvern - ACC: 5
+INSERT INTO `item_mods_pet` VALUES (13974,25,10,2); -- Wyvern - ACC: 10
 
 -- Evokers Bracers
 INSERT INTO `item_mods_pet` VALUES (13975,27,-2,1); -- Avatar - ENMITY: -2


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds a retail-accurate Ix'aern (DRK) spell list with a 3-hour capture from retail.
* Adds missing family modifiers for Wamoura & Draugar
* Corrects the amount of bolts/arrows you get from Rotten Quiver / Rusty Bolt Quiver
* Corrects the accuracy bonus Wyverns get from Drachen Finger Gauntlets

## Captures
https://www.youtube.com/watch?v=aYs1HwdqLZE - Draugar
https://www.youtube.com/watch?v=5Ui0VDHgPVk - Wamoura
https://wiki.ffo.jp/html/5079.html - Bolt Box
https://www.youtube.com/watch?v=0ostzkBJgug - Drachen Finger Gauntlets Accuracy

## Steps to test these changes

Fight Ix DRK, see the new spell list
Get 10-20 bolts from old bolt case
Check the stats of your Wyvern with Drachen Finger Gauntlets to see +10 ACC
Check mod on Wamura -1250 UDMGPHYS and get mod on Dragar for -1250 UDMGMAGIC