### PR TITLE
[core] getMaxGearMod/getGearModFromSlot fixup

### DIFF
--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -2119,9 +2119,7 @@ int16 CBattleEntity::getMaxGearMod(xi::Mod modID)
 
     if (!PChar)
     {
-        ShowWarning("CBattleEntity::getMaxGearMod() - Entity is not a player.");
-
-        return 0;
+        return this->getMod(modID);
     }
 
     for (uint8 i = 0; i < SLOT_BACK; ++i)
@@ -2129,6 +2127,12 @@ int16 CBattleEntity::getMaxGearMod(xi::Mod modID)
         auto* PItem = PChar->getEquip((SLOTTYPE)i);
         if (PItem && (PItem->isType(ITEM_EQUIPMENT) || PItem->isType(ITEM_WEAPON)))
         {
+            // TODO: support gear scaling
+            if (PItem->getReqLvl() > PChar->GetMLevel())
+            {
+                continue;
+            }
+
             uint16 modValue = PItem->getModifier(modID);
 
             if (modValue > maxModValue)

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -14902,20 +14902,18 @@ bool CLuaBaseEntity::hasAllLatentsActive(uint8 slot)
 
 int16 CLuaBaseEntity::getMaxGearMod(xi::Mod modId)
 {
-    if (m_PBaseEntity->objtype != TYPE_PC)
+    if (m_PBaseEntity->objtype == TYPE_NPC || m_PBaseEntity->objtype == TYPE_SHIP)
     {
-        ShowWarning("Invalid Entity (Non-PC: %s) calling function.", m_PBaseEntity->getName());
-
         return 0;
     }
 
-    return static_cast<CCharEntity*>(m_PBaseEntity)->getMaxGearMod(static_cast<xi::Mod>(modId));
+    return static_cast<CBattleEntity*>(m_PBaseEntity)->getMaxGearMod(static_cast<xi::Mod>(modId));
 }
 
 /************************************************************************
  *  Function: getGearModFromSlot()
  *  Purpose : Returns mod value from a specific item equipped
- *  Example : local maxValue = player:getMaxGearMod(xi.mod.GEOMANCY_BONUS)
+ *  Example : local maxValue = player:getGearModFromSlot(xi.slot.HEAD, xi.mod.GEOMANCY_BONUS)
  *  Notes   :
  ************************************************************************/
 int16 CLuaBaseEntity::getGearModFromSlot(uint8 slot, xi::Mod modId)
@@ -14930,7 +14928,8 @@ int16 CLuaBaseEntity::getGearModFromSlot(uint8 slot, xi::Mod modId)
     auto*           PChar = static_cast<CCharEntity*>(m_PBaseEntity);
     CItemEquipment* PItem = PChar->getEquip(static_cast<SLOTTYPE>(slot));
 
-    if (PItem)
+    // TODO: support gear scaling
+    if (PItem && PItem->getReqLvl() <= PChar->GetMLevel())
     {
         return PItem->getModifier(modId);
     }


### PR DESCRIPTION

<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

getMaxGearMod will now work for non-PCs by just returning the whole mod value. getMaxGearMod will also force disable stats if you are level synced with gear scaling on

the lua hooked function getGearModFromSlot will force disable stats if you are level synced with gear scaling on getGearModFromSlot will still print an error if called on a non-PC, but the current only use is gated behind a PC check so this is ok for now

supercedes #11178 
closes #8767

## Steps to test these changes

use !exec to print max gear mod/gear mod from slot, with gear scaling enabled ensure that the appropriate levels are disabled
