### PR TITLE
Core, Tests: Reset the item count when a container is cleared

### DIFF
--- a/src/map/item_container.cpp
+++ b/src/map/item_container.cpp
@@ -259,4 +259,6 @@ void CItemContainer::Clear()
     {
         m_ItemList[SlotID].reset();
     }
+
+    m_count = 0;
 }

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(xi_test
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/zones/regions_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/data/zones/settings_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/entity_list_tests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/item_container_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/rng_runtime_tests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/tests/roam_region_tests.cpp
     ${resource})

--- a/src/test/tests/item_container_tests.cpp
+++ b/src/test/tests/item_container_tests.cpp
@@ -1,0 +1,62 @@
+/*
+===========================================================================
+
+  Copyright (c) 2026 LandSandBoat Dev Teams
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see http://www.gnu.org/licenses/
+
+===========================================================================
+*/
+
+//
+// CItemContainer bookkeeping tests.
+//
+// The container tracks how many slots are taken separately from the items
+// themselves, and every caller reads that count rather than counting the
+// items. Clear() has to keep the two in step.
+//
+
+#include "map/item_container.h"
+#include "map/items/item.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <memory>
+
+TEST_CASE("CItemContainer Clear resets the item count", "[item_container]")
+{
+    auto container = CItemContainer(LOC_TEMPITEMS);
+
+    container.SetSize(10);
+
+    for (auto i = 0; i < 3; ++i)
+    {
+        container.InsertItem(std::make_unique<CItem>(static_cast<uint16>(4096 + i)));
+    }
+
+    REQUIRE(container.GetFreeSlotsCount() == 7);
+
+    container.Clear();
+
+    SECTION("the slots the cleared items held come back")
+    {
+        REQUIRE(container.GetFreeSlotsCount() == 10);
+    }
+
+    SECTION("the container can then shrink past what it used to hold")
+    {
+        // SetSize refuses any size below the count, so a stale count pins the container open.
+        REQUIRE(container.SetSize(1) == 1);
+    }
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

`Clear()` should clear, innit.