### PR TITLE
[lua] Add Missing Job Emotes

### DIFF
--- a/scripts/quests/bastok/Blade_of_Darkness.lua
+++ b/scripts/quests/bastok/Blade_of_Darkness.lua
@@ -14,6 +14,7 @@ quest.reward =
 {
     fame     = 20,
     fameArea = xi.fameArea.BASTOK,
+    keyItem  = xi.ki.JOB_GESTURE_DARK_KNIGHT,
     title    = xi.title.DARK_SIDER,
 }
 

--- a/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
+++ b/scripts/quests/windurst/SMN_I_Can_Hear_a_Rainbow.lua
@@ -109,6 +109,7 @@ quest.reward =
 {
     fame     = 20,
     fameArea = xi.fameArea.WINDURST,
+    keyItem  = xi.ki.JOB_GESTURE_SUMMONER,
     title    = xi.title.RAINBOW_WEAVER,
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds two missing job emotes. [They were changed to be awarded when the unlock quest is completed](https://forum.square-enix.com/ffxi/threads/46068-Feb-19-2015-(JST)-Version-Update).

## Steps to test these changes

Do the quests, see you get the job emote now.
