### PR TITLE
[lua] Skip getMaxGearMod for non-PC entities

### DIFF
--- a/scripts/combat/basic/damage_additions.lua
+++ b/scripts/combat/basic/damage_additions.lua
@@ -15,7 +15,12 @@ xi.combat.damage.souleaterAddition = function(actor)
         return 0
     end
 
-    local souleaterEffect        = actor:getMaxGearMod(xi.mod.SOULEATER_EFFECT) / 100
+    -- Trusts (e.g. Zeid II) can use Souleater; they have no player gear.
+    local souleaterEffect = 0
+    if actor:getObjType() == xi.objType.PC then
+        souleaterEffect = actor:getMaxGearMod(xi.mod.SOULEATER_EFFECT) / 100
+    end
+
     local souleaterEffectII      = actor:getMod(xi.mod.SOULEATER_EFFECT_II) / 100
     local stalwartSoulMultiplier = 1 - actor:getMod(xi.mod.STALWART_SOUL) / 100
     local soulEaterResistance    = 1 -- TODO: Add soul eater resistance for AV and others.

--- a/scripts/effects/avatars_favor.lua
+++ b/scripts/effects/avatars_favor.lua
@@ -32,8 +32,10 @@ effectObject.onEffectTick = function(target, effect)
         end
     end
 
-    -- Applying gear bonus
-    effect:setPower(effect:getPower() + target:getMaxGearMod(xi.mod.AVATARS_FAVOR_ENHANCE))
+    -- Applying gear bonus (Trusts have no player gear; getMaxGearMod warns on non-PCs)
+    if target:getObjType() == xi.objType.PC then
+        effect:setPower(effect:getPower() + target:getMaxGearMod(xi.mod.AVATARS_FAVOR_ENHANCE))
+    end
 
     -- TODO add Job Point Gift Bonus
     -- if GET PLAYERS JP TOTAL >= 550 then

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -779,8 +779,13 @@ xi.job_utils.corsair.applyRoll = function(caster, target, inAbility, total, isDo
     end
 
     -- Apply Additional Phantom Roll+ Buff
-    local phantomMult = caster:getMaxGearMod(xi.mod.PHANTOM_ROLL)
-    effectpower       = effectpower + rollInfo.phantomBase * phantomMult
+    -- Trusts/NPCs have no player gear; skip getMaxGearMod (e.g. Qultada).
+    local phantomMult = 0
+    if caster:getObjType() == xi.objType.PC then
+        phantomMult = caster:getMaxGearMod(xi.mod.PHANTOM_ROLL)
+    end
+
+    effectpower = effectpower + rollInfo.phantomBase * phantomMult
 
     -- Effect Power varies depending on COR level (Main vs Sub)
     local actorLevel  = utils.getActiveJobLevel(caster, xi.job.COR)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`getMaxGearMod` logs a Non-PC warning when Trusts use abilities that look up player gear.

Skip those lookups unless the actor is a PC, matching the existing guard in `scripts/globals/job_utils/geomancer.lua`:

- Avatar's Favor tick (`scripts/effects/avatars_favor.lua`)
- Souleater (`scripts/combat/basic/damage_additions.lua`) -- Trust Zeid II
- Phantom Roll+ (`scripts/globals/job_utils/corsair.lua`) -- Trust Qultada

## Steps to test these changes

- [ ] Summon a Trust that uses Souleater (Zeid II) and confirm map log has no `getMaxGearMod` Non-PC warning; damage still applies.
- [ ] Summon Qultada, use a Phantom Roll, confirm no Non-PC warning; roll power is unchanged for a PC with no Phantom Roll+ gear.
- [ ] Apply Avatar's Favor on a PC with and without Avatars Favor + gear; Trust SMN should not warn.

Made with [Cursor](https://cursor.com)