### PR TITLE
[yaml, lua] Some Chigoe Fixes

### DIFF
--- a/data/zones/bhaflau_thickets/mobs.yaml
+++ b/data/zones/bhaflau_thickets/mobs.yaml
@@ -589,7 +589,6 @@ templates:
   Chigoe:
     id:            714
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:
@@ -638,7 +637,6 @@ templates:
     id:            7188
     display_name:  Chigoe
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:

--- a/data/zones/caedarva_mire/mobs.yaml
+++ b/data/zones/caedarva_mire/mobs.yaml
@@ -365,7 +365,6 @@ templates:
   Chigoe:
     id:            714
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:
@@ -414,7 +413,6 @@ templates:
     id:            7299
     display_name:  Chigoe
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:
@@ -464,7 +462,6 @@ templates:
     id:            7188
     display_name:  Chigoe
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:

--- a/data/zones/wajaom_woodlands/mobs.yaml
+++ b/data/zones/wajaom_woodlands/mobs.yaml
@@ -642,7 +642,6 @@ templates:
   Chigoe:
     id:            714
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:
@@ -691,7 +690,6 @@ templates:
     id:            7188
     display_name:  Chigoe
     species:       chigoe
-    type:          [battlefield]
     roam:          [stealth]
     skill_list_id: 64
     attributes:

--- a/scripts/enum/mob_pool.lua
+++ b/scripts/enum/mob_pool.lua
@@ -24,6 +24,7 @@ xi.mobPool =
     INGESTER               = 2080, -- Fission (Number of Adds)
     INGURGITATOR           = 2081, -- Fission (Number of Adds)
     KING_VINEGARROON       = 2262, -- KV poison on Wild Rage
+    MOSSHORN               = 2753, -- Sheds two chigoes per TP move
     NIDHOGG                = 2840, -- Nidhogg's stronger hurricane wing
     HPEMDE_DIVING          = 2976, -- Om'hpemde in south half of Al'Taieu: the only hpemde that dive
     OSSCHAART              = 3064, -- Osschaart's charm duration.

--- a/scripts/mixins/families/chigoe_pet.lua
+++ b/scripts/mixins/families/chigoe_pet.lua
@@ -5,10 +5,22 @@ require('scripts/globals/mixins')
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
+-- Hosts spawn one chigoe per TP move unless listed here.
+local chigoesPerUse =
+{
+    [xi.mobPool.MOSSHORN]  = 2, -- Rams shed two at a time.
+    [xi.mobPool.PEALLAIDH] = 2,
+}
+
 g_mixins.families.chigoe_pet = function(hostMob)
     local ID = zones[hostMob:getZoneID()]
 
     hostMob:addListener('WEAPONSKILL_USE', 'MOB_SPAWN_CHIGOE', function(mob, target, skill, tp, action, damage)
+        -- AoE TP moves fire this once per target hit. Only the primary target's hit sheds.
+        if not target or target:getID() ~= skill:getPrimaryTargetID() then
+            return
+        end
+
         local mobName = mob:getName()
 
         -- Requires a Chigoe.lua with the chigoe mixin for this to work
@@ -16,24 +28,47 @@ g_mixins.families.chigoe_pet = function(hostMob)
             return
         end
 
-        local numChigoesToSpawn = 1
-        if mob:getPool() == xi.mobPool.PEALLAIDH then
-            numChigoesToSpawn = 2
+        local hostID = mob:getID()
+
+        -- Hosts share the pool. Count only the chigoes this host put out.
+        local aliveChigoes = 0
+        for _, mobID in pairs(ID.mob.CHIGOES[mobName]) do
+            local chigoe = GetMobByID(mobID)
+
+            if
+                chigoe and
+                chigoe:isSpawned() and
+                chigoe:getLocalVar('chigoeHost') == hostID
+            then
+                aliveChigoes = aliveChigoes + 1
+            end
+        end
+
+        -- Retail caps each host at 5 of its own chigoes.
+        local numChigoesToSpawn = math.min(chigoesPerUse[mob:getPool()] or 1, 5 - aliveChigoes)
+        if numChigoesToSpawn <= 0 then
+            return
+        end
+
+        -- Self-targeted TP moves like rage pass the host itself as the target.
+        if target:getID() == hostID then
+            target = mob:getTarget()
         end
 
         for _, mobID in pairs(ID.mob.CHIGOES[mobName]) do
             local chigoe = GetMobByID(mobID)
 
             if chigoe and not chigoe:isSpawned() then
-                chigoe:setSpawn(hostMob:getXPos() + math.randomInt(-2, 2), hostMob:getYPos() + math.randomInt(-2, 2), hostMob:getZPos() + math.randomInt(-2, 2), hostMob:getRotPos())
+                chigoe:setSpawn(hostMob:getXPos() + math.randomInt(-2, 2), hostMob:getYPos(), hostMob:getZPos() + math.randomInt(-2, 2), hostMob:getRotPos())
                 chigoe:spawn()
+                chigoe:setLocalVar('chigoeHost', hostID)
                 if target then
                     chigoe:updateEnmity(target)
                 end
 
-                chigoe:addListener('DISENGAGE', 'CHIGOE_DISENGAGE', function(mobArg)
+                chigoe:addListener('DISENGAGE', 'CHIGOE_PET_DESPAWN', function(mobArg)
                     DespawnMob(mobArg:getID())
-                    mobArg:removeListener('CHIGOE_DISENGAGE')
+                    mobArg:removeListener('CHIGOE_PET_DESPAWN')
                 end)
 
                 numChigoesToSpawn = numChigoesToSpawn - 1

--- a/scripts/zones/Wajaom_Woodlands/IDs.lua
+++ b/scripts/zones/Wajaom_Woodlands/IDs.lua
@@ -43,7 +43,8 @@ zones[xi.zone.WAJAOM_WOODLANDS] =
     {
         CHIGOES =
         {
-            ['Marid'] = GetTableOfIDs('Chigoe', 5),
+            ['Marid']       = GetTableOfIDs('Chigoe'),
+            ['Grand_Marid'] = GetTableOfIDs('Chigoe'),
         },
         JADED_JODY             = GetFirstID('Jaded_Jody'),
         ZORAAL_JAS_PKUUCHA     = GetFirstID('Zoraal_Jas_Pkuucha'),


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR does the following things for Chigoes in Wajaom Woodlands, Bhaflau Thickets, and Caedarva Mire:

- Makes them not NMs (they check as normal mobs on retail).
- Ensures that all mobs that can pop Chigoes in each zone can pop a total of 5 each. This limit of 5 is spread across the zone for that mob type. This cap was established in the July 25, 2006 update per JP patch notes and the JP wiki (and also retail captures). Some NMs have their own Chigoe pool.
- Mosshorns pop two chigoes per TP move.
- Grand Marids now pop Chigoes again.
- Pops spawn at the host's height instead of randomizing.

## Sources and Captures

https://www.playonline.com/pcd/update/ff11/200607253ps1M1/detail.html
https://wiki.ffo.jp/html/3714.html
https://wiki.ffo.jp/html/2162.html

Captures by @Valentine-PHX and me

[NM_Peallaidh.zip](https://github.com/user-attachments/files/31449884/NM_Peallaidh.zip)
[Peallaidh.zip](https://github.com/user-attachments/files/31449898/Peallaidh.zip)

## Steps to test these changes

Pop Chigoes and see there can only be 5 per mob type. See that Chigoes pop properly. See they are no longer NMs.
