### PR TITLE
[core] Run zone-in scripts after the char is placed in its zone

### DIFF
--- a/scripts/tests/systems/items/transactions.lua
+++ b/scripts/tests/systems/items/transactions.lua
@@ -176,5 +176,15 @@ describe('Item transaction invariants', function()
             assert(binned, 'the stack reached neither inventory nor the recycle bin')
             assert(binned:state() == xi.itemState.FREE, 'binned state: ' .. tostring(binned:state()))
         end)
+
+        -- character creation runs from the login sequence, and the gil it claims has to come back Free
+        it('leaves gil usable after character creation', function()
+            local newPlayer = xi.test.world:spawnPlayer({ zone = xi.zone.GM_HOME, new = true })
+            local gilBefore = newPlayer:getGil()
+
+            newPlayer:addGil(50)
+
+            assert(newPlayer:getGil() == gilBefore + 50, 'gil after creation: ' .. tostring(newPlayer:getGil()))
+        end)
     end)
 end)

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -463,6 +463,7 @@ public:
 
     WarpRequest requestedWarp       = WarpRequest::None; // see WarpRequest. This will be processed after the player's tick to warp.
     bool        requestedZoneChange = false;             // used in CLueBaseEntity::setPos(). This will be processed after the player's tick to change zones.
+    bool        arrivedByZoning     = false;             // set from char_stats.zoning by LoadChar, read by the 0x00A handler once the char is in its zone.
 
     uint8 GetGender();
 

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -2442,12 +2442,12 @@ void OnZoneIn(CCharEntity* PChar)
 {
     TracyZoneScoped;
 
-    CZone* destinationZone = zoneutils::GetZone(PChar->loc.destination);
+    CZone* destinationZone = zoneutils::GetZone(PChar->getZone());
     if (!destinationZone)
     {
         if (!PChar->inMogHouse())
         {
-            ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->loc.destination);
+            ShowWarning("Attempt to Zone In player to invalid/disabled zone %d.", PChar->getZone());
         }
         return;
     }

--- a/src/map/map_networking.cpp
+++ b/src/map/map_networking.cpp
@@ -31,6 +31,7 @@
 #include "packets/s2c/0x00b_logout.h"
 
 #include "utils/charutils.h"
+#include "utils/zoneutils.h"
 
 #include "ipc_client.h"
 #include "latent_effect_container.h"
@@ -302,13 +303,16 @@ int32 MapNetworking::recv_parse(uint8* buff, size_t* buffsize, MapSession* PSess
                 ShowError("recv_parse: Cannot load session_key for charid %u", packetCharID);
             }
 
-            PSession->PChar     = charutils::LoadChar(scheduler_, config_, packetCharID);
+            PSession->PChar     = charutils::LoadChar(packetCharID);
             PSession->charID    = packetCharID;
             PSession->accountID = accountID;
 
             auto* PChar = PSession->PChar.get();
 
             PChar->PSession = PSession;
+
+            // the 0x00A handler puts the char in this zone, so it has to be loaded before it gets there
+            zoneutils::EnsureZoneLoaded(scheduler_, config_, PChar->loc.destination);
 
             // If we're a new char on a new instance and prevzone != zone
             if (PSession->blowfish.status == BLOWFISH_WAITING && PChar->loc.destination != PChar->loc.prevzone)

--- a/src/map/packets/c2s/0x00a_login.cpp
+++ b/src/map/packets/c2s/0x00a_login.cpp
@@ -25,6 +25,7 @@
 #include "ai/ai_container.h"
 #include "ai/helpers/action_queue.h"
 #include "entities/char_entity.h"
+#include "lua/luautils.h"
 #include "packets/s2c/0x01c_item_max.h"
 #include "packets/s2c/0x04f_equip_clear.h"
 #include "packets/s2c/0x050_equip_list.h"
@@ -96,6 +97,15 @@ void GP_CLI_COMMAND_LOGIN::process(MapSession* PSession, CCharEntity* PChar) con
         }
 
         destZone->IncreaseZoneCounter(PChar);
+
+        if (PChar->loc.zone == nullptr)
+        {
+            ShowErrorFmt("GP_CLI_COMMAND_LOGIN: {} was not placed in zone {}", PChar->getName(), destination);
+            return;
+        }
+
+        luautils::OnZoneIn(PChar);
+        luautils::OnGameIn(PChar, PChar->arrivedByZoning);
 
         // Current zone could either be current zone or destination
         CZone* currentZone = zoneutils::GetZone(PChar->getZone());

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -438,7 +438,7 @@ void CalculateStats(CCharEntity* PChar)
  *                                                                       *
  ************************************************************************/
 
