### PR TITLE
[lua][module] Bug fixes for several job era modules

### DIFF
--- a/modules/era/lua/globals/job_utils/beastmaster.lua
+++ b/modules/era/lua/globals/job_utils/beastmaster.lua
@@ -34,12 +34,12 @@ m:addOverrideByEra('xi.server.onServerStart', {
 
         xi.job_utils.beastmaster.petFoodData =
         {
-            [xi.item.PET_FOOD_ALPHA_BISCUIT]   = { minHealing =  25, regen =  1, mndMult = 2, mndThreshold = 10 },
-            [xi.item.PET_FOOD_BETA_BISCUIT]    = { minHealing =  50, regen =  3, mndMult = 1, mndThreshold = 33 },
-            [xi.item.PET_FOOD_GAMMA_BISCUIT]   = { minHealing = 100, regen =  5, mndMult = 1, mndThreshold = 35 },
-            [xi.item.PET_FOOD_DELTA_BISCUIT]   = { minHealing = 150, regen =  8, mndMult = 2, mndThreshold = 40 },
-            [xi.item.PET_FOOD_EPSILON_BISCUIT] = { minHealing = 300, regen = 11, mndMult = 2, mndThreshold = 45 },
-            [xi.item.PET_FOOD_ZETA_BISCUIT]    = { minHealing = 350, regen = 14, mndMult = 3, mndThreshold = 45 },
+            [xi.item.PET_FOOD_ALPHA_BISCUIT]   = { minHealing =  25, regen = 1, mndMult = 2, mndThreshold = 10 },
+            [xi.item.PET_FOOD_BETA_BISCUIT]    = { minHealing =  50, regen = 2, mndMult = 1, mndThreshold = 33 },
+            [xi.item.PET_FOOD_GAMMA_BISCUIT]   = { minHealing = 100, regen = 3, mndMult = 1, mndThreshold = 35 },
+            [xi.item.PET_FOOD_DELTA_BISCUIT]   = { minHealing = 150, regen = 4, mndMult = 2, mndThreshold = 40 },
+            [xi.item.PET_FOOD_EPSILON_BISCUIT] = { minHealing = 300, regen = 5, mndMult = 2, mndThreshold = 45 },
+            [xi.item.PET_FOOD_ZETA_BISCUIT]    = { minHealing = 350, regen = 6, mndMult = 3, mndThreshold = 45 },
         }
     end,
 })

--- a/modules/era/lua/globals/job_utils/corsair.lua
+++ b/modules/era/lua/globals/job_utils/corsair.lua
@@ -134,6 +134,102 @@ m:addOverrideByEra('xi.server.onServerStart', {
     end,
 })
 
