### PR TITLE
[C++] [lua] Retail Accurate Automaton Defense Modifiers

### DIFF
--- a/modules/era/lua/globals/pets/automaton.lua
+++ b/modules/era/lua/globals/pets/automaton.lua
@@ -51,7 +51,8 @@ m:addOverrideByEra('xi.server.onServerStart', {
         {
             mods =
             {
-                { xi.mod.DMG, -625 },
+                { xi.mod.DMG,  -625 },
+                { xi.mod.DEFP,   20 },
             },
         }
 
@@ -60,6 +61,7 @@ m:addOverrideByEra('xi.server.onServerStart', {
             mods =
             {
                 { xi.mod.DMG, -1250 },
+                { xi.mod.DEFP,   50 },
             },
         }
 
@@ -70,6 +72,7 @@ m:addOverrideByEra('xi.server.onServerStart', {
                 { xi.mod.PIERCE_SDT,  8750 },
                 { xi.mod.DMGBREATH,  -1250 },
                 { xi.mod.DMGMAGIC,   -1250 },
+                { xi.mod.DEFP,          10 },
             },
         }
 
@@ -92,9 +95,30 @@ m:addOverrideByEra('xi.server.onServerStart', {
         super()
 
         -- Removes Frame Specific DT Taken Modifiers for Automaton Frames & Removes Valoredge Block : https://wiki.ffo.jp/html/19739.html / https://wiki.ffo.jp/html/31705.html
-        xi.pets.automaton.frameMods[xi.automaton.frame.HARLEQUIN ] = {}
-        xi.pets.automaton.frameMods[xi.automaton.frame.VALOREDGE ] = {}
-        xi.pets.automaton.frameMods[xi.automaton.frame.SHARPSHOT ] = {}
+        xi.pets.automaton.frameMods[xi.automaton.frame.HARLEQUIN] =
+        {
+            mods =
+            {
+                { xi.mod.DEFP, 20 },
+            },
+        }
+
+        xi.pets.automaton.frameMods[xi.automaton.frame.VALOREDGE] =
+        {
+            mods =
+            {
+                { xi.mod.DEFP, 50 },
+            },
+        }
+
+        xi.pets.automaton.frameMods[xi.automaton.frame.SHARPSHOT] =
+        {
+            mods =
+            {
+                { xi.mod.DEFP, 10 },
+            },
+        }
+
         xi.pets.automaton.frameMods[xi.automaton.frame.STORMWAKER] = {}
     end,
 })

--- a/scripts/effects/overdrive.lua
+++ b/scripts/effects/overdrive.lua
@@ -30,14 +30,6 @@ local statusAilmentResRanks =
     -- xi.mod.GRAVITY_RES_RANK,
 }
 
-local overdriveDefenseDivisors =
-{
-    [xi.automaton.frame.VALOREDGE ] = 24,
-    [xi.automaton.frame.STORMWAKER] = 16,
-    [xi.automaton.frame.SHARPSHOT ] = 18,
-    [xi.automaton.frame.HARLEQUIN ] = 20,
-}
-
 effectObject.onEffectGain = function(target, effect)
     if target:getObjType() == xi.objType.PC then
         effect:addMod(xi.mod.OVERLOAD_THRESH, 5000)
@@ -51,18 +43,12 @@ effectObject.onEffectGain = function(target, effect)
         effect:addMod(xi.mod.ACC, 25)
         effect:addMod(xi.mod.RACC, 25)
         effect:addMod(xi.mod.EVA, 25)
+        effect:addMod(xi.mod.DEFP, 25)
 
         local master = target:getMaster()
 
         if not master then
             return
-        end
-
-        local frameEquipped = target:getAutomatonFrame()
-        local frameDivisor  = overdriveDefenseDivisors[frameEquipped] or 24
-
-        if frameDivisor then
-            effect:addMod(xi.mod.DEFP, math.floor(400 / frameDivisor))
         end
 
         for _, mod in pairs(statusAilmentResRanks) do

--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -493,7 +493,8 @@ xi.pets.automaton.frameMods =
     {
         mods =
         {
-            { xi.mod.DMG, -625 },
+            { xi.mod.DMG,  -625 },
+            { xi.mod.DEFP,   20 },
         },
     },
 
@@ -511,6 +512,7 @@ xi.pets.automaton.frameMods =
         {
             { xi.mod.SHIELDBLOCKRATE,    45 },
             { xi.mod.DMG,             -1250 },
+            { xi.mod.DEFP,               50 },
         },
     },
 
@@ -524,6 +526,7 @@ xi.pets.automaton.frameMods =
             { xi.mod.PIERCE_SDT,  8750 },
             { xi.mod.DMGBREATH,  -1250 },
             { xi.mod.DMGMAGIC,   -1250 },
+            { xi.mod.DEFP,          10 },
         },
     },
 

