### PR TITLE
Blue magic fSTR/fSTR2, base damage, efflux, crit rate, chain affinity tweaks

### DIFF
--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -255,12 +255,24 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         bonusWSC = 2
     end
 
-    -- Chain Affinity -- TODO: add 'Damage/Accuracy/Critical Hit Chance varies with TP'
-    if caster:getStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        local tp   = caster:getTP() + caster:getMerit(xi.merit.ENCHAINMENT) -- Total TP available
+    local tp = 0
+
+    -- Efflux acts like a 1k tp Chain Affinity
+    -- With Chain Affinity, this is effectively TP bonus +1000.
+    if caster:hasStatusEffect(xi.effect.EFFLUX) then
+        tp = 1000 -- TOOD: add Efflux bonus gear as mod
+    end
+
+    -- TODO: add 'Damage/Accuracy varies with TP'
+    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        tp         = tp + caster:getTP() + caster:getMerit(xi.merit.ENCHAINMENT)
         tp         = utils.clamp(tp, 0, 3000)
-        multiplier = calculatefTP(tp, params.multiplier, params.tp150, params.tp300)
         bonusWSC   = bonusWSC + 1 -- Chain Affinity doubles base WSC
+    end
+
+    -- Efflux or Chain Affinity
+    if tp > 0 then
+        multiplier = calculatefTP(tp, params.multiplier, params.tp150, params.tp300)
     end
 
     -- WSC

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -212,12 +212,19 @@ end
 local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
     local skill      = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
     local multiplier = 2
+    local extraDmg   = 0
 
     if caster:hasStatusEffect(xi.effect.EFFLUX) then
         multiplier = 3
     end
 
-    return math.floor(skill * 0.11) * multiplier + 3
+    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        extraDmg = caster:getMod(xi.mod.ENHANCES_CHAIN_AFFINITY)
+    end
+
+    -- TODO: verify the chain affinity bonus is supposed to be multiplied here.
+    -- There's no documentation on it doing that and ilvl gear plainly states +X and not +X/2 which then gets multiplied by 2 or 3.
+    return math.floor(skill * 0.11) * multiplier + 3 + extraDmg
 end
 
 -----------------------------------

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -108,29 +108,30 @@ local function calculatefTP(tp, ftp0, ftp1500, ftp3000)
     end
 end
 
--- Get fSTR
-local function calculatefSTR(dSTR)
-    local fSTR2 = 0
-
-    if dSTR >= 12 then
-        fSTR2 = dSTR + 4
-    elseif dSTR >= 6 then
-        fSTR2 = dSTR + 6
-    elseif dSTR >= 1 then
-        fSTR2 = dSTR + 7
-    elseif dSTR >= -2 then
-        fSTR2 = dSTR + 8
-    elseif dSTR >= -7 then
-        fSTR2 = dSTR + 9
-    elseif dSTR >= -15 then
-        fSTR2 = dSTR + 10
-    elseif dSTR >= -21 then
-        fSTR2 = dSTR + 12
+-- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=V30
+---@param dSTR number
+---@param level number
+local function calculatefSTR(dSTR, level)
+    if dSTR > 2 then
+        return math.floor(math.min((dSTR + 4) / 4, math.floor((level / 5) + 7)))
     else
-        fSTR2 = dSTR + 13
+        return math.floor(math.max((dSTR + 8) / 4, (math.floor((level / 5) - 1) * -1)))
     end
+end
 
-    return fSTR2 / 2
+-- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S30
+---@param dSTR number
+---@param level number
+local function calculatefSTR2(dSTR, level)
+    if dSTR > 24 then
+        return math.floor(math.min((dSTR + 4) / 2, (math.floor((level / 5) + 7) * 2)))
+    elseif dSTR > 2 then
+        return math.floor((dSTR + 6) / 4)
+    elseif dSTR > -21 then
+        return math.floor((dSTR + 8) / 4)
+    else
+        return math.floor(math.max((dSTR + 10) / 4, (math.floor((level / 5) - 1) * -2)))
+    end
 end
 
 -- Get hitrate
@@ -204,6 +205,21 @@ local function calculateNukeWallFactor(target, spellElement, finalDamage)
     return 1 - potency / 10000
 end
 
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param spell CSpell
+---@return number
+local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
+    local skill      = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
+    local multiplier = 2
+
+    if caster:hasStatusEffect(xi.effect.EFFLUX) then
+        multiplier = 3
+    end
+
+    return math.floor(skill * 0.11) * multiplier + 3
+end
+
 -----------------------------------
 -- Global functions
 -----------------------------------
