### PR TITLE
[modules] [lua] Various Era Quest Wait Modules + Bug Fixes

### DIFF
--- a/modules/era/lua/quests/jeuno/your_crystal_ball.lua
+++ b/modules/era/lua/quests/jeuno/your_crystal_ball.lua
@@ -1,0 +1,33 @@
+-----------------------------------
+-- Your Crystal Ball
+-- Restores the JST midnight wait while the ahriman lens soaks in the Maze of Shakhrami.
+-- The June 17, 2014 version update shortened the wait to one minute.
+-- The update notes give no values; the JST midnight condition comes from the Japanese wiki.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-(JST)-Version-Update
+-- Source: https://wiki.ffo.jp/html/5214.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_your_crystal_ball', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/jeuno/Your_Crystal_Ball', function(quest)
+        local maze      = quest.sections[2][xi.zone.MAZE_OF_SHAKHRAMI]
+        local baseTrade = maze['Rockwell'].onTrade
+
+        -- The lens soaks overnight. Rockwell hands the sphere over at JST midnight.
+        maze['Rockwell'].onTrade = function(player, npc, trade)
+            local previousWait = quest:getVar(player, 'Wait')
+            local result       = baseTrade(player, npc, trade)
+
+            if quest:getVar(player, 'Wait') ~= previousWait then
+                quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+            end
+
+            return result
+        end
+    end)
+end)

--- a/modules/era/lua/quests/otherareas/better_the_demon_you_know.lua
+++ b/modules/era/lua/quests/otherareas/better_the_demon_you_know.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- Better the Demon You Know
+-- Restores the JST midnight wait before Koblakiq finishes reading the demon pen.
+-- The July 8, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_better_the_demon_you_know', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Better_The_Demon_You_Know', function(quest)
+        local oldton  = quest.sections[2][xi.zone.OLDTON_MOVALPOLOS]
+        local basePen = oldton.onEventFinish[22]
+
+        -- Koblakiq works on the pen overnight. He sends the player on at JST midnight.
+        oldton.onEventFinish[22] = function(player, csid, option, npc)
+            basePen(player, csid, option, npc)
+            quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+        end
+    end)
+end)

--- a/modules/era/lua/quests/otherareas/its_raining_mannequins.lua
+++ b/modules/era/lua/quests/otherareas/its_raining_mannequins.lua
@@ -1,0 +1,37 @@
+-----------------------------------
+-- It's Raining Mannequins!
+-- Restores the JST midnight wait while Fyi Chalmwoh assembles the mannequin.
+-- The June 17, 2014 version update shortened the wait to one minute.
+-- The update notes give no values; the JST midnight condition comes from the Japanese wiki.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-(JST)-Version-Update
+-- Source: https://wiki.ffo.jp/html/7101.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_its_raining_mannequins', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/otherAreas/Its_Raining_Mannequins', function(quest)
+        local mhauraTrade  = quest.sections[4][xi.zone.MHAURA]
+        local mhauraReward = quest.sections[5][xi.zone.MHAURA]
+        local basePartsCS  = mhauraTrade.onEventFinish[309]
+
+        -- The parts are assembled overnight. The mannequin is collected at JST midnight.
+        mhauraTrade.onEventFinish[309] = function(player, csid, option, npc)
+            basePartsCS(player, csid, option, npc)
+            quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+        end
+
+        -- Copy of the base handler. 'Wait' now holds the due time rather than the time of the trade.
+        mhauraReward['Fyi_Chalmwoh'].onTrigger = function(player, npc)
+            if GetSystemTime() >= quest:getVar(player, 'Wait') then -- Module change
+                return quest:progressEvent(311)
+            else
+                return quest:event(310) -- Please wait
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/outlands/the_missing_piece.lua
+++ b/modules/era/lua/quests/outlands/the_missing_piece.lua
@@ -1,0 +1,25 @@
+-----------------------------------
+-- The Missing Piece
+-- Restores the JST midnight wait before Charlaimagnat hands over the reward.
+-- The July 8, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_missing_piece', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/The_Missing_Piece', function(quest)
+        local sandoria   = quest.sections[2][xi.zone.NORTHERN_SAN_DORIA]
+        local baseTablet = sandoria.onEventFinish[703]
+
+        -- Charlaimagnat studies the tablet overnight. The reward is handed over at JST midnight.
+        sandoria.onEventFinish[703] = function(player, csid, option, npc)
+            baseTablet(player, csid, option, npc)
+            quest:setVar(player, 'Wait', JstMidnight()) -- Module change
+        end
+    end)
+end)

