### PR TITLE
[lua] Vanishing Act Chain Fixes + Era Modules

### DIFF
--- a/modules/era/lua/quests/ahturhgan/delivering_the_goods.lua
+++ b/modules/era/lua/quests/ahturhgan/delivering_the_goods.lua
@@ -1,0 +1,28 @@
+-----------------------------------
+-- Delivering the Goods
+-- Restores the JST midnight wait before Vanishing Act opens.
+-- The September 9, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/44090-Sep-9-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_delivering_the_goods', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/Delivering_the_Goods', function(quest)
+        local whitegate = quest.sections[3][xi.zone.AHT_URHGAN_WHITEGATE]
+
+        -- Copy of the base handler. Vanishing Act opens at JST midnight.
+        whitegate.onEventFinish[41] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.VANISHING_ACT, 'Stage', JstMidnight()) -- Module change
+
+                -- Player must zone before being able to flag the next quest
+                player:needToZone(true)
+            end
+        end
+    end)
+end)

--- a/modules/era/lua/quests/ahturhgan/vanishing_act.lua
+++ b/modules/era/lua/quests/ahturhgan/vanishing_act.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+-- Vanishing Act
+-- Restores the JST midnight wait before A Taste of Honey opens.
+-- The September 9, 2014 version update shortened the wait to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/44090-Sep-9-2014-(JST)-Version-Update
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_vanishing_act', xi.pre(xi.expansion.SOA))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/Vanishing_Act', function(quest)
+        local whitegate = quest.sections[2][xi.zone.AHT_URHGAN_WHITEGATE]
+
+        -- Copy of the base handler. A Taste of Honey opens at JST midnight.
+        whitegate.onEventFinish[45] = function(player, csid, option, npc)
+            if quest:complete(player) then
+                player:needToZone(true)
+                player:delKeyItem(xi.ki.RAINBOW_BERRY)
+                xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.A_TASTE_OF_HONEY, 'Stage', JstMidnight()) -- Module change
+            end
+        end
+    end)
+end)

--- a/scripts/quests/ahtUrhgan/A_Taste_of_Honey.lua
+++ b/scripts/quests/ahtUrhgan/A_Taste_of_Honey.lua
@@ -1,6 +1,8 @@
 -----------------------------------
--- A_Taste_of_Honey
--- Qutiba !pos 92 -7.5 -130 50
+-- A Taste of Honey
+-- Fochacha, Whitegate, !pos 3 -1 -10.781 50
+-- Qutiba, Whitegate, !pos 92 -7.5 -130 50
+-- Ulamaal, Whitegate, !pos 93 -7.5 -128 50
 -----------------------------------
 
 local quest = Quest:new(xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.A_TASTE_OF_HONEY)
@@ -36,10 +38,10 @@ quest.sections =
                 onTrigger = function(player, npc)
                     -- Variable set in ToAU quest 'Vanishing Act'.
                     if player:needToZone() or quest:getVar(player, 'Stage') > GetSystemTime() then
-                        return quest:progressEvent(55)
-                    else
-                        return quest:progressEvent(579)
+                        return quest:event(55)
                     end
+
+                    return quest:progressEvent(579)
                 end,
             },
 
@@ -47,6 +49,17 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     return quest:event(50)
+                end,
+            },
+
+            ['Ulamaal'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:needToZone() or quest:getVar(player, 'Stage') > GetSystemTime() then
+                        return quest:event(56)
+                    end
+
+                    return quest:progressEvent(579)
                 end,
             },
 
@@ -70,14 +83,14 @@ quest.sections =
         {
             ['Qutiba'] =
             {
-                onTrigger = function(player, npc)
-                    return quest:progressEvent(585)
-                end,
-
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { { xi.item.POT_OF_WHITE_HONEY, 3 } }) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.POT_OF_WHITE_HONEY, 3 } }) then
                         return quest:progressEvent(580)
                     end
+                end,
+
+                onTrigger = function(player, npc)
+                    return quest:event(585)
                 end,
             },
 
@@ -85,7 +98,7 @@ quest.sections =
             {
                 [580] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -108,7 +121,7 @@ quest.sections =
             ['Qutiba'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { xi.item.POT_OF_WHITE_HONEY }) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.POT_OF_WHITE_HONEY, 1 } }) then
                         return quest:progressEvent(581)
                     end
                 end,
@@ -116,6 +129,13 @@ quest.sections =
                 onTrigger = function(player, npc)
                     player:setLocalVar('recipe', 57)
                     return quest:event(57)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [581] = function(player, csid, option, npc)
+                    player:tradeComplete()
                 end,
             },
 

--- a/scripts/quests/ahtUrhgan/Delivering_the_Goods.lua
+++ b/scripts/quests/ahtUrhgan/Delivering_the_Goods.lua
@@ -31,13 +31,13 @@ quest.sections =
             ['Qutiba'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(51)
+                    return quest:event(51)
                 end,
             },
             ['Ulamaal'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(51)
+                    return quest:event(51)
                 end,
             },
 
