### PR TITLE
[lua] Fix Signpost text in Buburimu Peninsula

### DIFF
--- a/scripts/zones/Buburimu_Peninsula/npcs/Signpost.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Signpost.lua
@@ -9,10 +9,12 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     local offset = npc:getID() - ID.npc.SIGNPOST_OFFSET
-    if offset >= 4 or offset <= 6 then
-        player:messageSpecial(ID.text.SIGN_1)
-    elseif offset >= 0 and offset <= 3 then
-        player:messageSpecial(ID.text.SIGN_5 - offset)
+
+    -- First 3 Signpost all say SIGN_1. The next 4 Signposts increment the ID.
+    if offset <= 2 then
+        player:messageText(npc, ID.text.SIGN_1)
+    else
+        player:messageText(npc, ID.text.SIGN_1 + offset - 2)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes the message sent by the 7 Signposts in Buburimu Peninsula.

For convenience, these were the sign IDs and Message ID captured
17261165 - 7416 - SIGN_1
17261166 - 7416
17261167 - 7416
17261168 - 7417
17261169 - 7418
17261170 - 7419
17261171 - 7420

Capture showing order: https://drive.google.com/file/d/17BgPmq3z070WEK9a3I4e-9WyjAIpJySV/view?usp=drive_link

## Steps to test these changes

Go to Bubu and click all the signs.
