### PR TITLE
[yaml] Adjust HPP of some species to match retail captures

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -1308,6 +1308,7 @@ ecosystems:
                 - sight
               mods:
                 defp: 20
+                hpp:  10
               mob_mods:
                 sublink:     5
                 roam_cool:  50
@@ -1400,6 +1401,7 @@ ecosystems:
               mods:
                 mdef:         13
                 udmgmagic: -1250
+                hpp:          10
               mob_mods:
                 sublink: 10
           medusa:
@@ -1410,6 +1412,8 @@ ecosystems:
           merrow:
             id: 131
             attributes:
+              mods:
+                hpp: 10
               mob_mods:
                 sublink: 10
       mamool_ja:
@@ -1430,7 +1434,8 @@ ecosystems:
             id: 132
             attributes:
               mods:
-                eva: 10
+                eva:  10
+                hpp: -10
               mob_mods:
                 sublink: 8
           sage:
@@ -1607,7 +1612,7 @@ ecosystems:
             id: 150
             attributes:
               mods:
-                hpp: -5
+                hpp: -10
       sahagin:
         id: 68
         attributes:
@@ -1793,6 +1798,8 @@ ecosystems:
           apkallu:
             id: 171
             attributes:
+              mods:
+                hpp: -20
               mob_mods:
                 sublink:     14
                 sight_range:  5
@@ -1964,6 +1971,8 @@ ecosystems:
               detects:
                 - sight
               speed: 60
+              mods:
+                hpp: -20
               mob_mods:
                 mp_base:    50
                 roam_cool:  55
@@ -2178,7 +2187,8 @@ ecosystems:
             id: 212
             attributes:
               mods:
-                mdef: 24
+                mdef:  24
+                hpp:  -30
               mob_mods:
                 sublink:      13
                 roam_cool:    50
@@ -2889,6 +2899,8 @@ ecosystems:
           wanderer:
             id: 290
             attributes:
+              mods:
+                hpp: -10
               mob_mods:
                 mp_base: 50
       weeper:
@@ -2909,6 +2921,9 @@ ecosystems:
             id: 291
           weeper:
             id: 292
+            attributes:
+              mods:
+                hpp: 10
 
   humanoid:
     id: 12
@@ -3267,6 +3282,8 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              mods:
+                hpp: -10
       euvhi:
         id: 132
         species:
@@ -3282,6 +3299,8 @@ ecosystems:
                 chr: a
               detects:
                 - hearing
+              mods:
+                hpp: -20
       hpemde:
         id: 133
         species:
@@ -3381,6 +3400,7 @@ ecosystems:
             attributes:
               mods:
                 udmgmagic: -1250
+                hpp:         -20
           spider_ghrah:
             id: 329
       zdei:
@@ -3400,6 +3420,8 @@ ecosystems:
           zdei:
             id: 331
             attributes:
+              mods:
+                hpp: -20
               mob_mods:
                 sight_range: 10
 
@@ -4440,6 +4462,9 @@ ecosystems:
         species:
           chigoe:
             id: 435
+            attributes:
+              mods:
+                hpp: -70
           djigga:
             id: 436
       crawler:


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
As the title says adjust HP percentages to match retail captures. See sheet for HP values: https://docs.google.com/spreadsheets/d/1Pc11VpRKVc2xS5Y0_8ULN3JeutETEGL9KHwU5gE7nNQ/edit?gid=725870316#gid=725870316

There will be a follow up PR to implement the work InoUno has done to get the HP formulas slightly more accurate and bring that missing/extra 0-100hp on mobs to as close as we can get to a 0 HP difference from retail vs LSB

See the -20% HP difference below
Old:
<img width="391" height="54" alt="image" src="https://github.com/user-attachments/assets/79a72c49-5ac8-4905-900d-3a25fd0413e2" />

New:
<img width="474" height="58" alt="image" src="https://github.com/user-attachments/assets/0630a21a-4e0e-42c6-a792-ecb0a9b76bac" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
!gotoid 16896013
!getstats 1
If the mob is level 50 you should observe the HP above.
<!-- Clear and detailed steps to test your changes here -->
