### PR TITLE
[lua] Windurst 7-1 and 7-2 optional dialog and fixes

### DIFF
--- a/scripts/missions/windurst/7_1_The_Sixth_Ministry.lua
+++ b/scripts/missions/windurst/7_1_The_Sixth_Ministry.lua
@@ -74,8 +74,38 @@ mission.sections =
             return currentMission == mission.missionId
         end,
 
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Janshura-Rashura'] = mission:event(469),
+
+            ['Nine_of_Clubs'] = mission:event(470),
+
+            ['Puo_Rhen'] = mission:event(472),
+
+            ['Ten_of_Clubs'] = mission:event(471),
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Chawo_Shipeynyo'] = mission:event(364),
+
+            ['Keo-Koruo'] = mission:event(363),
+
+            ['Pakke-Pokke'] = mission:event(362),
+
+            ['Zokima-Rokima'] = mission:event(361),
+        },
+
         [xi.zone.WINDURST_WATERS] =
         {
+            ['Dagoza-Beruza'] = mission:event(713),
+
+            ['Mokyokyo'] = mission:event(711),
+
+            ['Panna-Donna'] = mission:event(712),
+
+            ['Ten_of_Hearts'] = mission:event(714),
+
             ['Tosuka-Porika'] =
             {
                 onTrigger = function(player, npc)
@@ -84,7 +114,7 @@ mission.sections =
                     if missionStatus == 0 then
                         return mission:progressEvent(715, 0, xi.ki.OPTISTERY_RING)
                     elseif missionStatus == 1 then
-                        return mission:progressEvent(716, 0, xi.ki.OPTISTERY_RING)
+                        return mission:event(716, 0, xi.ki.OPTISTERY_RING)
                     elseif missionStatus == 2 then
                         return mission:progressEvent(724)
                     end
@@ -105,6 +135,17 @@ mission.sections =
                 end
             },
         },
+
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Miiri-Wohri'] = mission:event(570),
+
+            ['Rakoh_Buuma'] = mission:event(569),
+
+            ['Sola_Jaab'] = mission:event(571),
+
+            ['Tih_Pikeh'] = mission:event(572),
+        },
     },
 
     {
@@ -121,12 +162,12 @@ mission.sections =
                     for i = toraimaraiID.mob.HINGE_OILS_OFFSET, toraimaraiID.mob.HINGE_OILS_OFFSET + 3 do
                         if not GetMobByID(i):isDead() then
                             -- At least one Hinge Oil is alive
-                            return mission:progressEvent(70, 0, 0, 0, 1)
+                            return mission:event(70, 0, 0, 0, 1)
                         end
                     end
 
                     -- All four Hinge Oils are dead
-                    return mission:progressEvent(70, 0, 0, 0, 2)
+                    return mission:progressCutscene(70, 0, 0, 0, 2)
                 end,
             },
 
@@ -137,9 +178,10 @@ mission.sections =
 
                     if
                         tomeOffset == 4 and
+                        player:getCurrentMission(mission.areaId) == mission.missionId and
                         player:getMissionStatus(mission.areaId) == 1
                     then
-                        return mission:progressEvent(69)
+                        return mission:progressEvent(69, 0, xi.ki.OPTISTERY_RING)
                     end
                 end,
             },

--- a/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
+++ b/scripts/missions/windurst/7_2_Awakening_of_the_Gods.lua
@@ -76,19 +76,45 @@ mission.sections =
             return currentMission == mission.missionId
         end,
 
+        [xi.zone.PORT_WINDURST] =
+        {
+            ['Janshura-Rashura'] = mission:event(474),
+
+            ['Nine_of_Clubs'] = mission:event(475),
+
+            ['Puo_Rhen'] = mission:event(477),
+
+            ['Ten_of_Clubs'] = mission:event(476),
+        },
+
+        [xi.zone.WINDURST_WALLS] =
+        {
+            ['Chawo_Shipeynyo'] = mission:event(369),
+
+            ['Keo-Koruo'] = mission:event(368),
+
+            ['Pakke-Pokke'] = mission:event(367),
+
+            ['Zokima-Rokima'] = mission:event(366),
+        },
+
         [xi.zone.WINDURST_WATERS] =
         {
+            ['Dagoza-Beruza'] = mission:event(731),
+
+            ['Kenapa-Keppa'] = mission:event(740),
+
             ['Kerutoto'] =
             {
                 onTrigger = function(player, npc)
                     local missionStatus = player:getMissionStatus(mission.areaId)
 
                     if missionStatus == 0 then
-                        return mission:progressEvent(737)
+                        return mission:event(737)
                     elseif missionStatus == 1 then
                         return mission:progressEvent(736)
-                    elseif missionStatus == 2 then
-                        return mission:progressEvent(738)
+                    elseif missionStatus >= 2 then
+                        return mission:event(738)
                     end
                 end,
             },
@@ -101,14 +127,22 @@ mission.sections =
                     if missionStatus == 0 then
                         return mission:progressEvent(734)
                     elseif missionStatus == 1 then
-                        return mission:progressEvent(735)
-                    elseif missionStatus == 2 then
-                        return mission:progressEvent(739)
+                        return mission:event(735)
+                    elseif missionStatus >= 2 and missionStatus <= 4 then
+                        return mission:event(739)
                     elseif missionStatus == 5 and player:hasKeyItem(xi.ki.BOOK_OF_THE_GODS) then
                         return mission:progressEvent(742)
                     end
                 end,
             },
