### PR TITLE
[lua] Restrict HELM in certain zones below level 20

### DIFF
--- a/scripts/globals/hobbies/helm/data.lua
+++ b/scripts/globals/hobbies/helm/data.lua
@@ -625,6 +625,7 @@ xi.helm.dataTable =
             [xi.zone.MAMOOK] =
             {
                 breakRate = 9.23, -- n=10903, 95% CI +/-0.54pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -653,6 +654,7 @@ xi.helm.dataTable =
             [xi.zone.CAEDARVA_MIRE] =
             {
                 breakRate = 7.57, -- n=9335, 95% CI +/-0.54pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -711,6 +713,7 @@ xi.helm.dataTable =
             [xi.zone.JUGNER_FOREST_S] =
             {
                 breakRate = 13.99, -- n=10089, 95% CI +/-0.68pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -739,6 +742,7 @@ xi.helm.dataTable =
             [xi.zone.FORT_KARUGO_NARUGO_S] =
             {
                 breakRate = 7.44, -- n=18304, 95% CI +/-0.38pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -1104,6 +1108,7 @@ xi.helm.dataTable =
             [xi.zone.NEWTON_MOVALPOLOS] =
             {
                 breakRate = 56.62, -- n=11963, 95% CI +/-0.89pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -1139,6 +1144,7 @@ xi.helm.dataTable =
             [xi.zone.MOUNT_ZHAYOLM] =
             {
                 breakRate = 46.67, -- n=11577, 95% CI +/-0.91pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -1188,6 +1194,7 @@ xi.helm.dataTable =
             [xi.zone.HALVUNG] =
             {
                 breakRate = 47.98, -- n=17865, 95% CI +/-0.73pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -1433,6 +1440,7 @@ xi.helm.dataTable =
             [xi.zone.GUSGEN_MINES] =
             {
                 breakRate = 52.36, -- n=12094, 95% CI +/-0.89pp
+                minLevel  = 20,
 
                 drops =
                 {
@@ -1473,6 +1481,7 @@ xi.helm.dataTable =
             [xi.zone.IFRITS_CAULDRON] =
             {
                 breakRate = 55.12, -- n=10602, 95% CI +/-0.95pp
+                minLevel  = 20,
 
                 drops =
                 {

--- a/scripts/globals/hobbies/helm/logic.lua
+++ b/scripts/globals/hobbies/helm/logic.lua
@@ -54,7 +54,13 @@ local function doesToolBreak(player, info)
 end
 
 local function pickItem(player, info)
-    local zoneId = player:getZoneID()
+    local zoneId   = player:getZoneID()
+    local minLevel = info.zone[zoneId].minLevel or 0
+
+    -- some zones award nothing below a level requirement, the tool still breaks
+    if player:getMainLvl() < minLevel then
+        return 0
+    end
 
     -- found nothing
     if math.randomInt(1, 100) > info.settingRate then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
> Characters under level 20 can no longer procure items from logging in the following areas:
Mamook / Caedarva Mire / Jugner Forrest (S) / Fort Karugo-Narugo (S)

March 2008 https://www.playonline.com/pcd/verup/ff11us/detail/3347/detail.html

> Characters below level 20 are no longer able to mine for items in the following areas:
Newton Movalpolos/Mount Zhayolm/Halvung/Gusgen Mines/Ifrit's Cauldron

June 2008 https://www.playonline.com/pcd/update/ff11us/20080311cPxl31/detail.html

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
