### PR TITLE
[C++] Fix CE Removal on Utsusemi

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -3109,6 +3109,15 @@ bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker)
             static_cast<CCharEntity*>(PDefender)->setPersist(CharPersist::Effects);
         }
 
+        // player loses 25 CE every time an attack is absorbed by an utsusemi shadow
+        if (xi::Mod::UTSUSEMI == modShadow && PDefender->objtype == TYPE_PC)
+        {
+            if (auto* PMob = dynamic_cast<CMobEntity*>(PAttacker))
+            {
+                PMob->PEnmityContainer->UpdateEnmity(PDefender, -25, 0);
+            }
+        }
+
         if (Shadow == 0)
         {
             switch (modShadow)
@@ -3140,11 +3149,6 @@ bool IsAbsorbByShadow(CBattleEntity* PDefender, CBattleEntity* PAttacker)
                         case 2:
                             icon = static_cast<uint16>(xi::StatusEffect::CopyImage2);
                             break;
-                    }
-                    // player loses 25 CE if attack absorbed by utsusemi shadow
-                    if (auto* PMob = dynamic_cast<CMobEntity*>(PAttacker))
-                    {
-                        PMob->PEnmityContainer->UpdateEnmity(PDefender, -25, 0);
                     }
                     PStatusEffect->SetIcon(icon);
                     PDefender->StatusEffectContainer->UpdateStatusIcons();


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The old code was removing CE for Utsusemi shadows *after* removing a shadow, which was leading to two bugs.

1) The last Utsusemi shadow taken would not reduce the players CE, because earlier code (Shadow == 0) would cause the status effect to cleanup then never hit the CE reduction
2) The first shadow of Utsusemi:San would also not have CE reduction, because it was gated by if Shadows < 4 (Utsusemi: San grants 5 shadows)

This change hoists the CE Reduction to happen before the rest of the status effect handling, ensuring that 25 CE is removed every time. 

## Steps to test these changes

Fight a monster, generate some enmity
Cast Utsusemi
!getenmity after each attack, see CE is getting reduced each hit.
