### PR TITLE
[lua] Windurst Rank 1-2 Mission Audits

### DIFF
--- a/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
+++ b/scripts/missions/windurst/1_1_The_Horutoto_Ruins_Experiment.lua
@@ -327,8 +327,9 @@ mission.sections =
     -- a Windurst citizen after completing this mission. For now, grouping with other
     -- gate guard-adjacent NPCs whose dialogue changes on accepting next mission.
     {
-        check = function(player)
-            return player:getNation() == mission.areaId and
+        check = function(player, currentMission)
+            return currentMission == xi.mission.id.nation.NONE and
+                player:getNation() == mission.areaId and
                 player:hasCompletedMission(mission.areaId, mission.missionId) and
                 not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_HEART_OF_THE_MATTER)
         end,

--- a/scripts/missions/windurst/1_2_The_Heart_of_the_Matter.lua
+++ b/scripts/missions/windurst/1_2_The_Heart_of_the_Matter.lua
@@ -341,7 +341,14 @@ mission.sections =
 
         [xi.zone.OUTER_HORUTOTO_RUINS] =
         {
-            ['_5e9'] = mission:cutscene(44),
+            ['_5e9'] =
+            {
+                onTrigger = function(player, npc)
+                    player:messageSpecial(outerHorutotoRuinsID.text.STAR_CHARM_DISAPPEARS, xi.zone.OUTER_HORUTOTO_RUINS, xi.ki.SOUTHEASTERN_STAR_CHARM)
+
+                    return mission:cutscene(44)
+                end,
+            },
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/1_3_The_Price_of_Peace.lua
+++ b/scripts/missions/windurst/1_3_The_Price_of_Peace.lua
@@ -278,10 +278,11 @@ mission.sections =
 
     -- All of the optional post-mission dialogue
     {
-        check = function(player)
-            return player:getNation() == mission.areaId and
+        check = function(player, currentMission)
+            return currentMission == xi.mission.id.nation.NONE and
+                player:getNation() == mission.areaId and
                 player:hasCompletedMission(mission.areaId, mission.missionId) and
-                not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.LOST_FOR_WODS)
+                not player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.LOST_FOR_WORDS)
         end,
 
         [xi.zone.PORT_WINDURST] =

--- a/scripts/missions/windurst/2_1_Lost_for_Words.lua
+++ b/scripts/missions/windurst/2_1_Lost_for_Words.lua
@@ -13,7 +13,8 @@
 -- Mahogany Door     : !pos -11 0 20 192
 -- House of the Hero : !pos -26 -13 260 239
 -----------------------------------
-local mazeID = zones[xi.zone.MAZE_OF_SHAKHRAMI]
+local mazeID          = zones[xi.zone.MAZE_OF_SHAKHRAMI]
+local windurstWallsID = zones[xi.zone.WINDURST_WALLS]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.WINDURST, xi.mission.id.windurst.LOST_FOR_WORDS)
@@ -43,6 +44,9 @@ local examineRock = function(player, npc)
         elseif missionStatus == 4 then
             return mission:messageSpecial(mazeID.text.NO_NEED_INVESTIGATE)
         end
+    -- Only the first eight rocks belong to the dig.
+    elseif rockOffset > 7 then
+        return mission:messageSpecial(mazeID.text.NOTHING_FOSSIL)
     else
         -- TODO: This multiline message should be converted to messageName, however the equivalent in
         -- interaction is used for a different purpose.  Find a new method to implement in the interaction
@@ -135,7 +139,29 @@ mission.sections =
             ['Miiri-Wohri'] = mission:event(161),
             ['Rakoh_Buuma'] = mission:event(160),
             ['Sola_Jaab']   = mission:event(162),
-            ['Tih_Pikeh']   = mission:event(163),
+
+            -- Tih Pikeh alternates two lines. The toggle advances in onEventFinish.
+            ['Tih_Pikeh'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:getLocalVar('TihPikehRepeatLine') == 0 then
+                        return mission:progressEvent(163)
+                    else
+                        return mission:progressEvent(164)
+                    end
+                end,
+            },
+
+            onEventFinish =
+            {
+                [163] = function(player, csid, option, npc)
+                    player:setLocalVar('TihPikehRepeatLine', 1)
+                end,
+
+                [164] = function(player, csid, option, npc)
+                    player:setLocalVar('TihPikehRepeatLine', 0)
+                end,
+            },
         },
     },
 
