### PR TITLE
[lua] Various fixes for Windurst 2-1, 8-2, 9-1, 9-2

### DIFF
--- a/scripts/missions/windurst/2_1_Lost_for_Words.lua
+++ b/scripts/missions/windurst/2_1_Lost_for_Words.lua
@@ -181,7 +181,7 @@ mission.sections =
 
         [xi.zone.WINDURST_WATERS] =
         {
-            ['Tosuka-Porika'] = mission:progressEvent(161),
+            ['Tosuka-Porika'] = mission:event(161),
         },
     },
 
@@ -193,9 +193,9 @@ mission.sections =
 
         [xi.zone.WINDURST_WOODS] =
         {
-            ['Bopa_Greso']  = mission:progressEvent(167),
-            ['Cha_Lebagta'] = mission:progressEvent(168),
-            ['Nanaa_Mihgo'] = mission:progressEvent(166),
+            ['Bopa_Greso']  = mission:event(167),
+            ['Cha_Lebagta'] = mission:event(168),
+            ['Nanaa_Mihgo'] = mission:event(166, 0, xi.ki.LAPIS_CORAL, xi.ki.LAPIS_MONOCLE),
         },
     },
 
@@ -247,9 +247,9 @@ mission.sections =
 
         [xi.zone.WINDURST_WOODS] =
         {
-            ['Bopa_Greso']  = mission:progressEvent(171),
-            ['Cha_Lebagta'] = mission:progressEvent(172),
-            ['Nanaa_Mihgo'] = mission:progressEvent(170),
+            ['Bopa_Greso']  = mission:event(171),
+            ['Cha_Lebagta'] = mission:event(172),
+            ['Nanaa_Mihgo'] = mission:event(170),
         },
 
         [xi.zone.INNER_HORUTOTO_RUINS] =
@@ -274,9 +274,9 @@ mission.sections =
 
         [xi.zone.WINDURST_WOODS] =
         {
-            ['Bopa_Greso']  = mission:progressEvent(174),
-            ['Cha_Lebagta'] = mission:progressEvent(175),
-            ['Nanaa_Mihgo'] = mission:progressEvent(173),
+            ['Bopa_Greso']  = mission:event(174),
+            ['Cha_Lebagta'] = mission:event(175),
+            ['Nanaa_Mihgo'] = mission:event(173),
         },
 
         [xi.zone.WINDURST_WALLS] =

--- a/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
+++ b/scripts/missions/windurst/8_2_The_Jester_Whod_be_King.lua
@@ -118,7 +118,7 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 1 and
                         not player:hasKeyItem(xi.ki.RHINOSTERY_RING)
                     then
-                        return mission:progressEvent(22, 0, xi.ki.RHINOSTERY_RING)
+                        return mission:progressCutscene(22, 0, xi.ki.RHINOSTERY_RING)
                     end
                 end,
             },
@@ -167,7 +167,7 @@ mission.sections =
             {
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 9 then
-                        return mission:progressEvent(75)
+                        return mission:progressCutscene(75)
                     end
                 end,
             },

--- a/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
+++ b/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
@@ -11,8 +11,7 @@
 -- Yoran-Oran        : !pos -109.987 -14 203.338 239
 -- Mandragora Warden : !pos 81.981 7.593 139.556 153
 -----------------------------------
-local boyahdaTreeID   = zones[xi.zone.THE_BOYAHDA_TREE]
-local windurstWoodsID = zones[xi.zone.WINDURST_WOODS]
+local boyahdaTreeID = zones[xi.zone.THE_BOYAHDA_TREE]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.WINDURST, xi.mission.id.windurst.DOLL_OF_THE_DEAD)
@@ -131,7 +130,7 @@ mission.sections =
 
                     if
                         (missionStatus == 4 or missionStatus == 5) and
-                        npcUtil.tradeMatches(trade, { { xi.item.CLUMP_OF_GOOBBUE_HUMUS, 1 } }) -- NOTE: No associated trade completion?
+                        npcUtil.tradeMatches(trade, { { xi.item.CLUMP_OF_GOOBBUE_HUMUS, 1 } })
                     then
                         return mission:progressEvent(13)
                     end
@@ -150,6 +149,7 @@ mission.sections =
             onEventFinish =
             {
                 [13] = function(player, csid, option, npc)
+                    player:tradeComplete()
                     player:setMissionStatus(mission.areaId, 6)
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_FROM_ZONPA_ZIPPA)
                 end,