--- a/modules/era/lua/quests/windurst/blue_ribbon_blues.lua
+++ b/modules/era/lua/quests/windurst/blue_ribbon_blues.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Blue Ribbon Blues
+-- Restores the JST midnight wait, and the zone change, before Kerutoto returns the purple ribbon.
+-- The July 8, 2014 version update replaced both conditions with a flat wait, mistakenly one hour long.
+-- The November 10, 2014 update corrected the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
+-- Source: https://wiki.ffo.jp/html/10406.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_blue_ribbon_blues', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/windurst/Blue_Ribbon_Blues', function(quest)
+        local watersOffer   = quest.sections[1][xi.zone.WINDURST_WATERS]
+        local watersAccept  = quest.sections[2][xi.zone.WINDURST_WATERS]
+        local baseFirstCS   = watersOffer.onEventFinish[358]
+        local baseRetradeCS = watersAccept.onEventFinish[365]
+
+        -- Kerutoto keeps the ribbon overnight, and only hands it back once the player has also zoned.
+        watersOffer.onEventFinish[358] = function(player, csid, option, npc)
+            baseFirstCS(player, csid, option, npc)
+            quest:setVar(player, 'Timer', JstMidnight()) -- Module change
+            quest:setMustZone(player) -- Module change
+        end
+
+        -- The player can hand the ribbon back a second time, which restarts the same wait.
+        watersAccept.onEventFinish[365] = function(player, csid, option, npc)
+            baseRetradeCS(player, csid, option, npc)
+            quest:setVar(player, 'Timer', JstMidnight()) -- Module change
+            quest:setMustZone(player) -- Module change
+        end
+
+        -- Copy of the base handler, with the zone change added to the wait branch.
+        watersAccept['Kerutoto'].onTrigger = function(player, npc)
+            local questProgress = quest:getVar(player, 'Prog')
+
+            if questProgress == 0 then
+                if
+                    GetSystemTime() < quest:getVar(player, 'Timer') or
+                    quest:getMustZone(player) -- Module change
+                then
+                    return quest:progressEvent(359)
+                else
+                    return quest:progressEvent(360)
+                end
+            elseif questProgress == 1 then
+                if not player:findItem(xi.item.PURPLE_RIBBON) then
+                    return quest:progressEvent(366, 0, xi.item.PURPLE_RIBBON)
+                else
+                    return quest:progressEvent(361, 0, xi.item.PURPLE_RIBBON)
+                end
+            elseif questProgress == 3 then
+                return quest:progressEvent(362)
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/zones/south_gustaberg/npcs/qm2.lua
+++ b/modules/era/lua/zones/south_gustaberg/npcs/qm2.lua
@@ -1,0 +1,23 @@
+-----------------------------------
+-- Smoke on the Mountain
+-- Restores the one Vana'diel day cook for meat left on the South Gustaberg campfire.
+-- The June 7, 2016 version update shortened the wait to one minute (Earth time).
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-- Source: https://wiki.ffo.jp/html/8848.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_smoke_on_the_mountain', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.zones.South_Gustaberg.npcs.qm2.onTrade', function(player, npc, trade)
+    local hadCook = player:getCharVar('SouthGustabergCampfire') ~= 0
+    local result  = super(player, npc, trade)
+
+    -- A fresh cook finishes one full Vana'diel day after the trade instead of at the next clock minute.
+    if not hadCook and player:getCharVar('SouthGustabergCampfire') ~= 0 then
+        player:setCharVar('SouthGustabergCampfire', GetSystemTime() + xi.vanaTime.DAY) -- Module change
+    end
+
+    return result
+end)

--- a/scripts/quests/bastok/Smoke_on_the_Mountain.lua
+++ b/scripts/quests/bastok/Smoke_on_the_Mountain.lua
@@ -1,12 +1,10 @@
 -----------------------------------
--- Shady Business
+-- Smoke on the Mountain
 -----------------------------------
 -- Log ID: 1, Quest ID: 15
 -- Hungry Wolf : !pos -25.861 -11 -30.172 237
