### PR TITLE
[lua] Craver Mobskill Bug Fixes

### DIFF
--- a/scripts/actions/mobskills/carousel.lua
+++ b/scripts/actions/mobskills/carousel.lua
@@ -7,11 +7,7 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:isMobType(xi.mobType.NOTORIOUS) then -- TODO: Set proper skill lists
-        return 0
-    end
-
-    return 1
+    return 0
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)

--- a/scripts/actions/mobskills/empty_thrash.lua
+++ b/scripts/actions/mobskills/empty_thrash.lua
@@ -7,10 +7,6 @@
 local mobskillObject = {}
 
 mobskillObject.onMobSkillCheck = function(target, mob, skill)
-    if mob:isMobType(xi.mobType.NOTORIOUS) then -- TODO: Set proper skill lists
-        return 1
-    end
-
     return 0
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Delver and Repinder were unable to use Carousel and Cumulator was unable to use Empty Trash because the onMobSkillCheck functions had an incorrect gate on them. This PR removes the notorious check from carousel.lua and empty_thrash.lua and lets the skill lists do the gating on their own so these mobs can use the skills they are supposed to per retail captures.

## Steps to test these changes

Fight the affected mobs and see they have access to all of their appropriate TP moves.

## Captures

Siknoz

[COP 1-2 Below the Arks and COP 1-3 The Mothercrystals.zip](https://github.com/user-attachments/files/31453491/COP.1-2.Below.the.Arks.and.COP.1-3.The.Mothercrystals.zip)