### PR TITLE
[lua][sql] Implement Maat's Concoction and Maat's Mix

### DIFF
--- a/scripts/enum/msg.lua
+++ b/scripts/enum/msg.lua
@@ -398,6 +398,7 @@ xi.msg.basic =
     AUTO_OVERLOAD_CHANCE            = 798, -- The <pet>'s overload chance is <number>%.
     AUTO_OVERLOADED                 = 799, -- The <pet>'s overload chance is <number>%. The <pet> is overloaded!
     SPIRIT_BOND                     = 800, -- Spirit Bond Activates. <Player> takes <number> points of damage. -- Wyvern Spirit bond
+    RECEIVES_JOB_POINTS             = 807, -- <player> receives <number> job points.
 }
 
 -- Used to modify certain basic messages.

--- a/scripts/globals/item_utils.lua
+++ b/scripts/globals/item_utils.lua
@@ -277,6 +277,45 @@ xi.itemUtils.removeMultipleEffects = function(target, effects, count, random)
     end
 end
 
+-- Maat's Concoction / Maat's Mix: grant job points to the current job.
+-- Retail cap is 500 total (unspent + spent) for that job.
+-- https://www.bg-wiki.com/ffxi/Maat%27s_Mix
+-- https://www.bg-wiki.com/ffxi/Maat%27s_Concoction
+-- Unverified: fail message IDs and item_usable animation; need retail captures.
+local jobPointsMax = 500
+
+---@nodiscard
+---@param target CBaseEntity
+---@return integer
+xi.itemUtils.jobPointItemOnItemCheck = function(target)
+    if
+        not target:isPC() or
+        target:getMainLvl() < 99
+    then
+        return xi.msg.basic.ITEM_UNABLE_TO_USE_2
+    end
+
+    local job   = target:getMainJob()
+    local total = target:getJobPoints(job) + target:getSpentJobPoints()
+    if total >= jobPointsMax then
+        return xi.msg.basic.ITEM_UNABLE_TO_USE_2
+    end
+
+    return 0
+end
+
+---@param target CBaseEntity
+---@param amount integer
+---@return nil
+xi.itemUtils.jobPointItemOnItemUse = function(target, amount)
+    local job   = target:getMainJob()
+    local total = target:getJobPoints(job) + target:getSpentJobPoints()
+    local grant = math.min(amount, jobPointsMax - total)
+    if grant > 0 then
+        target:addJobPoints(job, grant)
+    end
+end
+
 -- for applying pet mods based on arbitrary conditions
 -- I.E. avatar attack only for a particular pet
 -- example usage in fervor_ring.lua

--- a/scripts/globals/item_utils.lua
+++ b/scripts/globals/item_utils.lua
@@ -281,7 +281,10 @@ end
 -- Retail cap is 500 total (unspent + spent) for that job.
 -- https://www.bg-wiki.com/ffxi/Maat%27s_Mix
 -- https://www.bg-wiki.com/ffxi/Maat%27s_Concoction
--- Unverified: fail message IDs and item_usable animation; need retail captures.
+-- Animation 34 and 0x028 message 807 from siknoz captures (Concoction Raguza 2021-10-13,
+-- Mix Siknawz 2025-07-21 and 2026-05-23). At 500 JP retail sends no 0x029; capturer
+-- noted "just doesnt use it, no error message". onItemCheck -1 is RefuseSilently.
+-- Under-99 fail message is unverified.
 local jobPointsMax = 500
 
 ---@nodiscard
@@ -298,7 +301,7 @@ xi.itemUtils.jobPointItemOnItemCheck = function(target)
     local job   = target:getMainJob()
     local total = target:getJobPoints(job) + target:getSpentJobPoints()
     if total >= jobPointsMax then
-        return xi.msg.basic.ITEM_UNABLE_TO_USE_2
+        return -1
     end
 
     return 0
@@ -306,14 +309,18 @@ end
 
 ---@param target CBaseEntity
 ---@param amount integer
----@return nil
-xi.itemUtils.jobPointItemOnItemUse = function(target, amount)
+---@param action Action
+---@return integer
+xi.itemUtils.jobPointItemOnItemUse = function(target, amount, action)
     local job   = target:getMainJob()
     local total = target:getJobPoints(job) + target:getSpentJobPoints()
     local grant = math.min(amount, jobPointsMax - total)
     if grant > 0 then
         target:addJobPoints(job, grant)
+        action:messageID(target:getID(), xi.msg.basic.RECEIVES_JOB_POINTS)
     end
+
+    return grant
 end
 
 -- for applying pet mods based on arbitrary conditions

--- a/scripts/items/maats_concoction.lua
+++ b/scripts/items/maats_concoction.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, caster)
     return xi.itemUtils.jobPointItemOnItemCheck(target)
 end
 
-itemObject.onItemUse = function(target)
-    xi.itemUtils.jobPointItemOnItemUse(target, 50)
+itemObject.onItemUse = function(target, user, item, action)
+    return xi.itemUtils.jobPointItemOnItemUse(target, 50, action)
 end
 
 return itemObject

--- a/scripts/items/maats_concoction.lua
+++ b/scripts/items/maats_concoction.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- ID: 6597
+-- Item: Maat's Concoction
+-- Grants 50 Job Points to the current job
+-- https://www.bg-wiki.com/ffxi/Maat%27s_Concoction
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, caster)
+    return xi.itemUtils.jobPointItemOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    xi.itemUtils.jobPointItemOnItemUse(target, 50)
+end
+
+return itemObject

