### PR TITLE
[lua] Update various item rates on chests

### DIFF
--- a/scripts/globals/treasure.lua
+++ b/scripts/globals/treasure.lua
@@ -1240,8 +1240,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,         720 }, -- Gil
-            { xi.item.PHALANX_RING, 220 }, -- Item
+            { xi.item.NONE,         540 }, -- Gil
+            { xi.item.PHALANX_RING, 400 }, -- Item
             { xi.item.AMETRINE,      10 },
             { xi.item.GARNET,        10 },
             { xi.item.GOSHENITE,     10 },
@@ -1251,8 +1251,8 @@ local lootTable =
         },
         [treasureType.COFFER] =
         {
-            { xi.item.NONE,                      710 }, -- Gil
-            { xi.item.SCROLL_OF_MAGES_BALLAD_II, 210 }, -- Item
+            { xi.item.NONE,                      770 }, -- Gil
+            { xi.item.SCROLL_OF_MAGES_BALLAD_II, 150 }, -- Item
             { xi.item.AQUAMARINE,                 10 },
             { xi.item.CHRYSOBERYL,                10 },
             { xi.item.FLUORITE,                   10 },
@@ -1268,8 +1268,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,         720 }, -- Gil
-            { xi.item.PHALANX_RING, 220 }, -- Item
+            { xi.item.NONE,         540 }, -- Gil
+            { xi.item.PHALANX_RING, 400 }, -- Item
             { xi.item.GARNET,        10 },
             { xi.item.GOSHENITE,     10 },
             { xi.item.LIGHT_OPAL,    10 },
@@ -1451,8 +1451,9 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,         715 }, -- Gil
-            { xi.item.REPLICA_MAUL, 215 }, -- Item
+            { xi.item.NONE,         430 }, -- Gil
+            { xi.item.FROST_SHIELD, 400 }, -- Item
+            { xi.item.REPLICA_MAUL, 100 }, -- Item
             { xi.item.AMBER_STONE,   10 },
             { xi.item.AMETHYST,      10 },
             { xi.item.CLEAR_TOPAZ,   10 },
@@ -1467,8 +1468,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,       710 }, -- Gil
-            { xi.item.GIGANT_AXE, 210 }, -- Item
+            { xi.item.NONE,       520 }, -- Gil
+            { xi.item.GIGANT_AXE, 400 }, -- Item
             { xi.item.AMETRINE,    10 },
             { xi.item.GARNET,      10 },
             { xi.item.GOSHENITE,   10 },
@@ -1537,8 +1538,8 @@ local lootTable =
     {
         [treasureType.CHEST] =
         {
-            { xi.item.NONE,       710 }, -- Gil
-            { xi.item.LIFE_BELT,  210 }, -- Item
+            { xi.item.NONE,       420 }, -- Gil
+            { xi.item.LIFE_BELT,  500 }, -- Item
             { xi.item.AMETRINE,    10 },
             { xi.item.GARNET,      10 },
             { xi.item.GOSHENITE,   10 },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR updates the drop rate of various items that drop from chests.

This includes Life Belt, Gigant Axe, Mages Ballad II, Phalanx Ring, and adds the missing item of Frost Shield.

<img width="200" height="136" alt="image" src="https://github.com/user-attachments/assets/d198f817-ed04-4a09-b3af-b099a4d9c938" />

https://wiki.ffo.jp/html/11477.html

The shield was completely missing from the drop list for some reason.  I've set the rate completely on my gut from experiences of opening the Gusgen chest over the course of a day to plot the chest spawn positions. 

## Steps to test these changes

Pop open some chests.
