### PR TITLE
[lua] use phys util pdif for Blue magic, adjust Efflux multiplier location, remove Efflux on cast

### DIFF
--- a/modules/era/lua/combat/pdif_caps.lua
+++ b/modules/era/lua/combat/pdif_caps.lua
@@ -27,4 +27,5 @@ m:addOverride('xi.server.onServerStart', function()
     xi.combat.physical.pDifWeaponCapTable[xi.skill.ARCHERY         ] = 3
     xi.combat.physical.pDifWeaponCapTable[xi.skill.MARKSMANSHIP    ] = 3
     xi.combat.physical.pDifWeaponCapTable[xi.skill.THROWING        ] = 3
+    xi.combat.physical.pDifWeaponCapTable[xi.skill.BLUE_MAGIC      ] = 2
 end)

--- a/scripts/combat/physical_utilities.lua
+++ b/scripts/combat/physical_utilities.lua
@@ -68,6 +68,7 @@ xi.combat.physical.pDifWeaponCapTable =
     [xi.skill.ARCHERY         ] = 3.25,
     [xi.skill.MARKSMANSHIP    ] = 3.5,
     [xi.skill.THROWING        ] = 3.25,
+    [xi.skill.BLUE_MAGIC      ] = 3.0,  -- Jimmayus' blue magic sheet https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=2079701009#gid=2079701009&range=B21
 }
 
 local shieldSizeToBlockRateTable =

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -54,49 +54,6 @@ local function calculateWSC(attacker, params)
     return wsc
 end
 
--- Get cRatio
-local function calculatecRatio(ratio, atk_lvl, def_lvl)
-    -- Get ratio with level penalty
-    local levelcor = 0
-    if atk_lvl < def_lvl then
-        levelcor = 0.05 * (def_lvl - atk_lvl)
-    end
-
-    ratio = ratio - levelcor
-    ratio = utils.clamp(ratio, 0, 2)
-
-    -- Get cRatiomin
-    local cratiomin = 0
-    if ratio < 1.25 then
-        cratiomin = 1.2 * ratio - 0.5
-    elseif ratio >= 1.25 and ratio <= 1.5 then
-        cratiomin = 1
-    elseif ratio > 1.5 and ratio <= 2 then
-        cratiomin = 1.2 * ratio - 0.8
-    end
-
-    -- Get cRatiomax
-    local cratiomax = 0
-    if ratio < 0.5 then
-        cratiomax = 0.4 + 1.2 * ratio
-    elseif ratio <= 0.833 and ratio >= 0.5 then
-        cratiomax = 1
-    elseif ratio <= 2 and ratio > 0.833 then
-        cratiomax = 1.2 * ratio
-    end
-
-    -- Return data
-    local cratio = {}
-    if cratiomin < 0 then
-        cratiomin = 0
-    end
-
-    cratio[1] = cratiomin
-    cratio[2] = cratiomax
-
-    return cratio
-end
-
 -- Get the fTP multiplier (by applying 2 straight lines between ftp0-ftp1500 and ftp1500-ftp3000)
 local function calculatefTP(tp, ftp0, ftp1500, ftp3000)
     tp = utils.clamp(tp, 0, 3000)
@@ -289,12 +246,13 @@ end
 -----------------------------------
 
 -- Get the damage for a physical Blue Magic spell
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param spell CSpell
+---@param params table
+---@return number, number
 xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     spell:setCritical(false)
-
-    -----------------------
-    -- Get final D value --
-    -----------------------
 
     -- Initial D value
     local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell)
@@ -338,17 +296,15 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     -- Get the possible pDIF range and hit rate --
     ----------------------------------------------
 
-    if params.offcratiomod == nil then -- For all spells except Cannonball, which uses a DEF mod
-        params.offcratiomod = caster:getStat(xi.mod.ATT)
-    end
-
-    params.offcratiomod = params.offcratiomod * (caster:getMerit(xi.merit.PHYSICAL_POTENCY) + 100) / 100
     params.bonusacc     = params.bonusacc == nil and 0 or params.bonusacc
-    params.tphitslanded = 0
     params.critchance   = calculateCritChance(caster, target, params)
 
