### PR TITLE
[cpp][sql] Changes all trade logs to be logged on success only

### DIFF
--- a/sql/auction_house.sql
+++ b/sql/auction_house.sql
@@ -18,13 +18,15 @@ CREATE TABLE IF NOT EXISTS `auction_house` (
   `seller_name` varchar(15) DEFAULT NULL,
   `date` int(10) unsigned NOT NULL DEFAULT '0',
   `price` int(10) unsigned NOT NULL DEFAULT '0',
+  `buyer` int(10) unsigned NOT NULL DEFAULT '0',
   `buyer_name` varchar(15) DEFAULT NULL,
   `sale` int(10) unsigned NOT NULL DEFAULT '0',
   `sell_date` int(10) unsigned NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `idx_ah_active` (`buyer_name`, `itemid`, `stack`, `price`),
   KEY `idx_ah_history` (`itemid`, `stack`, `sell_date`),
-  KEY `charid` (`seller`)
+  KEY `charid` (`seller`),
+  KEY `buyer` (`buyer`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci AUTO_INCREMENT=1 ;
 
 --

--- a/src/map/items/transactions/npc_trade.cpp
+++ b/src/map/items/transactions/npc_trade.cpp
@@ -21,16 +21,51 @@
 
 #include "npc_trade.h"
 
+#include "common/earth_time.h"
 #include "common/logging.h"
+#include "common/settings.h"
 
+#include "entities/base_entity.h"
 #include "entities/char_entity.h"
 #include "items/item.h"
 #include "utils/charutils.h"
 
 #include <algorithm>
 
-NpcTradeTransaction::NpcTradeTransaction(xi::Badge<NpcTradeTransaction>, CCharEntity* player)
+namespace
+{
+
+const auto auditTrade = [](CCharEntity* PChar, const uint32 npcId, const std::string& npcName, const uint16 itemId, const uint32 quantity)
+{
+    // TODO: Don't pass around Scheduler& through PSession
+    if (!settings::get<bool>("map.AUDIT_PLAYER_TRADES") || !PChar->PSession || !PChar->PSession->scheduler)
+    {
+        return;
+    }
+
+    PChar->PSession->scheduler->postToWorkerThread(
+        [itemId,
+         quantity,
+         sender        = PChar->id,
+         sender_name   = PChar->getName(),
+         receiver      = npcId,
+         receiver_name = npcName,
+         date          = earth_time::timestamp()]()
+        {
+            const auto query = "INSERT INTO audit_trade(itemid, quantity, sender, sender_name, receiver, receiver_name, date) VALUES (?, ?, ?, ?, ?, ?, ?)";
+            if (!db::preparedStmt(query, itemId, quantity, sender, sender_name, receiver, receiver_name, date))
+            {
+                ShowErrorFmt("Failed to log trade transaction (item: {}, quantity: {}, sender: {}, receiver: {}, date: {})", itemId, quantity, sender, receiver, date);
+            }
+        });
+};
+
+} // namespace
+
+NpcTradeTransaction::NpcTradeTransaction(xi::Badge<NpcTradeTransaction>, CCharEntity* player, const CBaseEntity* npc)
 : player_(player)
+, npcId_(npc->id)
+, npcName_(npc->getName())
 {
 }
 
@@ -39,14 +74,14 @@ NpcTradeTransaction::~NpcTradeTransaction()
     this->rollbackIfOpen();
 }
 
-auto NpcTradeTransaction::start(CCharEntity* player) -> std::unique_ptr<NpcTradeTransaction>
+auto NpcTradeTransaction::start(CCharEntity* player, const CBaseEntity* npc) -> std::unique_ptr<NpcTradeTransaction>
 {
-    if (!player)
+    if (!player || !npc)
     {
         return nullptr;
     }
 
-    return std::unique_ptr<NpcTradeTransaction>(new NpcTradeTransaction(xi::Badge<NpcTradeTransaction>{}, player));
+    return std::unique_ptr<NpcTradeTransaction>(new NpcTradeTransaction(xi::Badge<NpcTradeTransaction>{}, player, npc));
 }
 
 auto NpcTradeTransaction::stage(const uint8 tradeSlot, CItem* item, const uint32 quantity) -> bool
@@ -152,6 +187,9 @@ auto NpcTradeTransaction::resolve(Slot& slot) -> CItem*
 
 auto NpcTradeTransaction::consumeConfirmed() -> bool
 {
+    // consumeSlot wipes the slots, so we need a way to save what changed hands now and log it only once the trade is successful
+    const auto traded = this->tradedItems(true);
+
     for (auto& slot : this->slots_)
     {
         // all or nothing: a partial take rolls back rather than leaving the offer half consumed
@@ -163,11 +201,25 @@ auto NpcTradeTransaction::consumeConfirmed() -> bool
         }
     }
 
-    return this->commit();
+    if (!this->commit())
+    {
+        return false;
+    }
+
+    // Log every item if it was successful AFTER the trade has been completed
+    for (const auto& item : traded)
+    {
+        auditTrade(this->player_, this->npcId_, this->npcName_, item.itemId, item.qty);
+    }
+
+    return true;
 }
 
 auto NpcTradeTransaction::consumeAll() -> bool
 {
+    // consumeSlot wipes the slots, so we need a way to save what changed hands now and log it only once the trade is successful
+    const auto traded = this->tradedItems(false);
+
     for (auto& slot : this->slots_)
     {
         if (slot.offered.isSet() && !this->consumeSlot(slot, slot.quantity))
@@ -178,7 +230,44 @@ auto NpcTradeTransaction::consumeAll() -> bool
         }
     }
 
