### PR TITLE
[lua] Gustaberg Tour Era Module

### DIFF
--- a/modules/era/lua/quests/bastok/the_gustaberg_tour.lua
+++ b/modules/era/lua/quests/bastok/the_gustaberg_tour.lua
@@ -1,0 +1,38 @@
+-----------------------------------
+-- The Gustaberg Tour
+-- Reverts the completion requirement to six party members of level five or below.
+-- The June 25, 2015 version update reduced it to two members of level fifteen or below.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/47481
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_the_gustaberg_tour', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/bastok/The_Gustaberg_Tour', function(quest)
+        local northGustaberg = quest.sections[2][xi.zone.NORTH_GUSTABERG]
+
+        -- Copy of the base handler with the level lowered to 5 and the party size raised to 6.
+        northGustaberg['Hunting_Bear'].onTrigger = function(player, npc)
+            local flag = true
+
+            for _, member in pairs(player:getAlliance()) do
+                if
+                    member:getMainLvl() > 5 or
+                    member:checkDistance(player) > 15
+                then
+                    flag = false
+                end
+            end
+
+            if flag and #player:getParty() == 6 then
+                return quest:progressEvent(22)
+            else
+                return quest:progressEvent(21)
+            end
+        end
+    end)
+end)

--- a/scripts/quests/outlands/The_Kuftal_Tour.lua
+++ b/scripts/quests/outlands/The_Kuftal_Tour.lua
@@ -2,8 +2,8 @@
 -- The Kuftal Tour
 -----------------------------------
 -- Log ID : 5, Quest ID: 195
--- Datta  : !pos -43.9 -10 -2.4 237
--- qm5    : !pos -29.195 -22.159 -183.716
+-- Datta  : !pos -24.768 8.324 70.722 247
+-- qm5    : !pos -29.195 -22.159 -183.716 174
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.OUTLANDS, xi.quest.id.outlands.THE_KUFTAL_TOUR)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds an era module for The Gustaberg Tour which used to require 6 people but was lessened in the [June 25, 2015 version update](https://forum.square-enix.com/ffxi/threads/47481). Also fixes errors I found in the quest header of The Kuftal Tour.

## Steps to test these changes

Load module. See you need 6 people to complete the quest per era instead of 2.
