### PR TITLE
[yaml] Adds species resistance rank data

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -35,6 +35,27 @@ ecosystems:
             attributes:
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
 
   amorph:
     id: 1
@@ -55,8 +76,52 @@ ecosystems:
         species:
           acuex:
             id: 1
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      0
+                  wind:     4
+                  earth:    6
+                  thunder:  4
+                  water:    8
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      4
+                  slow:         6
+                  poison:       8
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      4
           yecuex:
             id: 2
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -1
+                  wind:     4
+                  earth:    6
+                  thunder:  4
+                  water:    8
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         6
+                  poison:       8
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      4
       botuli:
         id: 2
         species:
@@ -74,6 +139,27 @@ ecosystems:
               detects:
                 - sight
                 - ability
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     4
+                  wind:    4
+                  earth:   4
+                  thunder: 0
+                  water:   6
+                  light:   1
+                  dark:    5
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     4
+                  slow:        4
+                  poison:      6
+                  light_sleep: 1
+                  dark_sleep:  5
+                  blind:       5
+                  stun:        0
+                  gravity:     4
       flan:
         id: 3
         attributes:
@@ -91,9 +177,52 @@ ecosystems:
         species:
           blancmage:
             id: 4
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder: -1
+                  water:    3
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:       3
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:      1
           flan:
             id: 5
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder: -1
+                  water:    3
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:       3
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:      1
               mods:
                 udmgbreath: 2500
                 udmgmagic:  2500
@@ -104,6 +233,28 @@ ecosystems:
                 no_link:       1
           gold_flan:
             id: 6
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder: -1
+                  water:    3
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:       3
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:      1
       hecteyes:
         id: 4
         species:
@@ -121,6 +272,27 @@ ecosystems:
               detects:
                 - hearing
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -2
+                  gravity:     -2
               mods:
                 eva: 10
               mob_mods:
@@ -145,12 +317,77 @@ ecosystems:
           leech:
             id: 8
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    4
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_distance: 15
           obdella:
             id: 9
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    4
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      0
           parasite:
             id: 10
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    4
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      0
       plovid:
         id: 6
         attributes:
@@ -169,8 +406,52 @@ ecosystems:
         species:
           golden_plovid:
             id: 11
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    1
+                  thunder:  2
+                  water:    9
+                  light:    2
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         1
+                  poison:       9
+                  light_sleep:  2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
           plovid:
             id: 12
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    1
+                  thunder:  2
+                  water:    9
+                  light:    2
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         1
+                  poison:       9
+                  light_sleep:  2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
       sandworm:
         id: 7
         attributes:
@@ -188,8 +469,52 @@ ecosystems:
         species:
           gigaworm:
             id: 13
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      4
+                  wind:     1
+                  earth:   11
+                  thunder:  4
+                  water:    4
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:        11
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         4
+                  gravity:      1
           sandworm:
             id: 14
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      4
+                  wind:     1
+                  earth:   11
+                  thunder:  4
+                  water:    4
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:        11
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         4
+                  gravity:      1
       slime:
         id: 8
         attributes:
@@ -208,12 +533,100 @@ ecosystems:
         species:
           boil:
             id: 15
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           clot:
             id: 16
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -1
+                  gravity:     -2
           scum:
             id: 17
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           slime:
             id: 18
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
       slug:
         id: 9
         species:
@@ -232,6 +645,27 @@ ecosystems:
               detects:
                 - hearing
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:   11 # absorbs on retail
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      0
+                  slow:         0
+                  poison:      11 # absorbs on retail
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
       worm:
         id: 10
         attributes:
@@ -251,13 +685,100 @@ ecosystems:
         species:
           entozoon:
             id: 20
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -3
           morion:
             id: 21
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -3
           red_worm:
             id: 22
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -3
           worm:
             id: 23
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -3
               mob_mods:
                 magic_cool: 25
                 roam_cool:  90
@@ -283,17 +804,126 @@ ecosystems:
         species:
           carrier_crab:
             id: 24
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           crab:
             id: 25
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
               mob_mods:
                 roam_cool: 15
           krabkatoa:
             id: 26
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           locus_crab:
             id: 27
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           volcanic_crabs:
             id: 28
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
       craklaw:
         id: 12
         species:
@@ -310,6 +940,27 @@ ecosystems:
                 chr: d
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:     4
+                  earth:    2
+                  thunder: -2
+                  water:    4
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      4
+                  slow:         2
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      4
       frog:
         id: 13
         attributes:
@@ -328,11 +979,76 @@ ecosystems:
         species:
           akagin:
             id: 30
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    1
+                  thunder: -1
+                  water:    8
+                  light:    6
+                  dark:     0
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           ginkoro:
             id: 31
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    1
+                  thunder: -1
+                  water:    8
+                  light:    6
+                  dark:     0
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           toad:
             id: 32
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    1
+                  thunder: -1
+                  water:    8
+                  light:    6
+                  dark:     0
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
               mob_mods:
                 no_standback: 1
       orobon:
@@ -353,9 +1069,52 @@ ecosystems:
         species:
           ogrebon:
             id: 33
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    6
+                  light:   -2
+                  dark:     3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:       6
+                  light_sleep: -2
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -2
+                  gravity:     -1
           orobon:
             id: 34
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    6
+                  light:   -2
+                  dark:     3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:       6
+                  light_sleep: -2
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -2
+                  gravity:     -1
               mods:
                 udmgphys:   -1250
                 udmgrange:  -1250
@@ -378,8 +1137,52 @@ ecosystems:
         species:
           pteraketo:
             id: 35
+            attributes:
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     3
+                  wind:    3
+                  earth:   1
+                  thunder: 2
+                  water:   2
+                  light:   4
+                  dark:    2
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        1
+                  poison:      2
+                  light_sleep: 4
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     3
           white_pteraketos:
             id: 36
+            attributes:
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     3
+                  wind:    3
+                  earth:   1
+                  thunder: 2
+                  water:   2
+                  light:   4
+                  dark:    2
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        1
+                  poison:      2
+                  light_sleep: 4
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     3
       pugil:
         id: 16
         attributes:
@@ -398,6 +1201,27 @@ ecosystems:
                 mnd: d
                 chr: e
                 eva: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    6
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           pugil:
             id: 38
             attributes:
@@ -408,6 +1232,27 @@ ecosystems:
                 int: d
                 mnd: d
                 chr: e
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    6
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
       rockfin:
         id: 17
         species:
@@ -419,6 +1264,27 @@ ecosystems:
                 vit: a
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    9
+                  ice:     4
+                  wind:    4
+                  earth:   2
+                  thunder: 2
+                  water:   9
+                  light:   4
+                  dark:    6
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     4
+                  slow:        2
+                  poison:      9
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        2
+                  gravity:     4
       ruszor:
         id: 18
         species:
@@ -435,6 +1301,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder: -1
+                  water:    5
+                  light:    0
+                  dark:     1
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       5
+                  light_sleep:  0
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -1
+                  gravity:      1
       sea_monk:
         id: 19
         attributes:
@@ -452,9 +1339,52 @@ ecosystems:
         species:
           azure_sea_monk:
             id: 41
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    4
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           sea_monk:
             id: 42
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    4
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
               mob_mods:
                 roam_cool: 30
       uragnite:
@@ -475,9 +1405,52 @@ ecosystems:
         species:
           limascabra:
             id: 43
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -3
+                  water:    3
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:       3
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -3
+                  gravity:     -1
           uragnite:
             id: 44
             attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -3
+                  water:    3
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:       3
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -3
+                  gravity:     -1
               mob_mods:
                 roam_cool: 40
                 roam_rate: 30
@@ -499,6 +1472,27 @@ ecosystems:
               detects:
                 - hearing
                 - magic
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      3
+                  wind:     3
+                  earth:    3
+                  thunder:  2
+                  water:    0
+                  light:    6
+                  dark:    11
+                rank_status:
+                  paralyze:     3
+                  bind:         3
+                  silence:      3
+                  slow:         3
+                  poison:       0
+                  light_sleep:  6
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      3
       bomb:
         id: 22
         attributes:
@@ -516,6 +1510,27 @@ ecosystems:
             id: 46
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:     4
+                  earth:    4
+                  thunder:  4
+                  water:    4
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     4
+                  slow:        4
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        4
+                  gravity:     4
               mob_mods:
                 roam_cool:  30
                 roam_turns:  5
@@ -524,10 +1539,52 @@ ecosystems:
             id: 47
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    3
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 3
+                  water:   3
+                  light:   1
+                  dark:    5
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      3
+                  light_sleep: 1
+                  dark_sleep:  5
+                  blind:       5
+                  stun:        3
+                  gravity:     3
           snoll:
             id: 48
             attributes:
               element: ice
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      3
+                  wind:     1
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
               mob_mods:
                 roam_cool:  40
                 roam_turns:  2
@@ -550,6 +1607,27 @@ ecosystems:
             id: 49
             attributes:
               element: earth
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
               mods:
                 mdef:         25
                 udmgmagic: -2500
@@ -561,14 +1639,77 @@ ecosystems:
             id: 50
             attributes:
               element: light
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           cups:
             id: 51
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           swords:
             id: 52
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
       caturae:
         id: 24
         attributes:
@@ -583,16 +1724,148 @@ ecosystems:
         species:
           bishop:
             id: 53
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     4
+                  wind:    2
+                  earth:   4
+                  thunder: 2
+                  water:   4
+                  light:   0
+                  dark:    8
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     2
+                  slow:        4
+                  poison:      4
+                  light_sleep: 0
+                  dark_sleep:  8
+                  blind:       8
+                  stun:        2
+                  gravity:     2
           king:
             id: 54
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     4
+                  wind:    2
+                  earth:   4
+                  thunder: 2
+                  water:   4
+                  light:   1
+                  dark:    8
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     2
+                  slow:        4
+                  poison:      4
+                  light_sleep: 1
+                  dark_sleep:  8
+                  blind:       8
+                  stun:        2
+                  gravity:     2
           knight:
             id: 55
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:     4
+                  earth:    5
+                  thunder:  3
+                  water:    1
+                  light:    1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         5
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         3
+                  gravity:      4
           pawn:
             id: 56
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:     4
+                  earth:    5
+                  thunder:  3
+                  water:    1
+                  light:    1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         5
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         3
+                  gravity:      4
           queen:
             id: 57
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:     4
+                  earth:    5
+                  thunder:  3
+                  water:    1
+                  light:    1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         5
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         3
+                  gravity:      4
           rook:
             id: 58
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:     -1
+                  wind:     4
+                  earth:    5
+                  thunder:  3
+                  water:    1
+                  light:    1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         5
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         3
+                  gravity:      4
       cluster:
         id: 25
         species:
@@ -608,6 +1881,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      3
+                  wind:     3
+                  earth:    3
+                  thunder:  3
+                  water:    3
+                  light:    3
+                  dark:     3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      3
+                  light_sleep: 3
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        3
+                  gravity:     3
               mob_mods:
                 roam_cool:  40
                 roam_turns:  2
@@ -627,12 +1921,55 @@ ecosystems:
           doll:
             id: 60
             attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    2
+                  thunder: -3
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -3
+                  gravity:      2
               mob_mods:
                 roam_distance:  5
                 roam_cool:     55
                 roam_rate:     30
           gargoyles:
             id: 61
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    2
+                  thunder: -3
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -3
+                  gravity:      2
       evil_weapon:
         id: 27
         species:
@@ -650,6 +1987,27 @@ ecosystems:
               detects:
                 - hearing
                 - magic
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -2
               mods:
                 udmgmagic: -1250
               mob_mods:
@@ -671,6 +2029,27 @@ ecosystems:
           golem:
             id: 63
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
               mob_mods:
                 sight_range:    4
                 roam_distance:  5
@@ -678,6 +2057,28 @@ ecosystems:
                 roam_rate:     30
           red_golems:
             id: 64
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       grimoire:
         id: 29
         attributes:
