### PR TITLE
[lua] Fix ToAU 4 bug with onEventUpdate

### DIFF
--- a/scripts/missions/toau/04_Knight_of_Gold.lua
+++ b/scripts/missions/toau/04_Knight_of_Gold.lua
@@ -88,11 +88,13 @@ mission.sections =
             onEventUpdate =
             {
                 [3026] = function(player, csid, option, npc)
-                    -- All 3 topics must be selected before you can advance
-                    local topics = utils.mask.setBit(mission:getLocalVar(player, 'Option'), option - 1, true)
+                    -- First option is always 10. Then it's 1, 2, or 3 based on selection.
+                    -- All 3 topics must be selected before you can advance.
+                    local bit    = utils.clamp(option, 1, 4) - 1
+                    local topics = utils.mask.setBit(mission:getLocalVar(player, 'Option'), bit, true)
                     mission:setLocalVar(player, 'Option', topics)
 
-                    player:updateEvent(8 + topics, 1)
+                    player:updateEvent(topics, 1)
                 end,
             },
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a bug in the onEventUpdate where option = 10 was not accounted for.

## Steps to test these changes

Add mission, set status, and test the event works.
