### PR TITLE
[lua] Mount Zhayolm HELM

### DIFF
--- a/scripts/globals/hobbies/helm/data.lua
+++ b/scripts/globals/hobbies/helm/data.lua
@@ -1608,22 +1608,29 @@ xi.helm.dataTable =
                 breakRate  = 46.67, -- n=11577, 95% CI +/-0.91pp
                 minLevel  = 20,
 
+                dailyCap =
+                {
+                    [xi.item.CHUNK_OF_ADAMAN_ORE] = 10,
+                    [xi.item.CHUNK_OF_KHROMA_ORE] = 2,
+                },
+
                 drops =
                 {
-                    { 2250, xi.item.PINCH_OF_SULFUR      },
-                    { 2990, xi.item.CHUNK_OF_IRON_ORE    },
-                    { 1590, xi.item.HANDFUL_OF_IRON_SAND },
-                    { 1540, xi.item.FLINT_STONE          },
-                    { 1340, xi.item.PINCH_OF_BOMB_ASH    },
-                    {  960, xi.item.SUIT_OF_MOBLIN_MAIL  },
-                    { 1150, xi.item.MOBLIN_HELM          },
-                    {  450, xi.item.SUIT_OF_MOBLIN_ARMOR },
-                    {  380, xi.item.TROLL_PAULDRON       },
-                    {  450, xi.item.TROLL_VAMBRACE       },
-                    {  430, xi.item.MOBLIN_MASK          },
-                    {  210, xi.item.DEMON_HORN           },
-                    {  140, xi.item.CHUNK_OF_ADAMAN_ORE  },
-                    {   30, xi.item.CHUNK_OF_KHROMA_ORE  },
+                    { 1580, xi.item.CHUNK_OF_IRON_ORE    }, -- n=1373/8690, 95% CI +/-0.77pp
+                    { 1370, xi.item.SLAB_OF_PLUMBAGO     }, -- n=1190/8690, 95% CI +/-0.72pp
+                    { 1360, xi.item.PINCH_OF_BOMB_ASH    }, -- n=1181/8690, 95% CI +/-0.72pp
+                    { 1330, xi.item.HANDFUL_OF_IRON_SAND }, -- n=1153/8690, 95% CI +/-0.71pp
+                    { 1310, xi.item.PINCH_OF_SULFUR      }, -- n=1138/8690, 95% CI +/-0.71pp
+                    { 1160, xi.item.FLINT_STONE          }, -- n=1011/8690, 95% CI +/-0.67pp
+                    {  290, xi.item.TROLL_VAMBRACE       }, -- n= 254/8690, 95% CI +/-0.35pp
+                    {  280, xi.item.DEMON_HORN           }, -- n= 239/8690, 95% CI +/-0.34pp
+                    {  270, xi.item.SUIT_OF_MOBLIN_MAIL  }, -- n= 238/8690, 95% CI +/-0.34pp
+                    {  270, xi.item.MOBLIN_HELM          }, -- n= 236/8690, 95% CI +/-0.34pp
+                    {  270, xi.item.MOBLIN_MASK          }, -- n= 235/8690, 95% CI +/-0.34pp
+                    {  260, xi.item.SUIT_OF_MOBLIN_ARMOR }, -- n= 222/8690, 95% CI +/-0.33pp
+                    {  250, xi.item.TROLL_PAULDRON       }, -- n= 214/8690, 95% CI +/-0.33pp
+                    {  100, xi.item.CHUNK_OF_ADAMAN_ORE  }, -- Special: rate goes down with each obtain and is capped daily
+                    {   15, xi.item.CHUNK_OF_KHROMA_ORE  }, -- Special: rate goes down with each obtain and is capped daily
                 },
 
                 points =

--- a/scripts/globals/hobbies/helm/logic.lua
+++ b/scripts/globals/hobbies/helm/logic.lua
@@ -44,6 +44,40 @@ local breakMods =
     [xi.helmType.EXCAVATION] = nil,
 }
 
+local function getDropWeight(player, zoneId, zoneInfo, drop)
+    local dailyCap = zoneInfo.dailyCap
+    local limit    = dailyCap and dailyCap[drop[2]]
+    if not limit then
+        return drop[1]
+    end
+
+    local capVar   = string.format('[HELM]DailyCap[%u][%u]', zoneId, drop[2])
+    local obtained = player:getCharVar(capVar)
+    if obtained >= limit then
+        return 0
+    end
+
+    return math.floor(drop[1] / (obtained + 1))
+end
+
+local function incrementDailyCap(player, zoneId, zoneInfo, itemId)
+    local dailyCap = zoneInfo.dailyCap
+    local limit    = dailyCap and dailyCap[itemId]
+    if not limit then
+        return
+    end
+
+    local capVar   = string.format('[HELM]DailyCap[%u][%u]', zoneId, itemId)
+    local resetVar = string.format('[HELM]DailyCap[%u][ResetTime]', zoneId)
+    local obtained = math.min(player:getCharVar(capVar) + 1, limit)
+
+    if player:getCharVar(resetVar) == 0 then
+        player:setCharVar(resetVar, JstMidnight())
+    end
+
+    player:setCharVar(capVar, obtained)
+end
+
 local function hasCampPenalty(player, npc, helmType)
     local positionIndex = npc:getLocalVar('[HELM]PositionIndex')
     if positionIndex == 0 then
