### PR TITLE
[module] [lua] Era OP Warp Module

### DIFF
--- a/modules/era/lua/globals/conquest.lua
+++ b/modules/era/lua/globals/conquest.lua
@@ -1,0 +1,66 @@
+-----------------------------------
+-- Era Outpost Teleport Payment Module - Removes conquest points as a payment option for outpost teleportation.
+-- Added December 14th, 2011 : https://forum.square-enix.com/ffxi/threads/18132
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_outpost_teleport_payment', xi.pre(xi.expansion.VOIDWATCH))
+
+-- The client menus always list the conquest point option. The server cannot hide it.
+-- A reported balance of 0 makes the client refuse the option with its own error message.
+m:addOverride('xi.conquest.vendorOnTrigger', function(player, vendorRegion, vendorEvent)
+    local pNation = player:getNation()
+    local owner   = GetRegionOwner(vendorRegion)
+    local nation  = 0
+    local fee     = xi.conquest.outpostFee(player, vendorRegion)
+
+    if owner == pNation then
+        nation = 1
+    elseif xi.conquest.areAllies(pNation, owner) then
+        nation = 2
+    end
+
+    player:setLocalVar('outpostCpNoticeShown', 0)
+    player:startEvent(vendorEvent, nation, fee, 0, fee / 10, 0, 0, 0, 0)
+end)
+
+m:addOverride('xi.conquest.vendorOnEventUpdate', function(player, vendorRegion)
+    local fee = xi.conquest.outpostFee(player, vendorRegion)
+
+    -- The event also updates mid-warp on the gil path. Notify once per interaction.
+    if player:getLocalVar('outpostCpNoticeShown') == 0 then
+        player:setLocalVar('outpostCpNoticeShown', 1)
+        player:printToPlayer('Outpost Teleportation using Conquest Points is out of era.', xi.msg.channel.SYSTEM_3)
+    end
+
+    player:updateEvent(player:getGil(), fee, 0, fee / 10, 0)
+end)
+
+m:addOverride('xi.conquest.vendorOnEventFinish', function(player, option, vendorRegion)
+    -- Option 6 pays with conquest points.
+    if option == 6 then
+        return
+    end
+
+    super(player, option, vendorRegion)
+end)
+
+m:addOverride('xi.conquest.teleporterOnEventUpdate', function(player, csid, option, teleporterEvent)
+    if csid == teleporterEvent then
+        local region = option - 1073741829
+        local fee    = xi.conquest.outpostFee(player, region)
+        local cpFee  = fee / 10
+
+        player:printToPlayer('Outpost Teleportation using Conquest Points is out of era.', xi.msg.channel.SYSTEM_3)
+        player:updateEvent(player:getGil(), fee, 0, cpFee, 0)
+    end
+end)
+
+m:addOverride('xi.conquest.teleporterOnEventFinish', function(player, csid, option, teleporterEvent)
+    -- Options 1029-1047 pay with conquest points.
+    if csid == teleporterEvent and option >= 1029 and option <= 1047 then
+        return
+    end
+
+    super(player, csid, option, teleporterEvent)
+end)

--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1722,13 +1722,13 @@ xi.conquest.vendorOnTrigger = function(player, vendorRegion, vendorEvent)
         nation = 2
     end
 
-    player:startEvent(vendorEvent, nation, fee, 0, fee, player:getCP(), 0, 0, 0)
+    player:startEvent(vendorEvent, nation, fee, 0, fee / 10, player:getCP(), 0, 0, 0)
 end
 
 xi.conquest.vendorOnEventUpdate = function(player, vendorRegion)
     local fee = xi.conquest.outpostFee(player, vendorRegion)
 
-    player:updateEvent(player:getGil(), fee, 0, fee, player:getCP())
+    player:updateEvent(player:getGil(), fee, 0, fee / 10, player:getCP())
 end
 
 xi.conquest.vendorOnEventFinish = function(player, option, vendorRegion)
@@ -1741,8 +1741,12 @@ xi.conquest.vendorOnEventFinish = function(player, option, vendorRegion)
             player:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.HOME_NATION, duration = 1, origin = player, icon = 0, subPower = vendorRegion })
         end
     elseif option == 6 then
-        player:delCP(fee)
-        player:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.HOME_NATION, duration = 1, origin = player, icon = 0, subPower = vendorRegion })
+        local cpFee = fee / 10
+
+        if player:getCP() >= cpFee then
+            player:delCP(cpFee)
+            player:addStatusEffect(xi.effect.TELEPORT, { power = xi.teleport.id.HOME_NATION, duration = 1, origin = player, icon = 0, subPower = vendorRegion })
+        end
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds and era module that removes Conquest Points as a form of payment for outpost warp teleportation because it was added in [December 2011](https://forum.square-enix.com/ffxi/threads/18132). The module operates by reporting a conquest points balance of 0 and refusing to do it. It also prints a custom message to the player letting them know what is happening. Finally, it also fixes the base outpost vendor warp, which charged the full gil fee in conquest points instead of 1/10 and never checked the player's balance before deducting.

## Steps to test these changes

Load the module. See you can't warp using conquest points.
