### PR TITLE
[roe] Add Total Successful Harvesting Attempts I and II

### DIFF
--- a/scripts/globals/roe_records.lua
+++ b/scripts/globals/roe_records.lua
@@ -5254,6 +5254,25 @@ xi.roe.records =
     },
 
     -----------------------------------
+    -- Harvesting (General)
+    -----------------------------------
+
+    [61] =
+    { -- Total Successful Harvesting Attempts
+        trigger = xi.roeTrigger.HELM_SUCCESS,
+        goal = 300,
+        reward = { sparks = 2000, exp = 6000, accolades = 200 },
+    },
+
+    [118] =
+    { -- Total Suc. Harvesting Attempts II
+        trigger = xi.roeTrigger.HELM_SUCCESS,
+        goal = 30,
+        flags = set { 'repeat' },
+        reward = { sparks = 200, exp = 600, accolades = 20 },
+    },
+
+    -----------------------------------
     -- Harvesting - Original Areas
     -----------------------------------
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds missing Records of Eminence objectives 61 and 118 to `scripts/globals/roe_records.lua`.

- **61** Total Successful Harvesting Attempts: 300 successes, 2000 sparks / 6000 exp / 200 accolades (2013-12-11).
- **118** Total Suc. Harvesting Attempts II: repeatable 30 successes, 200 sparks / 600 exp / 20 accolades (2015-01-15).

Sources: [XIchecklist RoE dump](https://github.com/HiPotionQ8/XIchecklist/blob/main/maps/roe_objectives.lua). Zone Harvesting records already use `HELM_SUCCESS` without a `skillType` filter (they include mines/logging zones), so these general records do the same.

## Steps to test these changes

- [ ] Set record 61, succeed at harvesting/mining/logging 300 times, confirm completion and rewards.
- [ ] Set record 118, succeed 30 times, confirm it is repeatable.
- [ ] Confirm existing zone Harvesting records still complete as before.

Made with [Cursor](https://cursor.com)