### PR TITLE
[sql] [lua] Adjust Dynamis Attack/Defense boost TP abilities.

### DIFF
--- a/scripts/actions/mobskills/arm_block_dynamis.lua
+++ b/scripts/actions/mobskills/arm_block_dynamis.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Arm Block
+-- Enhances defense.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    if mob:hasStatusEffect(xi.effect.DEFENSE_BOOST) then
+        return 1
+    end
+
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/howl_dynamis.lua
+++ b/scripts/actions/mobskills/howl_dynamis.lua
@@ -1,0 +1,22 @@
+-----------------------------------
+-- Howl
+--
+-- Description: Grants the effect of Warcry to user and any linked allies.
+-- Type: Enhancing
+-- Utsusemi/Blink absorb: N/A
+-- Range: Self and nearby mobs of same family and/or force up to 20'.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.WARCRY, 50, 0, 60))
+
+    return xi.effect.WARCRY
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/parry_dynamis.lua
+++ b/scripts/actions/mobskills/parry_dynamis.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Parry
+-- Enhances defense.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
+end
+
+return mobskillObject

--- a/scripts/actions/mobskills/shell_guard_dynamis.lua
+++ b/scripts/actions/mobskills/shell_guard_dynamis.lua
@@ -1,0 +1,18 @@
+-----------------------------------
+-- Shell Guard
+-- Increases defense of user.
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.DEFENSE_BOOST, 50, 0, 60))
+
+    return xi.effect.DEFENSE_BOOST
+end
+
+return mobskillObject

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1088,9 +1088,9 @@ INSERT INTO `mob_skills` VALUES (1053,432,'super_buff',0,0.0,1.0,2000,0,1,0,0,0,
 INSERT INTO `mob_skills` VALUES (1057,349,'aerial_wheel',0,0.0,7.0,1600,2000,4,0,0,0,0,0,0); -- Dynamis Orcs
 INSERT INTO `mob_skills` VALUES (1058,350,'shoulder_attack',0,0.0,7.0,1750,2000,4,0,0,1,0,0,0); -- Dynamis Orcs
 INSERT INTO `mob_skills` VALUES (1059,351,'slam_dunk',0,0.0,7.0,2000,2000,4,0,0,0,0,0,0); -- Dynamis Orcs
-INSERT INTO `mob_skills` VALUES (1060,352,'arm_block',0,0.0,7.0,1000,2000,1,0,0,0,0,0,0); -- Dynamis Orcs
+INSERT INTO `mob_skills` VALUES (1060,352,'arm_block_dynamis',0,0.0,7.0,1000,2000,1,0,0,0,0,0,0); -- Dynamis Orcs
 INSERT INTO `mob_skills` VALUES (1061,353,'battle_dance',1,0.0,15.0,2300,2000,4,0,0,0,0,0,0); -- Dynamis Orcs
-INSERT INTO `mob_skills` VALUES (1062,354,'howl',1,0.0,20.0,1500,2000,1,0,0,0,0,0,0); -- Dynamis Orcs
+INSERT INTO `mob_skills` VALUES (1062,354,'howl_dynamis',1,0.0,20.0,1500,2000,1,0,0,0,0,0,0); -- Dynamis Orcs
 -- INSERT INTO `mob_skills` VALUES (1063,807,'bow',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1064,351,'jump',0,0.0,9.5,4000,2000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1065,21,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
@@ -1098,16 +1098,16 @@ INSERT INTO `mob_skills` VALUES (1066,740,'fanatic_dance',1,0.0,10.0,3800,2000,4
 INSERT INTO `mob_skills` VALUES (1067,741,'doom',0,0.0,9.0,1700,200,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1068,361,'feather_storm',0,0.0,7.0,1700,2000,4,0,0,0,0,0,0); -- Dynamis Yagudo
 INSERT INTO `mob_skills` VALUES (1069,362,'double_kick',0,0.0,7.0,2400,2000,4,0,0,1,0,0,0); -- Dynamis Yagudo
-INSERT INTO `mob_skills` VALUES (1070,363,'parry',0,0.0,7.0,2100,2000,1,0,0,0,0,0,0); -- Dynamis Yagudo
+INSERT INTO `mob_skills` VALUES (1070,363,'parry_dynamis',0,0.0,7.0,2100,2000,1,0,0,0,0,0,0); -- Dynamis Yagudo
 INSERT INTO `mob_skills` VALUES (1071,364,'sweep',1,0.0,10.0,3500,2000,4,0,0,0,0,0,0); -- Dynamis Yagudo
-INSERT INTO `mob_skills` VALUES (1072,354,'howl',1,0.0,20.0,1500,2000,1,0,0,0,0,0,0); -- Dynamis Yagudo
+INSERT INTO `mob_skills` VALUES (1072,354,'howl_dynamis',1,0.0,20.0,1500,2000,1,0,0,0,0,0,0); -- Dynamis Yagudo
 INSERT INTO `mob_skills` VALUES (1073,741,'doom',0,0.0,9.0,1700,200,4,0,0,0,0,0,0); -- Dynamis Yagudo
 INSERT INTO `mob_skills` VALUES (1074,742,'the_wrath_of_gudha',1,0.0,15.0,1900,1000,4,0,0,7,0,0,0);
 INSERT INTO `mob_skills` VALUES (1075,355,'ore_toss',0,0.0,15.0,2200,3000,4,0,0,0,0,0,0); -- Dynamis Quadav
 INSERT INTO `mob_skills` VALUES (1076,356,'head_butt_quadav',0,0.0,7.0,3000,3000,4,0,0,1,0,0,0); -- Dynamis Quadav
 INSERT INTO `mob_skills` VALUES (1077,357,'shell_bash',0,0.0,7.0,1900,500,4,0,0,0,0,0,0); -- Dynamis Quadav
-INSERT INTO `mob_skills` VALUES (1078,358,'shell_guard',0,0.0,7.0,1700,3000,1,0,0,0,0,0,0); -- Dynamis Quadav
-INSERT INTO `mob_skills` VALUES (1079,354,'howl',1,0.0,20.0,1500,500,1,0,0,0,0,0,0); -- Dynamis Quadav
+INSERT INTO `mob_skills` VALUES (1078,358,'shell_guard_dynamis',0,0.0,7.0,1700,3000,1,0,0,0,0,0,0); -- Dynamis Quadav
+INSERT INTO `mob_skills` VALUES (1079,354,'howl_dynamis',1,0.0,20.0,1500,500,1,0,0,0,0,0,0); -- Dynamis Quadav
 INSERT INTO `mob_skills` VALUES (1080,742,'the_wrath_of_gudha',1,0.0,15.0,1900,1000,4,0,0,7,0,0,0); -- Dynamis Quadav
 INSERT INTO `mob_skills` VALUES (1081,743,'frypan',1,0.0,15.0,2500,2800,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1082,744,'smokebomb',4,0.0,10.0,3900,2000,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Howl and the defensive abilities of Dynamis mobs to their correct power level and durations.
As it turns out Dynamis is gnarly.

<img width="618" height="277" alt="image" src="https://github.com/user-attachments/assets/6989dd94-974e-41d6-bcd4-13496eaa44b4" />
<img width="613" height="261" alt="image" src="https://github.com/user-attachments/assets/9695084f-5688-4010-a5bb-f444982c241f" />


## Steps to test these changes

!tp 3000 some city dyna mobs.