@@ -97,7 +131,8 @@ end
 
 local function pickItem(player, info)
     local zoneId   = player:getZoneID()
-    local minLevel = info.zone[zoneId].minLevel or 0
+    local zoneInfo = info.zone[zoneId]
+    local minLevel = zoneInfo.minLevel or 0
 
     -- some zones award nothing below a level requirement, the tool still breaks
     if player:getMainLvl() < minLevel then
@@ -105,17 +140,19 @@ local function pickItem(player, info)
     end
 
     -- found nothing
-    if math.randomFloat(0, 100) >= info.zone[zoneId].obtainRate then
+    if math.randomFloat(0, 100) >= zoneInfo.obtainRate then
         return 0
     end
 
     -- possible drops
-    local drops = info.zone[zoneId].drops
+    local drops   = zoneInfo.drops
+    local weights = {}
 
     -- sum weights
     local sum = 0
     for i = 1, #drops do
-        sum = sum + drops[i][1]
+        weights[i] = getDropWeight(player, zoneId, zoneInfo, drops[i])
+        sum = sum + weights[i]
     end
 
     -- pick weighted result
@@ -124,7 +161,7 @@ local function pickItem(player, info)
     sum = 0
 
     for i = 1, #drops do
-        sum = sum + drops[i][1]
+        sum = sum + weights[i]
         if sum >= pick then
             item = drops[i][2]
             break
@@ -174,6 +211,18 @@ xi.helm.initZone = function(zone, helmType)
             movePoint(nil, npc, zoneId, info, helmType)
         end
     end
+end
+
+xi.helm.onZoneIn = function(player)
+    local zoneId    = player:getZoneID()
+    local capPrefix = string.format('[HELM]DailyCap[%u]', zoneId)
+    local resetTime = player:getCharVar(capPrefix .. '[ResetTime]')
+    if resetTime == 0 or GetSystemTime() < resetTime then
+        return
+    end
+
+    -- The new daily pool is applied on zone-in, not while the player remains in the zone.
+    player:clearVarsWithPrefix(capPrefix)
 end
 
 xi.helm.onZoneOut = function(player)
@@ -260,7 +309,9 @@ xi.helm.onTrade = function(player, npc, trade, helmType, csid, func)
 
         -- success! reward item and roll to relocate the point
         if itemID ~= 0 then
-            player:addItem(itemID)
+            if player:addItem(itemID) then
+                incrementDailyCap(player, zoneId, info.zone[zoneId], itemID)
+            end
 
             if math.randomInt(1, 100) <= info.relocateRate then
                 movePoint(player, npc, zoneId, info, helmType)

--- a/scripts/zones/Mount_Zhayolm/Zone.lua
+++ b/scripts/zones/Mount_Zhayolm/Zone.lua
@@ -16,6 +16,8 @@ end
 zoneObject.onZoneIn = function(player, prevZone)
     local cs = -1
 
+    xi.helm.onZoneIn(player)
+
     if prevZone == xi.zone.LEBROS_CAVERN then
         player:setPos(681.950, -24.00, 369.936, 40)
     elseif


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

> Items with a number next to the letter are special items with a limit on the number that can be mined in one [Earth day](https://wiki-ffo-jp.translate.goog/html/590.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) . For example, "F4" means that "the acquisition probability decreases by 1/4 each time you find it, and after finding it 4 times, you will not be able to obtain it again until after 24:00 [Earth time](https://wiki-ffo-jp.translate.goog/html/590.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp) ,

[ffo.jp](https://wiki-ffo-jp.translate.goog/html/911.html?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)

Based on my captures, I am reasonably confident that:
- Adaman Ore uses a per-player daily depletion mechanic and caps at 10.
- Khroma Ore uses the same general depletion mechanic.
- Adaman Ore acquisition rate decreases after each obtain across the captures.
- Crossing JST midnight does not refresh the pool while the player remains in the zone. You must zone out.
- The depletion state is personal and does not affect other players rates.
- This differs from the depletion behavior observed in Gusgen Mines, Ifrit’s Cauldron, and the logging zones.

Remaining uncertainties:
- ffo.jp lists Khroma Ore as F4, implying a cap of four. However, none of my dozens of 24h+ mining captures produced more than two. I have heard reports of three in one day, but have not been shown proofs.
- The exact decay formula. This is what simulated closest to captures.
- Both ores appear to be entries in the weight table. As their weights are depleted, their probability appears to be redistributed among the remaining items rather than converted into additional “found nothing” outcomes.

My captures are [available here](https://drive.google.com/file/d/1hmxobKV4zrvUqlbgasUmW4NZeg2Z6tm-/view?usp=drive_link), feel free to poke at it. I used Zhayolm as the break rate testing ground so I have more samples there than any other zone but I wasn't particularly paying attention to this cap in the gear testing and the zone-ins aren't very obvious. 

The analysis was done after retrieving exact zone-ins from my local continuously-running chatlog captures which are not going to be available in the capture.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
