### PR TITLE
[lua] Juice / Drink Audit

### DIFF
--- a/scripts/items/bottle_of_amrita.lua
+++ b/scripts/items/bottle_of_amrita.lua
@@ -10,20 +10,31 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    local worked = false
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect     = target:getStatusEffect(xi.effect.REGEN)
+    local refreshEffect   = target:getStatusEffect(xi.effect.REFRESH)
+    local canApplyRegen   = not regenEffect or regenEffect:getTier() == 0
+    local canApplyRefresh = not refreshEffect or refreshEffect:getTier() == 0
+
+    if canApplyRegen then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 5, duration = 300, origin = user, tick = 3 })
-        worked = true
     end
 
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+    if canApplyRefresh then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 5, duration = 300, origin = user, tick = 3 })
-        worked = true
     end
 
-    if not worked then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if
+        not canApplyRegen and
+        not canApplyRefresh
+    then
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when both Regen and Refresh are protected by tiered spell effects.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_apple_juice.lua
+++ b/scripts/items/bottle_of_apple_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 135, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_buffalo_bonanza_milk.lua
+++ b/scripts/items/bottle_of_buffalo_bonanza_milk.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 60, origin = user, tick = 1 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_grape_juice.lua
+++ b/scripts/items/bottle_of_grape_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 90, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_kitron_juice.lua
+++ b/scripts/items/bottle_of_kitron_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 3, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_melon_juice.lua
+++ b/scripts/items/bottle_of_melon_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 135, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_orange_juice.lua
+++ b/scripts/items/bottle_of_orange_juice.lua
@@ -10,17 +10,22 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    local power = 1
-    local legs = target:getEquipID(xi.slot.LEGS)
-    if legs == 11966 or legs == 11968 then -- Dream Trousers +1 & Dream Pants +1
-        power = power + 1
-    end
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+    local legsEquipped  = target:getEquipID(xi.slot.LEGS)
+    local refreshPower  = (legsEquipped == xi.item.DREAM_TROUSERS_P1 or legsEquipped == xi.item.DREAM_PANTS_P1) and 2 or 1
 
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
-        target:addStatusEffect(xi.effect.REFRESH, { power = power, duration = 90, origin = user, tick = 3 })
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
+        target:addStatusEffect(xi.effect.REFRESH, { power = refreshPower, duration = 90, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_pineapple_juice.lua
+++ b/scripts/items/bottle_of_pineapple_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 240, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_strange_juice.lua
+++ b/scripts/items/bottle_of_strange_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 300, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_tomato_juice.lua
+++ b/scripts/items/bottle_of_tomato_juice.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 1, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_vampire_juice.lua
+++ b/scripts/items/bottle_of_vampire_juice.lua
@@ -10,20 +10,31 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    local worked = false
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect     = target:getStatusEffect(xi.effect.REGEN)
+    local refreshEffect   = target:getStatusEffect(xi.effect.REFRESH)
+    local canApplyRegen   = not regenEffect or regenEffect:getTier() == 0
+    local canApplyRefresh = not refreshEffect or refreshEffect:getTier() == 0
+
+    if canApplyRegen then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 90, origin = user, tick = 3 })
-        worked = true
     end
 
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+    if canApplyRefresh then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 90, origin = user, tick = 3 })
-        worked = true
     end
 
-    if not worked then
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+    if
+        not canApplyRegen and
+        not canApplyRefresh
+    then
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when both Regen and Refresh are protected by tiered spell effects.
+
+        return 0
     end
 end
 

--- a/scripts/items/bottle_of_yagudo_drink.lua
+++ b/scripts/items/bottle_of_yagudo_drink.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REFRESH) then
+itemObject.onItemUse = function(target, user, item, action)
+    local refreshEffect = target:getStatusEffect(xi.effect.REFRESH)
+
+    if
+        not refreshEffect or
+        refreshEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REFRESH) -- All Refresh items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REFRESH, { power = 2, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2 or 3 Refresh.
+
+        return 0
     end
 end
 

--- a/scripts/items/bowl_of_yogurt.lua
+++ b/scripts/items/bowl_of_yogurt.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_apple_au_lait.lua
+++ b/scripts/items/flask_of_apple_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_ayran.lua
+++ b/scripts/items/flask_of_ayran.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 180, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_distilled_water.lua
+++ b/scripts/items/flask_of_distilled_water.lua
@@ -11,15 +11,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
     if
-        target:getMod(xi.mod.DRINK_DISTILLED) == 1 and
-        not target:hasStatusEffect(xi.effect.REGEN)
+        target:getMod(xi.mod.DRINK_DISTILLED) == 1 and -- TODO: Are there other items that need this? Could probably just check if the spear is equipped...
+        (not regenEffect or regenEffect:getTier() == 0)
     then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 300, origin = user, tick = 3 })
     else