--- a/scripts/items/maats_mix.lua
+++ b/scripts/items/maats_mix.lua
@@ -11,8 +11,8 @@ itemObject.onItemCheck = function(target, item, caster)
     return xi.itemUtils.jobPointItemOnItemCheck(target)
 end
 
-itemObject.onItemUse = function(target)
-    xi.itemUtils.jobPointItemOnItemUse(target, 10)
+itemObject.onItemUse = function(target, user, item, action)
+    return xi.itemUtils.jobPointItemOnItemUse(target, 10, action)
 end
 
 return itemObject

--- a/scripts/items/maats_mix.lua
+++ b/scripts/items/maats_mix.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- ID: 6598
+-- Item: Maat's Mix
+-- Grants 10 Job Points to the current job
+-- https://www.bg-wiki.com/ffxi/Maat%27s_Mix
+-----------------------------------
+---@type TItem
+local itemObject = {}
+
+itemObject.onItemCheck = function(target, item, caster)
+    return xi.itemUtils.jobPointItemOnItemCheck(target)
+end
+
+itemObject.onItemUse = function(target)
+    xi.itemUtils.jobPointItemOnItemUse(target, 10)
+end
+
+return itemObject

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -2414,8 +2414,8 @@ INSERT INTO `item_usable` VALUES (6593,'deep_yellow_curry',1,1,0,0,0,0,0,0);    
 INSERT INTO `item_usable` VALUES (6594,'seafood_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6595,'chicken_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6596,'duck_curry',1,10,0,0,0,0,0,0);                      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6597,'maats_concoction',1,1,0,0,0,0,0,0); -- TODO: animation from retail capture
-INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,0,0,0,0,0,0);        -- TODO: animation from retail capture
+INSERT INTO `item_usable` VALUES (6597,'maats_concoction',1,1,34,0,0,0,0,0); -- 0x028 ItemFinish animation (siknoz Raguza 2021-10-13)
+INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,34,0,0,0,0,0);        -- 0x028 ItemFinish animation (siknoz Siknawz 2025-07-21 / 2026-05-23)
 INSERT INTO `item_usable` VALUES (6599,'egg_sandwich',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6600,'egg_sandwich_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6601,'omelette_sandwich',1,1,28,0,0,0,0,0);

--- a/sql/item_usable.sql
+++ b/sql/item_usable.sql
@@ -2414,8 +2414,8 @@ INSERT INTO `item_usable` VALUES (6593,'deep_yellow_curry',1,1,0,0,0,0,0,0);    
 INSERT INTO `item_usable` VALUES (6594,'seafood_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6595,'chicken_curry',1,1,0,0,0,0,0,0);                   -- TODO: Not implemented
 INSERT INTO `item_usable` VALUES (6596,'duck_curry',1,10,0,0,0,0,0,0);                      -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6597,'mutton_curry',1,1,0,0,0,0,0,0);                    -- TODO: Not implemented
-INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,0,0,0,0,0,0);                       -- TODO: Not implemented
+INSERT INTO `item_usable` VALUES (6597,'maats_concoction',1,1,0,0,0,0,0,0); -- TODO: animation from retail capture
+INSERT INTO `item_usable` VALUES (6598,'maats_mix',1,1,0,0,0,0,0,0);        -- TODO: animation from retail capture
 INSERT INTO `item_usable` VALUES (6599,'egg_sandwich',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6600,'egg_sandwich_+1',1,1,28,0,0,0,0,0);
 INSERT INTO `item_usable` VALUES (6601,'omelette_sandwich',1,1,28,0,0,0,0,0);

--- a/src/map/enums/msg_basic.h
+++ b/src/map/enums/msg_basic.h
@@ -286,5 +286,6 @@ enum class MsgBasic : uint16_t
     ROEUnable                       = 742, // You are currently unable to undertake this objective.
     AutoExceedsCapacity             = 745, // Your automaton exceeds one or more elemental capacity values and cannot be activated.
     MountRequiredLevel              = 773, // You are unable to call forth your mount because your main job level is not at least <level>.
+    ReceivesJobPoints               = 807, // <player> receives <number> job points.
     AlterEgoUpgrade                 = 828, // <category> attribute increased to #.
 };


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements usable-item scripts for Maat's Concoction (6597, 50 JP) and Maat's Mix (6598, 10 JP).

`item_basic` already names 6597 `maats_concoction`. `item_usable` still had it as `mutton_curry` with both rows `-- TODO: Not implemented`. Deeds already grant these items.

JP is applied to the current main job and stops at the 500 spent+unspent cap. Use is blocked below 99 (and for non-PCs).

Sources:
- https://www.bg-wiki.com/ffxi/Maat%27s_Concoction
- https://www.bg-wiki.com/ffxi/Maat%27s_Mix

## Steps to test these changes

- [ ] Import/update `sql/item_usable.sql` (or run dbtool).
- [ ] On a 99 job with fewer than 500 JP, use Mix: +10 JP. Use Concoction: +50 JP.
- [ ] At 495 JP, Concoction should grant only 5 (cap 500) or refuse if already at cap.
- [ ] Below 99, item should fail to use.
- [ ] Confirm a PC with these items from deeds can consume them.

Made with [Cursor](https://cursor.com)