--- a/src/map/utils/petutils.cpp
+++ b/src/map/utils/petutils.cpp
@@ -618,23 +618,26 @@ void LoadAutomatonStats(CCharEntity* PMaster, CPetEntity* PPet, Pet_t* petStats,
         // Automatons are hard to interrupt
         PPet->addModifier(xi::Mod::SPELLINTERRUPT, 85);
 
+        // Base Automaton Defense Ranks // Cap at 1/2 the ranks skill cap // These get modified by a frame-specific DEFP Modifier.
+        // Harlequin : C / 2 + 20% DEFP / Valoredge : B- / 2 + 50% DEFP / Sharpshot : C- / 2 + 10% DEFP / Stormwaker : D / 2 + 0% DEFP
+        // https://docs.google.com/spreadsheets/d/1VukPnF1oJppXOVpqexcpDpEeR0bDqrkCYJrr0Vo5HpE
         switch (PAutomaton->frame())
         {
             default: // case AutomatonFrame::Harlequin:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(4, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(11, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(7, mlvl > 99 ? 99 : mlvl) / 2); // C
                 break;
             case AutomatonFrame::Valoredge:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(7, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(8, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(5, mlvl > 99 ? 99 : mlvl) / 2); // B-
                 break;
             case AutomatonFrame::Sharpshot:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(2, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(8, mlvl > 99 ? 99 : mlvl) / 2); // C-
                 break;
             case AutomatonFrame::Stormwaker:
                 PPet->WorkingSkills.evasion = battleutils::GetMaxSkill(10, mlvl > 99 ? 99 : mlvl);
-                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(12, mlvl > 99 ? 99 : mlvl));
+                PPet->setModifier(xi::Mod::DEF, battleutils::GetMaxSkill(9, mlvl > 99 ? 99 : mlvl) / 2); // D
                 break;
         }
 


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements retail-accurate automaton defense

After painstakingly capturing defense on every frame across 99 levels of PUP we were able to crack the formula:

DEF = frameMult × (8 + VIT × 1.5 + rankCap / 2)

Each frame has a specific skill rank whose cap is halved, and a frame-specific multiplier applied over the whole base (implemented as DEFP):

Harlequin  : C/2  + 20% DEFP
Valoredge  : B-/2 + 50% DEFP
Sharpshot  : C-/2 + 10% DEFP
Stormwaker : D/2  + 0% DEFP (no bonus)

## Steps to test these changes

Summon automatons, enjoy 1:1 retail accuracy

<img width="1787" height="857" alt="image" src="https://github.com/user-attachments/assets/f2d1bb95-3268-4e80-bc1f-cd306b8b5243" />

<img width="1648" height="659" alt="image" src="https://github.com/user-attachments/assets/eef826d7-5a31-4835-8f24-17daf3011b95" />

<img width="1648" height="738" alt="image" src="https://github.com/user-attachments/assets/154acf85-e75a-406c-be79-d27f432089fa" />

## Source
https://docs.google.com/spreadsheets/d/1VukPnF1oJppXOVpqexcpDpEeR0bDqrkCYJrr0Vo5HpE/edit?gid=0#gid=0