@@ -172,8 +198,13 @@ mission.sections =
             onEventFinish =
             {
                 [165] = function(player, csid, option, npc)
+                    -- Listening sends 1. Refusing sends 2 and grants nothing.
+                    if option ~= 1 then
+                        return
+                    end
+
                     npcUtil.giveKeyItem(player, xi.ki.LAPIS_MONOCLE)
-                    mission:setVar(player, 'Rock', math.randomInt(1, 6))
+                    mission:setVar(player, 'Rock', math.randomInt(0, 7))
                     player:setMissionStatus(mission.areaId, 3)
                 end,
             },
@@ -281,7 +312,14 @@ mission.sections =
 
         [xi.zone.WINDURST_WALLS] =
         {
-            ['_6n2'] = mission:progressEvent(337),
+            ['_6n2'] =
+            {
+                onTrigger = function(player, npc)
+                    player:messageText(npc, windurstWallsID.text.DOOR_UNLOCKED, false, 6)
+
+                    return mission:progressEvent(337)
+                end,
+            },
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/2_2_A_Testing_Time.lua
+++ b/scripts/missions/windurst/2_2_A_Testing_Time.lua
@@ -23,6 +23,7 @@ local handleAcceptMission = function(player, csid, option, npc)
     if option == 4 then
         mission:begin(player)
         player:setMissionStatus(mission.areaId, 1)
+        player:setCharVar('AurasteryMissionTaken', 1)
         player:messageSpecial(zones[player:getZoneID()].text.YOU_ACCEPT_THE_MISSION)
     end
 end
@@ -53,28 +54,48 @@ local assessment = function(player, npc)
         end
     end
 
-    -- handle the events for first-time doing the mission
-    if not completed then
-        local event = completed and 208 or 198
+    local event = completed and 208 or 198
 
-        if killCount >= 35 then
-            event = completed and 206 or 201
-        elseif killCount >= 30 then
-            event = completed and 209 or 200
-        elseif not completed and killCount >= 19 then
-            event = 199
-        end
-
-        return mission:progressEvent(event, 0, VanadielHour(), 1, killCount)
+    if killCount >= 35 then
+        event = completed and 206 or 201
+    elseif killCount >= 30 then
+        event = completed and 209 or 200
+    elseif not completed and killCount >= 19 then
+        event = 199
     end
+
+    return mission:progressEvent(event, 0, VanadielHour(), 1, killCount)
 end
 
 local failMission = function(player, csid, option, npc)
+    local completed = player:hasCompletedMission(mission.areaId, mission.missionId)
+
     mission:setVar(player, 'EndTime', 0)
     mission:setVar(player, 'KillCount', 0)
+    mission:setVar(player, 'Failed', 1)
+    mission:setMustZone(player)
     player:delKeyItem(xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
     player:setMissionStatus(mission.areaId, 0)
-    player:delMission(mission.areaId, mission.missionId)
+
+    -- delMission also wipes the completion bit. A repeat run is dropped with completeMission.
+    if completed then
+        player:completeMission(mission.areaId, mission.missionId)
+    else
+        player:delMission(mission.areaId, mission.missionId)
+    end
+end
+
+local acceptAssessment = function(player, csid, option, npc)
+    if option ~= 2 then
+        return
+    end
+
+    player:setMissionStatus(mission.areaId, 2)
+    npcUtil.giveKeyItem(player, xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
+    mission:setVar(player, 'EndTime', VanadielTime() + xi.vanaTime.DAY)
+
+    -- The retry briefing has played.
+    mission:setVar(player, 'Failed', 0)
 end
 
 local clearMission = function(player, csid, option, npc)
@@ -92,8 +113,7 @@ mission.sections =
     {
         check = function(player, currentMission)
             return currentMission == xi.mission.id.nation.NONE and
-                player:getNation() == mission.areaId and
-                not player:hasCompletedMission(mission.areaId, mission.missionId)
+                player:getNation() == mission.areaId
         end,
 
         [xi.zone.PORT_WINDURST] =
@@ -191,25 +211,22 @@ mission.sections =
             ['Moreno-Toeno'] =
             {
                 onTrigger = function(player, npc)
-                    local completed = player:hasCompletedMission(mission.areaId, mission.missionId)
-
-                    if not completed then
-                        return mission:progressEvent(182) -- first time
-                    elseif completed then
-                        return mission:progressEvent(687) -- repeating
+                    -- Repeat run.
+                    if player:hasCompletedMission(mission.areaId, mission.missionId) then
+                        return mission:progressEvent(687)
+                    -- Retry after a failed attempt.
+                    elseif mission:getVar(player, 'Failed') == 1 then
+                        return mission:progressEvent(181)
                     end
+
+                    return mission:progressEvent(182)
                 end,
             },
 
             onEventFinish =
             {
-                [182] = function(player, csid, option, npc)
-                    if option == 2 then
-                        player:setMissionStatus(mission.areaId, 2)
-                        npcUtil.giveKeyItem(player, xi.ki.CREATURE_COUNTER_MAGIC_DOLL)
-                        mission:setVar(player, 'EndTime', VanadielTime() + xi.vanaTime.DAY)
-                    end
-                end,
+                [181] = acceptAssessment,
+                [182] = acceptAssessment,
 
                 [687] = function(player, csid, option, npc)
                     if option == 2 then
@@ -330,6 +347,34 @@ mission.sections =
                 [206] = clearMission,
                 [209] = clearMission,
             },
+        },
+    },
+
+    -- Parting words after a failed assessment. They stop once the player zones.
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == xi.mission.id.nation.NONE and
+                mission:getVar(player, 'Failed') == 1 and
+                mission:getMustZone(player)
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moreno-Toeno'] = mission:event(203),
+        },
+    },
+
+    -- His usual line returns once the player has zoned.
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == xi.mission.id.nation.NONE and
+                mission:getVar(player, 'Failed') == 1 and
+                not mission:getMustZone(player)
+        end,
+
+        [xi.zone.WINDURST_WATERS] =
+        {
+            ['Moreno-Toeno'] = mission:event(438),
         },
     },
 }

