### PR TITLE
[lua] HELM camping break penalty

### DIFF
--- a/scripts/globals/hobbies/helm/data.lua
+++ b/scripts/globals/hobbies/helm/data.lua
@@ -12,11 +12,12 @@ xi.helm.dataTable =
 {
     [xi.helmType.HARVESTING] =
     {
-        id           = 'HARVESTING',
-        animation    = xi.emote.HARVESTING,
-        relocateRate = 50,
-        message      = 'HARVESTING_IS_POSSIBLE_HERE',
-        tool         = xi.item.SICKLE,
+        id             = 'HARVESTING',
+        animation      = xi.emote.HARVESTING,
+        relocateRate   = 50,
+        campMultiplier = 2.2,
+        message        = 'HARVESTING_IS_POSSIBLE_HERE',
+        tool           = xi.item.SICKLE,
 
         zone =
         {
@@ -483,11 +484,12 @@ xi.helm.dataTable =
 
     [xi.helmType.EXCAVATION] =
     {
-        id           = 'EXCAVATION',
-        animation    = xi.emote.EXCAVATION,
-        relocateRate = 50,
-        message      = 'MINING_IS_POSSIBLE_HERE',
-        tool         = xi.item.PICKAXE,
+        id             = 'EXCAVATION',
+        animation      = xi.emote.EXCAVATION,
+        relocateRate   = 50,
+        campMultiplier = 1.6,
+        message        = 'MINING_IS_POSSIBLE_HERE',
+        tool           = xi.item.PICKAXE,
 
         zone =
         {
@@ -765,11 +767,12 @@ xi.helm.dataTable =
 
     [xi.helmType.LOGGING] =
     {
-        id = 'LOGGING',
-        animation    = xi.emote.LOGGING,
-        relocateRate = 100,
-        message      = 'LOGGING_IS_POSSIBLE_HERE',
-        tool         = xi.item.HATCHET,
+        id             = 'LOGGING',
+        animation      = xi.emote.LOGGING,
+        relocateRate   = 100,
+        campMultiplier = 2.1,
+        message        = 'LOGGING_IS_POSSIBLE_HERE',
+        tool           = xi.item.HATCHET,
 
         zone =
         {
@@ -1532,11 +1535,12 @@ xi.helm.dataTable =
 
     [xi.helmType.MINING] =
     {
-        id           = 'MINING',
-        animation    = xi.emote.EXCAVATION,
-        relocateRate = 50,
-        message      = 'MINING_IS_POSSIBLE_HERE',
-        tool         = xi.item.PICKAXE,
+        id             = 'MINING',
+        animation      = xi.emote.EXCAVATION,
+        relocateRate   = 50,
+        campMultiplier = 1.6,
+        message        = 'MINING_IS_POSSIBLE_HERE',
+        tool           = xi.item.PICKAXE,
 
         zone =
         {

--- a/scripts/globals/hobbies/helm/logic.lua
+++ b/scripts/globals/hobbies/helm/logic.lua
@@ -44,14 +44,41 @@ local breakMods =
     [xi.helmType.EXCAVATION] = nil,
 }
 
+local function hasCampPenalty(player, npc, helmType)
+    local positionIndex = npc:getLocalVar('[HELM]PositionIndex')
+    if positionIndex == 0 then
+        return false
+    end
+
+    local penaltyVar   = string.format('[HELM][%u]Penalty', helmType)
+    local penaltyValue = player:getCharVar(penaltyVar)
+    if penaltyValue == 0 then
+        return false
+    end
+
+    if penaltyValue == positionIndex then
+        return true
+    end
+
+    -- Reaching a different HELM position clears the previous camp penalty.
+    player:setCharVar(penaltyVar, 0)
+    return false
+end
+
 ---@param player CBaseEntity
+---@param npc CBaseEntity
 ---@param info table
 ---@param helmType xi.helmType
 ---@return boolean
-local function doesToolBreak(player, info, helmType)
+local function doesToolBreak(player, npc, info, helmType)
     local roll        = math.randomFloat(0, 100)
     local mods        = breakMods[helmType]
     local breakChance = info.zone[player:getZoneID()].breakRate
+
+    -- Camp penalties and gear reductions are independent multipliers.
+    if hasCampPenalty(player, npc, helmType) then
+        breakChance = breakChance * info.campMultiplier
+    end
 
     if mods and mods[1] and mods[2] then
         local nqMultiplier = 0.893 ^ math.max(player:getMod(mods[1]), 0)
@@ -112,18 +139,23 @@ local function pickItem(player, info)
     return item
 end
 
-local function doMove(npc, x, y, z)
-    return function(entity)
-        entity:setPos(x, y, z, 0)
+local function movePoint(player, npc, zoneId, info, helmType)
+    if player then
+        local positionIndex = npc:getLocalVar('[HELM]PositionIndex')
+        if positionIndex > 0 then
+            player:setCharVar(string.format('[HELM][%u]Penalty', helmType), positionIndex)
+        end
     end
-end
 
-local function movePoint(player, npc, zoneId, info)
-    local points = info.zone[zoneId].points
-    local point  = points[math.randomInt(1, #points)]
+    local points        = info.zone[zoneId].points
+    local positionIndex = math.randomInt(1, #points)
+    local point         = points[positionIndex]
 
     npc:hideNPC(120)
-    npc:queue(3000, doMove(npc, unpack(point)))
+    npc:queue(3000, function(entity)
+        entity:setPos(point[1], point[2], point[3], 0)
+        entity:setLocalVar('[HELM]PositionIndex', positionIndex)
+    end)
 end
 
 -----------------------------------
@@ -139,9 +171,17 @@ xi.helm.initZone = function(zone, helmType)
         local npc = GetNPCByID(npcId)
         if npc then
             npc:setStatus(xi.status.NORMAL)
-            movePoint(nil, npc, zoneId, info)
+            movePoint(nil, npc, zoneId, info, helmType)
         end
     end
+end
+
+xi.helm.onZoneOut = function(player)
+    if player:getStatus() == xi.status.SHUTDOWN then
+        return
+    end
+
+    player:clearVarsWithPrefix('[HELM][')
 end
 
 xi.helm.result = function(player, helmType, broke, itemID)
@@ -196,7 +236,7 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
 
         -- start event
         local itemID = pickItem(player, info)
-        local broke  = doesToolBreak(player, info, helmType) and 1 or 0
+        local broke  = doesToolBreak(player, npc, info, helmType) and 1 or 0
         local full   = (player:getFreeSlotsCount() == 0) and 1 or 0
 
         -- Cutscene plays the emote in all zones but Adoulin.
@@ -223,7 +263,7 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
             player:addItem(itemID)
 
             if math.randomInt(1, 100) <= info.relocateRate then
-                movePoint(player, npc, zoneId, info)
+                movePoint(player, npc, zoneId, info, helmType)
             end
         end
 

--- a/scripts/zones/Abyssea-Attohwa/Zone.lua
+++ b/scripts/zones/Abyssea-Attohwa/Zone.lua
@@ -54,4 +54,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     xi.abyssea.onEventFinish(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Abyssea-Grauberg/Zone.lua
+++ b/scripts/zones/Abyssea-Grauberg/Zone.lua
@@ -54,4 +54,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     xi.abyssea.onEventFinish(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Abyssea-La_Theine/Zone.lua
+++ b/scripts/zones/Abyssea-La_Theine/Zone.lua
@@ -54,4 +54,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     xi.abyssea.onEventFinish(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Abyssea-Misareaux/Zone.lua
+++ b/scripts/zones/Abyssea-Misareaux/Zone.lua
@@ -54,4 +54,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     xi.abyssea.onEventFinish(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Abyssea-Tahrongi/Zone.lua
+++ b/scripts/zones/Abyssea-Tahrongi/Zone.lua
@@ -54,4 +54,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     xi.abyssea.onEventFinish(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Attohwa_Chasm/Zone.lua
+++ b/scripts/zones/Attohwa_Chasm/Zone.lua
@@ -95,4 +95,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Bhaflau_Thickets/Zone.lua
+++ b/scripts/zones/Bhaflau_Thickets/Zone.lua
@@ -49,4 +49,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Buburimu_Peninsula/Zone.lua
+++ b/scripts/zones/Buburimu_Peninsula/Zone.lua
@@ -50,4 +50,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Caedarva_Mire/Zone.lua
+++ b/scripts/zones/Caedarva_Mire/Zone.lua
@@ -126,4 +126,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Carpenters_Landing/Zone.lua
+++ b/scripts/zones/Carpenters_Landing/Zone.lua
@@ -75,4 +75,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/East_Ronfaure/Zone.lua
+++ b/scripts/zones/East_Ronfaure/Zone.lua
@@ -35,4 +35,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/East_Ronfaure_[S]/Zone.lua
+++ b/scripts/zones/East_Ronfaure_[S]/Zone.lua
@@ -42,4 +42,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
+++ b/scripts/zones/Fort_Karugo-Narugo_[S]/Zone.lua
@@ -39,4 +39,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Ghelsba_Outpost/Zone.lua
+++ b/scripts/zones/Ghelsba_Outpost/Zone.lua
@@ -35,4 +35,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Giddeus/Zone.lua
+++ b/scripts/zones/Giddeus/Zone.lua
@@ -36,4 +36,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Grauberg_[S]/Zone.lua
+++ b/scripts/zones/Grauberg_[S]/Zone.lua
@@ -39,4 +39,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Gusgen_Mines/Zone.lua
+++ b/scripts/zones/Gusgen_Mines/Zone.lua
@@ -85,4 +85,8 @@ zoneObject.onGameHour = function(zone)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Halvung/Zone.lua
+++ b/scripts/zones/Halvung/Zone.lua
@@ -31,4 +31,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Ifrits_Cauldron/Zone.lua
+++ b/scripts/zones/Ifrits_Cauldron/Zone.lua
@@ -47,4 +47,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Jugner_Forest/Zone.lua
+++ b/scripts/zones/Jugner_Forest/Zone.lua
@@ -64,4 +64,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Jugner_Forest_[S]/Zone.lua
+++ b/scripts/zones/Jugner_Forest_[S]/Zone.lua
@@ -38,4 +38,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Korroloka_Tunnel/Zone.lua
+++ b/scripts/zones/Korroloka_Tunnel/Zone.lua
@@ -77,4 +77,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Lufaise_Meadows/Zone.lua
+++ b/scripts/zones/Lufaise_Meadows/Zone.lua
@@ -48,4 +48,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Mamook/Zone.lua
+++ b/scripts/zones/Mamook/Zone.lua
@@ -31,4 +31,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Maze_of_Shakhrami/Zone.lua
+++ b/scripts/zones/Maze_of_Shakhrami/Zone.lua
@@ -71,4 +71,8 @@ zoneObject.onGameHour = function(zone)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Misareaux_Coast/Zone.lua
+++ b/scripts/zones/Misareaux_Coast/Zone.lua
@@ -63,4 +63,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Mount_Zhayolm/Zone.lua
+++ b/scripts/zones/Mount_Zhayolm/Zone.lua
@@ -58,4 +58,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Newton_Movalpolos/Zone.lua
+++ b/scripts/zones/Newton_Movalpolos/Zone.lua
@@ -36,4 +36,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/North_Gustaberg_[S]/Zone.lua
+++ b/scripts/zones/North_Gustaberg_[S]/Zone.lua
@@ -30,4 +30,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Oldton_Movalpolos/Zone.lua
+++ b/scripts/zones/Oldton_Movalpolos/Zone.lua
@@ -37,4 +37,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Palborough_Mines/Zone.lua
+++ b/scripts/zones/Palborough_Mines/Zone.lua
@@ -36,4 +36,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Tahrongi_Canyon/Zone.lua
+++ b/scripts/zones/Tahrongi_Canyon/Zone.lua
@@ -73,4 +73,8 @@ zoneObject.onZoneWeatherChange = function(weather)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Wajaom_Woodlands/Zone.lua
+++ b/scripts/zones/Wajaom_Woodlands/Zone.lua
@@ -41,4 +41,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/West_Sarutabaruta/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta/Zone.lua
@@ -57,4 +57,8 @@ zoneObject.onEventFinish = function(player, csid, option, npc)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/West_Sarutabaruta_[S]/Zone.lua
+++ b/scripts/zones/West_Sarutabaruta_[S]/Zone.lua
@@ -37,4 +37,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Yhoator_Jungle/Zone.lua
+++ b/scripts/zones/Yhoator_Jungle/Zone.lua
@@ -64,4 +64,8 @@ zoneObject.onZoneWeatherChange = function(weather)
     xi.helm.weatherChange(weather, { xi.weather.RAIN, xi.weather.SQUALL }, ID.npc.HARVESTING)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Yughott_Grotto/Zone.lua
+++ b/scripts/zones/Yughott_Grotto/Zone.lua
@@ -36,4 +36,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Yuhtunga_Jungle/Zone.lua
+++ b/scripts/zones/Yuhtunga_Jungle/Zone.lua
@@ -90,4 +90,8 @@ zoneObject.onZoneWeatherChange = function(weather)
     end
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject

--- a/scripts/zones/Zeruhn_Mines/Zone.lua
+++ b/scripts/zones/Zeruhn_Mines/Zone.lua
@@ -37,4 +37,8 @@ end
 zoneObject.onEventFinish = function(player, csid, option, npc)
 end
 
+zoneObject.onZoneOut = function(player)
+    xi.helm.onZoneOut(player)
+end
+
 return zoneObject


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Hitting a second respawned node at the same position index "massively" increases your tool break rate.

Methodology:
- 1 (or 3 in Oldton) character stayed at a given index and harvested whatever node ID spawned there
- 1 character roamed every position except the position indexes occupied by the camper characters

I have enough captures to prove the mechanic exists, I don't have enough samples to pin the exact rate so this is going to be best guess.

<img width="1984" height="1764" alt="image" src="https://github.com/user-attachments/assets/9ea4312e-466d-45c0-9149-916bccb7c798" />

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
