### PR TITLE
[lua] Fix Sharp Strike duration

### DIFF
--- a/scripts/actions/mobskills/sharp_strike.lua
+++ b/scripts/actions/mobskills/sharp_strike.lua
@@ -16,7 +16,7 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local power = 50
-    local duration = 180
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.ATTACK_BOOST, power, 0, duration))
     return xi.effect.ATTACK_BOOST


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes the duration of scorpion's sharp strike to correctly vary with tp from 3 to 9 minutes.

<img width="795" height="310" alt="image" src="https://github.com/user-attachments/assets/c10f09aa-6fb7-4771-9c58-740999b67453" />


<img width="54" height="66" alt="image" src="https://github.com/user-attachments/assets/9a1ebf3b-566e-48c2-9bbc-7902c68ca07a" />

## Steps to test these changes

!tp 3000 a scorp and behold a 9 minute buff.