--- Offa: !pos -283-6 -15.9 -140.3 235
--- ??? (Campfire) !pos 461.8 -20.9 -578.5 107
------------------------------------
-local southGustabergID = zones[xi.zone.SOUTH_GUSTABERG]
+-- Offa : !pos -281.628 -15.971 -140.607 235
+-- ??? (Campfire) !pos 461.841 -21.515 -580.105 107
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.BASTOK, xi.quest.id.bastok.SMOKE_ON_THE_MOUNTAIN)
@@ -67,47 +65,7 @@ quest.sections =
 
         [xi.zone.BASTOK_MARKETS] =
         {
-            ['Offa'] = quest:event(222),
-        },
-
-        [xi.zone.SOUTH_GUSTABERG] =
-        {
-            ['qm2'] =
-            {
-                onTrade = function(player, npc, trade)
-                    if npcUtil.tradeMatches(trade, { { xi.item.SLICE_OF_GIANT_SHEEP_MEAT, 1 } }) then
-                        if quest:getLocalVar(player, 'Timer') == 0 then
-                            player:tradeComplete()
-                            quest:setLocalVar(player, 'Timer', GetSystemTime() + 60)
-
-                            return quest:messageSpecial(southGustabergID.text.FIRE_PUT, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
-                        else
-                            return quest:messageSpecial(southGustabergID.text.MEAT_ALREADY_PUT, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
-                        end
-                    end
-                end,
-
-                onTrigger = function(player, npc)
-                    local cookTimer = quest:getLocalVar(player, 'Timer')
-
-                    if cookTimer == 0 then
-                        return quest:messageSpecial(southGustabergID.text.FIRE_GOOD)
-                    elseif GetSystemTime() < cookTimer then
-                        return quest:messageSpecial(southGustabergID.text.FIRE_LONGER, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
-                    else
-                        quest:setLocalVar(player, 'Timer', 0)
-
-                        if player:getFreeSlotsCount() == 0 then
-                            return quest:messageSpecial(southGustabergID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.GALKAN_SAUSAGE)
-                        else
-                            player:messageSpecial(southGustabergID.text.FIRE_TAKE, xi.item.GALKAN_SAUSAGE)
-                            npcUtil.giveItem(player, xi.item.GALKAN_SAUSAGE)
-
-                            return quest:noAction()
-                        end
-                    end
-                end,
-            },
+            ['Offa'] = quest:event(222):oncePerZone(),
         },
     },
 }

--- a/scripts/quests/jeuno/Your_Crystal_Ball.lua
+++ b/scripts/quests/jeuno/Your_Crystal_Ball.lua
@@ -80,7 +80,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 1 then
-                        if GetSystemTime() >= quest:getVar(player, 'Wait') + 60 then -- 1 minute wait time
+                        if GetSystemTime() >= quest:getVar(player, 'Wait') then
                             return quest:progressEvent(52)
                         else
                             return quest:messageSpecial(mazeID.text.WAIT_A_BIT_LONGER, 0, xi.item.DIVINATION_SPHERE)
@@ -94,7 +94,7 @@ quest.sections =
                         if progress == 0 then
                             player:confirmTrade()
                             quest:setVar(player, 'Prog', 1)
-                            quest:setVar(player, 'Wait', GetSystemTime() + 60)
+                            quest:setVar(player, 'Wait', GetSystemTime() + 60) -- 1 minute wait time
                             return quest:messageSpecial(mazeID.text.SUBMERGED_ITEM, xi.item.AHRIMAN_LENS)
                         elseif progress == 1 then
                             return quest:messageSpecial(mazeID.text.MORE_THAN_ONE, xi.item.AHRIMAN_LENS)

--- a/scripts/quests/otherAreas/Better_The_Demon_You_Know.lua
+++ b/scripts/quests/otherAreas/Better_The_Demon_You_Know.lua
@@ -54,11 +54,11 @@ quest.sections =
                     if progress == 0 then
                         return quest:event(21, 0, xi.item.DEMON_PEN):setPriority(101) -- Reminder to get Demon Pen
                     elseif progress == 1 then
-                            if GetSystemTime() >= waitTime + 60 then
-                                return quest:progressCutscene(24) -- Go to Castle Zvahl Baileys
-                            else
-                                return quest:event(23):setPriority(101) -- Wait Longer
-                            end
+                        if GetSystemTime() >= waitTime then
+                            return quest:progressCutscene(24) -- Go to Castle Zvahl Baileys
+                        else
+                            return quest:event(23):setPriority(101) -- Wait Longer
+                        end
                     elseif progress == 2 then
                         return quest:event(25):setPriority(101) -- Reminder to go to castle Zvahl Baileys
                     elseif progress == 3 then

--- a/scripts/quests/outlands/The_Missing_Piece.lua
+++ b/scripts/quests/outlands/The_Missing_Piece.lua
@@ -115,12 +115,12 @@ quest.sections =
                         progress == 3 and
                         GetSystemTime() < quest:getVar(player, 'Wait')
                     then
-                        return quest:event(704) -- Player has not waited a game day
+                        return quest:event(704) -- Player has not finished the wait
                     elseif
                         progress == 3 and
                         GetSystemTime() >= quest:getVar(player, 'Wait')
                     then
-                        return quest:progressEvent(705) -- Player has waited a game day. Quest Finished
+                        return quest:progressEvent(705) -- Player has finished the wait. Quest finished
                     end
                 end,
             },

