### PR TITLE
[core] Clamp getBaseExp / DistributeExperiencePoints  to Lv99

### DIFF
--- a/scripts/enum/item.lua
+++ b/scripts/enum/item.lua
@@ -9636,6 +9636,7 @@ xi.item =
     GOBBIE_GOODIE_BAG                   = 21370,
     GINSEN                              = 21371,
     DUNNA                               = 21372,
+    MAGNETO                             = 21375,
     VANIR_BATTERY                       = 21380,
     SERAPHICALLER                       = 21381,
     EMINENT_SACHET                      = 21383,

--- a/scripts/tests/systems/combat/ilvl_pet_exp.lua
+++ b/scripts/tests/systems/combat/ilvl_pet_exp.lua
@@ -1,0 +1,44 @@
+-- Test ensures item level pets do not dirty EXP calculations for their masters.
+describe('item level pets do not dirty EXP', function()
+    ---@type CClientEntityPair
+    local player
+
+    ---@type CTestEntity
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.PUP,
+                level = 99,
+                zone  = xi.zone.CEIZAK_BATTLEGROUNDS,
+            })
+
+        mob = player.entities:moveTo('Blanched_Mandragora')
+        mob:setLevelRange(100, 100)
+        mob:respawn()
+        player:setUnkillable(true)
+    end)
+
+    it('survives a pet that outlevels its master', function()
+        player:addItem(xi.item.MAGNETO)
+        player:equipItem(xi.item.MAGNETO, nil, xi.slot.RANGED)
+        player:spawnPet(xi.petId.AUTOMATON)
+
+        local pet = player:getPet()
+        assert(pet)
+        assert(pet:getMainLvl() == 117,
+            string.format('expected a level 117 automaton, got %d', pet:getMainLvl()))
+
+        stub('xi.combat.physicalHitRate.getPhysicalHitRate', 1) -- Sets the hit rate to 100%
+
+        pet:engage(mob:getTargID())
+
+        for _ = 1, 4 do
+            xi.test.world:tickEntity(pet)
+            xi.test.world:skipTime(5)
+        end
+
+        assert(player:checkKillCredit(mob), 'master still gets credit for defeating the mob')
+    end)
+end)

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -4456,9 +4456,12 @@ EMobDifficulty CheckMob(uint8 charlvl, CBattleEntity* PMob)
 
 uint32 GetBaseExp(uint8 charlvl, int16 moblvl)
 {
+    // Pets can surpass level 99, but they do not count against the player for EXP calculations.
+    charlvl = std::min<uint8>(charlvl, 99);
+
     const int32 levelDif = moblvl - charlvl + 44;
 
-    if (charlvl > 0 && charlvl < 100)
+    if (charlvl > 0)
     {
         return g_ExpTable[std::clamp(levelDif, 0, ExpTableRowCount - 1)][(charlvl - 1) / 5];
     }
@@ -4675,7 +4678,7 @@ void DistributeExperiencePoints(CCharEntity* PChar, CMobEntity* PMob)
     // clang-format on
 
     pcinzone            = std::max(pcinzone, PMob->m_HiPartySize);
-    maxlevel            = std::max(maxlevel, PMob->m_HiPCLvl);
+    maxlevel            = std::min<uint8>(std::max(maxlevel, PMob->m_HiPCLvl), 99);
     PMob->m_HiPartySize = pcinzone;
     PMob->m_HiPCLvl     = maxlevel;
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Clamps getBaseExp / DistributeExperiencePoints to Lv99 so that item level pets / charmed pets (which can surpass level 99) do not dirty the experience points for their master. Verified this also applies to charmed pets with a capture below, so it is very likely that SE handles this the exact same way. 

Regression test included

## Capture

Lv108 Charmed Saptrap vs Lv108 Saptrap
<img width="523" height="69" alt="image" src="https://github.com/user-attachments/assets/f69a6127-0d8d-46fe-ae15-09e4086bfd8b" />
Lv99 Dancer (Solo) vs Lv108 Saptrap
<img width="416" height="76" alt="image" src="https://github.com/user-attachments/assets/2f62921f-d309-4648-bb59-e5a475ea194e" />


Closes https://github.com/LandSandBoat/server/issues/11185

## Steps to test these changes

!changejob PUP 99
!additem Magneto
Equip it, summon your automaton and fight a Lv100 enemy (Blanched Mandragora works)
See that you still get EXP.
