### PR TITLE
[lua] Divine Might Era Module

### DIFF
--- a/modules/era/lua/quests/outlands/divine_might.lua
+++ b/modules/era/lua/quests/outlands/divine_might.lua
@@ -1,0 +1,61 @@
+-----------------------------------
+-- Divine Might
+-- Restores the clear full moon night, 00:00 to 03:00, at the Qu'Hau Spring.
+-- The June 7, 2016 version update widened the window to 18:00 through 06:00 and dropped the weather.
+-- Divine Might (Repeat) shares the spring and the window.
+-- The Ro'Maeve moongates, bridges and fountain are already restored by era_moongate_time.
+-- The weather check reads the zone. A scholar's storm does not close the spring.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_divine_might', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/Divine_Might', function(quest)
+        local romaeve = quest.sections[2][xi.zone.ROMAEVE]
+
+        -- Copy of the base handler. The spring accepts the trade on a clear full moon night.
+        romaeve['QuHau_Spring'].onTrade = function(player, npc, trade)
+            local vanaHour = VanadielHour()
+            local weather  = player:getZone():getWeather() -- Module change
+
+            if
+                (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
+                (vanaHour >= 0 and vanaHour < 3) and -- Module change
+                (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE) and -- Module change
+                npcUtil.tradeHasExactly(trade, { xi.item.BOTTLE_OF_ILLUMININK, xi.item.SHEET_OF_PARCHMENT })
+            then
+                return quest:progressEvent(7, xi.item.SHEET_OF_PARCHMENT, xi.item.BOTTLE_OF_ILLUMININK)
+            end
+        end
+    end)
+
+    xi.module.modifyInteractionEntry('scripts/quests/outlands/Divine_Might_Repeat', function(quest)
+        local romaeve = quest.sections[2][xi.zone.ROMAEVE]
+
+        -- Copy of the base handler. The window also gates the chunk of light ore trade.
+        romaeve['QuHau_Spring'].onTrade = function(player, npc, trade)
+            local vanaHour = VanadielHour()
+            local weather  = player:getZone():getWeather() -- Module change
+
+            if
+                (getVanadielMoonCycle() == xi.moonCycle.FULL_MOON) and
+                (vanaHour >= 0 and vanaHour < 3) and -- Module change
+                (weather == xi.weather.NONE or weather == xi.weather.SUNSHINE) -- Module change
+            then
+                if npcUtil.tradeHasExactly(trade, { xi.item.BOTTLE_OF_ILLUMININK, xi.item.SHEET_OF_PARCHMENT }) then
+                    return quest:progressEvent(7, xi.item.SHEET_OF_PARCHMENT, xi.item.BOTTLE_OF_ILLUMININK)
+                elseif
+                    not player:hasKeyItem(xi.ki.MOONLIGHT_ORE) and
+                    npcUtil.tradeHasExactly(trade, xi.item.CHUNK_OF_LIGHT_ORE)
+                then
+                    return quest:progressEvent(8)
+                end
+            end
+        end
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adds an era module to restore the era trade window at the Qu'Hau Spring in Ro'Maeve. Divine Might and Divine Might (Repeat) accept the trade only on a clear full moon night between 00:00 and 03:00.

Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
