### PR TITLE
[core][yaml] Add EVA Percent Modifier

### DIFF
--- a/data/enums/mod.yaml
+++ b/data/enums/mod.yaml
@@ -125,6 +125,7 @@ values:
   storetp:                   73 # Increases the rate at which TP is gained
   tactical_parry:           486 # Tactical Parry Tp Bonus
   inhibit_tp:               488 # Inhibits TP Gain (percent)
+  eva_percent:             1214 # % Evasion Multiplier
   # Working Skills (weapon combat skills)
   # These are NOT item Level skill, they are skill in your status menu. iLvl "skill" happens in item_weapon.sql
   hth:                80 # Hand To Hand Skill
@@ -1275,4 +1276,4 @@ values:
 
   # The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
   # 570 through 825 used by WS DMG mods these are not spares.
-  # SPARE IDs: 1214 and onward
+  # SPARE IDs: 1215 and onward

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -1639,28 +1639,34 @@ uint16 CBattleEntity::DEF()
 
 uint16 CBattleEntity::EVA()
 {
-    int16 evasion = 1;
-
     const bool isAutomaton = this->objtype == TYPE_PET && static_cast<CPetEntity*>(this)->getPetType() == PET_TYPE::AUTOMATON;
+
+    int32 evasion = 1;
 
     if (this->objtype == TYPE_MOB || (this->objtype == TYPE_PET && !isAutomaton))
     {
-        evasion = getMod(xi::Mod::EVA); // Mobs and pets base evasion is based off the EVA mod
+        // Mobs and non automaton pets use EVA mod as their base evasion
+        evasion = getMod(xi::Mod::EVA);
     }
-    else // Players and automatons use xi::SkillType::Evasion
+    else
     {
+        // Players and automatons use Evasion skill
         evasion = GetSkill(xi::SkillType::Evasion);
 
-        // Skill based evasion calculation
         if (evasion > 200)
         {
             evasion = 200 + (evasion - 200) * 0.9;
         }
+
+        // EVA mod is additional evasion for players and automatons
+        evasion += getMod(xi::Mod::EVA);
     }
 
     evasion += AGI() / 2;
 
-    return std::max(1, evasion + (this->objtype == TYPE_MOB || (this->objtype == TYPE_PET && !isAutomaton) ? 0 : getMod(xi::Mod::EVA))); // The mod for a pet or mob is already calclated in the above so return 0
+    evasion += static_cast<int32>(std::floor(static_cast<float>(evasion) * static_cast<float>(getMod(xi::Mod::EVA_PERCENT)) / 100.0f));
+
+    return static_cast<uint16>(std::clamp<int32>(evasion, 1, UINT16_MAX));
 }
 
 auto CBattleEntity::GetMJob() const -> xi::Job


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Adds EVAP mod to support evasion % adjustments. Use case is mainly for mobskills that increase the mob's evasion by a percent instead of a static amount.

<img width="921" height="355" alt="image" src="https://github.com/user-attachments/assets/9b730cbd-6f42-4f7c-a9a0-80e14582c9df" />


## Steps to test these changes

See picture above.

Not currently used for anything at the moment but will be used for future mobskill PRs.
