### PR TITLE
[lua] Eruca/Sleep Mixin Adjustments + Mob Weather Optimization

### DIFF
--- a/scripts/actions/mobskills/incinerate.lua
+++ b/scripts/actions/mobskills/incinerate.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
     params.percentMultipier = 0.1375
-    params.damageCap        = 700
+    params.damageCap        = 800
     params.bonusDamage      = 0
     params.mAccuracyBonus   = { 0, 0, 0 }
     params.resistStat       = xi.mod.INT
@@ -22,10 +22,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.attackType       = xi.attackType.BREATH
     params.damageType       = xi.damageType.FIRE
     params.shadowBehavior   = xi.mobskills.shadowBehavior.IGNORE_SHADOWS
-
-    if mob:getPool() == xi.mobPool.ENERGETIC_ERUCA then
-        params.damageCap = 800
-    end
 
     local info = xi.mobskills.mobBreathMove(mob, target, skill, action, params)
 

--- a/scripts/mixins/families/eruca.lua
+++ b/scripts/mixins/families/eruca.lua
@@ -6,32 +6,37 @@ g_mixins.families = g_mixins.families or {}
 -----------------------------------
 
 g_mixins.families.eruca = function(erucaMob)
-    erucaMob:addListener('ROAM_TICK', 'ERUCA_ROAM_TICK', function(mob)
-        if
-            VanadielDayElement() == xi.element.FIRE and
-            mob:getMod(xi.mod.REGAIN) == 0
-        then
-            mob:setMod(xi.mod.REGAIN, 30)
-        elseif
-            VanadielDayElement() ~= xi.element.FIRE and
-            mob:getMod(xi.mod.REGAIN) ~= 0
-        then
+    erucaMob:addListener('SPAWN', 'ERUCA_SPAWN', function(mob)
+        if xi.data.element.getWeatherElement(mob:getWeather()) == xi.element.FIRE then
+            mob:setMod(xi.mod.REGAIN, 150)
+        end
+    end)
+
+    erucaMob:addListener('WEATHER_CHANGE', 'ERUCA_WEATHER_CHANGE', function(mob, weather, element)
+        if not mob:isAlive() then
+            return
+        end
+
+        if element == xi.element.FIRE then
+            mob:setMod(xi.mod.REGAIN, 150)
+        else
             mob:setMod(xi.mod.REGAIN, 0)
         end
     end)
 
-    erucaMob:addListener('COMBAT_TICK', 'ERUCA_COMBAT_TICK', function(mob)
-        if
-            VanadielDayElement() == xi.element.FIRE and
-            mob:getMod(xi.mod.REGAIN) == 0
-        then
-            mob:setMod(xi.mod.REGAIN, 30)
-        elseif
-            VanadielDayElement() ~= xi.element.FIRE and
-            mob:getMod(xi.mod.REGAIN) ~= 0
-        then
-            mob:setMod(xi.mod.REGAIN, 0)
+    erucaMob:addListener('ENGAGE', 'ERUCA_ENGAGE', function(mob)
+        if mob:isCharmed() then
+            return
         end
+
+        -- If fire weather is active, Eruca will instantly use a mobskill when they engage.
+        if xi.data.element.getWeatherElement(mob:getWeather()) == xi.element.FIRE then
+            mob:setTP(3000)
+        end
+    end)
+
+    erucaMob:addListener('DESPAWN', 'ERUCA_DESPAWN', function(mob)
+        mob:setMod(xi.mod.REGAIN, 0)
     end)
 end
 

--- a/scripts/mixins/sleep_at_night.lua
+++ b/scripts/mixins/sleep_at_night.lua
@@ -11,24 +11,26 @@ local column =
     SLEEP_HOUR_END   = 3,
     CAN_CAST         = 4,
     AGGRESSIVE       = 5,
+    LINK             = 6,
 }
 
 -- AnimationSub used to sleep.
 local dataTable =
 {
-    ['Carmine_Eruca'    ] = { 1, 21,  6, true,  true  }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
-    ['Date_Eruca'       ] = { 1, 21,  6, true,  true  }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
-    ['Jnun'             ] = { 1,  6, 18, false, true  }, -- Fat horrible things -> Awake from 18:00 to 5:59, Only 0 or 1. 1 is asleep.
-    ['Magmatic_Eruca'   ] = { 1, 21,  6, true,  true  }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
-    ['Scoriaceous_Eruca'] = { 1, 21,  6, true,  true  }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
-    ['Wild_Karakul'     ] = { 1, 20,  6, false, false }, -- Sheep               -> Awake from 6:00 to 19:59, Only 0 or 1. 1 is asleep.
-    ['Ziz'              ] = { 3, 20,  4, false, true  }, -- Cockatrices         -> Awake from 4:00 to 19:59, 1 and 2 control puch. 3 sets them to sleep, leaving pouch as is. 0 does nothing different than 1.
+    ['Carmine_Eruca'    ] = { 1, 21,  6, true,  true,  0 }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
+    ['Date_Eruca'       ] = { 1, 21,  6, true,  true,  1 }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep. -- TODO: Audit Link Behavior
+    ['Jnun'             ] = { 1,  6, 18, false, true,  1 }, -- Fat horrible things -> Awake from 18:00 to 5:59, Only 0 or 1. 1 is asleep.
+    ['Magmatic_Eruca'   ] = { 1, 21,  6, true,  true,  0 }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
+    ['Scoriaceous_Eruca'] = { 1, 21,  6, true,  true,  0 }, -- Red Crawlers        -> Awake from 6:00 to 20:59, Only 0 or 1. 1 is asleep.
+    ['Wild_Karakul'     ] = { 1, 20,  6, false, false, 1 }, -- Sheep               -> Awake from 6:00 to 19:59, Only 0 or 1. 1 is asleep. -- TODO: Audit Link Behavior
+    ['Ziz'              ] = { 3, 20,  4, false, true,  1 }, -- Cockatrices         -> Awake from 4:00 to 19:59, 1 and 2 control puch. 3 sets them to sleep, leaving pouch as is. 0 does nothing different than 1.
 }
 
 local function fallAsleep(mob, mobName)
     mob:setAnimationSub(dataTable[mobName][column.SLEEP_ANIMATION])
     mob:setMobMod(xi.mobMod.NO_MOVE, 1)
     mob:setAggressive(false)
+    mob:setMobMod(xi.mobMod.NO_LINK, 1)
     mob:setMagicCastingEnabled(false)
     mob:setLocalVar('[Sleep]wasEngaged', 0)
     mob:setLocalVar('[Sleep]reSleepTime', 0)
@@ -38,6 +40,7 @@ local function wakeUp(mob, mobName)
     mob:setAnimationSub(dataTable[mobName][column.SLEEP_ANIMATION] - 1)
     mob:setMobMod(xi.mobMod.NO_MOVE, 0)
     mob:setAggressive(dataTable[mobName][column.AGGRESSIVE])
+    mob:setMobMod(xi.mobMod.NO_LINK, dataTable[mobName][column.LINK])
     mob:setMagicCastingEnabled(dataTable[mobName][column.CAN_CAST])
     mob:setLocalVar('[Sleep]wasEngaged', 0)
     mob:setLocalVar('[Sleep]reSleepTime', 0)

--- a/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
+++ b/scripts/zones/Cape_Teriggan/mobs/Kreutzet.lua
@@ -68,11 +68,27 @@ entity.spawnPoints =
 }
 
 entity.onMobInitialize = function(mob)
