### PR TITLE
[lua] allow phys blu spells to inflict added effect on 0 damage

### DIFF
--- a/scripts/actions/spells/blue/battle_dance.lua
+++ b/scripts/actions/spells/blue/battle_dance.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/delta_thrust.lua
+++ b/scripts/actions/spells/blue/delta_thrust.lua
@@ -48,9 +48,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/disseverment.lua
+++ b/scripts/actions/spells/blue/disseverment.lua
@@ -48,9 +48,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/feather_storm.lua
+++ b/scripts/actions/spells/blue/feather_storm.lua
@@ -48,9 +48,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/frypan.lua
+++ b/scripts/actions/spells/blue/frypan.lua
@@ -48,9 +48,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/head_butt.lua
+++ b/scripts/actions/spells/blue/head_butt.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/pinecone_bomb.lua
+++ b/scripts/actions/spells/blue/pinecone_bomb.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/queasyshroom.lua
+++ b/scripts/actions/spells/blue/queasyshroom.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/seedspray.lua
+++ b/scripts/actions/spells/blue/seedspray.lua
@@ -42,9 +42,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/spiral_spin.lua
+++ b/scripts/actions/spells/blue/spiral_spin.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sprout_smack.lua
+++ b/scripts/actions/spells/blue/sprout_smack.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sub-zero_smash.lua
+++ b/scripts/actions/spells/blue/sub-zero_smash.lua
@@ -43,9 +43,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sudden_lunge.lua
+++ b/scripts/actions/spells/blue/sudden_lunge.lua
@@ -43,9 +43,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/tail_slap.lua
+++ b/scripts/actions/spells/blue/tail_slap.lua
@@ -43,9 +43,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/terror_touch.lua
+++ b/scripts/actions/spells/blue/terror_touch.lua
@@ -50,9 +50,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/whirl_of_rage.lua
+++ b/scripts/actions/spells/blue/whirl_of_rage.lua
@@ -42,9 +42,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/wild_oats.lua
+++ b/scripts/actions/spells/blue/wild_oats.lua
@@ -41,9 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.chr_wsc    = 0.0
 
     -- Handle damage.
-    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if damage <= 0 then
+    if hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -358,7 +358,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     end
 
     spell:setCritical(anyCrit)
-    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget)
+    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget), hitslanded
 end
 
 -- Get the damage for a magical Blue Magic spell. Called from spell scripts.

--- a/scripts/specs/types/Spell.lua
+++ b/scripts/specs/types/Spell.lua
@@ -2,4 +2,4 @@
 
 ---@class TSpell
 ---@field onMagicCastingCheck? fun(PChar: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): integer?
----@field onSpellCast? fun(PCaster: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): integer?
+---@field onSpellCast? fun(PCaster: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): (integer?, integer?)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows BLU spells to inflict their additional effects even if the spell hits for 0 - this will typically be against Stoneskin, as no spell can do 0 damage just normally. The old code doesn't work properly because it assumes a 0-damage hit is a miss, while the new code explicitly checks to see if any hits landed.

Siknoz test attempting to sleep an earth elemental with stoneskin up:
<img width="592" height="603" alt="image" src="https://github.com/user-attachments/assets/36e39992-08eb-4e6b-ae9a-d739b1bb10d9" />

## Steps to test these changes

Find a troll in Mt Zhayolm or anywhere
!mobskill 1744 for diamondhide
Use headbutt or pinecone bomb or something on it and ensure the additional effect lands