--- a/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
+++ b/scripts/missions/windurst/2_3_0_The_Three_Kingdoms.lua
@@ -90,7 +90,9 @@ mission.sections =
 
         [xi.zone.WINDURST_WATERS] =
         {
-            ['Mokyokyo'] = mission:progressEvent(215),
+            ['Dagoza-Beruza'] = mission:event(213),
+            ['Mokyokyo']      = mission:progressEvent(215),
+            ['Panna-Donna']   = mission:event(212),
         },
 
         [xi.zone.WINDURST_WOODS] =
@@ -115,8 +117,11 @@ mission.sections =
                         end
                     elseif missionStatus == 11 then
                         return mission:progressEvent(101, 0, 0, xi.ki.ADVENTURERS_CERTIFICATE)
+                    -- Kupipi alternates two lines. The toggle advances in onEventFinish.
+                    elseif player:getLocalVar('KupipiRepeatLine') == 0 then
+                        return mission:progressEvent(97)
                     else
-                        return mission:event(97)
+                        return mission:progressEvent(98)
                     end
                 end,
             },
@@ -136,6 +141,15 @@ mission.sections =
                     end
                 end,
 
+                -- onTrigger also runs on clicks where the action is discarded for the NPC's own file.
+                [97] = function(player, csid, option, npc)
+                    player:setLocalVar('KupipiRepeatLine', 1)
+                end,
+
+                [98] = function(player, csid, option, npc)
+                    player:setLocalVar('KupipiRepeatLine', 0)
+                end,
+
                 [101] = function(player, csid, option, npc)
                     if mission:complete(player) then
                         player:delKeyItem(xi.ki.KINDRED_REPORT)
@@ -144,20 +158,38 @@ mission.sections =
             },
         },
 
-        [xi.zone.CHATEAU_DORAGUILLE] =
+        [xi.zone.METALWORKS] =
         {
-            ['Halver'] =
+            ['Mih_Ketto'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) < 3 then
-                        return mission:event(532)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    -- Both consuls have been visited.
+                    if missionStatus == 11 then
+                        return mission:event(268)
+                    -- Carrying the letter of introduction.
+                    elseif missionStatus > 0 then
+                        return mission:event(266)
                     end
                 end,
             },
-        },
 
-        [xi.zone.METALWORKS] =
-        {
+            ['Moyoyo'] =
+            {
+                onTrigger = function(player, npc)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    -- Both consuls have been visited.
+                    if missionStatus == 11 then
+                        return mission:event(265)
+                    -- Carrying the letter of introduction.
+                    elseif missionStatus > 0 then
+                        return mission:event(263)
+                    end
+                end,
+            },
+
             ['Patt-Pott'] =
             {
                 onTrigger = function(player, npc)
@@ -175,18 +207,34 @@ mission.sections =
                 end,
             },
 
+            ['Topuru-Kuperu'] =
+            {
+                onTrigger = function(player, npc)
+                    local missionStatus = player:getMissionStatus(mission.areaId)
+
+                    -- Both consuls have been visited.
+                    if missionStatus == 11 then
+                        return mission:event(262)
+                    -- Carrying the letter of introduction.
+                    elseif missionStatus > 0 then
+                        return mission:event(260)
+                    end
+                end,
+            },
+
             onEventFinish =
             {
                 [254] = function(player, csid, option, npc)
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK)
-                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                     player:setMissionStatus(mission.areaId, 3)
                 end,
 
+                -- The second consul visited takes the letter.
                 [256] = function(player, csid, option, npc)
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2)
+                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                     player:setMissionStatus(mission.areaId, 8)
                 end,
             },