-    mob:addImmunity(xi.immunity.DARK_SLEEP)
-    mob:addImmunity(xi.immunity.TERROR)
     xi.mob.updateNMSpawnPoint(mob)
+
     mob:setRespawnTime(math.randomInt(32400, 43200)) -- 9 to 12 hours
     DisallowRespawn(mob:getID(), true) -- prevents accidental 'pop' during no wind weather and immediate despawn
+
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:addImmunity(xi.immunity.TERROR)
+
+    mob:addListener('WEATHER_CHANGE', 'KREUTZET_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
+
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if element ~= xi.element.WIND then
+            DespawnMob(mobArg:getID())
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
@@ -81,33 +97,25 @@ entity.onMobSpawn = function(mob)
     mob:setfTPModifierOverride(xi.mobSkill.STORMWIND, stormwindFTP[1], stormwindFTP[1], stormwindFTP[1])
 end
 
-entity.onMobRoam = function(mob)
-    local weather = mob:getWeather()
-    if
-        weather ~= xi.weather.WIND and
-        weather ~= xi.weather.GALES
-    then
-        DespawnMob(mob:getID())
-    end
-end
-
 entity.onMobFight = function(mob, target)
-    local stormwindCounter = mob:getLocalVar('stormwindCounter')
-    if mob:canUseAbilities() then
-        if stormwindCounter == 3 then
-            mob:setLocalVar('stormwindCounter', 0)
-            mob:setfTPModifierOverride(xi.mobSkill.STORMWIND, stormwindFTP[1], stormwindFTP[1], stormwindFTP[1])
-        elseif
-            stormwindCounter >= 1 and
-            mob:checkDistance(target) <= 15
-        then
-            stormwindCounter = stormwindCounter + 1
-            mob:setLocalVar('stormwindCounter', stormwindCounter)
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
 
-            local ftp = stormwindFTP[stormwindCounter]
-            mob:setfTPModifierOverride(xi.mobSkill.STORMWIND, ftp, ftp, ftp)
-            mob:useMobAbility(xi.mobSkill.STORMWIND)
-        end
+    local stormwindCounter = mob:getLocalVar('stormwindCounter')
+    if stormwindCounter == 3 then
+        mob:setLocalVar('stormwindCounter', 0)
+        mob:setfTPModifierOverride(xi.mobSkill.STORMWIND, stormwindFTP[1], stormwindFTP[1], stormwindFTP[1])
+    elseif
+        stormwindCounter >= 1 and
+        mob:checkDistance(target) <= 15
+    then
+        stormwindCounter = stormwindCounter + 1
+        mob:setLocalVar('stormwindCounter', stormwindCounter)
+
+        local ftp = stormwindFTP[stormwindCounter]
+        mob:setfTPModifierOverride(xi.mobSkill.STORMWIND, ftp, ftp, ftp)
+        mob:useMobAbility(xi.mobSkill.STORMWIND)
     end
 end
 
@@ -118,6 +126,12 @@ entity.onMobWeaponSkill = function(mob, target, skill, action)
         stormwindCounter == 0
     then
         mob:setLocalVar('stormwindCounter', 1)
+    end
+end
+
+entity.onMobDisengage = function(mob)
+    if xi.data.element.getWeatherElement(mob:getWeather()) ~= xi.element.WIND then
+        DespawnMob(mob:getID())
     end
 end
 

--- a/scripts/zones/Misareaux_Coast/mobs/Odqan.lua
+++ b/scripts/zones/Misareaux_Coast/mobs/Odqan.lua
@@ -7,10 +7,24 @@ local ID = zones[xi.zone.MISAREAUX_COAST]
 ---@type TMobEntity
 local entity = {}
 
-entity.onMobRoam = function(mob)
-    local weather = mob:getWeather()
+entity.onMobInitialize = function(mob)
+    mob:addListener('WEATHER_CHANGE', 'ODQAN_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
 
-    if weather ~= xi.weather.FOG then
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if weather ~= xi.weather.FOG then
+            DespawnMob(mobArg:getID())
+        end
+    end)
+end
+
+entity.onMobDisengage = function(mob)
+    if mob:getWeather() ~= xi.weather.FOG then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/zones/Qufim_Island/Zone.lua
+++ b/scripts/zones/Qufim_Island/Zone.lua
@@ -40,29 +40,23 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
 zoneObject.onZoneWeatherChange = function(weather)
-    -- NM Dosetsu Tree only spawns during thunder weather
+    -- NM Dosetsu Tree spawn logic.
     local dosetsuTree = GetMobByID(ID.mob.DOSETSU_TREE)
-
     if not dosetsuTree then
         return
     end
 
-    if weather == xi.weather.THUNDER or weather == xi.weather.THUNDERSTORMS then
-        -- Spawn if respawn is up
-        if
-            not dosetsuTree:isSpawned() and
-            GetSystemTime() > dosetsuTree:getLocalVar('respawn')
-        then
-            xi.mob.updateNMSpawnPoint(dosetsuTree)
-            SpawnMob(ID.mob.DOSETSU_TREE)
-        end
-    else
-        if
-            dosetsuTree:isSpawned() and
-            not dosetsuTree:isEngaged()
-        then
-            DespawnMob(ID.mob.DOSETSU_TREE)
-        end
+    if dosetsuTree:isSpawned() then
+        return
+    end
+
+    if GetSystemTime() < dosetsuTree:getLocalVar('respawn') then
+        return
+    end
+
+    if xi.data.element.getWeatherElement(weather) == xi.element.THUNDER then
+        xi.mob.updateNMSpawnPoint(dosetsuTree)
+        SpawnMob(ID.mob.DOSETSU_TREE)
     end
 end
 

--- a/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
+++ b/scripts/zones/Qufim_Island/mobs/Dosetsu_Tree.lua
@@ -25,6 +25,20 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.TERROR)
     mob:addImmunity(xi.immunity.PLAGUE)
     mob:addImmunity(xi.immunity.SLOW)
