### PR TITLE
[sql][module] Remove ability to mount in certain zones module

### DIFF
--- a/modules/era/sql/rov/zone_settings.sql
+++ b/modules/era/sql/rov/zone_settings.sql
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Module: RoV Zone Settings Adjustments
+-- This module reverts relevant zone_settings rows to their pre-RoV values
+-----------------------------------
+
+-- Revert mount riding in the zones opened to chocobos and other mounts in June 2016
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+SET @MISC_MOUNT = 4;
+
+UPDATE `zone_settings`
+SET `misc` = `misc` & ~@MISC_MOUNT
+WHERE `name` IN (
+    'Beaucedine_Glacier',
+    'Xarcabard',
+    'Cape_Teriggan',
+    'RoMaeve',
+    'Qufim_Island',
+    'Behemoths_Dominion',
+    'Valley_of_Sorrows',
+    'Mount_Zhayolm',
+    'Caedarva_Mire'
+);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a module to remove the ability to mount in a set of zones that had the functionality added in 2016:
   - Beaucedine Glacier / Xarcabard / Cape Teriggan / Ro'Maeve / Qufim Island / Behemoth's Dominion / Valley of Sorrows / Mount Zhayolm / Caedarva Mire

## Steps to test these changes

- Update init.txt to load the new module and run dbtool
- Zone to The Santuary of Zi'tah
- !mount
- Try to zone into Ro'Maeve
- See that you are blocked from zoning in on the mount 