@@ -692,8 +2093,52 @@ ecosystems:
         species:
           grimoire:
             id: 65
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      5
+                  wind:     5
+                  earth:    5
+                  thunder:  5
+                  water:   -1
+                  light:    7
+                  dark:     7
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:      5
+                  slow:         5
+                  poison:      -1
+                  light_sleep:  7
+                  dark_sleep:   7
+                  blind:        7
+                  stun:         5
+                  gravity:      5
           sentient_tome:
             id: 66
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      5
+                  wind:     5
+                  earth:    5
+                  thunder:  5
+                  water:   -1
+                  light:    7
+                  dark:     7
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:      5
+                  slow:         5
+                  poison:      -1
+                  light_sleep:  7
+                  dark_sleep:   7
+                  blind:        7
+                  stun:         5
+                  gravity:      5
       khimaira:
         id: 30
         attributes:
@@ -707,8 +2152,52 @@ ecosystems:
         species:
           khimaira:
             id: 67
+            attributes:
+              resists:
+                rank_element:
+                  fire:    8
+                  ice:     5
+                  wind:    8
+                  earth:   7
+                  thunder: 9
+                  water:   5
+                  light:   7
+                  dark:    5
+                rank_status:
+                  paralyze:    7
+                  bind:        7
+                  silence:     7
+                  slow:        7
+                  poison:      7
+                  light_sleep: 7
+                  dark_sleep:  7
+                  blind:       7
+                  stun:        9
+                  gravity:     8
           khrysokhimaira:
             id: 68
+            attributes:
+              resists:
+                rank_element:
+                  fire:    8
+                  ice:     5
+                  wind:    8
+                  earth:   7
+                  thunder: 9
+                  water:   5
+                  light:   7
+                  dark:    5
+                rank_status:
+                  paralyze:    7
+                  bind:        7
+                  silence:     7
+                  slow:        7
+                  poison:      7
+                  light_sleep: 7
+                  dark_sleep:  7
+                  blind:       7
+                  stun:        9
+                  gravity:     8
       magic_pot:
         id: 31
         attributes:
@@ -724,6 +2213,27 @@ ecosystems:
           magic_pot:
             id: 69
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
               mods:
                 udmgmagic: -5000
               mob_mods:
@@ -732,6 +2242,28 @@ ecosystems:
                 roam_rate:     30
           millstones:
             id: 70
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       marolith:
         id: 32
         attributes:
@@ -745,8 +2277,52 @@ ecosystems:
         species:
           marolith:
             id: 71
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    3
+                  thunder: -3
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         3
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -3
+                  gravity:      2
           mirulith:
             id: 72
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    3
+                  thunder: -3
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         3
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -3
+                  gravity:      2
       mimic:
         id: 33
         species:
@@ -764,6 +2340,27 @@ ecosystems:
                 - hearing
                 - magic
               speed: 0
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       spheroid:
         id: 34
         attributes:
@@ -781,6 +2378,27 @@ ecosystems:
                 agi: a
                 int: b
                 mnd: e
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:      0
               mob_mods:
                 always_aggro: 1
       mammet:
@@ -802,6 +2420,27 @@ ecosystems:
                 mnd: d
                 chr: d
                 eva: d
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
 
   archaic_machine:
     id: 4
@@ -820,12 +2459,77 @@ ecosystems:
           chariot:
             id: 75
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 7
+                  water:   0
+                  light:   5
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      0
+                  light_sleep: 5
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        7
+                  gravity:     3
               mob_mods:
                 sublink: 15
           long_armed_chariot:
             id: 76
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 7
+                  water:   0
+                  light:   5
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      0
+                  light_sleep: 5
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        7
+                  gravity:     3
           shielded_chariot:
             id: 77
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 7
+                  water:   0
+                  light:   5
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      0
+                  light_sleep: 5
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        7
+                  gravity:     3
       gear:
         id: 36
         attributes:
@@ -843,15 +2547,102 @@ ecosystems:
         species:
           cog:
             id: 78
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 6
+                  water:   1
+                  light:   6
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      1
+                  light_sleep: 6
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        6
+                  gravity:     3
           gear:
             id: 79
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  4
+                  water:   -1
+                  light:    4
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  4
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         4
+                  gravity:      1
               mob_mods:
                 sublink: 15
           triple_cog:
             id: 80
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 6
+                  water:   1
+                  light:   6
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      1
+                  light_sleep: 6
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        6
+                  gravity:     3
           triple_gear:
             id: 81
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  4
+                  water:   -1
+                  light:    4
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  4
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         4
+                  gravity:      1
       iron_giant:
         id: 37
         attributes:
@@ -866,8 +2657,52 @@ ecosystems:
         species:
           iron_giant:
             id: 82
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     6
+                  wind:    4
+                  earth:   4
+                  thunder: 0
+                  water:   2
+                  light:   4
+                  dark:    4
+                rank_status:
+                  paralyze:    6
+                  bind:        6
+                  silence:     4
+                  slow:        4
+                  poison:      2
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        0
+                  gravity:     4
           metal_head:
             id: 83
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     6
+                  wind:    4
+                  earth:   4
+                  thunder: 0
+                  water:   2
+                  light:   4
+                  dark:    4
+                rank_status:
+                  paralyze:    6
+                  bind:        6
+                  silence:     4
+                  slow:        4
+                  poison:      2
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        0
+                  gravity:     4
       rampart:
         id: 38
         species:
@@ -880,6 +2715,27 @@ ecosystems:
               detects:
                 - hearing
                 - magic
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      1
+                  wind:     4
+                  earth:    1
+                  thunder:  3
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     4
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        3
+                  gravity:     4
               mob_mods:
                 sublink: 15
 
@@ -896,12 +2752,77 @@ ecosystems:
           behemoth:
             id: 85
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
               mob_mods:
                 roam_cool: 50
           elasmoth:
             id: 86
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
           skormoth:
             id: 87
+            attributes:
+              resists:
+                rank_element:
+                  fire:    10
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  1
+                  water:   -2
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -2
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      1
       buffalo:
         id: 40
         species:
@@ -919,6 +2840,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 attp: 10
                 defp: 20
@@ -944,6 +2886,27 @@ ecosystems:
               detects:
                 - hearing
               speed: 60
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     9
+                  wind:    9
+                  earth:   4
+                  thunder: 4
+                  water:   4
+                  light:   6
+                  dark:    2
+                rank_status:
+                  paralyze:    9
+                  bind:        9
+                  silence:     9
+                  slow:        4
+                  poison:      4
+                  light_sleep: 6
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        4
+                  gravity:     9
       cerberus:
         id: 42
         attributes:
@@ -962,10 +2925,53 @@ ecosystems:
           cerberus:
             id: 90
             attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
               mob_mods:
                 roam_cool: 50
           orthrus:
             id: 91
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   10
+                  dark:    10
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: 10
+                  dark_sleep:  10
+                  blind:       10
+                  stun:         0
+                  gravity:      0
       coeurl:
         id: 43
         attributes:
@@ -985,14 +2991,79 @@ ecosystems:
           coeurl:
             id: 92
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -3
+                  thunder:  0
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -3
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:     -2
               mob_mods:
                 roam_distance:  5
                 roam_cool:     55
                 roam_rate:     30
           collared_lynx:
             id: 93
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder: -2
+                  water:   -1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -2
+                  gravity:      1
           lynx:
             id: 94
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -3
+                  thunder:  0
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -3
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:     -2
       dhalmel:
         id: 44
         species:
@@ -1011,6 +3082,27 @@ ecosystems:
                 - sight
                 - scent
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -3
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -3
               mob_mods:
                 roam_cool:  30
                 roam_turns:  2
@@ -1032,6 +3124,27 @@ ecosystems:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -1
+                  dark:     3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         0
+                  gravity:      0
       manticore:
         id: 46
         attributes:
@@ -1051,9 +3164,52 @@ ecosystems:
         species:
           legendary_manticore:
             id: 97
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      4
+                  wind:    -2
+                  earth:   10
+                  thunder: 10
+                  water:    4
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     -2
+                  slow:        10
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        10
+                  gravity:     -2
           manticore:
             id: 98
             attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -2
+                  wind:     4
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:        -2
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      4
               mods:
                 attp: 10
                 hpp:  50
@@ -1077,6 +3233,27 @@ ecosystems:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:    -1
+                  earth:    2
+                  thunder: -1
+                  water:    0
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         2
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 defp: 20
               mob_mods:
@@ -1102,6 +3279,27 @@ ecosystems:
                 - sight
                 - scent
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -1
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -1
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:     -1
               mob_mods:
                 roam_cool:  35
                 roam_turns:  3
@@ -1122,8 +3320,52 @@ ecosystems:
         species:
           fazz:
             id: 101
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
           raaz:
             id: 102
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
       rabbit:
         id: 50
         attributes:
@@ -1142,13 +3384,100 @@ ecosystems:
         species:
           alabaster_rabbit:
             id: 103
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -2
+                  earth:   -1
+                  thunder: -3
+                  water:   -3
+                  light:   -1
+                  dark:    -3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -1
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
           lapinion:
             id: 104
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -2
+                  earth:   -1
+                  thunder: -3
+                  water:   -3
+                  light:   -1
+                  dark:    -3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -1
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
           onyx_rabbit:
             id: 105
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -2
+                  earth:   -1
+                  thunder: -3
+                  water:   -3
+                  light:   -1
+                  dark:    -3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -1
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
           rabbit:
             id: 106
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -2
+                  earth:   -1
+                  thunder: -3
+                  water:   -3
+                  light:   -1
+                  dark:    -3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -1
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
               mob_mods:
                 roam_distance: 15
                 roam_cool:     35
@@ -1170,9 +3499,52 @@ ecosystems:
         species:
           ovim:
             id: 107
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
           ram:
             id: 108
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
               mods:
                 attp: 10
                 defp: 20
@@ -1197,18 +3569,81 @@ ecosystems:
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -1
+                  earth:    1
+                  thunder: -2
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:         1
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
           lucerewe:
             id: 110
             attributes:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           sheep:
             id: 111
             attributes:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
               mob_mods:
                 roam_distance: 15
                 roam_cool:     60
@@ -1233,18 +3668,81 @@ ecosystems:
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      4
+                  wind:     4
+                  earth:    4
+                  thunder:  4
+                  water:    4
+                  light:   10
+                  dark:    -2
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         4
+                  poison:       4
+                  light_sleep: 10
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         4
+                  gravity:      4
           smilodon:
             id: 113
             attributes:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:      0
           tiger:
             id: 114
             attributes:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:      0
               mods:
                 attp: 10
               mob_mods:
@@ -1264,8 +3762,52 @@ ecosystems:
         species:
           red_yztarg:
             id: 115
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    2
+                  earth:   7
+                  thunder: 2
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     2
+                  slow:        7
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        2
+                  gravity:     2
           yztarg:
             id: 116
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    2
+                  earth:   7
+                  thunder: 2
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     2
+                  slow:        7
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        2
+                  gravity:     2
 
   beastmen:
     id: 6
@@ -1288,6 +3830,27 @@ ecosystems:
               detects:
                 - hearing
                 - scent
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:    -3
+                  earth:    4
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         4
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -1
+                  gravity:     -3
       bugbear:
         id: 56
         species:
@@ -1306,6 +3869,27 @@ ecosystems:
                 eva: b
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         0
+                  poison:      -1
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
               mods:
                 defp: 20
                 hpp:  10
@@ -1330,11 +3914,76 @@ ecosystems:
         species:
           berglisi:
             id: 119
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  4
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      0
           giants:
             id: 120
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  4
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      0
           gigas:
             id: 121
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  4
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      0
               mob_mods:
                 roam_distance:   5
                 roam_cool:      25
@@ -1343,8 +3992,52 @@ ecosystems:
                 gil_bonus:     180
           hecatoncheirs:
             id: 122
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  4
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      0
           jotunn:
             id: 123
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  4
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         4
+                  gravity:      0
       goblin:
         id: 58
         attributes:
@@ -1362,20 +4055,104 @@ ecosystems:
             id: 124
             attributes:
               element: thunder
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -2
           armored_moblin:
             id: 125
             attributes:
               element: thunder
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -2
           goblin:
             id: 126
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 sublink: 5
           moblin:
             id: 127
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         0
+                  poison:      -1
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
               mob_mods:
                 sublink: 5
       lamiae:
@@ -1395,9 +4172,52 @@ ecosystems:
         species:
           experimental:
             id: 128