--- a/scripts/zones/South_Gustaberg/DefaultActions.lua
+++ b/scripts/zones/South_Gustaberg/DefaultActions.lua
@@ -1,7 +1,4 @@
-local ID = zones[xi.zone.SOUTH_GUSTABERG]
-
 return {
     ['Fish_Eyes']      = { event = 903 },
-    ['qm2']            = { messageSpecial = ID.text.FIRE_GOOD }, -- Note: even when the fire is out on retail it emits this message.
     ['Stone_Monument'] = { event = 900 },
 }

--- a/scripts/zones/South_Gustaberg/npcs/qm2.lua
+++ b/scripts/zones/South_Gustaberg/npcs/qm2.lua
@@ -1,0 +1,52 @@
+-----------------------------------
+-- Area: South Gustaberg
+--  NPC: qm2 (???)
+-- Involved in Quest: Smoke on the Mountain
+-- !pos 461.841 -21.515 -580.105 107
+-----------------------------------
+local ID = zones[xi.zone.SOUTH_GUSTABERG]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrade = function(player, npc, trade)
+    if not npcUtil.tradeMatches(trade, { { xi.item.SLICE_OF_GIANT_SHEEP_MEAT, 1 } }) then
+        return
+    end
+
+    if player:getCharVar('SouthGustabergCampfire') ~= 0 then
+        return player:messageSpecial(ID.text.MEAT_ALREADY_PUT, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
+    end
+
+    player:tradeComplete()
+
+    -- The meat is done at the next Earth clock minute, not after a flat duration.
+    -- 2023-09-12 capture: traded at :35, still cooking at :58, done at :02.
+    player:setCharVar('SouthGustabergCampfire', (math.floor(GetSystemTime() / 60) + 1) * 60)
+
+    return player:messageSpecial(ID.text.FIRE_PUT, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
+end
+
+entity.onTrigger = function(player, npc)
+    local cookTimer = player:getCharVar('SouthGustabergCampfire')
+
+    -- Retail emits this as speakerless npc text (flag unset, type 6), even while the fire looks out.
+    if cookTimer == 0 then
+        return player:messageText(npc, ID.text.FIRE_GOOD, false, 6)
+    end
+
+    if GetSystemTime() < cookTimer then
+        return player:messageSpecial(ID.text.FIRE_LONGER, xi.item.SLICE_OF_GIANT_SHEEP_MEAT)
+    end
+
+    if player:getFreeSlotsCount() == 0 then
+        return player:messageSpecial(ID.text.ITEM_CANNOT_BE_OBTAINED, xi.item.GALKAN_SAUSAGE)
+    end
+
+    player:setCharVar('SouthGustabergCampfire', 0)
+    npcUtil.giveItem(player, xi.item.GALKAN_SAUSAGE, { silent = true })
+
+    return player:messageSpecial(ID.text.FIRE_TAKE, xi.item.GALKAN_SAUSAGE)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds era wait modules and fixes some bugs for the following quests:

1. **Smoke on the Mountain**: The campfire is quest-independent now and cooks until the next clock minute, the timer survives zoning and logout, and the era module stretches the cook to a full Vana'diel day.
2. **Your Crystal Ball:** The modern wait is a flat minute instead of a double-counted two, and the era module has Rockwell hold the lens until JST midnight.
3. **Better the Demon You Know**: Same double-counted timer fix, and the era module has Koblakiq keep the pen until JST midnight.
4. **The Missing Piece**: Comment fixes only, plus an era module that has Charlaimagnat hold the reward until JST midnight.
5. **Blue Ribbon Blues**: The era module brings back both old requirements before Kerutoto returns the ribbon, crossing JST midnight and changing areas.
6. **It's Raining Mannequins**: The era module has Fyi Chalmwoh hold the mannequin until JST midnight.

Sources:

https://forum.square-enix.com/ffxi/threads/42614-Jun-17-2014-(JST)-Version-Update
https://forum.square-enix.com/ffxi/threads/43135-Jul-8-2014-(JST)-Version-Update
https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update

## Steps to test these changes

Do the quests, see they still work, and in the case of 2 and 3 above no longer give you a double wait. Load the modules. See the quests still work but also now have era wait times.

## Captures

Siknoz

Quest - Bastok - Smoke on the Mountain
https://youtu.be/qw2V12iHusg
https://www.dropbox.com/scl/fi/u7wh6698sm74h8ihxg2en/Quest-Bastok-Smoke-on-the-Mountain.zip?rlkey=nq72tavn54n52u4bah28xyz1p&dl=0

Hatberg

https://youtube.com/live/0GsRhKW4xws