### PR TITLE
[sql] Bloodpact Skillchain Properties Module

### DIFF
--- a/modules/era/sql/soa/bloodpact_skillchains.sql
+++ b/modules/era/sql/soa/bloodpact_skillchains.sql
@@ -1,0 +1,36 @@
+------------------------------------
+-- Seekers of Adoulin Bloodpact Skillchain Properties SQL Adjustments
+-- This module reverts skillchain properties of certain bloodpacts.
+-- These skills did not gain skillchain properties until the November 10th 2014 update.
+-- https://wiki.ffo.jp/html/32087.html
+------------------------------------
+
+UPDATE pet_skills SET `primary_sc` = 0 WHERE `pet_skill_name` IN (
+    'chaotic_strike',
+    'eclipse_bite',
+    'flaming_crush',
+    'mountain_buster',
+    'predator_claws',
+    'rush',
+    'spinning_dive'
+);
+
+UPDATE pet_skills SET `secondary_sc` = 0 WHERE `pet_skill_name` IN (
+    'chaotic_strike',
+    'eclipse_bite',
+    'flaming_crush',
+    'mountain_buster',
+    'predator_claws',
+    'rush',
+    'spinning_dive'
+);
+
+UPDATE pet_skills SET `tertiary_sc` = 0 WHERE `pet_skill_name` IN (
+    'chaotic_strike',
+    'eclipse_bite',
+    'flaming_crush',
+    'mountain_buster',
+    'predator_claws',
+    'rush',
+    'spinning_dive'
+);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Adds a module to remove skillchain properties from the following bloodpacts:
- Chaotic Strike
- Eclipse Bite
- Flaming Crush
- Mountain Buster
- Predator Claws
- Rush
- Spinning Dive

These bloodpacts did not gain skill chain properties until the Nov. 10th 2014 update.
https://wiki.ffo.jp/html/32087.html

## Steps to test these changes

1. Summon an avatar.
2. Attempt to skillchain using one of these bloodpacts, see that you not not.
2b. Check database in pet_skills.sql, see that their skillchain properties are set to 0.
