### PR TITLE
Add xi_data_schema to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,4 @@ clang_tidy_summary.md
 *.codegen.lua
 /data/schemas/*.schema.json
 !/data/schemas/_*.schema.json
+xi_data_schema


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

xi_data_schema gets auto-generated into the base directory of my git repo, and probably should be in `.gitignore`.

## Steps to test these changes

N/A