-        -- Retail will consume the item while doing nothing but telling you there was no effect.
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when Lance is not equipped or attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_dragon_fruit_au_lait.lua
+++ b/scripts/items/flask_of_dragon_fruit_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 6, duration = 300, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_orange_au_lait.lua
+++ b/scripts/items/flask_of_orange_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 300, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_pamama_au_lait.lua
+++ b/scripts/items/flask_of_pamama_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 600, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_pear_au_lait.lua
+++ b/scripts/items/flask_of_pear_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 3, duration = 300, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_persikos_au_lait.lua
+++ b/scripts/items/flask_of_persikos_au_lait.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 4, duration = 600, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/flask_of_strange_milk.lua
+++ b/scripts/items/flask_of_strange_milk.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 5, duration = 300, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/jug_of_selbina_milk.lua
+++ b/scripts/items/jug_of_selbina_milk.lua
@@ -10,15 +10,22 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
-        if target:getEquipID(xi.slot.BODY) == 14520 then -- Dream Robe +1
-            target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 150, origin = user, tick = 3 })
-        else
-            target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 120, origin = user, tick = 3 })
-        end
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect   = target:getStatusEffect(xi.effect.REGEN)
+    local bodyEquipped  = target:getEquipID(xi.slot.BODY)
+    local regenDuration = bodyEquipped == xi.item.DREAM_ROBE_P1 and 150 or 120
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
+        target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = regenDuration, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/jug_of_soy_milk.lua
+++ b/scripts/items/jug_of_soy_milk.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 1, duration = 120, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 

--- a/scripts/items/jug_of_uleguerand_milk.lua
+++ b/scripts/items/jug_of_uleguerand_milk.lua
@@ -10,11 +10,20 @@ itemObject.onItemCheck = function(target, item, caster)
     return 0
 end
 
-itemObject.onItemUse = function(target, user)
-    if not target:hasStatusEffect(xi.effect.REGEN) then
+itemObject.onItemUse = function(target, user, item, action)
+    local regenEffect = target:getStatusEffect(xi.effect.REGEN)
+
+    if
+        not regenEffect or
+        regenEffect:getTier() == 0
+    then
+        target:delStatusEffectSilent(xi.effect.REGEN) -- All Regen items overwrite freely, and their effect expires silently if overwritten.
+
         target:addStatusEffect(xi.effect.REGEN, { power = 2, duration = 120, origin = user, tick = 3 })
     else
-        target:messageBasic(xi.msg.basic.NO_EFFECT)
+        action:messageID(target:getID(), xi.msg.basic.ITEM_NO_EFFECT) -- Displays no effect when attempting to overwrite tier 1, 2, 3, 4 or 5 Regen.
+
+        return 0
     end
 end
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Audits how Juice / Drink items are handled. 

Captures uncovered a few rules

1) These Regen / Refresh effects are considered "tier 0" and can be over-written by Refresh / Regen (spell) which are considered tier 1, 2, 3 etc.
2) These effects can not overwrite Refresh or Regen (spell)
3) These effects can be freely over-ridden by other Juice / Drinks no matter how strong they are or how much duration is left. (For example, Kitron Juice can be over-ridden by a Orange Juice, which is much weaker)
4) Drinks that apply both effects (like Vampire Juice) is essentially like drinking a Juice and a Drink at the same time - the Refresh / Regen effects are independent and can be over-ridden seperately by Refresh / Regen (spell) or other Drink / Juice effects. 

Supercedes : https://github.com/LandSandBoat/server/pull/10911

## Captures
https://youtu.be/XHPKicGxP-o 
https://youtu.be/tSXKX2fVbSI
https://youtu.be/VaFsII66aks

## Steps to test these changes