@@ -204,7 +204,6 @@ mission.sections =
 
                 [621] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 7)
-                    player:messageSpecial(windurstWoodsID.text.KEYITEM_LOST, xi.ki.LETTER_FROM_ZONPA_ZIPPA)
                     player:delKeyItem(xi.ki.LETTER_FROM_ZONPA_ZIPPA)
                 end,
             },

--- a/scripts/missions/windurst/9_2_Moon_Reading.lua
+++ b/scripts/missions/windurst/9_2_Moon_Reading.lua
@@ -82,9 +82,16 @@ mission.sections =
             onZoneIn = function(player, prevZone)
                 if
                     prevZone == xi.zone.QUICKSAND_CAVES and
-                    player:getMissionStatus(mission.areaId) >= 1
+                    player:getMissionStatus(mission.areaId) == 1 and
+                    not player:hasKeyItem(xi.ki.ANCIENT_VERSE_OF_ALTEPA)
                 then
-                    return 3
+                    local cutsceneFlags = bit.bor(
+                        xi.cutsceneFlag.RESET_CAMERA,
+                        xi.cutsceneFlag.NO_PCS,
+                        xi.cutsceneFlag.NO_NPCS
+                    )
+
+                    return { 3, -1, cutsceneFlags }
                 end
             end,
 
@@ -105,6 +112,9 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 2 and
                         player:getLocalVar('battlefieldWin') == xi.battlefield.id.MOON_READING
                     then
+                        player:delKeyItem(xi.ki.ANCIENT_VERSE_OF_ROMAEVE)
+                        player:delKeyItem(xi.ki.ANCIENT_VERSE_OF_ALTEPA)
+                        player:delKeyItem(xi.ki.ANCIENT_VERSE_OF_UGGALEPIH)
                         player:setMissionStatus(mission.areaId, 3)
                     end
                 end,
@@ -176,7 +186,10 @@ mission.sections =
             ['QuHau_Spring'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) >= 1 then
+                    if
+                        player:getMissionStatus(mission.areaId) == 1 and
+                        not player:hasKeyItem(xi.ki.ANCIENT_VERSE_OF_ROMAEVE)
+                    then
                         return mission:progressEvent(4)
                     end
                 end,
@@ -195,7 +208,10 @@ mission.sections =
             ['qm_windy_9_2'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) >= 1 then
+                    if
+                        player:getMissionStatus(mission.areaId) == 1 and
+                        not player:hasKeyItem(xi.ki.ANCIENT_VERSE_OF_UGGALEPIH)
+                    then
                         return mission:progressEvent(68)
                     end
                 end,
@@ -286,12 +302,12 @@ mission.sections =
 
         [xi.zone.PORT_WINDURST] =
         {
-            ['Janshura_Rashura'] = mission:event(567):oncePerZone(),
+            ['Janshura-Rashura'] = mission:event(567):oncePerZone(),
         },
 
         [xi.zone.WINDURST_WATERS] =
         {
-            ['Mokyoko']       = mission:event(837):oncePerZone(),
+            ['Mokyokyo']      = mission:event(837):oncePerZone(),
             ['Tosuka-Porika'] = mission:event(380):replaceDefault(),
         },
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Windurst 2-1
Fixes event 166 missing inputs. Demotes several progressEvent to event
Capture by Siknoz: https://discord.com/channels/443544205206355968/443553403168358401/1109671523494666302

Windurst 8-2
Cutscene for event 22: https://youtu.be/9qupSLFklIU?t=2504
Cutscene for event 75: https://youtu.be/ihPyJkrhd7A?t=1926

Windurst 9-1
Removes trade item
Doesn't send a message special saying the key item was lost.
Capture by Wiggo: https://drive.google.com/open?id=1wjU5kOIDEy60Y7Hym2_CRvtKVD66S9yZ

Windurst 9-2
Correctly gates getting the 3 KI in the mission
Adds cutscene flags for event 3
Removes the KI when needed
Corrects two name misspellings
Capture by Wiggo: https://drive.google.com/open?id=15Mqd3b2VGRHsVWiklGy505zUabrB4vm-

## Steps to test these changes

Add mission, set status, go to pos, test.