@@ -217,13 +233,17 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     -----------------------
 
     -- Initial D value
-    local initialD = math.floor(caster:getSkillLevel(xi.skill.BLUE_MAGIC) * 0.11) * 2 + 3
+    local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell)
     initialD       = utils.clamp(initialD, 0, params.duppercap)
 
     -- fSTR
-    local fStr = calculatefSTR(caster:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT))
-    if params.ignorefstrcap == nil then -- Smite of Rage / Grand Slam don't have this cap applied
-        fStr = math.min(fStr, 22)
+    local dSTR = caster:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
+    local fStr = 0
+
+    if params.attackType and params.attackType == xi.attackType.RANGED then
+        fStr = calculatefSTR2(dSTR, caster:getMainLvl())
+    else
+        fStr = calculatefSTR(dSTR, caster:getMainLvl())
     end
 
     -- Multiplier, bonus WSC
@@ -271,10 +291,20 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     params.offcratiomod = params.offcratiomod * (caster:getMerit(xi.merit.PHYSICAL_POTENCY) + 100) / 100
     params.bonusacc     = params.bonusacc == nil and 0 or params.bonusacc
     params.tphitslanded = 0
+    params.critchance   = 0
 
-    -- params.critchance will only be non-nil if base critchance is passed from spell lua
-    local nativecrit  = xi.combat.physical.calculateSwingCriticalRate(caster, target, 0, xi.slot.MAIN)
-    params.critchance = params.critchance == nil and 0 or utils.clamp(params.critchance / 100 + nativecrit, 0.05, 0.95)
+    if
+        params.critchance ~= nil and
+        (caster:hasStatusEffect(xi.effect.AZURE_LORE) or
+        caster:hasStatusEffect(xi.effect.EFFLUX) or
+        caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY))
+    then
+        -- native blue magic crit rate is 0%. Remove 5% on input.
+        -- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S8:Y8
+        local nativecrit = xi.combat.physical.calculateSwingCriticalRate(caster, target, 0, xi.slot.MAIN) - 0.05
+
+        params.critchance = utils.clamp(params.critchance / 100 + nativecrit, 0.00, 1.0)
+    end
 
     local cratio  = calculatecRatio(params.offcratiomod / target:getStat(xi.mod.DEF), caster:getMainLvl(), target:getMainLvl())
     local hitrate = calculateHitrate(caster, target, params.bonusacc)

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -227,6 +227,26 @@ local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
     return math.floor(skill * 0.11) * multiplier + 3 + extraDmg
 end
 
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param params table
+---@return number
+local calculateCritChance = function(caster, target, params)
+    if
+        params.critchance ~= nil and
+        (caster:hasStatusEffect(xi.effect.AZURE_LORE) or
+        caster:hasStatusEffect(xi.effect.EFFLUX) or
+        caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY))
+    then
+        -- native blue magic crit rate is 0%. Remove 5% on input.
+        -- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S8:Y8
+        local nativecrit = xi.combat.physical.calculateSwingCriticalRate(caster, target, 0, xi.slot.MAIN) - 0.05
+
+        return utils.clamp(params.critchance / 100 + nativecrit, 0.00, 1.0)
+    end
+
+    return 0
+end
 -----------------------------------
 -- Global functions
 -----------------------------------
@@ -296,7 +316,6 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     -- Final D
     local finalD = math.floor(initialD + fStr + wsc)
-    -- TODO: Implement ENHANCES_CHAIN_AFFINITY. Increase base damage of spell, but not limited to spell's damage cap
     -- ENHANCES_CHAIN_AFFINITY should also not modify skillchain damage
 
     ----------------------------------------------
@@ -310,20 +329,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     params.offcratiomod = params.offcratiomod * (caster:getMerit(xi.merit.PHYSICAL_POTENCY) + 100) / 100
     params.bonusacc     = params.bonusacc == nil and 0 or params.bonusacc
     params.tphitslanded = 0
-    params.critchance   = 0
-
-    if
-        params.critchance ~= nil and
-        (caster:hasStatusEffect(xi.effect.AZURE_LORE) or
-        caster:hasStatusEffect(xi.effect.EFFLUX) or
-        caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY))
-    then
-        -- native blue magic crit rate is 0%. Remove 5% on input.
-        -- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S8:Y8
-        local nativecrit = xi.combat.physical.calculateSwingCriticalRate(caster, target, 0, xi.slot.MAIN) - 0.05
-
-        params.critchance = utils.clamp(params.critchance / 100 + nativecrit, 0.00, 1.0)
-    end
+    params.critchance   = calculateCritChance(caster, target, params)
 
     local cratio  = calculatecRatio(params.offcratiomod / target:getStat(xi.mod.DEF), caster:getMainLvl(), target:getMainLvl())
     local hitrate = calculateHitrate(caster, target, params.bonusacc)

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -247,6 +247,43 @@ local calculateCritChance = function(caster, target, params)
 
     return 0
 end
