### PR TITLE
[lua] Add missing idle animation for Hariga-Origa, Serukoko, Sohdede

### DIFF
--- a/scripts/zones/Windurst_Waters/npcs/Hariga-Origa.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Hariga-Origa.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Windurst Waters
+--  NPC: Hariga-Origa
+-- !pos -62.511 -5.499 105.234 238
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+local function idle(npc)
+    npc:entityAnimationPacket('sha0')
+
+    npc:timer(math.randomInt(3000, 4000), function(npcArg)
+        idle(npcArg)
+    end)
+end
+
+entity.onSpawn = function(npc)
+    idle(npc)
+end
+
+return entity

--- a/scripts/zones/Windurst_Waters/npcs/Serukoko.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Serukoko.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Windurst Waters
+--  NPC: Serukoko
+-- !pos -54.916 -6.499 114.855 238
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+local function idle(npc)
+    npc:entityAnimationPacket('sha0')
+
+    npc:timer(math.randomInt(3000, 4000), function(npcArg)
+        idle(npcArg)
+    end)
+end
+
+entity.onSpawn = function(npc)
+    idle(npc)
+end
+
+return entity

--- a/scripts/zones/Windurst_Waters/npcs/Sohdede.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Sohdede.lua
@@ -1,0 +1,21 @@
+-----------------------------------
+-- Area: Windurst Waters
+--  NPC: Sohdede
+-- !pos -60.601 -6.499 111.639 238
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+local function idle(npc)
+    npc:entityAnimationPacket('sha0')
+
+    npc:timer(math.randomInt(3000, 4000), function(npcArg)
+        idle(npcArg)
+    end)
+end
+
+entity.onSpawn = function(npc)
+    idle(npc)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #10208. These three NPCs in the Windurst Waters Opistery had no script at all, so their periodic casting animation never played. Added an onSpawn timer that fires entityAnimationPacket('sha0') every 3-4s, matching the retail capture in the issue.

## Steps to test these changes

 !pos -62.511 -5.499 105.234 238 Watch Hariga-Origa cast his magic writing spell. Can see Sohdede from there, too.