### PR TITLE
[lua][module] Adjusts Ominous Cloud era list of accepted items module

### DIFF
--- a/modules/era/lua/zones/ominous_cloud_toolbags.lua
+++ b/modules/era/lua/zones/ominous_cloud_toolbags.lua
@@ -1,0 +1,53 @@
+-----------------------------------
+-- Ominous Cloud Toolbag Adjustment Module
+-- Limits the toolbags Ominous Cloud makes to the original ninja tools.
+-- Shared across Port_Bastok, Southern_San_dOria, and Windurst_Woods.
+-- Source: https://forum.square-enix.com/ffxi/threads/44592-Oct-7-2014-%28JST%29-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_ominous_cloud_toolbags', xi.pre(xi.expansion.SOA))
+
+local function checkEligibility(player, trade)
+    local toolList =
+    {
+        [xi.item.HIRAISHIN      ] = true,
+        [xi.item.JUSATSU        ] = true,
+        [xi.item.KAGINAWA       ] = true,
+        [xi.item.KAWAHORI_OGI   ] = true,
+        [xi.item.KODOKU         ] = true,
+        [xi.item.MAKIBISHI      ] = true,
+        [xi.item.MIZU_DEPPO     ] = true,
+        [xi.item.SAIRUI_RAN     ] = true,
+        [xi.item.SANJAKU_TENUGUI] = true,
+        [xi.item.SHIHEI         ] = true,
+        [xi.item.SHINOBI_TABI   ] = true,
+        [xi.item.TSURARA        ] = true,
+        [xi.item.UCHITAKE       ] = true,
+    }
+
+    for i = 0, 8 do
+        local itemId = trade:getItemId(i)
+
+        if
+            itemId > 0 and
+            itemId ~= xi.item.WIJNRUIT and
+            not toolList[itemId]
+        then
+            player:messageSpecial(zones[player:getZoneID()].text.CLOUD_BAD_ITEM)
+            return true
+        end
+    end
+
+    return false
+end
+
+for _, zoneName in ipairs({ 'Port_Bastok', 'Southern_San_dOria', 'Windurst_Woods' }) do
+    m:addOverride('xi.zones.' .. zoneName .. '.npcs.Ominous_Cloud.onTrade', function(player, npc, trade)
+        if checkEligibility(player, trade) then
+            return
+        end
+
+        super(player, npc, trade)
+    end)
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Creates a module to reduce Ominous Cloud's list of acceptable items to turn into pouches into the era accurate list so that players cannot create shuriken pouches.

## Steps to test these changes

- Load module
- !additem Fuma_Shuriken 99 !additem wijnruit
- Trade to Ominous Cloud NPC in whichever nation he is in
- See that you get rejected