-    return this->commit();
+    if (!this->commit())
+    {
+        return false;
+    }
+
+    // Log every item if it was successful AFTER the trade has been completed
+    for (const auto& item : traded)
+    {
+        auditTrade(this->player_, this->npcId_, this->npcName_, item.itemId, item.qty);
+    }
+
+    return true;
+}
+
+auto NpcTradeTransaction::tradedItems(const bool confirmedOnly) const -> std::vector<TradedItem>
+{
+    std::vector<TradedItem> traded;
+
+    for (const auto& slot : this->slots_)
+    {
+        const auto qty = [&]() -> uint32
+        {
+            if (confirmedOnly)
+            {
+                return slot.confirmed;
+            }
+
+            return slot.quantity;
+        }();
+
+        const CItem* PStaged = slot.offered.resolve();
+        if (qty > 0 && PStaged)
+        {
+            traded.push_back({ .itemId = PStaged->getID(), .qty = qty });
+        }
+    }
+
+    return traded;
 }
 
 auto NpcTradeTransaction::consumeSlot(Slot& slot, const uint32 quantity) -> bool

--- a/src/map/items/transactions/npc_trade.h
+++ b/src/map/items/transactions/npc_trade.h
@@ -31,7 +31,10 @@
 
 #include <array>
 #include <memory>
+#include <string>
+#include <vector>
 
+class CBaseEntity;
 class CCharEntity;
 class CItem;
 
@@ -47,9 +50,9 @@ class CItem;
 class NpcTradeTransaction final : public Transaction
 {
 public:
-    static auto start(CCharEntity* player) -> std::unique_ptr<NpcTradeTransaction>;
+    static auto start(CCharEntity* player, const CBaseEntity* npc) -> std::unique_ptr<NpcTradeTransaction>;
 
-    NpcTradeTransaction(xi::Badge<NpcTradeTransaction>, CCharEntity* player);
+    NpcTradeTransaction(xi::Badge<NpcTradeTransaction>, CCharEntity* player, const CBaseEntity* npc);
     ~NpcTradeTransaction() override;
 
     DISALLOW_COPY_AND_MOVE(NpcTradeTransaction);
@@ -87,9 +90,20 @@ private:
     // resolves the offered stack, re-claiming it if the claim was released after onTrade
     auto resolve(Slot& slot) -> CItem*;
 
+    struct TradedItem
+    {
+        uint16 itemId{};
+        uint32 qty{};
+    };
+
+    // everything saved from the offer, for auditing once the trade is successful
+    auto tradedItems(bool confirmedOnly) const -> std::vector<TradedItem>;
+
     // takes quantity from the slot and clears it
     [[nodiscard]] auto consumeSlot(Slot& slot, uint32 quantity) -> bool;
 
     CCharEntity*                     player_{};
+    uint32                           npcId_{};
+    std::string                      npcName_;
     std::array<Slot, CONTAINER_SIZE> slots_{};
 };