-    local cratio  = calculatecRatio(params.offcratiomod / target:getStat(xi.mod.DEF), caster:getMainLvl(), target:getMainLvl())
-    local hitrate = calculateHitrate(caster, target, params.bonusacc)
+    local isCannonball         = spell:getID() == xi.magic.spell.CANNONBALL
+    local potencyAttackMod     = 1 + (caster:getMerit(xi.merit.PHYSICAL_POTENCY) * 2) / 256 -- Each merit value is 2, but SE uses 4/256 for attack merit values.
+    local spellAttackMod       = 1 -- TODO: implement
+    local attackMultiplier     = spellAttackMod * potencyAttackMod
+    local applyLevelCorrection = xi.data.levelCorrection.isLevelCorrectedZone(caster)
+    local hitrate              = calculateHitrate(caster, target, params.bonusacc)
 
     -------------------------
     -- Perform the attacks --
@@ -374,6 +330,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         end
     end
 
+    params.tphitslanded = 0
+
     while hitsdone < params.numhits do
         local chance = math.randomFloat(0, 1)
 
@@ -383,14 +341,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         then
             -- TODO: Check for shadow absorbs. Right now the whole spell will be absorbed by one shadow before it even gets here.
 
-            -- Generate a random pDIF between min and max
-            local pdif = math.randomInt(cratio[1] * 1000, cratio[2] * 1000)
-            pdif       = pdif / 1000
-
             local isCritical = sneakIsApplicable or math.randomFloat(0, 1) < params.critchance
-            if isCritical then
-                pdif = pdif + 1
-            end
+            local pdif       = xi.combat.physical.calculateMeleePDIF(caster, target, xi.skill.BLUE_MAGIC, attackMultiplier, isCritical, applyLevelCorrection, false, 0, false, xi.slot.MAIN, isCannonball)
 
             anyCrit = anyCrit or isCritical
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -381,6 +381,9 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     end
 
     spell:setCritical(anyCrit)
+
+    caster:delStatusEffectSilent(xi.effect.EFFLUX)
+
     return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget), hitslanded
 end
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -168,11 +168,11 @@ end
 ---@return number
 local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
     local skill      = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
-    local multiplier = 2
+    local multiplier = 1
     local extraDmg   = 0
 
     if caster:hasStatusEffect(xi.effect.EFFLUX) then
-        multiplier = 3
+        multiplier = 1.5
     end
 
     if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
@@ -180,8 +180,8 @@ local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
     end
 
     -- TODO: verify the chain affinity bonus is supposed to be multiplied here.
-    -- There's no documentation on it doing that and ilvl gear plainly states +X and not +X/2 which then gets multiplied by 2 or 3.
-    return math.floor(skill * 0.11) * multiplier + 3 + extraDmg
+    -- There's no documentation on it doing that and ilvl gear plainly states +X
+    return (math.floor(skill * 0.11) * 2 + 3) * multiplier + extraDmg
 end
 
 ---@param caster CBaseEntity

--- a/scripts/tests/systems/spells/blue_correlation.lua
+++ b/scripts/tests/systems/spells/blue_correlation.lua
@@ -13,9 +13,9 @@ describe('Blue Magic monster correlation', function()
     -- ecosystemMultiplier() hands back 1.0 for a neutral matchup, so it has to be
     -- turned into a bonus before it's added to anything. Added raw, every spell
     -- picks up a flat +1.0.
-    local neutralDamage      = 9  -- This seems to roll a 9.6~ that truncates to 9 so the below results aren't exactly *1.25 and *.75
-    local favourableDamage   = 12 -- 1.00 -> 1.25
-    local unfavourableDamage = 7  -- 1.00 -> 0.75
+    local neutralDamage      = 37
+    local favourableDamage   = 46 -- 1.00 -> 1.25
+    local unfavourableDamage = 27 -- 1.00 -> 0.75
 
     before_each(function()
         xi.test.world:setSeed(1)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

See title, but also adjust the era pdif module for 2.0 pdif on blue magic.

## Steps to test these changes

Cast phys spells and stuff and it works.