@@ -228,13 +276,14 @@ mission.sections =
                 [546] = function(player, csid, option, npc)
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA)
-                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                     player:setMissionStatus(mission.areaId, 3)
                 end,
 
+                -- The second consul visited takes the letter.
                 [547] = function(player, csid, option, npc)
                     player:delMission(mission.areaId, mission.missionId)
                     player:addMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA2)
+                    player:delKeyItem(xi.ki.LETTER_TO_THE_CONSULS_WINDURST)
                     player:setMissionStatus(mission.areaId, 8)
                 end,
 
@@ -247,9 +296,15 @@ mission.sections =
 
     {
         check = function(player, currentMission, missionStatus, vars)
-            return player:hasCompletedMission(mission.areaId, mission.missionId) and
+            return currentMission == xi.mission.id.nation.NONE and
+                player:hasCompletedMission(mission.areaId, mission.missionId) and
                 player:getNation() == xi.nation.WINDURST
         end,
+
+        [xi.zone.HEAVENS_TOWER] =
+        {
+            ['Kupipi'] = mission:event(102),
+        },
 
         [xi.zone.NORTHERN_SAN_DORIA] =
         {

--- a/scripts/missions/windurst/2_3_2_The_Three_Kingdoms_Bastok.lua
+++ b/scripts/missions/windurst/2_3_2_The_Three_Kingdoms_Bastok.lua
@@ -63,6 +63,11 @@ mission.sections =
                 end,
             },
 
+            -- The staff comment on the errand while the leg runs.
+            ['Mih_Ketto']     = mission:event(267),
+            ['Moyoyo']        = mission:event(264),
+            ['Topuru-Kuperu'] = mission:event(261),
+
             onEventFinish =
             {
                 [255] = function(player, csid, option, npc)

--- a/scripts/missions/windurst/2_3_4_The_Three_Kingdoms_Bastok2.lua
+++ b/scripts/missions/windurst/2_3_4_The_Three_Kingdoms_Bastok2.lua
@@ -58,6 +58,15 @@ mission.sections =
                 end,
             },
 
+            -- Event 702 is the door line for players on a mission. Both the door and Iron Eater serve it.
+            ['_6ld']          = mission:event(702),
+            ['Iron_Eater']    = mission:event(702),
+
+            -- The staff comment on the errand while the leg runs.
+            ['Mih_Ketto']     = mission:event(267),
+            ['Moyoyo']        = mission:event(264),
+            ['Topuru-Kuperu'] = mission:event(261),
+
             onEventFinish =
             {
                 [257] = function(player, csid, option, npc)

--- a/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
+++ b/scripts/zones/Port_Windurst/npcs/Janshura-Rashura.lua
@@ -19,8 +19,11 @@ entity.onTrigger = function(player, npc)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
             local param3 = player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.WRITTEN_IN_THE_STARS) and 1 or 0
             local flagMission, repeatMission = xi.mission.getMissionMask(player)
+            -- Set once the player has taken an Aurastery mission. Swaps the A Testing Time line.
+            local seenAurastery = (player:getCharVar('AurasteryMissionTaken') > 0 or
+                player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.A_TESTING_TIME)) and 1 or 0
 
-            player:startEvent(78, flagMission, 0, param3, 0, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
+            player:startEvent(78, flagMission, 0, param3, seenAurastery, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
         end
     end
 end

--- a/scripts/zones/Windurst_Walls/IDs.lua
+++ b/scripts/zones/Windurst_Walls/IDs.lua
@@ -31,6 +31,7 @@ zones[xi.zone.WINDURST_WALLS] =
         FISHING_MESSAGE_OFFSET         = 7099,  -- You can't fish here.
         RECEIVE_BAYLD                  = 7197,  -- You receive <number> bayld!
         DOORS_SEALED_SHUT              = 7775,  -- The doors are firmly sealed shut.
+        DOOR_UNLOCKED                  = 7998,  -- The door is unlocked.
         MOGHOUSE_EXIT                  = 8232,  -- You have learned your way through the back alleys of Windurst! Now you can exit to any area from your residence.
         RECEIVED_CONQUEST_POINTS       = 8460,  -- You received <number> conquest points!
         SCAVNIX_SHOP_DIALOG            = 8716,  -- <Pshoooooowaaaaa> I'm goood Goblin from underwooorld. I find lotshhh of gooodieshhh. You want try shhhome chipshhh? Cheap for yooou.

--- a/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
+++ b/scripts/zones/Windurst_Walls/npcs/Zokima-Rokima.lua
@@ -19,8 +19,11 @@ entity.onTrigger = function(player, npc)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
             local param3 = player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.WRITTEN_IN_THE_STARS) and 1 or 0
             local flagMission, repeatMission = xi.mission.getMissionMask(player)
+            -- Set once the player has taken an Aurastery mission. Swaps the A Testing Time line.
+            local seenAurastery = (player:getCharVar('AurasteryMissionTaken') > 0 or
+                player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.A_TESTING_TIME)) and 1 or 0
 