-auto LoadChar(Scheduler& scheduler, MapConfig config, const uint32 charId) -> std::unique_ptr<CCharEntity>
+auto LoadChar(const uint32 charId) -> std::unique_ptr<CCharEntity>
 {
     TracyZoneScoped;
 
@@ -845,6 +845,8 @@ auto LoadChar(Scheduler& scheduler, MapConfig config, const uint32 charId) -> st
 
     db::preparedStmt("UPDATE char_stats SET zoning = 0 WHERE charid = ? LIMIT 1", PChar->id);
 
+    PChar->arrivedByZoning = zoning == 1;
+
     if (zoning == 2)
     {
         ShowDebug("Player <%s> logging in to zone <%u>", PChar->name.c_str(), PChar->getZone());
@@ -993,18 +995,6 @@ auto LoadChar(Scheduler& scheduler, MapConfig config, const uint32 charId) -> st
     PChar->health.hp = canRestore ? PChar->GetMaxHP() : HP;
     PChar->health.mp = canRestore ? PChar->GetMaxMP() : MP;
     PChar->UpdateHealth();
-
-    // Lazy loading: ensure initial zone is loaded synchronously before OnZoneIn
-    // TODO: Hoist his block out of LoadChar() so we're guaranteeing that a char's zone exists
-    //     : before we try to put them in it.
-    if (zoneutils::IsLazyLoadingEnabled() && !zoneutils::GetZone(PChar->loc.destination))
-    {
-        // TODO: Remove this usage of blockOnMain, it's here to help with xi_test
-        scheduler.blockOnMainThread(zoneutils::LoadZones(scheduler, config, { PChar->loc.destination }));
-    }
-
-    luautils::OnZoneIn(PChar);
-    luautils::OnGameIn(PChar, zoning == 1);
 
     PChar->status = xi::Status::Disappear;
 

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -78,7 +78,7 @@ namespace charutils
 
 void LoadExpTable();
 void SetExpDifficultyCurve(std::vector<std::pair<uint16, EMobDifficulty>>& curve, std::pair<uint16, uint8>& incrediblyEasyPreyData);
-auto LoadChar(Scheduler& scheduler, MapConfig config, uint32 charId) -> std::unique_ptr<CCharEntity>;
+auto LoadChar(uint32 charId) -> std::unique_ptr<CCharEntity>;
 void LoadSpells(CCharEntity* PChar);
 void LoadInventory(CCharEntity* PChar);
 void LoadEquip(CCharEntity* PChar);

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -994,6 +994,17 @@ auto IsLazyLoadingEnabled() -> bool
     return lazyLoad.enabled;
 }
 
+void EnsureZoneLoaded(Scheduler& scheduler, MapConfig config, const xi::ZoneId zoneId)
+{
+    if (!IsLazyLoadingEnabled() || GetZone(zoneId))
+    {
+        return;
+    }
+
+    // TODO: Remove this usage of blockOnMain, it's here to help with xi_test
+    scheduler.blockOnMainThread(LoadZones(scheduler, config, { zoneId }));
+}
+
 // Returns all zones managed by this process (ID and name)
 // - Lazy mode: queries database for zone names
 // - Immediate mode: uses already-loaded zone objects

--- a/src/map/utils/zoneutils.h
+++ b/src/map/utils/zoneutils.h
@@ -56,6 +56,8 @@ auto ProcessLoadQueue(Scheduler& scheduler, MapConfig config) -> Task<void>;
 
 auto IsLazyLoadingEnabled() -> bool;
 
+void EnsureZoneLoaded(Scheduler& scheduler, MapConfig config, xi::ZoneId zoneId);
+
 // TODO:
 // This shouldn't have side effects, it should be const and the caller should be responsible
 // for requesting the zone is loaded if it isn't ready.

--- a/src/map/zone_instance.cpp
+++ b/src/map/zone_instance.cpp
@@ -268,10 +268,7 @@ void CZoneInstance::IncreaseZoneCounter(CCharEntity* PChar)
             zoneutils::GetZone(zoneid)->IncreaseZoneCounter(PChar);
         }
 
-        // They are properly sent to zone, but bypassed the onZoneIn position fixup, do that now
-        PChar->loc.prevzone    = GetID();
-        PChar->loc.destination = zoneid;
-        luautils::OnZoneIn(PChar);
+        PChar->loc.prevzone = GetID();
         charutils::SaveCharPosition(PChar);
     }
 }

--- a/src/test/lua/helpers/lua_client_entity_pair_packets.cpp
+++ b/src/test/lua/helpers/lua_client_entity_pair_packets.cpp
@@ -36,6 +36,7 @@
 #include "test_char.h"
 #include "test_common.h"
 #include "utils/charutils.h"
+#include "utils/zoneutils.h"
 
 CLuaClientEntityPairPackets::CLuaClientEntityPairPackets(CLuaClientEntityPair* parent)
 : parent_(parent)
@@ -113,7 +114,8 @@ void CLuaClientEntityPairPackets::sendZonePackets()
     // TestChar holds the actual CCharEntity, while parent_ is the Lua wrapper
     // that also needs its internal pointer updated to the newly loaded entity
     testChar->setBlowfish(BLOWFISH_PENDING_ZONE);
-    testChar->setEntity(charutils::LoadChar(parent_->engine()->scheduler(), parent_->engine()->config(), testChar->charId()));
+    testChar->setEntity(charutils::LoadChar(testChar->charId()));
+    zoneutils::EnsureZoneLoaded(parent_->engine()->scheduler(), parent_->engine()->config(), testChar->entity()->loc.destination);
     parent_->setEntity(testChar->entity());
 
     // Send LOGIN packet to begin zone-in sequence

--- a/src/test/test_char.cpp
+++ b/src/test/test_char.cpp
@@ -207,7 +207,6 @@ void TestChar::setEntity(std::unique_ptr<CCharEntity> entity) const
         session_->charID          = entity->id;
         session_->PChar           = std::move(entity);
         session_->PChar->PSession = session();
-        session_->PChar->status   = xi::Status::Normal;
     }
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
LoadChar ran OnZone and OnGameIn before the character was even in the zone, leading to subtle bugs such as gil getting locked during the initial cutscene post-creation.

Shuffled code around so they run as a response to 0x00A instead

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Create char with intro CS, trade Coupon, end with 60g

<!-- Clear and detailed steps to test your changes here -->