+
+---@param caster CBaseEntity
+---@return number
+local getTPBonus = function(caster)
+    local tp = 0
+
+    -- Efflux acts like a 1k tp Chain Affinity
+    -- With Chain Affinity, this is effectively TP bonus +1000.
+    if caster:hasStatusEffect(xi.effect.EFFLUX) then
+        tp = 1000 -- TOOD: add Efflux bonus gear as mod
+    end
+
+    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        tp = tp + caster:getTP() + caster:getMerit(xi.merit.ENCHAINMENT)
+        tp = utils.clamp(tp, 0, 3000)
+    end
+
+    return tp
+end
+
+---@param caster CBaseEntity
+---@return number
+local getWSCBonuses = function(caster)
+    local bonusWSC = 0
+
+    -- BLU AF3 bonus (triples the base WSC when it procs)
+    if math.randomInt(1, 100) <= caster:getMod(xi.mod.AUGMENT_BLU_MAGIC) then
+        bonusWSC = 2
+    end
+
+    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+        bonusWSC = bonusWSC + 1 -- Chain Affinity doubles base WSC
+    end
+
+    return bonusWSC
+end
+
 -----------------------------------
 -- Global functions
 -----------------------------------
@@ -275,29 +312,9 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     -- Multiplier, bonus WSC
     local multiplier = params.multiplier or 1
-    local bonusWSC   = 0
+    local bonusWSC   = getWSCBonuses(caster)
+    local tp         = getTPBonus(caster)
 
-    -- BLU AF3 bonus (triples the base WSC when it procs)
-    if math.randomInt(1, 100) <= caster:getMod(xi.mod.AUGMENT_BLU_MAGIC) then
-        bonusWSC = 2
-    end
-
-    local tp = 0
-
-    -- Efflux acts like a 1k tp Chain Affinity
-    -- With Chain Affinity, this is effectively TP bonus +1000.
-    if caster:hasStatusEffect(xi.effect.EFFLUX) then
-        tp = 1000 -- TOOD: add Efflux bonus gear as mod
-    end
-
-    -- TODO: add 'Damage/Accuracy varies with TP'
-    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        tp         = tp + caster:getTP() + caster:getMerit(xi.merit.ENCHAINMENT)
-        tp         = utils.clamp(tp, 0, 3000)
-        bonusWSC   = bonusWSC + 1 -- Chain Affinity doubles base WSC
-    end
-
-    -- Efflux or Chain Affinity
     if tp > 0 then
         multiplier = calculatefTP(tp, params.multiplier, params.tp150, params.tp300)
     end
@@ -316,7 +333,6 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     -- Final D
     local finalD = math.floor(initialD + fStr + wsc)
-    -- ENHANCES_CHAIN_AFFINITY should also not modify skillchain damage
 
     ----------------------------------------------
     -- Get the possible pDIF range and hit rate --

--- a/scripts/globals/job_utils/blue_mage.lua
+++ b/scripts/globals/job_utils/blue_mage.lua
@@ -58,45 +58,45 @@ end
 -----------------------------------
 
 xi.job_utils.blue_mage.useAzureLore = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.AZURE_LORE, { power = 1, duration = 30, origin = player })
+    player:addStatusEffect(xi.effect.AZURE_LORE, { duration = 30, origin = player })
 
     return xi.effect.AZURE_LORE
 end
 
 xi.job_utils.blue_mage.useBurstAffinity = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.BURST_AFFINITY, { power = 1, duration = 30, origin = player })
+    player:addStatusEffect(xi.effect.BURST_AFFINITY, { duration = 30, origin = player })
     return xi.effect.BURST_AFFINITY
 end
 
 xi.job_utils.blue_mage.useChainAffinity = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.CHAIN_AFFINITY, { power = 1, duration = 30, origin = player })
+    player:addStatusEffect(xi.effect.CHAIN_AFFINITY, { duration = 30, origin = player })
     return xi.effect.CHAIN_AFFINITY
 end
 
 xi.job_utils.blue_mage.useDiffusion = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.DIFFUSION, { power = 1, duration = 60, origin = player })