--- a/src/map/items/transactions/player_trade.cpp
+++ b/src/map/items/transactions/player_trade.cpp
@@ -21,7 +21,9 @@
 
 #include "player_trade.h"
 
+#include "common/earth_time.h"
 #include "common/logging.h"
+#include "common/settings.h"
 
 #include "entities/char_entity.h"
 #include "enums/item_flag.h"
@@ -51,6 +53,31 @@ auto withinTradeRange(const CCharEntity* initiator, const CCharEntity* target) -
 {
     return distance(initiator->loc.p, target->loc.p) <= TradeRange && initiator->m_moghouseID == target->m_moghouseID;
 }
+
+const auto auditTrade = [](CCharEntity* PChar, const CCharEntity* PTarget, const uint16 itemId, const uint32 quantity)
+{
+    // TODO: Don't pass around Scheduler& through PSession
+    if (!settings::get<bool>("map.AUDIT_PLAYER_TRADES") || !PChar->PSession || !PChar->PSession->scheduler)
+    {
+        return;
+    }
+
+    PChar->PSession->scheduler->postToWorkerThread(
+        [itemId,
+         quantity,
+         sender        = PChar->id,
+         sender_name   = PChar->getName(),
+         receiver      = PTarget->id,
+         receiver_name = PTarget->getName(),
+         date          = earth_time::timestamp()]()
+        {
+            const auto query = "INSERT INTO audit_trade(itemid, quantity, sender, sender_name, receiver, receiver_name, date) VALUES (?, ?, ?, ?, ?, ?, ?)";
+            if (!db::preparedStmt(query, itemId, quantity, sender, sender_name, receiver, receiver_name, date))
+            {
+                ShowErrorFmt("Failed to log trade transaction (item: {}, quantity: {}, sender: {}, receiver: {}, date: {})", itemId, quantity, sender, receiver, date);
+            }
+        });
+};
 
 } // namespace
 
@@ -467,11 +494,49 @@ auto PlayerTradeTransaction::doCommit() -> bool
         return true;
     };
 
-    // a failure anywhere rolls the whole exchange back, so neither side ends up short
-    return deliverSide(this->sides_[0], target) &&
-           deliverSide(this->sides_[1], initiator) &&
-           consumeSide(this->sides_[0]) &&
-           consumeSide(this->sides_[1]);
+    // consumeSide wipes the slots, so we need a way to save what changed hands now and log it only once the trade is successful
+    const auto traded = this->tradedItems(initiator, target);
+
+    // is the trade successfully executed?
+    const auto exchanged = deliverSide(this->sides_[0], target) &&
+                           deliverSide(this->sides_[1], initiator) &&
+                           consumeSide(this->sides_[0]) &&
+                           consumeSide(this->sides_[1]);
+
+    // If anything is not successful, trade fails
+    if (!exchanged)
+    {
+        return false;
+    }
+
+    // Log every item if it was successful AFTER the trade has been completed
+    for (const auto& item : traded)
+    {
+        auditTrade(item.sender, item.receiver, item.itemId, item.qty);
+    }
+
+    return true;
+}
+
+auto PlayerTradeTransaction::tradedItems(CCharEntity* initiator, CCharEntity* target) const -> std::vector<TradedItem>
+{
+    std::vector<TradedItem> traded;
+
+    const auto collect = [&](const Side& side, CCharEntity* sender, CCharEntity* receiver)
+    {
+        for (const auto& slot : side.slots)
+        {
+            if (const CItem* PStaged = slot.staged.resolve())
+            {
+                traded.push_back({ .sender = sender, .receiver = receiver, .itemId = PStaged->getID(), .qty = slot.qty });
+            }
+        }
+    };
+
+    collect(this->sides_[0], initiator, target);
+    collect(this->sides_[1], target, initiator);
+
+    return traded;
 }
 
 void PlayerTradeTransaction::doRollback()

