### PR TITLE
[lua] Pet Trait Filtering

### DIFF
--- a/scripts/globals/traits.lua
+++ b/scripts/globals/traits.lua
@@ -22,8 +22,9 @@ local mobExcludedTraits =
     [xi.trait.FENCER         ] = true,
 }
 
--- Traits only beastmen monsters get
-local beastmenOnlyTraits =
+-- Resist Traits
+-- For mobs, usually only beastmen get these.
+local resistTraits =
 {
     [xi.trait.RESIST_SLEEP   ] = true,
     [xi.trait.RESIST_POISON  ] = true,
@@ -51,19 +52,35 @@ local beastmenOnlyTraits =
 ---@param zone CZone?
 ---@return boolean
 xi.traits.canApplyTrait = function(trait, entity, zone)
-    -- Only monsters are filtered, everything else gets its traits for now
-    if not entity:isMob() then
+    -- Mobs and pets get filtered.
+
+    -- Pets:
+    -- Avatars get do not gain Arcana Killer from their DRK main job.
+    -- Jug pets get innate killer modifiers. They don't need the job trait.
+    -- Wyverns get innate killer modifiers + Job Traits.
+    -- Automatons do not gain killer effects from their job.
+    if
+        not entity:isMob() and
+        not entity:isPet()
+    then
         return true
     end
 
-    local traitId = trait:getID()
+    local traitId     = trait:getID()
+    local isWyvernPet = entity:isPet() and entity:getPetID() == xi.petId.WYVERN
+    local isBeastmen  = entity:getEcosystem() == xi.ecosystem.BEASTMEN
 
-    if mobExcludedTraits[traitId] then
+    if
+        mobExcludedTraits[traitId] and
+        not isWyvernPet
+    then
         return false
     end
 
-    if beastmenOnlyTraits[traitId] then
-        return entity:getEcosystem() == xi.ecosystem.BEASTMEN
+    -- TODO: Research if pets besides Wyverns ever gain Resist traits.
+    -- Note: Wyverns can in fact gain Resist traits when their master utilizes Wyrm Mail.
+    if resistTraits[traitId] then
+        return isWyvernPet or isBeastmen
     end
 
     return true

--- a/scripts/tests/systems/trait_filtering.lua
+++ b/scripts/tests/systems/trait_filtering.lua
@@ -27,6 +27,31 @@ describe('Job trait filtering', function()
         assert(quadav:hasTrait(xi.trait.RESIST_SLEEP), 'Steel Quadav should have Resist Sleep')
     end)
 
+    it('gives Dragon Killer to a pet Wyvern', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.BEADEAUX, job = xi.job.DRG, level = 99  })
+        player:spawnPet(xi.petId.WYVERN)
+
+        local wyvern = player:getPet()
+
+        if wyvern then
+            assert(wyvern:hasTrait(xi.trait.DRAGON_KILLER), 'Wyvern should have Dragon Killer from job')
+        end
+    end)
+
+    it('gives Resist Petrify to a pet Wyvern when master has Wyrm Mail equipped', function()
+        local player = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE, job = xi.job.DRG, level = 99  })
+        player:changesJob(xi.job.RDM)
+        player:setsLevel(49)
+        player:setMod(xi.mod.WYVERN_SUBJOB_TRAITS, 1)
+        player:spawnPet(xi.petId.WYVERN)
+
+        local wyvern = player:getPet()
+
+        if wyvern then
+            assert(wyvern:hasTrait(xi.trait.RESIST_PETRIFY), 'Wyvern should have Resist Petrify from RDM sub job')
+        end
+    end)
+
     it('gives Resist Sleep to a player', function()
         local player = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE, job = xi.job.PLD, level = 99 })
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Extends Trait filtering to pets.
- Pets with native killer effects already gain their modifiers from battleutils::addEcosystemKillerEffects(). They probably should not get additional job traits for it.
- Fixes Avatars that were able to intimidate arcana because of their DRK main job which is not supposed to happen.

## Steps to test these changes

1. Summon an avatar.
2. `!getmod Arcana_Killer`
3. See that Arcana Killer is now 0.
