### PR TITLE
[core] Destroy plants in flower pots when removing them as furnishings

### DIFF
--- a/scripts/tests/systems/gardening.lua
+++ b/scripts/tests/systems/gardening.lua
@@ -79,6 +79,10 @@ describe('Gardening', function()
 
         player:gotoMogHouse(xi.zone.WINDURST_WOODS)
         stockSafe(player, xi.item.EARTHEN_FLOWERPOT)
+
+        local pot = mogItem(player, xi.item.EARTHEN_FLOWERPOT)
+        player.actions:placeFurniture(xi.inv.MOGSAFE, pot:getSlotID(), 0, 0)
+        player.actions:finishFurnishing()
     end)
 
     it('refuses to plant a pot into itself', function()
@@ -232,6 +236,9 @@ describe('Gardening', function()
                     -- A full mog safe blocks the next sowing.
                     player:delContainerItems(xi.inv.MOGSAFE)
                     stockSafe(player, xi.item.EARTHEN_FLOWERPOT)
+                    local nextPot = mogItem(player, xi.item.EARTHEN_FLOWERPOT)
+                    player.actions:placeFurniture(xi.inv.MOGSAFE, nextPot:getSlotID(), 0, 0)
+                    player.actions:finishFurnishing()
                 end
 
                 assert(gotOre, string.format('expected %s feed to yield %s ore', feedEntry.element, feedEntry.element))

--- a/src/map/packets/c2s/0x0fb_myroom_bankin.cpp
+++ b/src/map/packets/c2s/0x0fb_myroom_bankin.cpp
@@ -26,6 +26,7 @@
 #include "entities/char_entity.h"
 #include "enums/item_lockflg.h"
 #include "items/exdata/mannequin.h"
+#include "items/item_flowerpot.h"
 #include "items/item_furnishing.h"
 #include "lua/luautils.h"
 #include "packets/s2c/0x01c_item_max.h"
@@ -98,6 +99,12 @@ void GP_CLI_COMMAND_MYROOM_BANKIN::process(MapSession* PSession, CCharEntity* PC
     PFurnishing->setRow(0);
     PFurnishing->setLevel(0);
     PFurnishing->setRotation(0);
+
+    // If this furniture is a flowerpot, destroy anything planted in it.
+    if (auto* PPotItem = dynamic_cast<CItemFlowerpot*>(PFurnishing))
+    {
+        PPotItem->cleanPot();
+    }
 
     // If this furniture is a mannequin, clear its appearance and unlock all items that were on it!
     if (PFurnishing->isMannequin())

--- a/src/map/packets/c2s/0x0fc_myroom_plant_add.cpp
+++ b/src/map/packets/c2s/0x0fc_myroom_plant_add.cpp
@@ -84,6 +84,12 @@ void GP_CLI_COMMAND_MYROOM_PLANT_ADD::process(MapSession* PSession, CCharEntity*
         return;
     }
 
+    if (!PPotItem->isInstalled())
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_MYROOM_PLANT_ADD: {} tried to interact with an uninstalled flowerpot", PChar->getName());
+        return;
+    }
+
     if (PItem == nullptr || PItem->getQuantity() < 1)
     {
         return;

--- a/src/map/packets/c2s/0x0fd_myroom_plant_check.cpp
+++ b/src/map/packets/c2s/0x0fd_myroom_plant_check.cpp
@@ -67,6 +67,12 @@ void GP_CLI_COMMAND_MYROOM_PLANT_CHECK::process(MapSession* PSession, CCharEntit
         return;
     }
 
+    if (!PPotItem->isInstalled())
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_MYROOM_PLANT_CHECK: {} tried to interact with an uninstalled flowerpot", PChar->getName());
+        return;
+    }
+
     if (PPotItem->isPlanted())
     {
         PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, CItemFlowerpot::getSeedID(PPotItem->getPlant()), 0, MsgBasic::GardeningSeedSown);

--- a/src/map/packets/c2s/0x0fe_myroom_plant_crop.cpp
+++ b/src/map/packets/c2s/0x0fe_myroom_plant_crop.cpp
@@ -74,6 +74,12 @@ void GP_CLI_COMMAND_MYROOM_PLANT_CROP::process(MapSession* PSession, CCharEntity
         return;
     }
 
+    if (!PPotItem->isInstalled())
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_MYROOM_PLANT_CROP: {} tried to interact with an uninstalled flowerpot", PChar->getName());
+        return;
+    }
+
     // Try to catch packet abuse, leading to gardening pots being placed on 2nd floor.
     if (PPotItem->getOn2ndFloor() && PPotItem->isGardeningPot())
     {

--- a/src/map/packets/c2s/0x0ff_myroom_plant_stop.cpp
+++ b/src/map/packets/c2s/0x0ff_myroom_plant_stop.cpp
@@ -48,6 +48,12 @@ void GP_CLI_COMMAND_MYROOM_PLANT_STOP::process(MapSession* PSession, CCharEntity
     CItemContainer* PItemContainer = PChar->getStorage(this->MyroomPlantCategory);
     CItemFlowerpot* PItem          = dynamic_cast<CItemFlowerpot*>(PItemContainer->GetItem(this->MyroomPlantItemIndex));
 
+    if (PItem != nullptr && !PItem->isInstalled())
+    {
+        ShowWarningFmt("GP_CLI_COMMAND_MYROOM_PLANT_STOP: {} tried to interact with an uninstalled flowerpot", PChar->getName());
+        return;
+    }
+
     if (PItem != nullptr && PItem->isPlanted() && PItem->getStage() > FLOWERPOT_STAGE_INITIAL && PItem->getStage() < FLOWERPOT_STAGE_WILTED && !PItem->isDried())
     {
         PChar->pushPacket<GP_SERV_COMMAND_MESSAGE>(this->MyroomPlantItemNo, MsgStd::MoogleDriesPlant);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Cleans up plants inside of pots when removing them as furnishings
* Adds some protection against packet injection to gardening related commands

## Capture
https://youtu.be/mPhITa2gYvY

## Steps to test these changes

Go to your home nation mog house
!additem Wooden_Flowerpot
!additem Grain_Seeds
Place the flowerpot as a furnishing and plant the seed
Remove the flower pot -> you should be prompted if you want to destroy the plant in it. 
Replant the flower pot, examine it, see that its empty. 