+
+    mob:addListener('WEATHER_CHANGE', 'DOSETSU_TREE_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
+
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if xi.data.element.getWeatherElement(element) ~= xi.element.THUNDER then
+            DespawnMob(mobArg:getID())
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
@@ -43,11 +57,7 @@ entity.onMobRoam = function(mob)
 end
 
 entity.onMobDisengage = function(mob)
-    local weather = mob:getWeather()
-    if
-        weather ~= xi.weather.THUNDER and
-        weather ~= xi.weather.THUNDERSTORMS
-    then
+    if xi.data.element.getWeatherElement(mob:getWeather()) ~= xi.element.THUNDER then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/Dahu.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/Dahu.lua
@@ -29,16 +29,25 @@ entity.spawnPoints =
     { x =  -75.693, y =  0.144, z =  273.371 }
 }
 
-local validWeather =
-{
-    xi.weather.DUST_STORM,
-    xi.weather.SAND_STORM,
-    xi.weather.HOT_SPELL,
-    xi.weather.HEAT_WAVE,
-}
-
 entity.onMobInitialize = function(mob)
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+
+    mob:addListener('WEATHER_CHANGE', 'DAHU_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
+
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if
+            element ~= xi.element.FIRE and
+            element ~= xi.element.EARTH
+        then
+            DespawnMob(mobArg:getID())
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
@@ -62,10 +71,12 @@ entity.onAdditionalEffect = function(mob, target, damage)
     return xi.combat.action.executeAddEffectDamage(mob, target, pTable)
 end
 
-entity.onMobRoam = function(mob)
-    local weather = mob:getWeather()
-
-    if not utils.contains(weather, validWeather) then
+entity.onMobDisengage = function(mob)
+    local weatherElement = xi.data.element.getWeatherElement(mob:getWeather())
+    if
+        weatherElement ~= xi.element.FIRE and
+        weatherElement ~= xi.element.EARTH
+    then
         DespawnMob(mob:getID())
     end
 end

--- a/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
+++ b/scripts/zones/Western_Altepa_Desert/mobs/King_Vinegarroon.lua
@@ -59,6 +59,14 @@ entity.spawnPoints =
     { x = -238.409, y =  0.703, z = -664.933 }
 }
 