+    player:addStatusEffect(xi.effect.DIFFUSION, { duration = 60, origin = player })
     return xi.effect.DIFFUSION
 end
 
 xi.job_utils.blue_mage.useConvergence = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.CONVERGENCE, { power = 1, duration = 60, origin = player })
+    player:addStatusEffect(xi.effect.CONVERGENCE, { duration = 60, origin = player })
     return xi.effect.CONVERGENCE
 end
 
 xi.job_utils.blue_mage.useEfflux = function(player, target, ability, action)
-    player:addStatusEffect(xi.effect.EFFLUX, { power = 16, duration = 60, origin = player, tick = 1 })
+    player:addStatusEffect(xi.effect.EFFLUX, { duration = 60, origin = player })
 
     return xi.effect.EFFLUX
 end
 
 xi.job_utils.blue_mage.useUnbridledWisdom = function(player, target, ability, action)
-    target:addStatusEffect(xi.effect.UNBRIDLED_WISDOM, { power = 16, duration = 30, origin = player, tick = 1 })
+    target:addStatusEffect(xi.effect.UNBRIDLED_WISDOM, { duration = 30, origin = player })
 
     return xi.effect.UNBRIDLED_WISDOM
 end
 
 xi.job_utils.blue_mage.useUnbridledLearning = function(player, target, ability, action)
-    target:addStatusEffect(xi.effect.UNBRIDLED_LEARNING, { power = 16, duration = 60, origin = player, tick = 1 })
+    target:addStatusEffect(xi.effect.UNBRIDLED_LEARNING, { duration = 60, origin = player })
 
     return xi.effect.UNBRIDLED_LEARNING
 end

--- a/scripts/tests/packets/s2c/0x028_battle2/basic_attacks.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/basic_attacks.lua
@@ -190,6 +190,7 @@ local packets =
             -- Not all paths use the lua function? Need the MOD for now.
             stub('xi.combat.physical.isGuarded', true)
             mnkMob:setMod(xi.mod.ADDITIVE_GUARD, 100)
+            mnkMob:updateEnmity(player)
 
             player.actions:engage(mnkMob)
             for i = 1, 20 do

--- a/scripts/tests/packets/s2c/0x028_battle2/ranged.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/ranged.lua
@@ -267,6 +267,8 @@ local packets =
             player:equipItem(xi.item.POWER_BOW)
             player:equipItem(xi.item.KABURA_ARROW)
             player.actions:engage(mob)
+            mob:updateEnmity(player)
+
             for i = 1, 10 do
                 player.actions:rangedAttack(mob)
                 xi.test.world:skipTime(10)

--- a/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
+++ b/scripts/tests/packets/s2c/0x028_battle2/weaponskills.lua
@@ -445,6 +445,7 @@ local packets =
             player:setLevel(99)
             player:addItem(xi.item.VERETHRAGNA_99)
             player:equipItem(xi.item.VERETHRAGNA_99, nil, xi.slot.MAIN)
+            mob:updateEnmity(player)
             player.actions:engage(mob)
             xi.test.world:skipTime(1)
 

--- a/scripts/tests/systems/spells/blue_correlation.lua
+++ b/scripts/tests/systems/spells/blue_correlation.lua
@@ -13,9 +13,9 @@ describe('Blue Magic monster correlation', function()
     -- ecosystemMultiplier() hands back 1.0 for a neutral matchup, so it has to be
     -- turned into a bonus before it's added to anything. Added raw, every spell
     -- picks up a flat +1.0.
-    local neutralDamage      = 11
-    local favourableDamage   = 14 -- 1.00 -> 1.25
-    local unfavourableDamage = 8  -- 1.00 -> 0.75
+    local neutralDamage      = 9  -- This seems to roll a 9.6~ that truncates to 9 so the below results aren't exactly *1.25 and *.75
+    local favourableDamage   = 12 -- 1.00 -> 1.25
+    local unfavourableDamage = 7  -- 1.00 -> 0.75
 
     before_each(function()
         xi.test.world:setSeed(1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Partially implement Efflux (TP bonus mod, base damage multiplier)
* Implement Chain Affinity bonus gear mod
* use more accurate fSTR/fSTR2 formulas
* blue magic uses base 0% and not 5% crit rate
* use fSTR2 for the few ranged spells blue magic has
* Remove useless effect params in blue_mage job utils (tick = 1 was printing a warning for no reason, power being set is a no-op since they aren't used)

## Steps to test these changes

Cast Pinecone bomb (ranged) and use CA/Efflux and CA + Efflux with all phys spells
