### PR TITLE
[lua] Anniversary Ring Enum

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -7245,6 +7245,7 @@ xi.item =
     ARMORED_RING                        = 15783,
     DOMINION_RING                       = 15784,
     MULTIPLE_RING                       = 15790,
+    ANNIVERSARY_RING                    = 15793,
     IOTA_RING                           = 15799,
     OMEGA_RING                          = 15800,
     FERAL_RING                          = 15802,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds an enum for the Anniversary Ring which is used in multiple versions of the Adventurer Appreciation Campaign event present in different eras of the game's life.

## Steps to test these changes

Load the server. 
