### PR TITLE
[module][lua] Stop Ninja from losing xp with 2H before WOTG

### DIFF
--- a/modules/era/lua/globals/job_utils/ninja.lua
+++ b/modules/era/lua/globals/job_utils/ninja.lua
@@ -44,21 +44,9 @@ m:addOverrideByEra('xi.effects.sange.onEffectGain', {
 
 -- Mijin Gakure: Now applies weakness and normal HP gain on raise
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(07/20/2009)
-m:addOverrideByEra('xi.job_utils.ninja.useMijinGakure', {
-    [xi.expansion.WOTG] = function(player, target, ability, action)
-        local dmg        = math.floor(player:getHP() * 0.8)
-        local resist     = xi.combat.magicHitRate.calculateResistRate(player, target, { magicalElement = xi.element.NONE, actorStat = xi.mod.INT })
-        local tmdaFactor = xi.combat.damage.calculateDamageAdjustment(target, false, true, false, false)
-        local jpFactor   = 1 + player:getJobPointLevel(xi.jp.MIJIN_GAKURE_EFFECT) * 0.03
-
-        dmg = math.floor(dmg * resist)
-        dmg = math.floor(dmg * tmdaFactor)
-        dmg = math.floor(dmg * jpFactor)
-        dmg = utils.handleStoneskin(target, dmg)
-
-        target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
-        player:setHP(0)
-
-        return dmg
+m:addOverrideByEra('xi.player.onPlayerDeath', {
+    [xi.expansion.WOTG] = function(player)
+        super(player)
+        player:setLocalVar('MijinGakure', 0)
     end,
 })


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

With the module enabled, Ninja lost xp when using 2h. This fixes it by allowing no exp loss, then disabling the variable so weakness and hp is normal.. Also, the old way the module was maintained, the useMijinGakure differed from what was actually in LSB, so now you don't have to maintain a module if useMijinGakure changes.

## Steps to test these changes

In server\modules\init.txt, add era/lua
In server\settings\main.lua set RESTRICT_CONTENT to 1 and ENABLE_WOTG to 0
Go die as a ninja and get raised.
