### PR TITLE
[lua] Fix Survival Guide currency check & bitmask checking

### DIFF
--- a/scripts/globals/teleports/survival_guide.lua
+++ b/scripts/globals/teleports/survival_guide.lua
@@ -54,7 +54,9 @@ xi.survivalGuide.onTrigger = function(player)
         return
     end
 
-    local param = bit.bor(tableIndex, bit.lshift(player:getCurrency('valor_point'), 16))
+    local noTutorialFlag = 0x4000 -- For some reason, this bit is high when you DONT have the tutorial free warp active.
+    local tabsCurrency   = bit.lshift(player:getCurrency('valor_point'), 16)
+    local param          = bit.bor(tableIndex, tabsCurrency + noTutorialFlag)
 
     -- Get the teleport menu option.
     -- Menu options can be organized by Region or Content.
@@ -71,14 +73,14 @@ xi.survivalGuide.onTrigger = function(player)
         param = bit.bor(param, 0x0800)
     end
 
-    -- Tutorial quest special option.
-    if player:getCharVar('TutorialBypass') == 2 then
-        param = bit.bor(param, 0x1000)
-    end
-
     -- "Rhapsody in White" key item reduces teleport fee by 80%
     if player:hasKeyItem(xi.ki.RHAPSODY_IN_WHITE) then
         param = bit.bor(param, 0x2000)
+    end
+
+    -- Tutorial quest special option. Set the bit at 0x4000 to zero.
+    if player:getCharVar('TutorialBypass') == 2 then
+        param = bit.band(param, bit.bnot(0x4000))
     end
 
     -- Params 4, 5, 6 and 7
@@ -194,15 +196,15 @@ xi.survivalGuide.onEventFinish = function(player, eventId, option, npc)
         teleportCostGil  = 0
         teleportCostTabs = 0
 
-    -- If the player has the "Rhapsody in White" KI, the cost is 10% of original gil or 20% of original tabs.
+    -- If the player has the "Rhapsody in White" KI, the cost is 1/5 of original gil or 1/5 of original tabs.
     elseif player:hasKeyItem(xi.ki.RHAPSODY_IN_WHITE) then
-        teleportCostGil  = math.floor(teleportCostGil / 10)
+        teleportCostGil  = math.floor(teleportCostGil / 5)
         teleportCostTabs = math.floor(teleportCostTabs / 5)
     end
 
     -- Payment methods.
-    local paymentValor    = bit.band(bit.rshift(option, 8), 1) and true or false
-    local paymentTutorial = bit.band(bit.rshift(option, 9), 1) and true or false
+    local paymentValor    = bit.band(bit.rshift(option, 8), 1) == 1
+    local paymentTutorial = bit.band(bit.rshift(option, 9), 1) == 1
 
     -- Payment option when selecting "Travel using <amount> tabs." (Valor Points)
     if paymentValor then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

It looks like the survival guide "free warp" bitmask changed with the new event, and it functions where bit present = no free warp option instead of bit not present = no free warp option

also fixes a bad ternary operator check, and currency pricing for gil with rhapsody KI was half off accidentally.

Fixes #10759

## Steps to test these changes

Warp with free warp (use setCharVar) and warp without, see it all works