+            attributes:
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     0
+                  wind:    1
+                  earth:   1
+                  thunder: 0
+                  water:   5
+                  light:   0
+                  dark:    4
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     1
+                  slow:        1
+                  poison:      5
+                  light_sleep: 0
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        0
+                  gravity:     1
           lamiae:
             id: 129
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    3
+                  light:   -2
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:       3
+                  light_sleep: -2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -2
+                  gravity:     -1
               mods:
                 mdef:         13
                 udmgmagic: -1250
@@ -1407,11 +4227,53 @@ ecosystems:
           medusa:
             id: 130
             attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     4
+                  wind:    4
+                  earth:   2
+                  thunder: 9
+                  water:   9
+                  light:   4
+                  dark:    4
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     4
+                  slow:        2
+                  poison:      9
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        9
+                  gravity:     4
               mob_mods:
                 sublink: 10
           merrow:
             id: 131
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      0
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    4
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:        -1
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -1
               mods:
                 hpp: 10
               mob_mods:
@@ -1433,6 +4295,27 @@ ecosystems:
           knight_ja:
             id: 132
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     2
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      2
               mods:
                 eva:  10
                 hpp: -10
@@ -1440,10 +4323,76 @@ ecosystems:
                 sublink: 8
           sage:
             id: 133
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     2
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      2
           two_headed:
             id: 134
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    9
+                  earth:   9
+                  thunder: 4
+                  water:   4
+                  light:   4
+                  dark:    4
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     9
+                  slow:        9
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        4
+                  gravity:     9
           warrior:
             id: 135
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     2
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      2
       meeble:
         id: 61
         species:
@@ -1460,6 +4409,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:    3
+                  thunder:  0
+                  water:   -1
+                  light:   -1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         3
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     -1
       moogle:
         id: 62
         attributes:
@@ -1475,8 +4445,52 @@ ecosystems:
         species:
           king_mog:
             id: 137
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:   -3
+                  thunder: -3
+                  water:   -3
+                  light:   -3
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:        -3
+                  poison:      -3
+                  light_sleep: -3
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           moogle:
             id: 138
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:   -3
+                  thunder: -3
+                  water:   -3
+                  light:   -3
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:        -3
+                  poison:      -3
+                  light_sleep: -3
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
       orc:
         id: 63
         attributes:
@@ -1495,16 +4509,103 @@ ecosystems:
           orc:
             id: 139
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
               mods:
                 hpp: 5
               mob_mods:
                 sublink: 2
           red_orc:
             id: 140
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           warchief:
             id: 141
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           white_orc:
             id: 142
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
       orcish_warmachine:
         id: 64
         species:
@@ -1521,6 +4622,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
               mods:
                 hpp: 5
               mob_mods:
@@ -1545,6 +4667,27 @@ ecosystems:
                 int: a
                 mnd: e
                 eva: d
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    1
+                  thunder: -1
+                  water:    8
+                  light:    6
+                  dark:     0
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           green_poroggo:
             id: 145
             attributes:
@@ -1557,6 +4700,27 @@ ecosystems:
                 mnd: e
                 chr: g
                 def: a
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    1
+                  thunder: -1
+                  water:    8
+                  light:    6
+                  dark:     0
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           red_poroggo:
             id: 146
             attributes:
@@ -1568,6 +4732,27 @@ ecosystems:
                 int: a
                 mnd: e
                 eva: d
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    3
+                  thunder:  1
+                  water:   11
+                  light:    8
+                  dark:     2
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         3
+                  poison:      11
+                  light_sleep:  8
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         1
+                  gravity:      2
       qiqirn:
         id: 66
         attributes:
@@ -1586,10 +4771,53 @@ ecosystems:
           qiqirn:
             id: 147
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -2
+                  earth:    2
+                  thunder:  0
+                  water:   -1
+                  light:   -1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:         2
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     -2
               mob_mods:
                 sublink: 12
           qiqirn_child:
             id: 148
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -2
+                  earth:    2
+                  thunder:  0
+                  water:   -1
+                  light:   -1
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
+                  slow:         2
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     -2
       quadav:
         id: 67
         attributes:
@@ -1608,9 +4836,52 @@ ecosystems:
         species:
           golden_quadav:
             id: 149
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    0
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
           quadav:
             id: 150
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -3
+                  water:    0
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -3
+                  gravity:     -2
               mods:
                 hpp: -10
       sahagin:
@@ -1630,12 +4901,55 @@ ecosystems:
           blue_sahagin:
             id: 151
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -3
+                  water:    4
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:     -1
               mods:
                 water_meva: 128
               mob_mods:
                 sublink: 8
           yellow_sahagin:
             id: 152
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -3
+                  water:    4
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:     -1
       shadow_lord:
         id: 69
         species:
@@ -1652,6 +4966,27 @@ ecosystems:
                 chr: a
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       siege_turret:
         id: 70
         attributes:
@@ -1668,10 +5003,76 @@ ecosystems:
         species:
           orcish_turret:
             id: 154
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 1
+                  water:   4
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        1
+                  gravity:     2
           quadav_turret:
             id: 155
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 1
+                  water:   4
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        1
+                  gravity:     2
           yagudo_turret:
             id: 156
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 1
+                  water:   4
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        1
+                  gravity:     2
       tonberry:
         id: 71
         attributes:
@@ -1688,17 +5089,104 @@ ecosystems:
         species:
           cryptonberry:
             id: 157
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -3
+                  wind:    -1
+                  earth:    0
+                  thunder: -2
+                  water:    1
+                  light:    4
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -1
+                  slow:         0
+                  poison:       1
+                  light_sleep:  4
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -1
           kingberry:
             id: 158
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -3
+                  wind:    -1
+                  earth:    0
+                  thunder: -2
+                  water:    1
+                  light:    4
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -1
+                  slow:         0
+                  poison:       1
+                  light_sleep:  4
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -1
           tonberry:
             id: 159
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -3
+                  wind:    -1
+                  earth:    0
+                  thunder: -2
+                  water:    1
+                  light:    4
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -1
+                  slow:         0
+                  poison:       1
+                  light_sleep:  4
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -1
               mob_mods:
                 roam_cool:  25
                 roam_turns:  5
                 roam_rate:  30
           wantonberry:
             id: 160
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -3
+                  wind:    -1
+                  earth:    0
+                  thunder: -2
+                  water:    1
+                  light:    4
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -1
+                  slow:         0
+                  poison:       1
+                  light_sleep:  4
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:     -1
       troll:
         id: 72
         attributes:
@@ -1714,11 +5202,76 @@ ecosystems:
         species:
           destroyer:
             id: 161
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      0
+                  wind:    -1
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:     -1
           general:
             id: 162
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      0
+                  wind:    -1
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:     -1
           troll:
             id: 163
             attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      0
+                  wind:    -1
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:     -1
               mods:
                 hpp: 50
               mob_mods:
@@ -1739,8 +5292,52 @@ ecosystems:
         species:
           blue_velkk:
             id: 164
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:    4
+                  light:    0
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -2
+                  gravity:      0
           red_velkk:
             id: 165
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:    4
+                  light:    0
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -2
+                  gravity:      0
       yagudo:
         id: 74
         attributes:
@@ -1754,10 +5351,76 @@ ecosystems:
         species:
           armored_yagudo:
             id: 166
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
           manifest:
             id: 167
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
           yagudo:
             id: 168
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
 
   bird:
     id: 7
@@ -1777,8 +5440,52 @@ ecosystems:
         species:
           amphiptere:
             id: 169
+            attributes:
+              resists:
+                rank_element:
+                  fire:    8
+                  ice:     8
+                  wind:    8
+                  earth:   8
+                  thunder: 8
+                  water:   8
+                  light:   8
+                  dark:    8
+                rank_status:
+                  paralyze:    8
+                  bind:        8
+                  silence:     8
+                  slow:        8
+                  poison:      8
+                  light_sleep: 8
+                  dark_sleep:  8
+                  blind:       8
+                  stun:        8
+                  gravity:     8
           sanguipteres:
             id: 170
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     1
+                  wind:    8
+                  earth:   0
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    4
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     8
+                  slow:        0
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        2
+                  gravity:     8
       apkallu:
         id: 76
         attributes:
@@ -1798,6 +5505,27 @@ ecosystems:
           apkallu:
             id: 171
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    5
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:       5
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
               mods:
                 hpp: -20
               mob_mods:
@@ -1805,6 +5533,28 @@ ecosystems:
                 sight_range:  5
           inguza:
             id: 172
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    5
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:       5
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
       bat:
         id: 77
         attributes:
@@ -1823,6 +5573,27 @@ ecosystems:
           bat:
             id: 173
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -3
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -3
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -2
+                  gravity:     -3
               mob_mods:
                 sublink:     3
                 roam_cool:  35
@@ -1830,6 +5601,28 @@ ecosystems:
                 roam_rate:  30
           vermilion_bat:
             id: 174
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -3
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -3
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -2
+                  gravity:     -3
       bird:
         id: 78
         attributes:
@@ -1847,8 +5640,52 @@ ecosystems:
         species:
           bird:
             id: 175
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
           crow:
             id: 176
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
       cockatrice:
         id: 79
         attributes:
@@ -1866,6 +5703,27 @@ ecosystems:
                 int: d
                 mnd: d
                 chr: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder:  2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         2
+                  gravity:     -3
               mob_mods:
                 roam_cool:  30
                 roam_turns:  3
@@ -1881,6 +5739,27 @@ ecosystems:
                 mnd: d
                 chr: d
                 eva: e
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -3
+                  earth:    2
+                  thunder:  2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -3
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         2
+                  gravity:     -3
       colibri:
         id: 80
         attributes:
@@ -1902,6 +5781,27 @@ ecosystems:
           colibri:
             id: 179
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     6
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      6
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -1
+                  gravity:      6
               mods:
                 mdef: 10
                 eva:  20
@@ -1911,6 +5811,28 @@ ecosystems:
                 roam_rate:  30
           toucalibri:
             id: 180
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     6
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      6
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -1
+                  gravity:      6
       flock_bat:
         id: 81
         attributes:
@@ -1929,6 +5851,27 @@ ecosystems:
           flock_bat:
             id: 181
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -3
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -3
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -2
+                  gravity:     -3
               mob_mods:
                 sublink:     3
                 roam_cool:  35
@@ -1936,8 +5879,52 @@ ecosystems:
                 roam_rate:  30
           flock_vermillion_bats:
             id: 182
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -3
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -3
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -2
+                  gravity:     -3
           triple_flock:
             id: 183
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -1
+                  wind:    -3
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -3
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -2
+                  gravity:     -3
       harpeia:
         id: 82
         attributes:
@@ -1948,10 +5935,76 @@ ecosystems:
         species:
           harpeia:
             id: 184
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -1
+                  wind:     9
+                  earth:    5
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      9
+                  slow:         5
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      9
           pink_harpeia:
             id: 185
+            attributes:
+              resists:
+                rank_element:
+                  fire:     6
+                  ice:      4
+                  wind:    11 # absorbs on retail
+                  earth:   11
+                  thunder:  6
+                  water:    6
+                  light:   11
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     11 # absorbs on retail
+                  slow:        11
+                  poison:       6
+                  light_sleep: 11
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         6
+                  gravity:     11 # absorbs on retail
           white_harpeia:
             id: 186
+            attributes:
+              resists:
+                rank_element:
+                  fire:     6
+                  ice:      4
+                  wind:    11 # absorbs on retail
+                  earth:   11
+                  thunder:  6
+                  water:    6
+                  light:   11
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     11 # absorbs on retail
+                  slow:        11
+                  poison:       6
+                  light_sleep: 11
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         6
+                  gravity:     11 # absorbs on retail
       hippogryph:
         id: 83
         species:
@@ -1971,6 +6024,27 @@ ecosystems:
               detects:
                 - sight
               speed: 60
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     3
+                  earth:   -3
+                  thunder:  3
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      3
+                  slow:        -3
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         3
+                  gravity:      3
               mods:
                 hpp: -20
               mob_mods:
@@ -1989,14 +6063,79 @@ ecosystems:
           gagana:
             id: 188
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -2
+                  wind:     4
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      4
               mob_mods:
                 roam_cool:  40
                 roam_turns:  2
                 roam_rate:  30
           legendary_roc:
             id: 189
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -3
+                  wind:     4
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      4
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      4
           roc:
             id: 190
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -3
+                  wind:     4
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      4
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      4
       tulfaire:
         id: 85
         attributes:
@@ -2007,8 +6146,52 @@ ecosystems:
         species:
           blue_tulfaire:
             id: 191
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -2
+                  wind:     4
+                  earth:   -2
+                  thunder:  2
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:        -2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         2
+                  gravity:      4
           tulfaire:
             id: 192
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -2
+                  wind:     4
+                  earth:   -2
+                  thunder:  2
+                  water:    2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:        -2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         2
+                  gravity:      4
       waktza:
         id: 86
         attributes:
@@ -2018,8 +6201,52 @@ ecosystems:
         species:
           black_waktza:
             id: 193
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    9
+                  earth:   2
+                  thunder: 9
+                  water:   4
+                  light:   4
+                  dark:    6
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     9
+                  slow:        2
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        9
+                  gravity:     9
           waktza:
             id: 194
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    9
+                  earth:   2
+                  thunder: 9
+                  water:   4
+                  light:   4
+                  dark:    6
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     9
+                  slow:        2
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        9
+                  gravity:     9
 
   demon:
     id: 8
@@ -2041,6 +6268,27 @@ ecosystems:
           ahriman:
             id: 195
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        6
+                  stun:         0
+                  gravity:      0
               mods:
                 silenceres:    20
                 udmgmagic:  -2500
@@ -2051,8 +6299,52 @@ ecosystems:
                 hp_standback: -1
           akoman:
             id: 196
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        6
+                  stun:         0
+                  gravity:      0
           shadow_eyes:
             id: 197
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        6
+                  stun:         0
+                  gravity:      0
       demon:
         id: 88
         attributes:
@@ -2069,22 +6361,106 @@ ecosystems:
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           demon:
             id: 199
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           golden_demon:
             id: 200
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           kindred:
             id: 201
             attributes:
               detects:
                 - sight
                 - scent
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mods:
                 mdef:         25
                 udmgmagic: -2500
@@ -2100,6 +6476,27 @@ ecosystems:
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
       dvergr:
         id: 89
         attributes:
@@ -2115,6 +6512,27 @@ ecosystems:
                 vit: d
                 agi: d
                 mnd: f
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    4
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
           dvergr:
             id: 204
             attributes:
@@ -2123,6 +6541,27 @@ ecosystems:
                 int: a
                 mnd: e
                 chr: d
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    4
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
           warden:
             id: 205
             attributes:
@@ -2131,6 +6570,27 @@ ecosystems:
                 vit: d
                 agi: d
                 mnd: f
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    4
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
       gallu:
         id: 90
         attributes:
@@ -2145,8 +6605,52 @@ ecosystems:
         species:
           gallu:
             id: 206
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      4
+                  wind:     3
+                  earth:    4
+                  thunder:  3
+                  water:    4
+                  light:   -1
+                  dark:     9
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      3
+                  slow:         4
+                  poison:       4
+                  light_sleep: -1
+                  dark_sleep:   9
+                  blind:        9
+                  stun:         3
+                  gravity:      3
           white_gallu:
             id: 207
+            attributes:
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      4
+                  wind:     3
+                  earth:    4
+                  thunder:  3
+                  water:    4
+                  light:   -1
+                  dark:     9
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      3
+                  slow:         4
+                  poison:       4
+                  light_sleep: -1
+                  dark_sleep:   9
+                  blind:        9
+                  stun:         3
+                  gravity:      3
       gargouille:
         id: 91
         attributes:
@@ -2163,8 +6667,52 @@ ecosystems:
         species:
           gargouille:
             id: 208
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:    -1
+                  earth:    4
+                  thunder:  1
+                  water:    0
+                  light:   -1
+                  dark:     5
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:         4
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:   5
+                  blind:        5
+                  stun:         1
+                  gravity:     -1
           vodoriga:
             id: 209
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:    -1
+                  earth:    4
+                  thunder:  1
+                  water:    0
+                  light:   -1
+                  dark:     5
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:         4
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:   5
+                  blind:        5
+                  stun:         1
+                  gravity:     -1
       imp:
         id: 92
         attributes:
@@ -2181,11 +6729,76 @@ ecosystems:
         species:
           devilet:
             id: 210
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -1
+                  gravity:      2
           horned_imp:
             id: 211
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -1
+                  gravity:      2
           imp:
             id: 212
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -1
+                  gravity:      2
               mods:
                 mdef:  24
                 hpp:  -30
@@ -2198,6 +6811,28 @@ ecosystems:
                 sound_range:   5
           white_imp:
             id: 213
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:     2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     6
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        -1
+                  gravity:      2
       soulflayer:
         id: 93
         attributes:
@@ -2221,9 +6856,52 @@ ecosystems:
         species:
           black_robe_flayer:
             id: 214
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:   -3
+                  thunder: -3
+                  water:   -3
+                  light:   -3
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:        -3
+                  poison:      -3
+                  light_sleep: -3
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           soulflayer:
             id: 215
             attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:   -3
+                  thunder: -3
+                  water:   -3
+                  light:   -3
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:        -3
+                  poison:      -3
+                  light_sleep: -3
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
               mob_mods:
                 sublink:    11
                 roam_cool:  50
@@ -2243,9 +6921,52 @@ ecosystems:
         species:
           falxitaur:
             id: 216
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
           taurus:
             id: 217
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -1
+                  gravity:     -1
               mob_mods:
                 sublink:     1
                 roam_cool:  40
@@ -2267,9 +6988,52 @@ ecosystems:
         species:
           dahak:
             id: 218
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   1
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      1
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
           dragon:
             id: 219
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
               mods:
                 attp: 20
               mob_mods:
@@ -2280,6 +7044,28 @@ ecosystems:
                 gil_bonus:   1000
           purple_dragon:
             id: 220
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       hydra:
         id: 96
         attributes:
@@ -2294,10 +7080,53 @@ ecosystems:
         species:
           alfard:
             id: 221
+            attributes:
+              resists:
+                rank_element:
+                  fire:    9
+                  ice:     9
+                  wind:    9
+                  earth:   6
+                  thunder: 6
+                  water:   6
+                  light:   6
+                  dark:    6
+                rank_status:
+                  paralyze:    9
+                  bind:        9
+                  silence:     9
+                  slow:        6
+                  poison:      6
+                  light_sleep: 6
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        6
+                  gravity:     9
           hydra:
             id: 222
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:    9
+                  ice:     9
+                  wind:    9
+                  earth:   6
+                  thunder: 6
+                  water:   6
+                  light:   6
+                  dark:    6
+                rank_status:
+                  paralyze:    9
+                  bind:        9
+                  silence:     9
+                  slow:        6
+                  poison:      6
+                  light_sleep: 6
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        6
+                  gravity:     9
               mob_mods:
                 roam_distance:  5
                 roam_cool:     55
@@ -2319,8 +7148,52 @@ ecosystems:
         species:
           peapuk:
             id: 223
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:    11 # absorbs on retail
+                  earth:   -1
+                  thunder:  0
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     11 # absorbs on retail
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:     11 # absorbs on retail
           puk:
             id: 224
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:    11 # absorbs on retail
+                  earth:   -1
+                  thunder:  0
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     11 # absorbs on retail
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:     11 # absorbs on retail
       wyrm:
         id: 98
         attributes:
@@ -2338,6 +7211,27 @@ ecosystems:
               element: fire
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_cool: 55
           black_wyrm:
@@ -2346,6 +7240,27 @@ ecosystems:
               element: fire
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  6
+                  dark_sleep:   6
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           blue_wyrm:
             id: 227
             attributes:
@@ -2353,6 +7268,27 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     11
+                  wind:    11
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
           dark_wyrm:
             id: 228
             attributes:
@@ -2360,24 +7296,108 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           earth_wyrm:
             id: 229
             attributes:
               element: earth
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   11
+                  thunder: 11
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        11
+                  gravity:     -2
           orange_wyrm:
             id: 230
             attributes:
               element: fire
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           white_feathered:
             id: 231
             attributes:
               element: fire
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
       wyvern:
         id: 99
         attributes:
@@ -2395,18 +7415,102 @@ ecosystems:
             id: 232
             attributes:
               element: wind
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      0
+                  wind:     2
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      2
+                  slow:         0
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -1
+                  gravity:      2
           legendary_wyvern:
             id: 233
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      1
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:      0
           red_wyvern:
             id: 234
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      1
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:      0
           wyvern:
             id: 235
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      1
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -3
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:      0
               mob_mods:
                 roam_cool: 55
       wyvern_pet:
@@ -2425,10 +7529,53 @@ ecosystems:
           blue_wyvern:
             id: 236
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 mp_base: 40
           shadow_wyvern:
             id: 237
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
       zilant:
         id: 101
         species:
@@ -2439,6 +7586,27 @@ ecosystems:
               detects:
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    4
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
 
   elemental:
     id: 10
@@ -2461,6 +7629,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:     5
+                  ice:      5
+                  wind:     5
+                  earth:    5
+                  thunder:  5
+                  water:    5
+                  light:   11
+                  dark:     5
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:      5
+                  slow:         5
+                  poison:       5
+                  light_sleep: 11
+                  dark_sleep:   5
+                  blind:        5
+                  stun:         5
+                  gravity:      5
               mob_mods:
                 hp_standback: -1
           atomos:
@@ -2469,6 +7658,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   -3
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      -3
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
               mob_mods:
                 hp_standback: -1
           bahamut:
@@ -2476,17 +7686,80 @@ ecosystems:
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    6
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        0
+                  gravity:     0
           cait_sith:
             id: 242
             attributes:
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    2
+                  thunder:  2
+                  water:    2
+                  light:    8
+                  dark:    -1
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep:  8
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         2
+                  gravity:      2
           carbuncle:
             id: 243
             attributes:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:     6
+                  ice:      6
+                  wind:     6
+                  earth:    6
+                  thunder:  6
+                  water:    6
+                  light:   11 # absorbs on retail
+                  dark:     0
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      6
+                  slow:         6
+                  poison:       6
+                  light_sleep: 11 # absorbs on retail
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         6
+                  gravity:      6
               mob_mods:
                 mp_base:      100
                 hp_standback:  -1
@@ -2496,12 +7769,54 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   -3
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      -3
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
           diabolos:
             id: 245
             attributes:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   0
+                  dark:    4
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 0
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        1
+                  gravity:     1
               mob_mods:
                 hp_standback: -1
           fenrir:
@@ -2511,6 +7826,27 @@ ecosystems:
                 - sight
                 - magic
               speed: 80
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      3
+                  wind:     3
+                  earth:    3
+                  thunder:  3
+                  water:    3
+                  light:   -2
+                  dark:    11
+                rank_status:
+                  paralyze:     3
+                  bind:         3
+                  silence:      3
+                  slow:         3
+                  poison:       3
+                  light_sleep: -2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         3
+                  gravity:      3
               mob_mods:
                 hp_standback: -1
           garuda:
@@ -2519,6 +7855,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     -3
+                  wind:    11 # absorbs on retail
+                  earth:   11
+                  thunder: 11
+                  water:   11
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     11 # absorbs on retail
+                  slow:        11
+                  poison:      11
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11 # absorbs on retail
               mob_mods:
                 hp_standback: -1
           ifrit:
@@ -2527,6 +7884,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   -3
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      -3
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
               mob_mods:
                 hp_standback: -1
           leviathan:
@@ -2535,6 +7913,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: -3
+                  water:   11 # absorbs on retail
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      11 # absorbs on retail
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        -3
+                  gravity:     11
               mob_mods:
                 hp_standback: -1
           odin:
@@ -2543,6 +7942,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:     5
+                  ice:      7
+                  wind:     5
+                  earth:    7
+                  thunder:  5
+                  water:    7
+                  light:    4
+                  dark:    11
+                rank_status:
+                  paralyze:     7
+                  bind:         7
+                  silence:      5
+                  slow:         7
+                  poison:       7
+                  light_sleep:  4
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         5
+                  gravity:      5
               mob_mods:
                 hp_standback: -1
           phoenix:
@@ -2551,12 +7971,54 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   -3
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      -3
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
           ramuh:
             id: 252
             attributes:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:    11
+                  earth:   -3
+                  thunder: 11 # absorbs on retail
+                  water:   11
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        -3
+                  poison:      11
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11 # absorbs on retail
+                  gravity:     11
               mob_mods:
                 hp_standback: -1
           shiva:
@@ -2565,6 +8027,27 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     11 # absorbs on retail
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   11
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11 # absorbs on retail
+                  bind:        11 # absorbs on retail
+                  silence:     11
+                  slow:        11
+                  poison:      11
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
               mob_mods:
                 hp_standback: -1
           siren:
@@ -2573,12 +8056,54 @@ ecosystems:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11
+                  wind:    11
+                  earth:   11
+                  thunder: 11
+                  water:   -3
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:        11
+                  poison:      -3
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     11
           titan:
             id: 255
             attributes:
               detects:
                 - sight
                 - magic
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:    -3
+                  earth:   11 # absorbs on retail
+                  thunder: 11
+                  water:   11
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     -3
+                  slow:        11 # absorbs on retail
+                  poison:      11
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        11
+                  gravity:     -3
               mob_mods:
                 hp_standback: -1
       elemental:
@@ -2600,23 +8125,107 @@ ecosystems:
             id: 256
             attributes:
               element: wind
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
           baelfyr:
             id: 257
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns: 3
           byrgen:
             id: 258
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns: 3
           dark_elemental:
             id: 259
             attributes:
               element: dark
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:    11
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -2624,6 +8233,27 @@ ecosystems:
             id: 260
             attributes:
               element: earth
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -3
+                  earth:   11
+                  thunder: 11
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -3
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        11
+                  gravity:     -3
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -2631,18 +8261,81 @@ ecosystems:
             id: 261
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
           gefyrst:
             id: 262
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns: 3
           ice_elemental:
             id: 263
             attributes:
               element: ice
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     11
+                  wind:    11
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -2650,6 +8343,27 @@ ecosystems:
             id: 264
             attributes:
               element: light
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   11
+                  dark:    -3
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: 11
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -2657,18 +8371,81 @@ ecosystems:
             id: 265
             attributes:
               element: thunder
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -3
+                  thunder: 11
+                  water:   11
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -3
+                  poison:      11
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        11
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
           ungeweder:
             id: 266
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_turns: 3
           water_elemental:
             id: 267
             attributes:
               element: water
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -3
+                  water:   11
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      11
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -3
+                  gravity:      0
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -2689,6 +8466,27 @@ ecosystems:
               detects:
                 - magic
                 - scent
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      4
+                  wind:     4
+                  earth:    4
+                  thunder:  4
+                  water:    4
+                  light:   11
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         4
+                  poison:       4
+                  light_sleep: 11
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         4
+                  gravity:      4
       macuil:
         id: 105
         attributes:
@@ -2706,8 +8504,52 @@ ecosystems:
         species:
           fragmented_macuil:
             id: 269
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      1
+                  wind:     8
+                  earth:    2
+                  thunder:  8
+                  water:    2
+                  light:    2
+                  dark:    11
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      8
+                  slow:         2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         8
+                  gravity:      8
           macuil:
             id: 270
+            attributes:
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      1
+                  wind:     8
+                  earth:    2
+                  thunder:  8
+                  water:    2
+                  light:    2
+                  dark:    11
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      8
+                  slow:         2
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         8
+                  gravity:      8
       monoceros:
         id: 106
         attributes:
@@ -2725,9 +8567,52 @@ ecosystems:
         species:
           alicorn:
             id: 271
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:   -2
+                  thunder:  6
+                  water:    2
+                  light:    0
+                  dark:     4
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:        -2
+                  poison:       2
+                  light_sleep:  0
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         6
+                  gravity:      2
           monoceros:
             id: 272
             attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:   -2
+                  thunder:  6
+                  water:    2
+                  light:    0
+                  dark:     4
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:        -2
+                  poison:       2
+                  light_sleep:  0
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         6
+                  gravity:      2
               mob_mods:
                 hp_standback: -1
       pixie:
@@ -2747,12 +8632,100 @@ ecosystems:
         species:
           danaid:
             id: 273
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    11
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     8
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     11
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   8
+                  blind:        8
+                  stun:         1
+                  gravity:     11
           pixie:
             id: 274
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    11
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     8
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     11
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   8
+                  blind:        8
+                  stun:         1
+                  gravity:     11
           undeen:
             id: 275
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    11
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     8
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     11
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   8
+                  blind:        8
+                  stun:         1
+                  gravity:     11
           veela:
             id: 276
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    11
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:    1
+                  dark:     8
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     11
+                  slow:         1
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   8
+                  blind:        8
+                  stun:         1
+                  gravity:     11
       porxie:
         id: 108
         species:
@@ -2770,6 +8743,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     5
+                  earth:   -1
+                  thunder:  2
+                  water:    2
+                  light:    4
+                  dark:     1
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      5
+                  slow:        -1
+                  poison:       2
+                  light_sleep:  4
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         2
+                  gravity:      5
       umbril:
         id: 109
         attributes:
@@ -2787,8 +8781,52 @@ ecosystems:
         species:
           lava_umbril:
             id: 278
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     4
+                  earth:    0
+                  thunder:  4
+                  water:    4
+                  light:   -3
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         0
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         4
+                  gravity:      4
           umbril:
             id: 279
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     4
+                  earth:    0
+                  thunder:  4
+                  water:    4
+                  light:   -3
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         0
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         4
+                  gravity:      4
 
   empty:
     id: 11
@@ -2808,8 +8846,52 @@ ecosystems:
         species:
           apex_craver:
             id: 280
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     11
+                  wind:    11
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
           craver:
             id: 281
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     11
+                  wind:    11
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:     11
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
       gorger:
         id: 111
         attributes:
@@ -2825,8 +8907,52 @@ ecosystems:
         species:
           apex_gorger:
             id: 282
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:    11
+                  earth:   11
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     11
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
           gorger:
             id: 283
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:    11
+                  earth:   11
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     11
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     11
       receptacle:
         id: 112
         species:
@@ -2844,6 +8970,27 @@ ecosystems:
               detects:
                 - scent
               speed: 0
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       seether:
         id: 113
         attributes:
@@ -2860,8 +9007,52 @@ ecosystems:
         species:
           apex_seether:
             id: 285
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           seether:
             id: 286
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       thinker:
         id: 114
         attributes:
@@ -2878,8 +9069,52 @@ ecosystems:
         species:
           apex_thinker:
             id: 287
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -3
+                  earth:   11
+                  thunder: 11
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -3
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        11
+                  gravity:     -3
           thinker:
             id: 288
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -3
+                  earth:   11
+                  thunder: 11
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -3
+                  slow:        11
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        11
+                  gravity:     -3
       wanderer:
         id: 115
         attributes:
@@ -2896,9 +9131,52 @@ ecosystems:
         species:
           apex_wanderer:
             id: 289
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           wanderer:
             id: 290
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     4
+                  earth:    2
+                  thunder:  4
+                  water:    0
+                  light:    4
+                  dark:     2
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      4
+                  slow:         2
+                  poison:       0
+                  light_sleep:  4
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         4
+                  gravity:      4
               mods:
                 hpp: -10
               mob_mods:
@@ -2919,9 +9197,52 @@ ecosystems:
         species:
           apex_weeper:
             id: 291
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           weeper:
             id: 292
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     4
+                  earth:    2
+                  thunder:  4
+                  water:    0
+                  light:    4
+                  dark:     2
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      4
+                  slow:         2
+                  poison:       0
+                  light_sleep:  4
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         4
+                  gravity:      4
               mods:
                 hpp: 10
 
@@ -2943,6 +9264,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       galka:
         id: 118
         species:
@@ -2958,6 +9300,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       hume:
         id: 119
         species:
@@ -2974,6 +9337,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:      5
+                  wind:     4
+                  earth:    5
+                  thunder:  4
+                  water:    5
+                  light:    8
+                  dark:    11 # absorbs on retail
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:      4
+                  slow:         5
+                  poison:       5
+                  light_sleep:  8
+                  dark_sleep:  11 # absorbs on retail
+                  blind:       11 # absorbs on retail
+                  stun:         4
+                  gravity:      4
               mob_mods:
                 sight_range: 30
       mithra:
@@ -2991,6 +9375,27 @@ ecosystems:
                 chr: f
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    11 # absorbs on retail
+                  ice:     11 # absorbs on retail
+                  wind:    11 # absorbs on retail
+                  earth:   11 # absorbs on retail
+                  thunder: 11 # absorbs on retail
+                  water:   11 # absorbs on retail
+                  light:   11 # absorbs on retail
+                  dark:    11 # absorbs on retail
+                rank_status:
+                  paralyze:    11 # absorbs on retail
+                  bind:        11 # absorbs on retail
+                  silence:     11 # absorbs on retail
+                  slow:        11 # absorbs on retail
+                  poison:      11 # absorbs on retail
+                  light_sleep: 11 # absorbs on retail
+                  dark_sleep:  11 # absorbs on retail
+                  blind:       11 # absorbs on retail
+                  stun:        11 # absorbs on retail
+                  gravity:     11 # absorbs on retail
       tarutaru:
         id: 121
         species:
@@ -3007,6 +9412,27 @@ ecosystems:
                 chr: f
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     2
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   2
+                  light:   0
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     1
+                  slow:        1
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        1
+                  gravity:     1
 
   lizard:
     id: 13
@@ -3031,6 +9457,27 @@ ecosystems:
             attributes:
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -2
+                  wind:     4
+                  earth:   11
+                  thunder: 11
+                  water:   11
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:        11
+                  poison:      11
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        11
+                  gravity:      4
               mods:
                 defp: 20
               mob_mods:
@@ -3041,12 +9488,54 @@ ecosystems:
             attributes:
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:     4
+                  ice:     -2
+                  wind:     4
+                  earth:   11
+                  thunder: 11
+                  water:   11
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:        11
+                  poison:      11
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        11
+                  gravity:      4
           legendary_adamantoise:
             id: 300
             attributes:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:    10
+                  ice:      4
+                  wind:     4
+                  earth:    4
+                  thunder: -2
+                  water:   10
+                  light:    4
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         4
+                  poison:      10
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:      4
       bugard:
         id: 123
         attributes:
@@ -3064,9 +9553,52 @@ ecosystems:
         species:
           abyssobugard:
             id: 301
+            attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:    2
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep:  2
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
           bugard:
             id: 302
             attributes:
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:    2
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep:  2
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 attp: 10
                 defp: 20
@@ -3093,12 +9625,55 @@ ecosystems:
           eft:
             id: 303
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     2
+                  earth:    2
+                  thunder: -1
+                  water:    2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      2
               mob_mods:
                 roam_cool:  50
                 roam_turns:  5
                 roam_rate:  30
           tarichuk:
             id: 304
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     2
+                  earth:    2
+                  thunder: -1
+                  water:    2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      2
       gabbrath:
         id: 125
         species:
@@ -3116,6 +9691,27 @@ ecosystems:
               detects:
                 - scent
               speed: 30
+              resists:
+                rank_element:
+                  fire:    9
+                  ice:     9
+                  wind:    4
+                  earth:   4
+                  thunder: 2
+                  water:   2
+                  light:   6
+                  dark:    4
+                rank_status:
+                  paralyze:    9
+                  bind:        9
+                  silence:     4
+                  slow:        4
+                  poison:      2
+                  light_sleep: 6
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        2
+                  gravity:     4
       lizard:
         id: 126
         attributes:
@@ -3134,6 +9730,27 @@ ecosystems:
             id: 306
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:     -3
               mob_mods:
                 roam_cool:  60
                 roam_turns:  4
@@ -3142,10 +9759,52 @@ ecosystems:
             id: 307
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:     -3
           snow_lizard:
             id: 308
             attributes:
               element: ice
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mob_mods:
                 roam_cool:  60
                 roam_turns:  4
@@ -3168,8 +9827,52 @@ ecosystems:
         species:
           matamata:
             id: 309
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    0
+                  earth:   0
+                  thunder: 2
+                  water:   4
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     0
+                  slow:        0
+                  poison:      4
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        2
+                  gravity:     0
           white_matamata:
             id: 310
+            attributes:
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    0
+                  earth:   0
+                  thunder: 2
+                  water:   4
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     0
+                  slow:        0
+                  poison:      4
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        2
+                  gravity:     0
       peiste:
         id: 128
         attributes:
@@ -3186,10 +9889,76 @@ ecosystems:
         species:
           far_east_peiste:
             id: 311
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   2
+                  thunder: 0
+                  water:   3
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        2
+                  poison:      3
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           peiste:
             id: 312
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   2
+                  thunder: 0
+                  water:   3
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        2
+                  poison:      3
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           sibilus:
             id: 313
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   2
+                  thunder: 0
+                  water:   3
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        2
+                  poison:      3
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       raptor:
         id: 129
         attributes:
@@ -3211,6 +9980,27 @@ ecosystems:
                 mnd: d
                 chr: d
                 eva: a
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
           raptor:
             id: 315
             attributes:
@@ -3221,6 +10011,27 @@ ecosystems:
                 int: d
                 mnd: d
                 chr: d
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_distance: 30
                 roam_cool:     40
@@ -3236,6 +10047,27 @@ ecosystems:
                 mnd: d
                 chr: d
                 eva: a
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -3
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
       wivre:
         id: 130
         attributes:
@@ -3255,11 +10087,76 @@ ecosystems:
         species:
           mamool_ja_riden:
             id: 317
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -2
+                  wind:    -2
+                  earth:    3
+                  thunder:  1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         3
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         1
+                  gravity:     -2
           unusual_wivre:
             id: 318
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -2
+                  wind:    -2
+                  earth:    3
+                  thunder:  1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         3
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         1
+                  gravity:     -2
           wivre:
             id: 319
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -2
+                  wind:    -2
+                  earth:    3
+                  thunder:  1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         3
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         1
+                  gravity:     -2
               mob_mods:
                 roam_cool: 50
                 roam_rate: 30
@@ -3282,6 +10179,27 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:    6
+                  dark:    -2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep:  6
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -1
+                  gravity:     -1
               mods:
                 hpp: -10
       euvhi:
@@ -3299,6 +10217,27 @@ ecosystems:
                 chr: a
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:    3
+                  light:    3
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:       3
+                  light_sleep:  3
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 hpp: -20
       hpemde:
@@ -3316,6 +10255,27 @@ ecosystems:
                 chr: e
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:    1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep:  1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -2
       phuabo:
         id: 134
         species:
@@ -3330,6 +10290,27 @@ ecosystems:
               detects:
                 - hearing
               speed: 70
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:    1
+                  dark:    -2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep:  1
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 mp_base: 50
       wynav:
@@ -3346,6 +10327,27 @@ ecosystems:
                 chr: e
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       xzomit:
         id: 136
         attributes:
@@ -3361,8 +10363,52 @@ ecosystems:
         species:
           xzomit:
             id: 325
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     0
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:        -2
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           xzomit_child:
             id: 326
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     0
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:        -2
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
       yovra:
         id: 137
         species:
@@ -3378,6 +10424,27 @@ ecosystems:
                 chr: f
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:   -2
+                  thunder:  6
+                  water:    0
+                  light:    2
+                  dark:    -1
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:        -2
+                  poison:       0
+                  light_sleep:  2
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         6
+                  gravity:      0
               mob_mods:
                 mp_base: 50
 
@@ -3398,11 +10465,54 @@ ecosystems:
           bird_ghrah:
             id: 328
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:    11
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         0
+                  gravity:      0
               mods:
                 udmgmagic: -1250
                 hpp:         -20
           spider_ghrah:
             id: 329
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:    11
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         0
+                  gravity:      0
       zdei:
         id: 139
         attributes:
@@ -3417,9 +10527,52 @@ ecosystems:
         species:
           green_zdei:
             id: 330
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
           zdei:
             id: 331
             attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
               mods:
                 hpp: -20
               mob_mods:
@@ -3445,8 +10598,52 @@ ecosystems:
         species:
           belladonna:
             id: 332
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     2
+                  wind:    1
+                  earth:   7
+                  thunder: 1
+                  water:   6
+                  light:   4
+                  dark:    6
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     1
+                  slow:        7
+                  poison:      6
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        1
+                  gravity:     1
           white_belladonna:
             id: 333
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     2
+                  wind:    1
+                  earth:   7
+                  thunder: 1
+                  water:   6
+                  light:   4
+                  dark:    6
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     1
+                  slow:        7
+                  poison:      6
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        1
+                  gravity:     1
       cactaur:
         id: 141
         attributes:
@@ -3464,6 +10661,27 @@ ecosystems:
           sabotender:
             id: 334
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:    4
+                  light:    4
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:      0
               mob_mods:
                 sublink:    7
                 roam_cool: 10
@@ -3471,6 +10689,27 @@ ecosystems:
           sabotender_florido:
             id: 335
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:    4
+                  light:    4
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:      0
               mob_mods:
                 sublink: 7
       flytrap:
@@ -3491,6 +10730,27 @@ ecosystems:
               detects:
                 - hearing
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -1
+                  wind:     3
+                  earth:    0
+                  thunder:  0
+                  water:    3
+                  light:    3
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      3
+                  slow:         0
+                  poison:       3
+                  light_sleep:  3
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:      3
       funguar:
         id: 143
         attributes:
@@ -3508,15 +10768,80 @@ ecosystems:
         species:
           coppercap:
             id: 337
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -3
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   4
+                  blind:        6
+                  stun:        -2
+                  gravity:     -2
           funguar:
             id: 338
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -3
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   4
+                  blind:        6
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_distance: 15
                 roam_cool:     60
                 roam_rate:     30
           mycelar:
             id: 339
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   6
+                  light:   0
+                  dark:    6
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      6
+                  light_sleep: 0
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        0
+                  gravity:     0
       goobbue:
         id: 144
         species:
@@ -3533,6 +10858,27 @@ ecosystems:
                 chr: d
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:    -2
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         0
+                  gravity:      0
               mods:
                 attp: 10
               mob_mods:
@@ -3556,12 +10902,100 @@ ecosystems:
         species:
           cirrus:
             id: 341
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:    -2
+                  earth:    5
+                  thunder:  1
+                  water:    2
+                  light:    3
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -2
+                  slow:         5
+                  poison:       2
+                  light_sleep:  3
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         1
+                  gravity:     -2
           leafkin:
             id: 342
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    8
+                  light:   11
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       8
+                  light_sleep: 11
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         2
+                  gravity:      2
           rosalia:
             id: 343
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    8
+                  light:   11
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       8
+                  light_sleep: 11
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         2
+                  gravity:      2
           tulittia:
             id: 344
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:    8
+                  light:   11
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      2
+                  slow:         4
+                  poison:       8
+                  light_sleep: 11
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         2
+                  gravity:      2
       mandragora:
         id: 146
         attributes:
@@ -3580,18 +11014,172 @@ ecosystems:
         species:
           adenium:
             id: 345
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           ake_ome:
             id: 346
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           citrullus:
             id: 347
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   3
+                  thunder: 0
+                  water:   3
+                  light:   0
+                  dark:    3
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        3
+                  poison:      3
+                  light_sleep: 0
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        0
+                  gravity:     0
           korrigan:
             id: 348
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           lycopodium:
             id: 349
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           mandragora:
             id: 350
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
           pachypodium:
             id: 351
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -3
+                  wind:    -3
+                  earth:    0
+                  thunder: -3
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -3
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -3
       morbol:
         id: 147
         attributes:
@@ -3609,18 +11197,127 @@ ecosystems:
         species:
           ameretat:
             id: 352
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
           morbol:
             id: 353
             attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_cool: 30
                 roam_rate: 30
           morbol_menace:
             id: 354
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
           purbol:
             id: 355
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
           scarce_morbol:
             id: 356
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
       panopt:
         id: 148
         species:
@@ -3638,6 +11335,27 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     2
+                  wind:    4
+                  earth:   2
+                  thunder: 1
+                  water:   2
+                  light:   3
+                  dark:    5
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     4
+                  slow:        2
+                  poison:      2
+                  light_sleep: 3
+                  dark_sleep:  5
+                  blind:       5
+                  stun:        1
+                  gravity:     4
       rafflesia:
         id: 149
         attributes:
@@ -3654,9 +11372,52 @@ ecosystems:
         species:
           mitrastema:
             id: 358
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:    -1
+                  earth:    3
+                  thunder:  1
+                  water:    0
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:         3
+                  poison:       0
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         1
+                  gravity:     -1
           rafflesia:
             id: 359
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      0
+                  wind:    -1
+                  earth:    3
+                  thunder:  1
+                  water:    0
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -1
+                  slow:         3
+                  poison:       0
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         1
+                  gravity:     -1
               mob_mods:
                 mp_base: 50
       sapling:
@@ -3676,6 +11437,27 @@ ecosystems:
               detects:
                 - hearing
               charmable: true
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 sublink:        4
                 roam_distance: 20
@@ -3697,8 +11479,52 @@ ecosystems:
         species:
           jewelweed:
             id: 361
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     4
+                  earth:    2
+                  thunder:  4
+                  water:    3
+                  light:    2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:         2
+                  poison:       3
+                  light_sleep:  2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         4
+                  gravity:      4
           snapweed:
             id: 362
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -2
+                  wind:     4
+                  earth:    2
+                  thunder:  4
+                  water:    3
+                  light:    2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      4
+                  slow:         2
+                  poison:       3
+                  light_sleep:  2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         4
+                  gravity:      4
       treant:
         id: 152
         attributes:
@@ -3715,13 +11541,100 @@ ecosystems:
         species:
           fall_treant:
             id: 363
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
           spring_treant:
             id: 364
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
           summer_treant:
             id: 365
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
           treant:
             id: 366
             attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
               mods:
                 defp: 20
               mob_mods:
@@ -3730,6 +11643,28 @@ ecosystems:
                 roam_rate: 30
           winter_treant:
             id: 367
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:     -2
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:    0
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -2
+                  gravity:     -2
       yggdreant:
         id: 153
         attributes:
@@ -3746,8 +11681,52 @@ ecosystems:
         species:
           white_yggdreant:
             id: 368
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      6
+                  wind:     2
+                  earth:   11
+                  thunder: 11
+                  water:   10
+                  light:    4
+                  dark:     6
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      2
+                  slow:        11
+                  poison:      10
+                  light_sleep:  4
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        11
+                  gravity:      2
           yggdreant:
             id: 369
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      6
+                  wind:     2
+                  earth:   11
+                  thunder: 11
+                  water:   10
+                  light:    4
+                  dark:     6
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      2
+                  slow:        11
+                  poison:      10
+                  light_sleep:  4
+                  dark_sleep:   6
+                  blind:        6
+                  stun:        11
+                  gravity:      2
 
   supreme_beings:
     id: 17
@@ -3769,6 +11748,27 @@ ecosystems:
               detects:
                 - sight
               speed: 50
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       aminon:
         id: 157
         species:
@@ -3786,6 +11786,27 @@ ecosystems:
               detects:
                 - sight
               speed: 50
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       automaton:
         id: 158
         species:
@@ -3802,6 +11823,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
       cloud_of_darkness:
         id: 159
         species:
@@ -3821,6 +11863,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      9
+                  wind:     3
+                  earth:    9
+                  thunder:  3
+                  water:    9
+                  light:    2
+                  dark:    11
+                rank_status:
+                  paralyze:     9
+                  bind:         9
+                  silence:      3
+                  slow:         9
+                  poison:       9
+                  light_sleep:  2
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         3
+                  gravity:      3
       hades:
         id: 160
         species:
@@ -3839,6 +11902,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:     3
+                  ice:      9
+                  wind:     6
+                  earth:    8
+                  thunder:  3
+                  water:    6
+                  light:    3
+                  dark:    11
+                rank_status:
+                  paralyze:     9
+                  bind:         9
+                  silence:      6
+                  slow:         8
+                  poison:       6
+                  light_sleep:  3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         3
+                  gravity:      6
       metus:
         id: 161
         species:
@@ -3857,6 +11941,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       plouton:
         id: 162
         species:
@@ -3875,6 +11980,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     4
+                  wind:    4
+                  earth:   4
+                  thunder: 4
+                  water:   4
+                  light:   4
+                  dark:    4
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     4
+                  slow:        4
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        4
+                  gravity:     4
       promathia:
         id: 163
         species:
@@ -3893,6 +12019,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      2
+                  wind:     2
+                  earth:    2
+                  thunder:  2
+                  water:    2
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      2
+                  slow:         2
+                  poison:       2
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         2
+                  gravity:      2
       provenance_watcher:
         id: 164
         species:
@@ -3911,6 +12058,27 @@ ecosystems:
                 - sight
                 - hearing
               speed: 50
+              resists:
+                rank_element:
+                  fire:    3
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 3
+                  water:   3
+                  light:   6
+                  dark:    3
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      3
+                  light_sleep: 6
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        3
+                  gravity:     3
       sempurne:
         id: 165
         species:
@@ -3928,6 +12096,27 @@ ecosystems:
               detects:
                 - sight
               speed: 50
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       shinryu:
         id: 166
         species:
@@ -3945,6 +12134,27 @@ ecosystems:
               detects:
                 - sight
               speed: 50
+              resists:
+                rank_element:
+                  fire:    3
+                  ice:     3
+                  wind:    3
+                  earth:   3
+                  thunder: 3
+                  water:   3
+                  light:   6
+                  dark:    6
+                rank_status:
+                  paralyze:    3
+                  bind:        3
+                  silence:     3
+                  slow:        3
+                  poison:      3
+                  light_sleep: 6
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        3
+                  gravity:     3
 
   undead:
     id: 18
@@ -3969,10 +12179,76 @@ ecosystems:
         species:
           corpselight:
             id: 391
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    2
+                  thunder:  0
+                  water:    2
+                  light:   -1
+                  dark:     6
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         2
+                  poison:       2
+                  light_sleep: -1
+                  dark_sleep:   6
+                  blind:        6
+                  stun:         0
+                  gravity:      0
           crowned_corpselight:
             id: 392
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    2
+                  thunder:  0
+                  water:    2
+                  light:   -1
+                  dark:     6
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         2
+                  poison:       2
+                  light_sleep: -1
+                  dark_sleep:   6
+                  blind:        6
+                  stun:         0
+                  gravity:      0
           psychopomp:
             id: 393
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    2
+                  thunder:  0
+                  water:    2
+                  light:   -1
+                  dark:     6
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         2
+                  poison:       2
+                  light_sleep: -1
+                  dark_sleep:   6
+                  blind:        6
+                  stun:         0
+                  gravity:      0
       corse:
         id: 168
         attributes:
@@ -3991,6 +12267,27 @@ ecosystems:
           corse:
             id: 394
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:    2
+                  thunder: -1
+                  water:   -1
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:         2
+                  poison:      -1
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -1
+                  gravity:     -1
               mods:
                 mdef:          25
                 udmgbreath: -5000
@@ -4001,8 +12298,52 @@ ecosystems:
                 roam_rate:  30
           golden_hat_corse:
             id: 395
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:    2
+                  thunder: -1
+                  water:   -1
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:         2
+                  poison:      -1
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -1
+                  gravity:     -1
           kumakatok:
             id: 396
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:    2
+                  thunder: -1
+                  water:   -1
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:         2
+                  poison:      -1
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -1
+                  gravity:     -1
       defiant:
         id: 169
         species:
@@ -4021,6 +12362,27 @@ ecosystems:
               detects:
                 - hearing
                 - lowhp
+              resists:
+                rank_element:
+                  fire:     2
+                  ice:      6
+                  wind:     6
+                  earth:    8
+                  thunder:  4
+                  water:    8
+                  light:    4
+                  dark:    11
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      6
+                  slow:         8
+                  poison:       8
+                  light_sleep:  4
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         4
+                  gravity:      6
       doomed:
         id: 170
         species:
@@ -4037,6 +12399,27 @@ ecosystems:
               detects:
                 - hearing
                 - lowhp
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      3
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    2
+                  light:   -2
+                  dark:     8
+                rank_status:
+                  paralyze:     3
+                  bind:         3
+                  silence:      0
+                  slow:         0
+                  poison:       2
+                  light_sleep: -2
+                  dark_sleep:   8
+                  blind:        8
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_cool: 55
                 roam_rate: 30
@@ -4057,8 +12440,52 @@ ecosystems:
         species:
           dullahan:
             id: 399
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      6
+                  wind:     2
+                  earth:    3
+                  thunder:  2
+                  water:    3
+                  light:   -2
+                  dark:     9
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      2
+                  slow:         3
+                  poison:       3
+                  light_sleep: -2
+                  dark_sleep:   9
+                  blind:        9
+                  stun:         2
+                  gravity:      2
           infernal_knight:
             id: 400
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      6
+                  wind:     2
+                  earth:    3
+                  thunder:  2
+                  water:    3
+                  light:   -2
+                  dark:     9
+                rank_status:
+                  paralyze:     6
+                  bind:         6
+                  silence:      2
+                  slow:         3
+                  poison:       3
+                  light_sleep: -2
+                  dark_sleep:   9
+                  blind:        9
+                  stun:         2
+                  gravity:      2
       fomor:
         id: 172
         attributes:
@@ -4078,6 +12505,27 @@ ecosystems:
                 agi: d
                 int: d
                 mnd: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      1
           fallen:
             id: 402
             attributes:
@@ -4088,6 +12536,27 @@ ecosystems:
                 agi: d
                 int: d
                 mnd: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      1
           fomor:
             id: 403
             attributes:
@@ -4101,6 +12570,27 @@ ecosystems:
               detects:
                 - hearing
                 - lowhp
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      1
               mob_mods:
                 roam_cool:   50
                 roam_turns:   2
@@ -4116,6 +12606,27 @@ ecosystems:
                 agi: e
                 int: d
                 mnd: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      0
           spectre:
             id: 405
             attributes:
@@ -4126,6 +12637,27 @@ ecosystems:
                 agi: d
                 int: d
                 mnd: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      1
           valkyr:
             id: 406
             attributes:
@@ -4136,6 +12668,27 @@ ecosystems:
                 agi: d
                 int: d
                 mnd: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:     1
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      1
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      1
       ghost:
         id: 173
         attributes:
@@ -4153,11 +12706,53 @@ ecosystems:
           bhoot:
             id: 407
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      5
+                  wind:    -1
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     5
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:     -1
+                  slow:         0
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   5
+                  blind:        5
+                  stun:        -1
+                  gravity:     -1
               mods:
                 paralyzeres: 20
           ghost:
             id: 408
             attributes:
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     4
+                rank_status:
+                  paralyze:     5
+                  bind:         5
+                  silence:     -2
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   4
+                  blind:        5
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_cool: 50
                 roam_rate: 30
@@ -4180,6 +12775,27 @@ ecosystems:
               detects:
                 - hearing
                 - lowhp
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      4
+                  wind:    -2
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     -2
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_cool:  50
                 roam_turns:  3
@@ -4194,10 +12810,76 @@ ecosystems:
         species:
           green_naraka:
             id: 410
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     5
+                  wind:    2
+                  earth:   3
+                  thunder: 2
+                  water:   2
+                  light:   0
+                  dark:    9
+                rank_status:
+                  paralyze:    5
+                  bind:        5
+                  silence:     2
+                  slow:        3
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  9
+                  blind:       9
+                  stun:        2
+                  gravity:     2
           naraka:
             id: 411
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     5
+                  wind:    2
+                  earth:   3
+                  thunder: 2
+                  water:   2
+                  light:   0
+                  dark:    9
+                rank_status:
+                  paralyze:    5
+                  bind:        5
+                  silence:     2
+                  slow:        3
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  9
+                  blind:       9
+                  stun:        2
+                  gravity:     2
           white_naraka:
             id: 412
+            attributes:
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     5
+                  wind:    2
+                  earth:   3
+                  thunder: 2
+                  water:   2
+                  light:   0
+                  dark:    9
+                rank_status:
+                  paralyze:    5
+                  bind:        5
+                  silence:     2
+                  slow:        3
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  9
+                  blind:       9
+                  stun:        2
+                  gravity:     2
       qutrub:
         id: 176
         attributes:
@@ -4214,9 +12896,52 @@ ecosystems:
         species:
           adorned_qutrub:
             id: 413
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:    -1
+                  earth:    1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     -1
+                  slow:         1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -1
+                  gravity:     -1
           qutrub:
             id: 414
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      4
+                  wind:    -1
+                  earth:    1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:     -1
+                  slow:         1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -1
+                  gravity:     -1
               mob_mods:
                 roam_cool:  50
                 roam_turns:  3
@@ -4236,6 +12961,27 @@ ecosystems:
               detects:
                 - hearing
                 - lowhp
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_cool:  50
                 roam_turns:  2
@@ -4251,6 +12997,27 @@ ecosystems:
           draugar:
             id: 416
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -1
+                  gravity:     -1
               mods:
                 mdef:         20
                 udmgmagic: -1250
@@ -4271,6 +13038,27 @@ ecosystems:
                 int: d
                 mnd: e
                 chr: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:  11
+                  blind:        4
+                  stun:        -1
+                  gravity:     -1
           robed_skeletons:
             id: 418
             attributes:
@@ -4281,6 +13069,27 @@ ecosystems:
                 int: d
                 mnd: e
                 chr: d
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:      2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:  11
+                  blind:        4
+                  stun:        -1
+                  gravity:     -1
           skeleton:
             id: 419
             attributes:
@@ -4291,6 +13100,27 @@ ecosystems:
                 int: d
                 mnd: e
                 chr: d
+              resists:
+                rank_element:
+                  fire:    -3
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     4
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:        4
+                  stun:        -2
+                  gravity:     -2
               mob_mods:
                 roam_cool:  65
                 roam_turns:  5
@@ -4314,9 +13144,52 @@ ecosystems:
         species:
           strigoi:
             id: 420
+            attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      4
+                  wind:     3
+                  earth:    3
+                  thunder:  1
+                  water:    1
+                  light:   -1
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      3
+                  slow:         3
+                  poison:       1
+                  light_sleep: -1
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         1
+                  gravity:      3
           vampyr:
             id: 421
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      4
+                  wind:     3
+                  earth:    3
+                  thunder:  1
+                  water:    1
+                  light:   -1
+                  dark:    11
+                rank_status:
+                  paralyze:     4
+                  bind:         4
+                  silence:      3
+                  slow:         3
+                  poison:       1
+                  light_sleep: -1
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         1
+                  gravity:      3
               mob_mods:
                 sublink:     3
                 roam_cool:  50
@@ -4345,6 +13218,27 @@ ecosystems:
           antlion:
             id: 422
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:    3
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:         3
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         0
+                  gravity:     -2
               mods:
                 defp: 20
               mob_mods:
@@ -4353,8 +13247,52 @@ ecosystems:
                 roam_rate:  30
           formiceros:
             id: 423
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:    3
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:         3
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         0
+                  gravity:     -2
           pitlion:
             id: 424
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:    -2
+                  earth:    3
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     3
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:         3
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         0
+                  gravity:     -2
       bee:
         id: 181
         attributes:
@@ -4374,15 +13312,102 @@ ecosystems:
           blue_bee:
             id: 425
             attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      2
               mob_mods:
                 roam_cool:  15
                 roam_turns:  2
           pephredo:
             id: 426
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      2
           red_bee:
             id: 427
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      2
           yellow_bee:
             id: 428
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      2
       beetle:
         id: 182
         attributes:
@@ -4401,14 +13426,79 @@ ecosystems:
           beetle:
             id: 429
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 roam_distance: 15
                 roam_cool:     60
                 roam_rate:     30
           black_beetles:
             id: 430
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           elytra:
             id: 431
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   0
+                  dark:    2
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       bztavian:
         id: 183
         species:
@@ -4425,6 +13515,27 @@ ecosystems:
                 chr: e
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    9
+                  earth:   9
+                  thunder: 4
+                  water:   4
+                  light:   6
+                  dark:    4
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     9
+                  slow:        9
+                  poison:      4
+                  light_sleep: 6
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        4
+                  gravity:     9
       chapuli:
         id: 184
         attributes:
@@ -4442,8 +13553,52 @@ ecosystems:
         species:
           caeferli:
             id: 433
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:     2
+                  earth:    2
+                  thunder:  4
+                  water:   -2
+                  light:    0
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:         2
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         4
+                  gravity:      2
           chapuli:
             id: 434
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     2
+                  earth:    2
+                  thunder: -2
+                  water:   -2
+                  light:    0
+                  dark:     2
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         2
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:   2
+                  blind:        2
+                  stun:        -2
+                  gravity:      2
       chigoe:
         id: 185
         attributes:
@@ -4463,10 +13618,53 @@ ecosystems:
           chigoe:
             id: 435
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     1
+                  earth:    2
+                  thunder:  1
+                  water:   -1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         2
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      1
               mods:
                 hpp: -70
           djigga:
             id: 436
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      1
+                  wind:     1
+                  earth:    2
+                  thunder:  1
+                  water:   -1
+                  light:    1
+                  dark:     1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         2
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      1
       crawler:
         id: 186
         attributes:
@@ -4486,6 +13684,27 @@ ecosystems:
               element: earth
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
               mob_mods:
                 roam_cool: 55
                 roam_rate: 30
@@ -4495,6 +13714,27 @@ ecosystems:
               element: earth
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:    0
+                  dark:    -3
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
           eruca:
             id: 439
             attributes:
@@ -4502,12 +13742,54 @@ ecosystems:
               detects:
                 - hearing
                 - scent
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -1
+                  wind:    -1
+                  earth:    0
+                  thunder: -1
+                  water:   -2
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
           lugcrawler:
             id: 440
             attributes:
               element: earth
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    2
+                  earth:   6
+                  thunder: 0
+                  water:   2
+                  light:   6
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     2
+                  slow:        6
+                  poison:      2
+                  light_sleep: 6
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     2
       diremite:
         id: 187
         attributes:
@@ -4526,9 +13808,52 @@ ecosystems:
         species:
           arundimite:
             id: 441
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -3
+                  light:   -2
+                  dark:     3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -1
+                  gravity:     -1
           diremite:
             id: 442
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -3
+                  light:   -2
+                  dark:     3
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -3
+                  light_sleep: -2
+                  dark_sleep:   3
+                  blind:        3
+                  stun:        -1
+                  gravity:     -1
               mob_mods:
                 roam_cool:  50
                 roam_turns:  2
@@ -4549,10 +13874,76 @@ ecosystems:
         species:
           apex_flys:
             id: 443
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:     2
+                  earth:    2
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      2
+                  slow:         2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      2
           fly:
             id: 444
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
           vermilion_fly:
             id: 445
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -2
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -2
+                  dark:    -2
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      0
       gnat:
         id: 189
         attributes:
@@ -4569,10 +13960,76 @@ ecosystems:
         species:
           croc:
             id: 446
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      0
+                  wind:     3
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      3
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      3
           gnat:
             id: 447
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      0
+                  wind:     3
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      3
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      3
           midge:
             id: 448
+            attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      0
+                  wind:     3
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      3
+                  slow:         0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      3
       ladybug:
         id: 190
         attributes:
@@ -4589,8 +14046,52 @@ ecosystems:
         species:
           ladybug:
             id: 449
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     6
+                  earth:    2
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      6
+                  slow:         2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      6
           luckybug:
             id: 450
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     6
+                  earth:    2
+                  thunder:  0
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      6
+                  slow:         2
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      6
       lucani:
         id: 191
         species:
@@ -4607,6 +14108,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     6
+                  earth:    2
+                  thunder:  0
+                  water:    0
+                  light:   -1
+                  dark:     3
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      6
+                  slow:         2
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         0
+                  gravity:      6
       mantid:
         id: 192
         attributes:
@@ -4623,12 +14145,100 @@ ecosystems:
         species:
           golden_mantid:
             id: 452
+            attributes:
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    6
+                  earth:   6
+                  thunder: 2
+                  water:   0
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     6
+                  slow:        6
+                  poison:      0
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     6
           green_mantid:
             id: 453
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:     4
+                  earth:    4
+                  thunder:  0
+                  water:   -2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      4
           red_mantid:
             id: 454
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:     4
+                  earth:    4
+                  thunder:  0
+                  water:   -2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      4
           white_mantid:
             id: 455
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -1
+                  wind:     4
+                  earth:    4
+                  thunder:  0
+                  water:   -2
+                  light:    2
+                  dark:     2
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:      4
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      4
       mosquito:
         id: 193
         species:
@@ -4645,6 +14255,27 @@ ecosystems:
                 chr: d
               detects:
                 - sight
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     3
+                  earth:    0
+                  thunder: -2
+                  water:    1
+                  light:   -2
+                  dark:     4
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      3
+                  slow:         0
+                  poison:       1
+                  light_sleep: -2
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -2
+                  gravity:      3
       scorpion:
         id: 194
         attributes:
@@ -4663,13 +14294,100 @@ ecosystems:
         species:
           clawed_scolopendrid:
             id: 457
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           great_scorpion:
             id: 458
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:    4
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         0
+                  poison:       4
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           scolopendrid:
             id: 459
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           scorpion:
             id: 460
             attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -2
+                  water:   -2
+                  light:   -3
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
               mods:
                 attp: 20
               mob_mods:
@@ -4692,12 +14410,100 @@ ecosystems:
         species:
           anansi:
             id: 461
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           arachne:
             id: 462
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           attercop:
             id: 463
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
           spider:
             id: 464
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:   -1
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:      -1
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0
       twitherym:
         id: 196
         attributes:
@@ -4717,12 +14523,100 @@ ecosystems:
         species:
           brown_fluturini:
             id: 465
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    4
+                  thunder: -2
+                  water:   -2
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           brown_twitherym:
             id: 466
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    4
+                  thunder: -2
+                  water:   -2
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           fluturini:
             id: 467
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    4
+                  thunder: -2
+                  water:   -2
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
           twitherym:
             id: 468
+            attributes:
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:     -2
+                  wind:     0
+                  earth:    4
+                  thunder: -2
+                  water:   -2
+                  light:    2
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      0
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  2
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -2
+                  gravity:      0
       wamoura:
         id: 197
         attributes:
@@ -4741,9 +14635,52 @@ ecosystems:
         species:
           coral_wamoura:
             id: 469
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     -2
+                  wind:     2
+                  earth:   -1
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:        -1
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:      2
           wamoura:
             id: 470
             attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     -2
+                  wind:     2
+                  earth:   -1
+                  thunder:  0
+                  water:   -2
+                  light:    0
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:        -1
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         0
+                  gravity:      2
               mob_mods:
                 mp_base: 50
                 sublink:  6
@@ -4754,6 +14691,27 @@ ecosystems:
             id: 471
             attributes:
               element: fire
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -2
+                  wind:    -1
+                  earth:    2
+                  thunder:  0
+                  water:   -2
+                  light:   -1
+                  dark:     0
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:         2
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:     -1
               mods:
                 dmgphys: -1250
               stats:
@@ -4780,6 +14738,27 @@ ecosystems:
             attributes:
               detects:
                 - magic
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     2
+                  wind:    0
+                  earth:   4
+                  thunder: 2
+                  water:   2
+                  light:   0
+                  dark:    4
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     0
+                  slow:        4
+                  poison:      2
+                  light_sleep: 0
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        2
+                  gravity:     0
       clionidae:
         id: 200
         species:
@@ -4788,6 +14767,27 @@ ecosystems:
             attributes:
               detects:
                 - lowhp
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     4
+                  wind:    2
+                  earth:   2
+                  thunder: 0
+                  water:   4
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    4
+                  bind:        4
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        0
+                  gravity:     2
       limule:
         id: 201
         species:
@@ -4796,6 +14796,27 @@ ecosystems:
             attributes:
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    4
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   0
+                  light:   4
+                  dark:    0
+                rank_status:
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      0
+                  light_sleep: 4
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        2
+                  gravity:     2
       murex:
         id: 202
         species:
@@ -4805,6 +14826,27 @@ ecosystems:
               detects:
                 - magic
                 - ability
+              resists:
+                rank_element:
+                  fire:    2
+                  ice:     0
+                  wind:    4
+                  earth:   0
+                  thunder: 4
+                  water:   2
+                  light:   2
+                  dark:    2
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     4
+                  slow:        0
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        4
+                  gravity:     4
 
   structures:
     id: 21
@@ -4820,6 +14862,27 @@ ecosystems:
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
               mob_mods:
                 sight_range: 30
           boxxes:
@@ -4827,38 +14890,207 @@ ecosystems:
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
           exoplates:
             id: 372
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
           fortalices:
             id: 373
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
           fortifications:
             id: 374
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
           gyre:
             id: 375
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
           mirrors:
             id: 376
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           rocks:
             id: 377
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
           sculptures:
             id: 378
             attributes:
               stats:
                 vit: a
+              resists:
+                rank_element:
+                  fire:    1
+                  ice:     1
+                  wind:    1
+                  earth:   1
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
+                rank_status:
+                  paralyze:    1
+                  bind:        1
+                  silence:     1
+                  slow:        1
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     1
       tubes:
         id: 155
         species:
@@ -4869,6 +15101,27 @@ ecosystems:
                 vit: a
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
+                rank_status:
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
 
   weapons:
     id: 22
@@ -4890,6 +15143,27 @@ ecosystems:
                 def: a
               detects:
                 - hearing
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:      2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -1
+                  dark:     2
+                rank_status:
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 mp_base: 50
       omega:
@@ -4901,6 +15175,27 @@ ecosystems:
               detects:
                 - sight
                 - hearing
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:    11
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:  11
+                  blind:       11
+                  stun:        -1
+                  gravity:      0
       statue:
         id: 205
         attributes:
@@ -4914,6 +15209,27 @@ ecosystems:
           goblin_statue:
             id: 478
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 storetp: 100
               mob_mods:
@@ -4922,6 +15238,27 @@ ecosystems:
           orc_statue:
             id: 479
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:      1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:   -2
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:     1
+                  bind:         1
+                  silence:     -1
+                  slow:        -1
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:     -1
               mods:
                 storetp: 100
               mob_mods:
@@ -4930,6 +15267,27 @@ ecosystems:
           quadav_statue:
             id: 480
             attributes:
+              resists:
+                rank_element:
+                  fire:     1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:       1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
               mods:
                 storetp: 100
               mob_mods:
@@ -4938,6 +15296,27 @@ ecosystems:
           yagudo_statue:
             id: 481
             attributes:
+              resists:
+                rank_element:
+                  fire:    -1
+                  ice:     -2
+                  wind:     1
+                  earth:    1
+                  thunder: -1
+                  water:   -1
+                  light:   -1
+                  dark:    -1
+                rank_status:
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -1
+                  gravity:      1
               mods:
                 storetp: 100
               mob_mods:
@@ -4953,3 +15332,24 @@ ecosystems:
                 - sight
                 - hearing
               speed: 20
+              resists:
+                rank_element:
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:    0
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:        -1
+                  gravity:      0

--- a/data/zones/crawlers_nest/mobs.yaml
+++ b/data/zones/crawlers_nest/mobs.yaml
@@ -52,21 +52,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -480,21 +465,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -528,21 +498,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -720,21 +675,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -908,21 +848,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -952,21 +877,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1066,21 +976,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1423,21 +1318,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1469,21 +1349,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1513,21 +1378,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1858,21 +1708,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds species res ranks to every species in the game. This data was NOT taken from our sql data as we know most of it is either slight wrong or very wrong. https://docs.google.com/spreadsheets/d/e/2PACX-1vQrTyOKU-9JrGilcKysLO3d-hTcveEUHsodQYXtxW57iYpi1QTcy-ePvgbIDGduZSMK0exPdVXRkepu/pubhtml?gid=1407029835&single=true

This sheet was made comparing two sources. [Jimmayus EEM Sheet](https://docs.google.com/spreadsheets/d/1YBoveP-weMdidrirY-vPDzHyxbEI2ryECINlfCnFkLI/edit?gid=1367309866#gid=1367309866) and every single resistance chart on: https://w.atwiki.jp/bartlett3/pages/313.html

These were compared/combined and put into an excel sheet for review. A column was added on which source the info came from. 

We still need to edit every single mob in mobs.yaml file to make sure there are no drastic differences for notorious monsters that were coded already. These will come in a follow up PR for per mob yaml removal
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
I did crawlers in crawlers nest as an example.

!zone crawlers nest
Walk until you see the first worker crawler
`!getmod DARK_RES_RANK` should return -3
`!getmod LIGHT_RES_RANK` should return 0

I tested this an extreme value setting all crawlers to 11 rank to make sure everything works. See image: 
<img width="431" height="60" alt="image" src="https://github.com/user-attachments/assets/bfd97730-b538-43ee-8a8f-5fc1ac58c1b0" />

<!-- Clear and detailed steps to test your changes here -->