+-- Table of single target skills KV will use after an AOE TP Move
+local skillTable =
+{
+    [1] = xi.mobSkill.DEATH_SCISSORS,
+    [2] = xi.mobSkill.CRITICAL_BITE,
+    [3] = xi.mobSkill.VENOM_STING_1,
+}
+
 local function mobRegen(mob)
     local hour = VanadielHour()
 
@@ -80,6 +88,20 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.DARK_SLEEP)
 
     mob:setMobMod(xi.mobMod.ADD_EFFECT, 1)
+
+    mob:addListener('WEATHER_CHANGE', 'KV_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
+
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if xi.data.element.getWeatherElement(element) ~= xi.element.EARTH then
+            DespawnMob(mobArg:getID())
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
@@ -92,14 +114,6 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobRoam = function(mob)
-    local weather = mob:getWeather()
-    if
-        weather ~= xi.weather.DUST_STORM and
-        weather ~= xi.weather.SAND_STORM
-    then
-        DespawnMob(mob:getID())
-    end
-
     mobRegen(mob)
 end
 
@@ -128,14 +142,6 @@ entity.onMobFight = function(mob, target)
     mobRegen(mob)
 end
 
--- Table of single target skills KV will use after an AOE TP Move
-local skillTable =
-{
-    [1] = xi.mobSkill.DEATH_SCISSORS,
-    [2] = xi.mobSkill.CRITICAL_BITE,
-    [3] = xi.mobSkill.VENOM_STING_1,
-}
-
 entity.onMobSkillTarget = function(target, mob, mobskill)
     if mobskill:isAoE() then
         -- Chance for draw in to be single target or alliance
@@ -160,6 +166,12 @@ entity.onMobSkillTarget = function(target, mob, mobskill)
 
         -- KV always does an AOE TP move followed by a single target TP move
         mob:useMobAbility(skillTable[math.randomInt(1, #skillTable)])
+    end
+end
+
+entity.onMobDisengage = function(mob)
+    if xi.data.element.getWeatherElement(mob:getWeather()) ~= xi.element.EARTH then
+        DespawnMob(mob:getID())
     end
 end
 

--- a/scripts/zones/Yuhtunga_Jungle/mobs/Bayawak.lua
+++ b/scripts/zones/Yuhtunga_Jungle/mobs/Bayawak.lua
@@ -23,6 +23,20 @@ entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.GRAVITY)
     mob:addImmunity(xi.immunity.BIND)
     mob:addImmunity(xi.immunity.TERROR)
+
+    mob:addListener('WEATHER_CHANGE', 'BAYAWAK_WEATHER_CHANGE', function(mobArg, weather, element)
+        if not mobArg:isSpawned() then
+            return
+        end
+
+        if mobArg:isEngaged() then
+            return
+        end
+
+        if xi.data.element.getWeatherElement(element) ~= xi.element.FIRE then
+            DespawnMob(mobArg:getID())
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
@@ -30,12 +44,8 @@ entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
 end
 
-entity.onMobRoam = function(mob)
-    local weather = mob:getWeather()
-    if
-        weather ~= xi.weather.HOT_SPELL and
-        weather ~= xi.weather.HEAT_WAVE
-    then
+entity.onMobDisengage = function(mob)
+    if xi.data.element.getWeatherElement(mob:getWeather()) ~= xi.element.FIRE then
         DespawnMob(mob:getID())
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

### 1. Sets the damage cap of mobskill "Incinerate" to 800.
- Retail capture in screenshot below:
<img width="513" height="117" alt="image" src="https://github.com/user-attachments/assets/b989f351-0cba-4b46-b1c4-b937a32f9fee" />


### 2. Adjusts Eruca regain mechanic.
- It was set to work on Firesday on LSB.
- Retail testing showed that Eruca do not gain regain on Firesday but instead gain it on Fire Weather.
- The regain values were also adjusted based on retail observation(150 Regain in combat).
- Retail capture: https://youtu.be/kvhiHzbnev8?t=633
- Note: The capture is on fireday but I did end up doing an independent test with no Fire weather and they exhibited no special regain mechanics. Likewise, Fire weapon on any other day besides Firesday resulted in regain.
- Note: JP wiki says they gain a Haste effect but I witnessed no change in mob delay while fighting them in fire weather or Firesday.

### 3. Fixes mob linking behavior in sleep mode.
- On LSB, if you pulled an aggro'd linking mob past a sleeping mob of the same type, the sleeping mob would wake up and aggro.
- Retail behavior makes mobs not link while sleeping.
- Retail capture: https://www.youtube.com/watch?v=NrEjjoy_UTM
- Note: I extended this to other sleeping mobs in the mixin and based their linking behavior on their mob pool setting. Left TODO notes to audit these (Non TOAU sheep often link for example).

### 4. Optimizes and cleans up zone/mob scripts that utilize weather changes for their spawn/despawn mechanics.
- Thanks to @Xaver-DaRed for script clean up commits.


## Steps to test these changes

1. Zone into Mount Zhayolm and find an Eruca.
1a. `!gotoid 17027126`

2. Fight an Eruca in day time. Get it to link with others. See that they link. Kill them.

3. Wait until 21:00. See Eruca go to sleep. They should no longer aggro.

4. Attack an eruca, walk it past a sleeping eruca. See that the sleeping eruca no longer wakes up to link the one in active combat.

5. `!setweather 4` to turn on fire weather.

6. Engage an eruca, see that it now opens with a mobskill.

7. Use `!getmobmod regain` to check its regain mod. See that it uses skills more often.

8. With the mob at high HP, see that the Incinerate skill now caps at 800 damage if not resisted.

9. `!setweather 8` to swap to Earth weather. Check the mob's regain and see that is now 0.
9a. Note: Existing TP stored will decay if current weather is not fire.
