### PR TITLE
[lua] HELM per-zone break rates

### DIFF
--- a/scripts/globals/hobbies/helm/data.lua
+++ b/scripts/globals/hobbies/helm/data.lua
@@ -16,7 +16,6 @@ xi.helm.dataTable =
         animation    = xi.emote.HARVESTING,
         mod          = xi.mod.HARVESTING_RESULT,
         settingRate  = xi.settings.main.HARVESTING_RATE,
-        settingBreak = xi.settings.main.HARVESTING_BREAK_CHANCE,
         message      = 'HARVESTING_IS_POSSIBLE_HERE',
         tool         = xi.item.SICKLE,
 
@@ -24,6 +23,8 @@ xi.helm.dataTable =
         {
             [xi.zone.WAJAOM_WOODLANDS] =
             {
+                breakRate = 6.61, -- n=10077, 95% CI +/-0.49pp
+
                 drops =
                 {
                     { 1880, xi.item.SPRIG_OF_FRESH_MARJORAM      },
@@ -64,6 +65,8 @@ xi.helm.dataTable =
 
             [xi.zone.BHAFLAU_THICKETS] =
             {
+                breakRate = 7.34, -- n=10011, 95% CI +/-0.51pp
+
                 drops =
                 {
                     { 1510, xi.item.CLUMP_OF_MOHBWA_GRASS        },
@@ -96,6 +99,8 @@ xi.helm.dataTable =
 
             [xi.zone.GRAUBERG_S] =
             {
+                breakRate = 6.46, -- n=11508, 95% CI +/-0.45pp
+
                 drops =
                 {
                     { 1830, xi.item.CLUMP_OF_MOKO_GRASS     },
@@ -121,6 +126,8 @@ xi.helm.dataTable =
 
             [xi.zone.WEST_SARUTABARUTA_S] =
             {
+                breakRate = 6.18, -- n=16341, 95% CI +/-0.37pp
+
                 drops =
                 {
                     { 1630, xi.item.SPRIG_OF_FRESH_MARJORAM },
@@ -150,6 +157,8 @@ xi.helm.dataTable =
 
             [xi.zone.PASHHOW_MARSHLANDS] =
             {
+                breakRate = 25.65, -- n=8426, 95% CI +/-0.93pp - NOTE: Harvesting gear has no effect in this zone!
+
                 drops =
                 {
                     { 1, xi.item.BLAZING_PEPPERS },
@@ -163,6 +172,8 @@ xi.helm.dataTable =
 
             [xi.zone.WEST_SARUTABARUTA] =
             {
+                breakRate = 6.05, -- n=10019, 95% CI +/-0.47pp
+
                 drops =
                 {
                     { 1680, xi.item.CLUMP_OF_MOKO_GRASS             },
@@ -195,6 +206,8 @@ xi.helm.dataTable =
 
             [xi.zone.YUHTUNGA_JUNGLE] =
             {
+                breakRate = 11.87, -- n=3666, 95% CI +/-1.05pp
+
                 drops =
                 {
                     { 4000, xi.item.WOOZYSHROOM     },
@@ -218,6 +231,8 @@ xi.helm.dataTable =
 
             [xi.zone.YHOATOR_JUNGLE] =
             {
+                breakRate = 12.69, -- n=607, 95% CI +/-2.65pp
+
                 drops =
                 {
                     { 4000, xi.item.WOOZYSHROOM     },
@@ -240,6 +255,8 @@ xi.helm.dataTable =
 
             [xi.zone.GIDDEUS] =
             {
+                breakRate = 11.43, -- n=10281, 95% CI +/-0.62pp
+
                 drops =
                 {
                     { 1500, xi.item.CLUMP_OF_RED_MOKO_GRASS         },
@@ -298,6 +315,8 @@ xi.helm.dataTable =
 
             [xi.zone.ABYSSEA_GRAUBERG] =
             {
+                breakRate = 6.03, -- n=2637, 95% CI +/-0.91pp
+
                 drops =
                 {
                     {  970, xi.item.BAG_OF_HERB_SEEDS        },
@@ -323,6 +342,8 @@ xi.helm.dataTable =
 
             [xi.zone.YAHSE_HUNTING_GROUNDS] =
             {
+                breakRate = 50, -- Capture needed
+
                 drops =
                 {
                     -- TODO
@@ -343,7 +364,6 @@ xi.helm.dataTable =
         animation    = xi.emote.EXCAVATION,
         mod          = nil,
         settingRate  = xi.settings.main.EXCAVATION_RATE,
-        settingBreak = xi.settings.main.EXCAVATION_BREAK_CHANCE,
         message      = 'MINING_IS_POSSIBLE_HERE',
         tool         = xi.item.PICKAXE,
 
@@ -351,6 +371,8 @@ xi.helm.dataTable =
         {
             [xi.zone.ATTOHWA_CHASM] =
             {
+                breakRate = 53.31, -- n=11119, 95% CI +/-0.93pp
+
                 drops =
                 {
                     { 2220, xi.item.BONE_CHIP                   },
@@ -377,6 +399,8 @@ xi.helm.dataTable =
 
             [xi.zone.TAHRONGI_CANYON] =
             {
+                breakRate = 36.69, -- n=9390, 95% CI +/-0.97pp
+
                 drops =
                 {
                     { 2690, xi.item.BONE_CHIP      },
@@ -413,6 +437,8 @@ xi.helm.dataTable =
 
             [xi.zone.KORROLOKA_TUNNEL] =
             {
+                breakRate = 48.63, -- n=12984, 95% CI +/-0.86pp
+
                 drops =
                 {
                     { 2130, xi.item.CHUNK_OF_ROCK_SALT     },
@@ -444,6 +470,8 @@ xi.helm.dataTable =
 
             [xi.zone.MAZE_OF_SHAKHRAMI] =
             {
+                breakRate = 51.35, -- n=10254, 95% CI +/-0.97pp
+
                 drops =
                 {
                     { 2560, xi.item.BONE_CHIP      },
@@ -474,6 +502,36 @@ xi.helm.dataTable =
                     {  405.577,  -0.284,  -44.539 },
                 },
             },
+
+            [xi.zone.ABYSSEA_TAHRONGI] =
+            {
+                breakRate = 36.66, -- n=622, 95% CI +/-3.79pp
+
+                drops =
+                {
+                    -- Capture needed
+                },
+
+                points =
+                {
+                    -- Capture needed
+                },
+            },
+
+            [xi.zone.ABYSSEA_ATTOHWA] =
+            {
+                breakRate = 51.74, -- n=949, 95% CI +/-3.18pp
+
+                drops =
+                {
+                    -- Capture needed
+                },
+
+                points =
+                {
+                    -- Capture needed
+                },
+            },
         },
     },
 
@@ -485,7 +543,6 @@ xi.helm.dataTable =
         animation    = xi.emote.LOGGING,
         mod          = xi.mod.LOGGING_RESULT,
         settingRate  = xi.settings.main.LOGGING_RATE,
-        settingBreak = xi.settings.main.LOGGING_BREAK_CHANCE,
         message      = 'LOGGING_IS_POSSIBLE_HERE',
         tool         = xi.item.HATCHET,
 
@@ -493,6 +550,8 @@ xi.helm.dataTable =
         {
             [xi.zone.CARPENTERS_LANDING] =
             {
+                breakRate = 12.18, -- n=11561, 95% CI +/-0.6pp
+
                 drops =
                 {
                     { 1750, xi.item.WALNUT_LOG    },
@@ -515,6 +574,8 @@ xi.helm.dataTable =
 
             [xi.zone.LUFAISE_MEADOWS] =
             {
+                breakRate = 17.78, -- n=12620, 95% CI +/-0.67pp
+
                 drops =
                 {
                     { 3330, xi.item.ARROWWOOD_LOG },
@@ -538,6 +599,8 @@ xi.helm.dataTable =
 
             [xi.zone.MISAREAUX_COAST] =
             {
+                breakRate = 18.47, -- n=10273, 95% CI +/-0.75pp
+
                 drops =
                 {
                     { 2220, xi.item.ARROWWOOD_LOG },
@@ -561,6 +624,8 @@ xi.helm.dataTable =
 
             [xi.zone.MAMOOK] =
             {
+                breakRate = 9.23, -- n=10903, 95% CI +/-0.54pp
+
                 drops =
                 {
                     { 1070, xi.item.ARROWWOOD_LOG        },
@@ -587,6 +652,8 @@ xi.helm.dataTable =
 
             [xi.zone.CAEDARVA_MIRE] =
             {
+                breakRate = 7.57, -- n=9335, 95% CI +/-0.54pp
+
                 drops =
                 {
                     { 2200, xi.item.DOGWOOD_LOG          },
@@ -613,6 +680,8 @@ xi.helm.dataTable =
 
             [xi.zone.EAST_RONFAURE_S] =
             {
+                breakRate = 10.15, -- n=12962, 95% CI +/-0.52pp
+
                 drops =
                 {
                     { 1890, xi.item.ARROWWOOD_LOG      },
@@ -641,6 +710,8 @@ xi.helm.dataTable =
 
             [xi.zone.JUGNER_FOREST_S] =
             {
+                breakRate = 13.99, -- n=10089, 95% CI +/-0.68pp
+
                 drops =
                 {
                     { 2000, xi.item.WALNUT        },
@@ -667,6 +738,8 @@ xi.helm.dataTable =
 
             [xi.zone.FORT_KARUGO_NARUGO_S] =
             {
+                breakRate = 7.44, -- n=18304, 95% CI +/-0.38pp
+
                 drops =
                 {
                     { 2910, xi.item.FLASK_OF_HOLY_WATER },
@@ -691,6 +764,8 @@ xi.helm.dataTable =
 
             [xi.zone.EAST_RONFAURE] =
             {
+                breakRate = 7.10, -- n=10069, 95% CI +/-0.5pp
+
                 drops =
                 {
                     { 2610, xi.item.ARROWWOOD_LOG      },
@@ -734,6 +809,8 @@ xi.helm.dataTable =
 
             [xi.zone.JUGNER_FOREST] =
             {
+                breakRate = 12.08, -- n=10058, 95% CI +/-0.64pp
+
                 drops =
                 {
                     { 2040, xi.item.WALNUT_LOG    },
@@ -779,6 +856,8 @@ xi.helm.dataTable =
 
             [xi.zone.BUBURIMU_PENINSULA] =
             {
+                breakRate = 16.78, -- n=10048, 95% CI +/-0.73pp
+
                 drops =
                 {
                     { 2410, xi.item.LAUAN_LOG                },
@@ -832,6 +911,8 @@ xi.helm.dataTable =
 
             [xi.zone.YUHTUNGA_JUNGLE] =
             {
+                breakRate = 15.60, -- n=14613, 95% CI +/-0.59pp
+
                 drops =
                 {
                     { 1900, xi.item.ARROWWOOD_LOG          },
@@ -859,6 +940,8 @@ xi.helm.dataTable =
 
             [xi.zone.YHOATOR_JUNGLE] =
             {
+                breakRate = 18.23, -- n=10001, 95% CI +/-0.76pp
+
                 drops =
                 {
                     { 2220, xi.item.ARROWWOOD_LOG          },
@@ -902,6 +985,8 @@ xi.helm.dataTable =
 
             [xi.zone.GHELSBA_OUTPOST] =
             {
+                breakRate = 7.46, -- n=14616, 95% CI +/-0.43pp
+
                 drops =
                 {
                     { 2950, xi.item.ARROWWOOD_LOG },
@@ -929,6 +1014,36 @@ xi.helm.dataTable =
                     {  23.524, -0.759,  53.766 },
                 },
             },
+
+            [xi.zone.ABYSSEA_LA_THEINE] =
+            {
+                breakRate = 11.17, -- n=797, 95% CI +/-2.19pp
+
+                drops =
+                {
+                    -- Capture needed
+                },
+
+                points =
+                {
+                    -- Capture needed
+                },
+            },
+
+            [xi.zone.ABYSSEA_MISAREAUX] =
+            {
+                breakRate = 16.57, -- n=851, 95% CI +/-2.5pp
+
+                drops =
+                {
+                    -- Capture needed
+                },
+
+                points =
+                {
+                    -- Capture needed
+                },
+            },
         },
     },
 
@@ -940,7 +1055,6 @@ xi.helm.dataTable =
         animation    = xi.emote.EXCAVATION,
         mod          = xi.mod.MINING_RESULT,
         settingRate  = xi.settings.main.MINING_RATE,
-        settingBreak = xi.settings.main.MINING_BREAK_CHANCE,
         message      = 'MINING_IS_POSSIBLE_HERE',
         tool         = xi.item.PICKAXE,
 
@@ -948,6 +1062,8 @@ xi.helm.dataTable =
         {
             [xi.zone.OLDTON_MOVALPOLOS] =
             {
+                breakRate = 41.61, -- n=11630, 95% CI +/-0.9pp
+
                 drops =
                 {
                     { 1150, xi.item.IGNEOUS_ROCK           },
@@ -987,6 +1103,8 @@ xi.helm.dataTable =
 
             [xi.zone.NEWTON_MOVALPOLOS] =
             {
+                breakRate = 56.62, -- n=11963, 95% CI +/-0.89pp
+
                 drops =
                 {
                     { 1660, xi.item.CHUNK_OF_COPPER_ORE    },
@@ -1020,6 +1138,8 @@ xi.helm.dataTable =
 
             [xi.zone.MOUNT_ZHAYOLM] =
             {
+                breakRate = 46.67, -- n=11577, 95% CI +/-0.91pp
+
                 drops =
                 {
                     { 2250, xi.item.PINCH_OF_SULFUR      },
@@ -1067,6 +1187,8 @@ xi.helm.dataTable =
 
             [xi.zone.HALVUNG] =
             {
+                breakRate = 47.98, -- n=17865, 95% CI +/-0.73pp
+
                 drops =
                 {
                     { 2010, xi.item.CHUNK_OF_AHT_URHGAN_BRASS },
@@ -1112,6 +1234,8 @@ xi.helm.dataTable =
 
             [xi.zone.NORTH_GUSTABERG_S] =
             {
+                breakRate = 36.80, -- n=10255, 95% CI +/-0.93pp
+
                 drops =
                 {
                     { 1870, xi.item.CHUNK_OF_COPPER_ORE   },
@@ -1164,6 +1288,8 @@ xi.helm.dataTable =
 
             [xi.zone.YUGHOTT_GROTTO] =
             {
+                breakRate = 50.69, -- n=13195, 95% CI +/-0.85pp
+
                 drops =
                 {
                     { 1460, xi.item.CHUNK_OF_COPPER_ORE    },
@@ -1219,6 +1345,8 @@ xi.helm.dataTable =
 
             [xi.zone.PALBOROUGH_MINES] =
             {
+                breakRate = 46.83, -- n=11346, 95% CI +/-0.92pp
+
                 drops =
                 {
                     { 1130, xi.item.CHUNK_OF_ZINC_ORE     },
@@ -1259,6 +1387,8 @@ xi.helm.dataTable =
 
             [xi.zone.ZERUHN_MINES] =
             {
+                breakRate = 38.32, -- n=12960, 95% CI +/-0.84pp
+
                 drops =
                 {
                     { 2450, xi.item.CHUNK_OF_IRON_ORE      },
@@ -1302,6 +1432,8 @@ xi.helm.dataTable =
 
             [xi.zone.GUSGEN_MINES] =
             {
+                breakRate = 52.36, -- n=12094, 95% CI +/-0.89pp
+
                 drops =
                 {
                     { 1890, xi.item.PEBBLE                 },
@@ -1340,6 +1472,8 @@ xi.helm.dataTable =
 
             [xi.zone.IFRITS_CAULDRON] =
             {
+                breakRate = 55.12, -- n=10602, 95% CI +/-0.95pp
+
                 drops =
                 {
                     { 3260, xi.item.FLINT_STONE             },

--- a/scripts/globals/hobbies/helm/logic.lua
+++ b/scripts/globals/hobbies/helm/logic.lua
@@ -37,14 +37,15 @@ local rocks =
 -----------------------------------
 
 local function doesToolBreak(player, info)
-    local roll  = math.randomInt(1, 100)
-    local mod   = info.mod
+    local roll        = math.randomFloat(0, 100)
+    local mod         = info.mod
+    local breakChance = info.zone[player:getZoneID()].breakRate
 
     if mod then
         roll = roll + (player:getMod(mod) / 10)
     end
 
-    if roll <= info.settingBreak then
+    if roll < breakChance then
         player:tradeComplete()
         return true
     end

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -186,10 +186,6 @@ xi.settings.main =
         '\129\153\129\154 The Alter Ego Expo Campaign is active! \129\154\129\153\n' ..
         'Trusts gain the benefits of Increased HP, MP, and Status Resistances!',
 
-    HARVESTING_BREAK_CHANCE = 33,    -- % chance for the sickle to break during harvesting.  Set between 0 and 100.
-    EXCAVATION_BREAK_CHANCE = 33,    -- % chance for the pickaxe to break during excavation.  Set between 0 and 100.
-    LOGGING_BREAK_CHANCE    = 33,    -- % chance for the hatchet to break during logging.  Set between 0 and 100.
-    MINING_BREAK_CHANCE     = 33,    -- % chance for the pickaxe to break during mining.  Set between 0 and 100.
     HARVESTING_RATE         = 50,    -- % chance to recieve an item from haresting.  Set between 0 and 100.
     EXCAVATION_RATE         = 50,    -- % chance to recieve an item from excavation.  Set between 0 and 100.
     LOGGING_RATE            = 50,    -- % chance to recieve an item from logging.  Set between 0 and 100.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Gets rid of the global BREAK settings in favor of actual captured zone break rates.
All captures involved in this PR were explicitly done with no gear by @KiplingFFXI and I. 

The break rates have shown to be consistent regardless of day of the week, weather, moon phases etc. 
There is a mechanic increasing break rates if you stay at a single location but the captures were all done by moving from point to point.

Added empty entries for the Abyssea zones as they use the exact same system (unlike SoA zones).

Worth noting:
- Abyssea zones have low samples because of the time limitation that's hard to work with on throwaway characters. 
- Jungles have low samples on Harvesting because you have to wait for rain for the nodes to spawn.
- Pashow is a special case and should be handled as such in the future

I'm still sorting out the captures and will publish them shortly.

tl;dr: harvesting/logging will see less tools breaking, mining will see more tools breaking. More nerfs are coming.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