--- a/src/map/items/transactions/player_trade.h
+++ b/src/map/items/transactions/player_trade.h
@@ -29,6 +29,8 @@
 #include "items/transaction.h"
 
 #include <array>
+#include <string>
+#include <vector>
 
 class CCharEntity;
 class CItem;
@@ -79,6 +81,17 @@ private:
         std::array<Slot, MaxSlots> slots{};
         bool                       accepted{};
     };
+
+    struct TradedItem
+    {
+        CCharEntity* sender{};
+        CCharEntity* receiver{};
+        uint16       itemId{};
+        uint32       qty{};
+    };
+
+    // everything saved on both sides, for auditing once the trade is successful
+    auto tradedItems(CCharEntity* initiator, CCharEntity* target) const -> std::vector<TradedItem>;
 
     auto sideOf(const CCharEntity* who) -> Side*;
     auto partnerOf(const CCharEntity* who) const -> CCharEntity*;

--- a/src/map/packets/c2s/0x034_trade_list.cpp
+++ b/src/map/packets/c2s/0x034_trade_list.cpp
@@ -30,28 +30,6 @@
 namespace
 {
 
-const auto auditTrade = [](Scheduler& scheduler, CCharEntity* PChar, CCharEntity* PTarget, const CItem* PItem, uint32_t ItemNum)
-{
-    if (settings::get<bool>("map.AUDIT_PLAYER_TRADES"))
-    {
-        scheduler.postToWorkerThread(
-            [itemID        = PItem->getID(),
-             quantity      = ItemNum,
-             sender        = PChar->id,
-             sender_name   = PChar->getName(),
-             receiver      = PTarget->id,
-             receiver_name = PTarget->getName(),
-             date          = earth_time::timestamp()]()
-            {
-                const auto query = "INSERT INTO audit_trade(itemid, quantity, sender, sender_name, receiver, receiver_name, date) VALUES (?, ?, ?, ?, ?, ?, ?)";
-                if (!db::preparedStmt(query, itemID, quantity, sender, sender_name, receiver, receiver_name, date))
-                {
-                    ShowErrorFmt("Failed to log trade transaction (item: {}, quantity: {}, sender: {}, receiver: {}, date: {})", itemID, quantity, sender, receiver, date);
-                }
-            });
-    }
-};
-
 const auto hasLinkshellEquipped = [](const CCharEntity* PChar, CItemLinkshell* POffered) -> bool
 {
     const auto asLinkshell = [](CItemEquipment* PEquipped) -> CItemLinkshell*
@@ -111,9 +89,5 @@ void GP_CLI_COMMAND_TRADE_LIST::process(MapSession* PSession, CCharEntity* PChar
         return;
     }
 
-    if (const auto* PItem = transaction->setSlot(PChar, this->TradeIndex, this->ItemIndex, this->ItemNo, this->ItemNum))
-    {
-        // TODO: Don't pass around Scheduler& through PSession
-        auditTrade(*PSession->scheduler, PChar, PTarget, PItem, this->ItemNum);
-    }
+    transaction->setSlot(PChar, this->TradeIndex, this->ItemIndex, this->ItemNo, this->ItemNum);
 }

--- a/src/map/packets/c2s/0x036_item_transfer.cpp
+++ b/src/map/packets/c2s/0x036_item_transfer.cpp
@@ -38,28 +38,6 @@ namespace
 // 8 trade window slots plus gil
 constexpr uint8 MAX_TRADE_SLOTS = 9;
 
-const auto auditTrade = [](Scheduler& scheduler, const CCharEntity* PChar, const CBaseEntity* PNpc, uint32_t itemId, uint32_t quantity)
-{
-    if (settings::get<bool>("map.AUDIT_PLAYER_TRADES"))
-    {
-        const auto  sender       = PChar->id;
-        const auto& senderName   = PChar->getName();
-        const auto  receiver     = PNpc->id;
-        const auto& receiverName = PNpc->getName();
-
-        scheduler.postToWorkerThread(
-            [itemId, quantity, sender, senderName, receiver, receiverName]()
-            {
-                const auto tradeDate = earth_time::timestamp();
-                const auto query     = "INSERT INTO audit_trade(itemid, quantity, sender, sender_name, receiver, receiver_name, date) VALUES (?, ?, ?, ?, ?, ?, ?)";
-                if (!db::preparedStmt(query, itemId, quantity, sender, senderName, receiver, receiverName, tradeDate))
-                {
-                    ShowErrorFmt("Failed to log trade transaction (item: {}, quantity: {}, sender: {}, receiver: {}, date: {})", itemId, quantity, sender, receiver, tradeDate);
-                }
-            });
-    }
-};
-
 } // namespace
 
 auto GP_CLI_COMMAND_ITEM_TRANSFER::validate(MapSession* PSession, const CCharEntity* PChar) const -> PacketValidationResult