@@ -58,6 +58,12 @@ quest.sections =
 
         [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
+            ['Fochacha'] =
+            {
+                onTrigger = function(player, npc)
+                    return quest:event(46)
+                end,
+            },
             ['Qutiba'] =
             {
                 onTrigger = function(player, npc)
@@ -97,13 +103,13 @@ quest.sections =
             ['Qutiba'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(52)
+                    return quest:event(52)
                 end,
             },
             ['Ulamaal'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(53)
+                    return quest:event(53)
                 end,
             },
 
@@ -111,10 +117,11 @@ quest.sections =
             {
                 [41] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:setVar('Quest[6][62]Stage', JstMidnight())
+                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.VANISHING_ACT, 'Stage', GetSystemTime() + 60) -- 1 minute wait time
 
                         -- Player must zone before being able to flag the next quest
-                        player:setLocalVar('Quest[6][62]mustZone', 1)
+                        -- Capture: retail still refused two minutes after the turn in. The timer alone does not open it.
+                        player:needToZone(true)
                     end
                 end,
             },

--- a/scripts/quests/ahtUrhgan/Vanishing_Act.lua
+++ b/scripts/quests/ahtUrhgan/Vanishing_Act.lua
@@ -27,13 +27,13 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if
-                        quest:getMustZone(player) or
+                        player:needToZone() or
                         quest:getVar(player, 'Stage') > GetSystemTime()
                     then
-                        return quest:progressEvent(52)
-                    else
-                        return quest:progressEvent(42) -- Starts Quest
+                        return quest:event(52)
                     end
+
+                    return quest:progressEvent(42) -- Starts Quest
                 end,
             },
 
@@ -41,17 +41,17 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if player:needToZone() or quest:getVar(player, 'Stage') > GetSystemTime() then
-                        return quest:progressEvent(53)
-                    else
-                        return quest:progressEvent(42) -- Starts Quest
+                        return quest:event(53)
                     end
+
+                    return quest:progressEvent(42) -- Starts Quest
                 end,
             },
 
             ['Fochacha'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(47)
+                    return quest:event(47)
                 end
             },
 
@@ -78,11 +78,15 @@ quest.sections =
             ['Fochacha'] =
             {
                 onTrigger = function(player, npc)
-                    if quest:getVar(player, 'Prog') == 0 then
+                    local progress = quest:getVar(player, 'Prog')
+
+                    if progress == 0 then
                         return quest:progressEvent(43)
-                    else
-                        return quest:progressEvent(49)
+                    elseif progress == 1 then
+                        return quest:event(48)
                     end
+
+                    return quest:event(49)
                 end,
             },
 
@@ -92,7 +96,7 @@ quest.sections =
                     if player:hasKeyItem(xi.ki.RAINBOW_BERRY) then
                         return quest:progressEvent(45)
                     else
-                        return quest:progressEvent(54)
+                        return quest:event(54)
                     end
                 end,
             },
@@ -103,7 +107,7 @@ quest.sections =
                     if player:hasKeyItem(xi.ki.RAINBOW_BERRY) then
                         return quest:progressEvent(45)
                     else
-                        return quest:progressEvent(54)
+                        return quest:event(54)
                     end
                 end,
             },
@@ -132,8 +136,7 @@ quest.sections =
                     if quest:complete(player) then
                         player:needToZone(true)
                         player:delKeyItem(xi.ki.RAINBOW_BERRY)
-                        -- Set variable for 'A taste of Honey' ToAU quest.
-                        player:setVar('Quest[6][12]Stage', JstMidnight())
+                        xi.quest.setVar(player, xi.questLog.AHT_URHGAN, xi.quest.id.ahtUrhgan.A_TASTE_OF_HONEY, 'Stage', GetSystemTime() + 60) -- 1 minute wait time
                     end
                 end,
             },
@@ -145,7 +148,7 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
-                        npcUtil.tradeHasExactly(trade, xi.item.SICKLE) and
+                        npcUtil.tradeMatches(trade, { { xi.item.SICKLE, 1 } }) and
                         quest:getVar(player, 'Prog') == 2 and
                         not player:hasKeyItem(xi.ki.RAINBOW_BERRY)
                     then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR updates the waits on the Vanishing Act quest chain to be retail accurate. Concurrently, it also implements era modules to restore the era wait times. This PR also fixes multiple bugs such as enforcing zone changes, fixing dialogue, and some trade interactions.

## Steps to test these changes

Do the quest chains, see they have the appropriate retail wait times now. Load the modules and see the era waits are restored.

## Captures

Siknoz

[Quests - Toau - Delivering The Goods.zip](https://github.com/user-attachments/files/31547280/Quests.-.Toau.-.Delivering.The.Goods.zip)
[Uncategorized - Misc-Zone - Wajaom Pephredo Hive Obtain White Honey.zip](https://github.com/user-attachments/files/31547281/Uncategorized.-.Misc-Zone.-.Wajaom.Pephredo.Hive.Obtain.White.Honey.zip)
[Quests - TOAU - Vanishing Act - Checking after new vana day.zip](https://github.com/user-attachments/files/31547282/Quests.-.TOAU.-.Vanishing.Act.-.Checking.after.new.vana.day.zip)