### PR TITLE
[lua] Fix Signet / Sigil Region Checks for TP loss prevention while resting

### DIFF
--- a/scripts/effects/healing.lua
+++ b/scripts/effects/healing.lua
@@ -56,6 +56,7 @@ effectObject.onEffectTick = function(target, effect)
             not target:hasStatusEffect(xi.effect.PLAGUE) and
             not target:hasStatusEffect(xi.effect.CURSE_II)
         then
+            local region = target:getCurrentRegion()
             local healHP = 0
             local healMP = 12 + ((healtime - 2) * (1 + target:getMod(xi.mod.CLEAR_MIND))) + target:getMod(xi.mod.MPHEAL)
 
@@ -71,8 +72,8 @@ effectObject.onEffectTick = function(target, effect)
                 healHP = hpBase + (healtime - 2) * hpRate
                 healMP = mpBase + (healtime - 2) * mpRate
             elseif
-                target:getContinentID() == 1 and
-                target:hasStatusEffect(xi.effect.SIGNET)
+                (region <= xi.region.LIMBUS and target:hasStatusEffect(xi.effect.SIGNET)) or
+                (region >= xi.region.RONFAURE_FRONT and region <= xi.region.VALDEAUNIA_FRONT and target:hasStatusEffect(xi.effect.SIGIL))
             then
                 healHP = 10 + (3 * math.floor(target:getMainLvl() / 10)) +
                     (healtime - 2) * (1 + math.floor(target:getMaxHP() / 300)) + target:getMod(xi.mod.HPHEAL)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Fixes the region check to activate TP loss prevention while resting for Signet & Sigil. Signet was relying on a binding that is currently true almost everywhere, which was allowing it to work in ToAU zones.

## Steps to test these changes

Get Signet, rest in Sea, observe no TP loss
Rest in Wajaom Woodlands, observe TP loss