@@ -138,7 +116,7 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
         tradeItems[slotId] = PItem;
     }
 
-    auto* transaction = PChar->addTransaction(NpcTradeTransaction::start(PChar));
+    auto* transaction = PChar->addTransaction(NpcTradeTransaction::start(PChar, PNpc));
     if (!transaction)
     {
         return;
@@ -157,9 +135,6 @@ void GP_CLI_COMMAND_ITEM_TRANSFER::process(MapSession* PSession, CCharEntity* PC
 
             return;
         }
-
-        // TODO: Don't pass around Scheduler& through PSession
-        auditTrade(*PSession->scheduler, PChar, PNpc, PItem->getID(), quantity);
 
         PChar->TradeContainer->setItem(slotId, PItem->getID(), PItem->getSlotID(), quantity);
     }

--- a/src/map/utils/auctionutils.cpp
+++ b/src/map/utils/auctionutils.cpp
@@ -277,8 +277,9 @@ auto auctionutils::PurchasingItems(CCharEntity* PChar, GP_AUC_PARAM_BID param) -
             const auto success = db::transaction(
                 [&]()
                 {
-                    const auto rset = db::preparedStmt("UPDATE auction_house SET buyer_name = ?, sale = ?, sell_date = ? WHERE itemid = ? AND buyer_name IS NULL "
+                    const auto rset = db::preparedStmt("UPDATE auction_house SET buyer = ?, buyer_name = ?, sale = ?, sell_date = ? WHERE itemid = ? AND buyer_name IS NULL "
                                                        "AND stack = ? AND price <= ? ORDER BY price LIMIT 1",
+                                                       PChar->id,
                                                        PChar->getName(),
                                                        param.BidPrice,
                                                        earth_time::timestamp(),

--- a/tools/migrations/063_auction_house_buyer.py
+++ b/tools/migrations/063_auction_house_buyer.py
@@ -1,0 +1,28 @@
+import mariadb
+
+
+def migration_name():
+    return "Adding buyer charid to auction_house"
+
+
+def check_preconditions(cur):
+    return
+
+
+def needs_to_run(cur):
+    cur.execute("show columns from auction_house where field = 'buyer';")
+    if cur.fetchone():
+        return False
+    return True
+
+
+def migrate(cur, db):
+    try:
+        cur.execute(
+            "ALTER TABLE auction_house "
+            "ADD COLUMN buyer int(10) unsigned NOT NULL DEFAULT 0 AFTER price, "
+            "ADD INDEX buyer (buyer);"
+        )
+        db.commit()
+    except mariadb.Error as err:
+        print("Something went wrong: {}".format(err))


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Moves the trade logging to only log when the trade is completed, not on the confirm prior to the trade actually completing.
Before this when you have two players trading, the second one player confirms the trade it would log it. This was causing false logs and confusion because you wouldn't know if the trade was actually completed. This was also happening with player to npcs.

Misc. additions to logging:
- Added buyer id to auction house sql.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
You need two characters for this. Player 1 and Player 2.
!additem 16534 to Player 1
Open trade between both characters
Player 1 inputs Onion Sword into the trade window and hits Ok.
Note that the trade DOES NOT LOG yet.
Player 2 hits Ok
See the log in the audit_trade sql.
<!-- Clear and detailed steps to test your changes here -->