-            player:startEvent(93, flagMission, 0, param3, 0, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission) -- Mission List
+            player:startEvent(93, flagMission, 0, param3, seenAurastery, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission) -- Mission List
         end
     end
 end

--- a/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
+++ b/scripts/zones/Windurst_Waters/npcs/Mokyokyo.lua
@@ -19,8 +19,11 @@ entity.onTrigger = function(player, npc)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
             local param3 = player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.WRITTEN_IN_THE_STARS) and 1 or 0
             local flagMission, repeatMission = xi.mission.getMissionMask(player)
+            -- Set once the player has taken an Aurastery mission. Swaps the A Testing Time line.
+            local seenAurastery = (player:getCharVar('AurasteryMissionTaken') > 0 or
+                player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.A_TESTING_TIME)) and 1 or 0
 
-            player:startEvent(111, flagMission, 0, param3, 0, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
+            player:startEvent(111, flagMission, 0, param3, seenAurastery, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
         end
     end
 end

--- a/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
+++ b/scripts/zones/Windurst_Woods/npcs/Rakoh_Buuma.lua
@@ -19,8 +19,11 @@ entity.onTrigger = function(player, npc)
             -- NPC dialog changes when starting 3-2 according to whether it's the first time or being repeated
             local param3 = player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.WRITTEN_IN_THE_STARS) and 1 or 0
             local flagMission, repeatMission = xi.mission.getMissionMask(player)
+            -- Set once the player has taken an Aurastery mission. Swaps the A Testing Time line.
+            local seenAurastery = (player:getCharVar('AurasteryMissionTaken') > 0 or
+                player:hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.A_TESTING_TIME)) and 1 or 0
 
-            player:startEvent(114, flagMission, 0, param3, 0, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
+            player:startEvent(114, flagMission, 0, param3, seenAurastery, xi.ki.STAR_CRESTED_SUMMONS_1, repeatMission)
         end
     end
 end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits all Windurst Missions in Rank 1 and 2. Specifically, it does the following:

**Mission 1-1 and 1-3**
- Fixes a typo that made twelve NPCs silent after The Price of Peace. The check pointed at a mission name that does not exist.
- Stops the 1-1 and 1-3 post-mission lines once the player takes the next mission. They used to compete with the new mission's dialogue.

**Mission 1-2**
- Adds the "Your southeastern star charm disappears in a flash of light" message before the Gate cutscene.

**Mission 2-1 Lost for Words**
- Widens the Fossil Rock pool. The rock retail actually used could never be the correct one.
- Rocks outside the dig now say they are ordinary, instead of the mission line.
- Adds "The door is unlocked" before the House of the Hero cutscene.
- Adds Tih Pikeh's second line. He alternates between two.
- Refusing Nanaa Mihgo's offer no longer grants the item and advances the mission anyway.

**Mission 2-2 A Testing Time**
- The mission can be repeated. The gate guard listed it, but choosing it did nothing.
- The repeat run can be graded. Three of the ending scenes were unreachable and the NPC returned nothing.
- Failing a repeat no longer erases the original completion.
- Adds the retry briefing for a player who failed a previous attempt.
- Adds Moreno-Toeno's line after a failure, and the line he gives once the player zones.
- The gate guards now say "You've been to the Aurastery before" on a second visit.

**Mission 2-3 The Three Kingdoms**
- The Letter to the Consuls is taken at the second consul, not the first.
- Adds Kupipi's second repeat line and her line after the mission is finished.
- Adds the Metalworks consulate staff dialogue. They have a line for each stage and only ever gave their idle one.
- Adds the President's Office door line during the Bastok leg.
- Adds the Windurst Waters gate house lines while the mission runs.
- Halver no longer greets Windurst players with San d'Oria's own line.

## Steps to test these changes

Run the missions. See they still work but also the above are fixed.

## Captures

Packet capture files in video descriptions.

https://www.youtube.com/watch?v=98lEjBw7jT0

https://youtu.be/J91eUhSUumc