### PR TITLE
[lua][module] Module to only allow one use of a job testimony

### DIFF
--- a/modules/era/lua/globals/testimony_single_use.lua
+++ b/modules/era/lua/globals/testimony_single_use.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Testimony Single Use
+-- Testimonies wear out after one battlefield entry instead of three
+-- Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('testimony_single_use', xi.pre(xi.expansion.ABYSSEA))
+
+m:addOverride('Battlefield.onBattlefieldEnter', function(self, player, battlefield)
+    local itemId    = self.requiredItems[1]
+    local totalUses = itemId and xi.battlefield.itemUses[itemId] or 1
+
+    -- Testimony use messaging in battlefield.lua relies on the item potentially having more than 1 use
+    -- For the message to display properly in game, fully increment wear upon entering the battlefield
+    if
+        totalUses > 1 and
+        player:getID() == battlefield:getInitiator() and
+        player:hasItem(itemId)
+    then
+        for _ = player:getWornUses(itemId) + 1, totalUses - 1 do
+            player:incrementItemWear(itemId)
+        end
+    end
+
+    super(self, player, battlefield)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a module to fully wear a testimony on first use to remove the three attempts added to testimonies in 2012.

## Steps to test these changes

- Load module
- !addquest 3 132
- !setplayervar player Quest[3][132]tradedTestimony 1
- !additem for your job of choice's testimony
- Zone to the right battlefield area for your job
- Trade the testimony to the circle, see that it immediately states that it is torn.