+-- Light Shot / Dark Shot: Revert Dia and Bio effect boost to +5% defense/attack down instead of +2%.
+-- Source: https://forum.square-enix.com/ffxi/threads/55263-April.-3-2019-%28JST%29-Version-Update
+m:addOverrideByEra('xi.job_utils.corsair.handleQuickDrawEffectBoost', {
+    [xi.expansion.ABYSSEA] = function(player, target, abilityId, multiplier)
+        local effectData = xi.job_utils.corsair.quickDrawEffectBoostTable[abilityId]
+        if not effectData then
+            return
+        end
+
+        -- Gather eligible effects that have not yet been boosted.
+        local effects = {}
+        for _, entryTable in ipairs(effectData) do
+            local effectChecked = target:getStatusEffect(entryTable.effectId)
+
+            if effectChecked then
+                local eligible = false
+
+                -- Check for Dia/Bio.
+                if entryTable.basePowerByTier then
+                    local basePower = entryTable.basePowerByTier[effectChecked:getTier()]
+                    eligible        = basePower and effectChecked:getSubPower() <= basePower
+
+                -- Check for all other eligible effects
+                else
+                    eligible = effectChecked:getPower() < entryTable.capGlobal
+                end
+
+                if eligible then
+                    table.insert(effects, { effect = effectChecked, entry = entryTable })
+                end
+            end
+        end
+
+        -- Early return: No effect can be boosted, either because it's capped or isn't present.
+        if #effects <= 0 then
+            return
+        end
+
+        -- Select effect entry from table and fetch it's content.
+        local selected = effects[math.randomInt(1, #effects)]
+        local effect   = selected.effect
+        local entry    = selected.entry
+
+        -- Fetch effect data.
+        local effectId        = effect:getEffectType()
+        local effectPower     = effect:getPower()
+        local effectTick      = effect:getTick() / 1000
+        local effectDuration  = effect:getDuration() / 1000
+        local effectSubPower  = effect:getSubPower()
+        local effectSubType   = effect:getSubType()
+        local effectTier      = effect:getTier()
+        local effectStartTime = effect:getStartTime()
+        local effectOriginID  = effect:getOriginID()
+
+        -- Apply boost to Dia or Bio effects. They can only be boosted once. "Cannot be stacked."
+        if entry.basePowerByTier then
+            if effectId == xi.effect.DIA then
+                effectPower = effectPower + 1
+            end
+
+            effectSubPower = effectSubPower + 5
+
+        -- Apply boost to all other eligible effects.
+        else
+            if effectId >= xi.effect.BURN and effectId <= xi.effect.DROWN then
+                effectPower = math.min(effectPower + 2, entry.capGlobal)
+            else
+                effectPower = math.min(effectPower * multiplier, entry.capGlobal)
+            end
+        end
+
+        -- Remove the existing effect and reapply it with the new power/subPower values.
+        target:delStatusEffectSilent(effectId)
+
+        local params =
+        {
+            power    = effectPower,
+            tick     = effectTick,
+            duration = effectDuration,
+            subPower = effectSubPower,
+            subType  = effectSubType,
+            tier     = effectTier,
+            origin   = player,
+        }
+
+        target:addStatusEffect(effectId, params)
+
+        -- Update the start time and origin ID of the new effect to match the original effect.
+        local newEffect = target:getStatusEffect(effectId)
+        if newEffect then
+            newEffect:setStartTime(effectStartTime)
+            newEffect:setOriginID(effectOriginID)
+        end
+    end,
+})
+
 -- Healer's Roll: Revert from Cure potency bonus to MP heal bonus
 -- TODO: find a patch note or source for this change
 m:addOverrideByEra('xi.effects.healers_roll.onEffectGain', {

--- a/modules/era/lua/globals/job_utils/dragoon.lua
+++ b/modules/era/lua/globals/job_utils/dragoon.lua
@@ -76,9 +76,9 @@ m:addOverrideByEra('xi.job_utils.dragoon.useDamageBreath', {
 })
 
 m:addOverrideByEra('xi.job_utils.dragoon.useSpiritLink', {
-    -- Spirit Link: Revert to pre-September 2015 healing formula.
+    -- Spirit Link: Revert to pre-September 2015 HP cost and heal formula.
     -- Source: https://forum.square-enix.com/ffxi/threads/48564-Sep-16-2015-%28JST%29-Version-Update
-    -- Formula taken from: https://wiki.ffo.jp/html/15079.html
+    -- Formula taken from: https://wiki.ffo.jp/html/1897.html
     [xi.expansion.ROV] = function(player, target, ability, action)
         local wyvern      = player:getPet()
         local playerHP    = player:getHP()
@@ -121,14 +121,14 @@ m:addOverrideByEra('xi.job_utils.dragoon.useSpiritLink', {
         end
 
         -- Handle master damage and pet healing.
-        player:takeDamage(drainamount - stoneskinPower)
+        player:takeDamage(math.max(0, drainamount - stoneskinPower))
 
         local playerMND = player:getStat(xi.mod.MND)
-        local alpha     = wyvern:getMainLvl() * 0.7
+        local alpha     = math.floor(wyvern:getMainLvl() * 0.7)
         local healPet   = (drainamount + playerMND + alpha) * 2
 
         if player:getEquipID(xi.slot.HEAD) == xi.item.DRACHEN_ARMET_P1 then
-            healPet = healPet + 15
+            healPet = healPet + 10
         end
 
         -- Spirit Link is self target but reports effect on Wyvern.
@@ -137,8 +137,9 @@ m:addOverrideByEra('xi.job_utils.dragoon.useSpiritLink', {
         return wyvern:addHP(healPet) -- add the hp to wyvern
     end,
 
-    -- Spirit Link: Revert TP transfer from wyvern to master and removes regen
+    -- Spirit Link: Revert TP transfer from wyvern to master, regen, and doubled heal
     -- TP Transfer Source: https://www.bg-wiki.com/ffxi/Version_Update_(06/21/2010)
+    -- Heal Doubling Source: https://forum.square-enix.com/ffxi/threads/20744
     -- Regen Source: https://www.bg-wiki.com/ffxi/Version_Update_(03/26/2012)
     [xi.expansion.ABYSSEA] = function(player, target, ability, action)
         local wyvern      = player:getPet()
@@ -178,16 +179,16 @@ m:addOverrideByEra('xi.job_utils.dragoon.useSpiritLink', {
         end
 
         -- Handle master damage and pet healing.
-        player:takeDamage(drainAmount - stoneskinPower)
+        player:takeDamage(math.max(0, drainAmount - stoneskinPower))
 
-        -- Pre-September 2015: Healing formula includes MND and wyvern level components.
-        -- Source: https://wiki.ffo.jp/html/1897.html https://www.bg-wiki.com/ffxi/Spirit_Link
+        -- Pre-February 2012: Heal is not doubled.
+        -- Source: https://wiki.ffo.jp/html/1897.html
         local playerMND = player:getStat(xi.mod.MND)
-        local alpha     = wyvern:getMainLvl() * 0.7
-        local healPet   = (drainAmount + playerMND + alpha) * 2
+        local alpha     = math.floor(wyvern:getMainLvl() * 0.7)
+        local healPet   = drainAmount + playerMND + alpha
 
         if player:getEquipID(xi.slot.HEAD) == xi.item.DRACHEN_ARMET_P1 then
-            healPet = healPet + 15
+            healPet = healPet + 10
         end
 
         -- Spirit Link is self target but reports effect on Wyvern.

--- a/modules/era/lua/globals/job_utils/paladin.lua
+++ b/modules/era/lua/globals/job_utils/paladin.lua
@@ -5,27 +5,64 @@ require('modules/module_utils')
 -----------------------------------
 local m = Module:new('era_job_utils_paladin')
 
--- Rampart: Revert to a magical damage stoneskin effect for party members
--- TODO: find a patch note or source for this change
+-- Rampart: Revert to a defense bonus plus a magic damage barrier for party members
+-- Source: https://forum.square-enix.com/ffxi/threads/56444-February-12-2020-%28JST%29-Version-Update
 m:addOverrideByEra('xi.job_utils.paladin.useRampart', {
     [xi.expansion.ROV] = function(player, target, ability)
-        local duration    = 30 + player:getMod(xi.mod.RAMPART_DURATION)
-        local stoneskinHP = player:getStat(xi.mod.VIT) * 2
-        local defense     = player:getMainLvl() == 75 and 23 or 21
+        local duration = 30 + player:getMod(xi.mod.RAMPART_DURATION)
+        local defense  = math.floor((player:getMainLvl() - 1) / 4 + 5)
 
-        -- Apply STONESKIN effect but display as RAMPART icon
-        target:addStatusEffect(xi.effect.STONESKIN, { power = defense, duration = duration, origin   = player, icon = xi.effect.RAMPART, subType  = 2, subPower = stoneskinHP })
+        -- Barrier is VIT * (1 + 0.5 * (members buffed - 1))
+        local members = 0
+        for _, member in pairs(player:getPartyWithTrusts()) do
+            if
+                member:isAlive() and
+                player:checkDistance(member) <= ability:getRadius()
+            then
+                members = members + 1
+            end
+        end
+
+        local barrier = math.floor(player:getStat(xi.mod.VIT) * (1 + 0.5 * (members - 1)))
+
+        target:addStatusEffect(xi.effect.RAMPART, { power = barrier, duration = duration, origin = player, subPower = defense })
 
         return xi.effect.RAMPART
     end,
 })
 
--- Stoneskin onEffectGain: Add defense buff when displayed as RAMPART
-m:addOverrideByEra('xi.effects.stoneskin.onEffectGain', {
+-- Rampart: DEF bonus in place of the damage taken reduction, power holds the magic barrier
+m:addOverrideByEra('xi.effects.rampart.onEffectGain', {
     [xi.expansion.ROV] = function(target, effect)
-        if effect:getIcon() == xi.effect.RAMPART then
-            effect:addMod(xi.mod.DEF, effect:getPower())
+        effect:addMod(xi.mod.DEF, effect:getSubPower())
+
+        if target:isPC() and target:hasTrait(xi.trait.IRON_WILL) then
+            effect:addMod(xi.mod.SPELLINTERRUPT, target:getMerit(xi.merit.IRON_WILL))
+
+            if target:getMod(xi.mod.ENHANCES_IRON_WILL) > 0 then
+                effect:addMod(xi.mod.FASTCAST, target:getMod(xi.mod.ENHANCES_IRON_WILL) * target:getMerit(xi.merit.IRON_WILL) / 19)
+            end
         end
+    end,
+})
+
+-- Remove rampart barrier prior to stoneskin
+m:addOverrideByEra('utils.handleStoneskin', {
+    [xi.expansion.ROV] = function(actor, damage, attackType)
+        if
+            damage > 0 and
+            attackType == xi.attackType.MAGICAL
+        then
+            local rampart = actor:getStatusEffect(xi.effect.RAMPART)
+            if rampart and rampart:getPower() > 0 then
+                local absorbed = math.min(rampart:getPower(), damage)
+
+                rampart:setPower(rampart:getPower() - absorbed)
+                damage = damage - absorbed
+            end
+        end
+
+        return super(actor, damage, attackType)
     end,
 })
 

--- a/modules/era/lua/globals/job_utils/ranger.lua
+++ b/modules/era/lua/globals/job_utils/ranger.lua
@@ -5,48 +5,58 @@ require('modules/module_utils')
 -----------------------------------
 local m = Module:new('era_job_utils_ranger')
 
--- Eagle Eye Shot: Revert shadow bypass
--- Source: https://forum.square-enix.com/ffxi/threads/47481-Jun-25-2015-%28JST%29-Version-Update
+local function useEagleEyeShot(player, target, action, enmityMult)
+    if player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.MARKSMANSHIP then
+        action:setAnimation(target:getID(), action:getAnimation(target:getID()) + 1)
+    end
+
+    local params = {}
+
+    params.numHits = 1
+
+    -- TP params.
+    local tp          = 1000 -- to ensure ftp multiplier is applied
+    params.ftpMod     = { 5.0, 5.0, 5.0 }
+    params.critVaries = { 0.0, 0.0, 0.0 }
+
+    -- Stat params.
+    params.str_wsc = 0
+    params.dex_wsc = 0
+    params.vit_wsc = 0
+    params.agi_wsc = 0
+    params.int_wsc = 0
+    params.mnd_wsc = 0
+    params.chr_wsc = 0
+
+    params.enmityMult = enmityMult
+
+    -- Job Point Bonus Damage
+    local jpValue = player:getJobPointLevel(xi.jp.EAGLE_EYE_SHOT_EFFECT)
+    player:addMod(xi.mod.ALL_WSDMG_ALL_HITS, jpValue * 3)
+
+    local damage, _, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, 0, params, tp, action, true)
+
+    -- Set the message id ourselves
+    if tpHits + extraHits > 0 then
+        action:messageID(target:getID(), xi.msg.basic.JA_DAMAGE)
+    else
+        action:messageID(target:getID(), xi.msg.basic.JA_MISS_2)
+    end
+
+    return damage
+end
+
 m:addOverrideByEra('xi.job_utils.ranger.useEagleEyeShot', {
+    -- Revert shadow bypass
+    -- Source: https://forum.square-enix.com/ffxi/threads/47481-Jun-25-2015-%28JST%29-Version-Update
     [xi.expansion.ROV] = function(player, target, ability, action)
-        if player:getWeaponSkillType(xi.slot.RANGED) == xi.skill.MARKSMANSHIP then
-            action:setAnimation(target:getID(), action:getAnimation(target:getID()) + 1)
-        end
+        return useEagleEyeShot(player, target, action, 0.5)
+    end,
 
-        local params = {}
-
-        params.numHits = 1
-
-        -- TP params.
-        local tp          = 1000 -- to ensure ftp multiplier is applied
-        params.ftpMod     = { 5.0, 5.0, 5.0 }
-        params.critVaries = { 0.0, 0.0, 0.0 }
-
-        -- Stat params.
-        params.str_wsc = 0
-        params.dex_wsc = 0
-        params.vit_wsc = 0
-        params.agi_wsc = 0
-        params.int_wsc = 0
-        params.mnd_wsc = 0
-        params.chr_wsc = 0
-
-        params.enmityMult = 0.5
-
-        -- Job Point Bonus Damage
-        local jpValue = player:getJobPointLevel(xi.jp.EAGLE_EYE_SHOT_EFFECT)
-        player:addMod(xi.mod.ALL_WSDMG_ALL_HITS, jpValue * 3)
-
-        local damage, _, tpHits, extraHits = xi.weaponskills.doRangedWeaponskill(player, target, 0, params, tp, action, true)
-
-        -- Set the message id ourselves
-        if tpHits + extraHits > 0 then
-            action:messageID(target:getID(), xi.msg.basic.JA_DAMAGE)
-        else
-            action:messageID(target:getID(), xi.msg.basic.JA_MISS_2)
-        end
-
-        return damage
+    -- Revert enmity reduction
+    -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(05/15/2012)
+    [xi.expansion.ABYSSEA] = function(player, target, ability, action)
+        return useEagleEyeShot(player, target, action, 1)
     end,
 })
 

--- a/modules/era/lua/globals/pets.lua
+++ b/modules/era/lua/globals/pets.lua
@@ -7,8 +7,12 @@ require('modules/module_utils')
 -----------------------------------
 local m = Module:new('era_globals_pets', xi.pre(xi.expansion.ABYSSEA))
 
-m:addOverride('xi.pet.spawnPet', function(caster, petID, state, target)
-    super(caster, petID, state, target)
+m:addOverride('xi.pets.avatar.onMobSpawn', function(mob)
+    super(mob)
 
-    xi.job_utils.summoner.applySpiritPerpetuationCost(caster)
+    local master = mob:getMaster()
+
+    if master and master:isPC() then
+        xi.job_utils.summoner.applySpiritPerpetuationCost(master)
+    end
 end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Beastmaster: reward was giving too powerful of a regen, reduced to in era values
- Corsair: Dia and Bio boost increased to 5% from Light/Dark Shot
- Dragoon: Spirit Link no longer heals the wyvern for a doubled heal
- Paladin: Rampart reworked once again. It is instead routed through the Rampart effect with a stoneskin override to consume the shield power. Increasing power of the magic barrier based on number of party members.
- Ranger: Eagle Eye Shot no longer has a reduced enmity generation in prior to the Abyssea era.
- Summoner: Bug fix for existing perpetuation cost mod to apply on pet spawn to correct the mod resetting on zoning.

## Steps to test these changes

- Load the modules in init
- Utilize the above described changes to see they properly reflect in game, 
- Such as changing to PLD/WHM with a  2nd character, use !geteffects and see the power is 1.5x your current VIT