+
+            ['Mokyokyo'] = mission:event(730),
+
+            ['Ohbiru-Dohbiru'] = mission:event(741),
+
+            ['Panna-Donna'] = mission:event(732),
+
+            ['Ten_of_Hearts'] = mission:event(733),
 
             onEventFinish =
             {
@@ -126,13 +160,24 @@ mission.sections =
             },
         },
 
+        [xi.zone.WINDURST_WOODS] =
+        {
+            ['Miiri-Wohri'] = mission:event(575),
+
+            ['Rakoh_Buuma'] = mission:event(574),
+
+            ['Sola_Jaab'] = mission:event(576),
+
+            ['Tih_Pikeh'] = mission:event(577),
+        },
+
         [xi.zone.KAZHAM] =
         {
             ['Jakoh_Wahcondalo'] =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 2 then
-                        return mission:progressEvent(265)
+                        return mission:event(265)
                     end
                 end,
             },
@@ -144,8 +189,10 @@ mission.sections =
 
                     if missionStatus == 2 then
                         return mission:progressEvent(266)
-                    elseif missionStatus == 3 then
-                        return mission:progressEvent(267)
+                    elseif missionStatus == 3 or missionStatus == 4 then
+                        return mission:event(267)
+                    elseif missionStatus >= 5 then
+                        return mission:event(263)
                     end
                 end,
             },
@@ -158,7 +205,7 @@ mission.sections =
                     if missionStatus == 3 then
                         return mission:progressEvent(264)
                     elseif missionStatus > 3 then
-                        return mission:progressEvent(268)
+                        return mission:event(268)
                     end
                 end,
             },
@@ -180,12 +227,16 @@ mission.sections =
             ['_4fx'] =
             {
                 onTrade = function(player, npc, trade)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
                     if
                         npcUtil.tradeMatches(trade, { { xi.item.CURSED_KEY, 1 } }) and
                         player:getZPos() < 332 and
-                        player:getMissionStatus(mission.areaId) >= 3
+                        missionStatus >= 3 and
+                        missionStatus <= 4
                     then
-                        return mission:progressEvent(23)
+                        -- TODO: The decompiled event shows a param[7]. Might be based on race?
+                        return mission:progressCutscene(23, 0, 0, 1, 0, 0, 0, 0, 0)
                     end
                 end,
             },
@@ -194,7 +245,6 @@ mission.sections =
             {
                 [23] = function(player, csid, option, npc)
                     player:tradeComplete()
-                    player:setPos(340, 0, 333)
                     player:delKeyItem(xi.ki.BLANK_BOOK_OF_THE_GODS)
                     player:setMissionStatus(mission.areaId, 5)
                     npcUtil.giveKeyItem(player, xi.ki.BOOK_OF_THE_GODS)

--- a/scripts/zones/Toraimarai_Canal/npcs/Tome_of_Magic.lua
+++ b/scripts/zones/Toraimarai_Canal/npcs/Tome_of_Magic.lua
@@ -14,6 +14,8 @@ entity.onTrigger = function(player, npc)
 
     if offset >= 0 and offset <= 3 then
         player:startEvent(65 + offset)
+    elseif offset == 4 then
+        player:startEvent(72)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Goes through Windurst 7-1 and 7-2 and
- Fixes events with incomplete inputs
- Turns event 70 in 7-1 into a progressCutscene: https://youtu.be/rq0xGZb6z04?t=2691
- Turns event 23 in 7-2 into a progressCutscene and removes setPos; the event does this: https://youtu.be/G7TC1Y37D0Y?t=2306
- Corrects progressEvents to events when no callback.
- Corrects a few small bugs with states not restricted properly
- Adds gate guard optional dialog
- Updates the Tome of Magic default event

## Steps to test these changes

Play through 7-1 and 7-2 testing changes and dialog.

## Captures
https://drive.google.com/file/d/1cfA97yyy1tci34BBYA8avnvsRQ6ZiDbH/view?usp=drive_link
Video 7-1: https://youtu.be/rq0xGZb6z04
Video 7-2: https://youtu.be/G7TC1Y37D0Y

## TODO
These are notes for me or for whoever comes after me
- Guards have post-mission new events as usual.
- Opistary npcs have some weird during mission and after mission dialog.
- Rhinostery has some extra dialog after 7-2