### PR TITLE
[lua] Implement Mamoolbane / Trollbane

### DIFF
--- a/scripts/items/mamoolbane.lua
+++ b/scripts/items/mamoolbane.lua
@@ -1,10 +1,10 @@
 -----------------------------------
--- ID: 18693
--- Item: Lamiabane
--- Item Effect: Enchantment: Refresh +1
+-- ID: 18692
+-- Item: Mamoolbane
+-- Item Effect: Enchantment: Evasion +10
 -- Duration: 60 Minutes
 -- Only usable in Arrapago Reef, Halvung, or Mamook. Effect lost upon zoning or unequipping.
--- https://wiki.ffo.jp/html/4402.html
+-- https://wiki.ffo.jp/html/4401.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -24,17 +24,17 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.LAMIABANE) then
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 3600, origin = user, flag = xi.effectFlag.ON_ZONE, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.LAMIABANE })
+    if target:hasEquipped(xi.item.MAMOOLBANE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 3600, origin = user, flag = xi.effectFlag.ON_ZONE, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.MAMOOLBANE })
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
-    effect:addMod(xi.mod.REFRESH, 1)
+    effect:addMod(xi.mod.EVA, 10)
 end
 
 itemObject.onItemUnequip = function(target, item)
-    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.LAMIABANE)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.MAMOOLBANE)
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/scripts/items/trollbane.lua
+++ b/scripts/items/trollbane.lua
@@ -1,10 +1,10 @@
 -----------------------------------
--- ID: 18693
--- Item: Lamiabane
--- Item Effect: Enchantment: Refresh +1
+-- ID: 18694
+-- Item: Trollbane
+-- Item Effect: Enchantment: VIT +10
 -- Duration: 60 Minutes
 -- Only usable in Arrapago Reef, Halvung, or Mamook. Effect lost upon zoning or unequipping.
--- https://wiki.ffo.jp/html/4402.html
+-- https://wiki.ffo.jp/html/4400.html
 -----------------------------------
 ---@type TItem
 local itemObject = {}
@@ -24,17 +24,17 @@ itemObject.onItemCheck = function(target, item, caster)
 end
 
 itemObject.onItemUse = function(target, user)
-    if target:hasEquipped(xi.item.LAMIABANE) then
-        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 3600, origin = user, flag = xi.effectFlag.ON_ZONE, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.LAMIABANE })
+    if target:hasEquipped(xi.item.TROLLBANE) then
+        target:addStatusEffect(xi.effect.ENCHANTMENT, { duration = 3600, origin = user, flag = xi.effectFlag.ON_ZONE, sourceType = xi.effectSourceType.EQUIPPED_ITEM, sourceTypeParam = xi.item.TROLLBANE })
     end
 end
 
 itemObject.onEffectGain = function(target, effect)
-    effect:addMod(xi.mod.REFRESH, 1)
+    effect:addMod(xi.mod.VIT, 10)
 end
 
 itemObject.onItemUnequip = function(target, item)
-    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.LAMIABANE)
+    target:delStatusEffect(xi.effect.ENCHANTMENT, nil, xi.effectSourceType.EQUIPPED_ITEM, xi.item.TROLLBANE)
 end
 
 itemObject.onEffectLose = function(target, effect)

--- a/sql/item_latents.sql
+++ b/sql/item_latents.sql
@@ -2945,10 +2945,20 @@ INSERT INTO `item_latents` VALUES (18683,287,2,58,0);    -- DMG+2 in Assault
 INSERT INTO `item_latents` VALUES (18684,24,10,58,0);    -- Ranged Attack +10 in Assault
 INSERT INTO `item_latents` VALUES (18684,287,2,58,0);    -- DMG+2 in Assault
 
+-- Mamoolbane
+INSERT INTO `item_latents` VALUES (18692, 25, 6, 23, 54); -- Accuracy +6 in Arrapago Reef
+INSERT INTO `item_latents` VALUES (18692, 25, 6, 23, 62); -- Accuracy +6 in Halvung
+INSERT INTO `item_latents` VALUES (18692, 25, 6, 23, 65); -- Accuracy +6 in Mamook
+
 -- Lamiabane
 INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 54); -- +2 Magic Attack Bonus in Arrapago Reef
 INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 62); -- +2 Magic Attack Bonus in Halvung
 INSERT INTO `item_latents` VALUES (18693, 28, 2, 23, 65); -- +2 Magic Attack Bonus in Mamook
+
+-- Trollbane
+INSERT INTO `item_latents` VALUES (18694, 165, 5, 23, 54); -- Critical Hit Rate +5% in Arrapago Reef
+INSERT INTO `item_latents` VALUES (18694, 165, 5, 23, 62); -- Critical Hit Rate +5% in Halvung
+INSERT INTO `item_latents` VALUES (18694, 165, 5, 23, 65); -- Critical Hit Rate +5% in Mamook
 
 -- Snakeeye
 INSERT INTO `item_latents` VALUES (18708,8,5,13,3);    -- +5 STR while Poisoned


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Implements Mamoolbane / Trollbane - Enchantment items that have latent effects in ToAU Beastmen strongholds. 
* Also fixes a bug where Lamiabane effect would stay even if you unequipped it.

## Sources
https://wiki.ffo.jp/html/4401.html
https://wiki.ffo.jp/html/4400.html

## Steps to test these changes

!additem Mamoolbane
!zone Mamook - zone out
Try to use, see "Cant be used in area"
Zone in, see that can you use it
Zone out, see effect lost
