### PR TITLE
[lua,cpp] New adventurer level module; New adventurer play time setting

### DIFF
--- a/modules/era/lua/globals/new_adventurer_level_limit.lua
+++ b/modules/era/lua/globals/new_adventurer_level_limit.lua
@@ -1,0 +1,24 @@
+-----------------------------------
+-- New Adventurer Level Up Module
+-- New adventurer icon is no longer removed on level cap on retail. This restores removal once player reaches 6 or above.
+-- Source: https://forum.square-enix.com/ffxi/threads/61014-August-9-2023-%28JST%29-Version-Update?p=656247&viewfull=1#post656247
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('new_adventurer_level_limit', xi.pre(xi.expansion.TVR))
+
+local function checkNewPlayer(player)
+    if not player:getNewPlayer() then
+        return
+    end
+
+    if player:getJobLevel(player:getMainJob()) >= 6 then
+        player:setNewPlayer(false)
+    end
+end
+
+m:addOverride('xi.player.onPlayerLevelUp', function(player)
+    super(player)
+
+    checkNewPlayer(player)
+end)

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -107,17 +107,18 @@ xi.settings.main =
     ABYSSEA_BONUSLIGHT_AMOUNT = 0,
 
     -- CHARACTER CONFIG
-    INITIAL_LEVEL_CAP              = 50, -- The initial level cap for new players.  There seems to be a hardcap of 255.
-    MAX_LEVEL                      = 99, -- Level max of the server, lowers the attainable cap by disabling Limit Break quests.
-    NORMAL_MOB_MAX_LEVEL_RANGE_MIN = 0,  -- Lower Bound of Max Level Range for Normal Mobs (0 = Uncapped)
-    NORMAL_MOB_MAX_LEVEL_RANGE_MAX = 0,  -- Upper Bound of Max Level Range for Normal Mobs (0 = Uncapped)
-    START_GIL                      = 10, -- Amount of gil given to newly created characters.
-    START_INVENTORY                = 30, -- Starting inventory and satchel size.  Ignores values < 30.  Do not set above 80!
-    NEW_CHARACTER_CUTSCENE         = 1,  -- Set to 1 to enable opening cutscenes, 0 to disable.
-    SUBJOB_QUEST_LEVEL             = 18, -- Minimum level to accept either subjob quest.  Set to 0 to start the game with subjobs unlocked.
-    ADVANCED_JOB_LEVEL             = 30, -- Minimum level to accept advanced job quests.  Set to 0 to start the game with advanced jobs.
-    ALL_MAPS                       = 0,  -- Set to 1 to give starting characters all the maps.
-    UNLOCK_OUTPOST_WARPS           = 0,  -- Set to 1 to give starting characters all outpost warps.  2 to add Tu'Lia and Tavnazia.
+    INITIAL_LEVEL_CAP              = 50,  -- The initial level cap for new players.  There seems to be a hardcap of 255.
+    MAX_LEVEL                      = 99,  -- Level max of the server, lowers the attainable cap by disabling Limit Break quests.
+    NORMAL_MOB_MAX_LEVEL_RANGE_MIN = 0,   -- Lower Bound of Max Level Range for Normal Mobs (0 = Uncapped)
+    NORMAL_MOB_MAX_LEVEL_RANGE_MAX = 0,   -- Upper Bound of Max Level Range for Normal Mobs (0 = Uncapped)
+    START_GIL                      = 10,  -- Amount of gil given to newly created characters.
+    START_INVENTORY                = 30,  -- Starting inventory and satchel size.  Ignores values < 30.  Do not set above 80!
+    NEW_CHARACTER_CUTSCENE         = 1,   -- Set to 1 to enable opening cutscenes, 0 to disable.
+    NEW_ADVENTURER_PLAYTIME_LIMIT  = 240, -- Hours played before the New Adventurer icon is removed. 240 for retail, 10 for pre-TVR.
+    SUBJOB_QUEST_LEVEL             = 18,  -- Minimum level to accept either subjob quest.  Set to 0 to start the game with subjobs unlocked.
+    ADVANCED_JOB_LEVEL             = 30,  -- Minimum level to accept advanced job quests.  Set to 0 to start the game with advanced jobs.
+    ALL_MAPS                       = 0,   -- Set to 1 to give starting characters all the maps.
+    UNLOCK_OUTPOST_WARPS           = 0,   -- Set to 1 to give starting characters all outpost warps.  2 to add Tu'Lia and Tavnazia.
 
     SHOP_PRICE          = 1.000, -- Multiplies prices in NPC shops.
     GIL_RATE            = 1.000, -- Multiplies gil earned from quests.  Won't always display in game.

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6341,8 +6341,9 @@ void SavePlayTime(CCharEntity* PChar)
 
     db::preparedStmt("UPDATE chars SET playtime = ? WHERE charid = ? LIMIT 1", playtime, PChar->id);
 
-    // Removes new player icon if played for more than 240 hours
-    if (PChar->isNewPlayer() && playDuration >= 240h)
+    // Removes new player icon if played for more than the configured number of hours
+    const uint32 playtimeLimit = settings::get<uint32>("main.NEW_ADVENTURER_PLAYTIME_LIMIT");
+    if (PChar->isNewPlayer() && playDuration >= std::chrono::hours(playtimeLimit))
     {
         PChar->playerConfig.NewAdventurerOffFlg = true;
         PChar->updatemask |= UPDATE_HP;


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Adds a new module to allow setting the new adventurer ? icon to be removed once players reach level 6.
- Adds new server setting to allow changing the hours played to have the new adventurer icon removed.

## Steps to test these changes

- Load module and create new character
- !changejob war 5
- Kill anything, see your new adventurer icon goes away with the level up
