### PR TITLE
[lua] Disable existing Ancient Lockboxes from old assault system

### DIFF
--- a/scripts/zones/Lebros_Cavern/npcs/Ancient_Lockbox.lua
+++ b/scripts/zones/Lebros_Cavern/npcs/Ancient_Lockbox.lua
@@ -5,6 +5,8 @@
 ---@type TNpcEntity
 local entity = {}
 
+-- Legacy code, for reference use only. Remove assault sections as they are migrated to the new system and when none are left, delete this NPC script.
+--[[
 entity.onTrigger = function(player, npc)
     local qItem =
     {
@@ -74,5 +76,6 @@ entity.onTrigger = function(player, npc)
     local area = player:getCurrentAssault()
     xi.appraisal.assaultChestTrigger(player, npc, qItem[area], regItem[area])
 end
+--]]
 
 return entity

--- a/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Ancient_Lockbox.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/npcs/Ancient_Lockbox.lua
@@ -5,6 +5,8 @@
 ---@type TNpcEntity
 local entity = {}
 
+-- Legacy code, for reference use only. Remove assault sections as they are migrated to the new system and when none are left, delete this NPC script.
+--[[
 entity.onTrigger = function(player, npc)
     local qItem =
     {
@@ -67,5 +69,6 @@ entity.onTrigger = function(player, npc)
     local area = player:getCurrentAssault()
     xi.appraisal.assaultChestTrigger(player, npc, qItem[area], regItem[area])
 end
+--]]
 
 return entity

--- a/scripts/zones/Periqia/npcs/Ancient_Lockbox.lua
+++ b/scripts/zones/Periqia/npcs/Ancient_Lockbox.lua
@@ -5,6 +5,8 @@
 ---@type TNpcEntity
 local entity = {}
 
+-- Legacy code, for reference use only. Remove assault sections as they are migrated to the new system and when none are left, delete this NPC script.
+--[[
 entity.onTrigger = function(player, npc)
     local qItem =
     {
@@ -100,5 +102,6 @@ entity.onTrigger = function(player, npc)
     local area = player:getCurrentAssault()
     xi.appraisal.assaultChestTrigger(player, npc, qItem[area], regItem[area])
 end
+--]]
 
 return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

These scripts are obsolete due to the new assault system
However, not all assaults are ported yet so these are useful as reference

These scripts should be deleted as the assaults come in and there's nothing left to reference.

## Steps to test these changes

N/A, CI passes.
