### PR TITLE
[lua] Opo-Opo TP ability adjustments

### DIFF
--- a/scripts/actions/mobskills/claw_storm.lua
+++ b/scripts/actions/mobskills/claw_storm.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 7, 3, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.POISON, 7, 3, 60) -- TODO:Poison power is level scaling
     end
 
     return info.damage

--- a/scripts/actions/mobskills/eye_scratch.lua
+++ b/scripts/actions/mobskills/eye_scratch.lua
@@ -25,7 +25,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 30, 0, 60)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.BLINDNESS, 50, 0, 60)
     end
 
     return info.damage

--- a/scripts/actions/mobskills/spinning_claw.lua
+++ b/scripts/actions/mobskills/spinning_claw.lua
@@ -14,13 +14,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.baseDamage     = mob:getWeaponDmg()
-    params.numHits        = 1
-    params.fTP            = { 2.0, 2.0, 2.0 }
+    params.numHits        = 3
+    params.fTP            = { 1.0, 1.0, 1.0 }
     params.attackType     = xi.attackType.PHYSICAL
     params.damageType     = xi.damageType.SLASHING
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_3 -- TODO: Capture shadowBehavior
     params.canCrit          = true
-    params.criticalChance   = { 0.20, 0.25, 0.30 } -- TODO : Capture more accurate crit rate data
+    params.criticalChance   = { 0.10, 0.15, 0.20 } -- TODO : Capture more accurate crit rate data
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Opo-Opo TP abilities.

Spinning Claw is 3 hits.
<img width="1204" height="270" alt="image" src="https://github.com/user-attachments/assets/653fe732-2990-4a26-af51-9ec76d3df783" />

ty @TiberonKalkaz for cap

Adjusts its crit rate with what I perceived from my original testing based on this new information.

Monke blind is static -50.

<img width="671" height="595" alt="image" src="https://github.com/user-attachments/assets/901b5fbc-b34e-4f3f-88e4-1d4c50b7e0fe" />


## Steps to test these changes

Get smacked by monke