### PR TITLE
[core, lua] Assorted time unit mismatch fixes

### DIFF
--- a/scripts/actions/abilities/modus_veritas.lua
+++ b/scripts/actions/abilities/modus_veritas.lua
@@ -32,7 +32,7 @@ abilityObject.onUseAbility = function(player, target, ability)
     -- Double power and halve remaining time
     local durationMultiplier = 0.5 + 0.05 * player:getMerit(xi.merit.MODUS_VERITAS_DURATION)
     local helixPower         = 2 * helix:getPower() + 3 * player:getJobPointLevel(xi.jp.MODUS_VERITAS_EFFECT)
-    local duration           = helix:getDuration()
+    local duration           = math.floor(helix:getDuration() / 1000)      -- from milliseconds
     local remaining          = math.floor(helix:getTimeRemaining() / 1000) -- from milliseconds
 
     duration = duration - remaining + math.floor(remaining * durationMultiplier)

--- a/scripts/actions/mobskills/emetic_discharge.lua
+++ b/scripts/actions/mobskills/emetic_discharge.lua
@@ -28,7 +28,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
             local statusEffect = mob:getStatusEffect(effect)
 
             if statusEffect then
-                target:addStatusEffect(effect, { power = statusEffect:getPower(), duration = statusEffect:getDuration(), origin = mob, tick = statusEffect:getTick() })
+                target:copyStatusEffect(statusEffect)
                 mob:delStatusEffect(effect)
             end
         end

--- a/scripts/actions/mobskills/wanion.lua
+++ b/scripts/actions/mobskills/wanion.lua
@@ -23,7 +23,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
 
         if currentEffect then
             -- TODO: Bio needs subPower copied over as well for the ATTP reduction.
-            xi.mobskills.mobStatusEffectMove(mob, target, effect, currentEffect:getPower(), currentEffect:getTick(), currentEffect:getTimeRemaining() / 1000)
+            xi.mobskills.mobStatusEffectMove(mob, target, effect, currentEffect:getPower(), currentEffect:getTick() / 1000, currentEffect:getTimeRemaining() / 1000)
             mob:delStatusEffect(effect)
         end
     end

--- a/scripts/actions/spells/white/sacrifice.lua
+++ b/scripts/actions/spells/white/sacrifice.lua
@@ -19,7 +19,7 @@ spellObject.onSpellCast = function(caster, target, spell)
 
             -- only add it to me if I don't have it
             if not caster:hasStatusEffect(effect) then
-                caster:addStatusEffect(effect, { power = statusEffect:getPower(), duration = statusEffect:getDuration(), origin = caster, tick = statusEffect:getTick() })
+                caster:copyStatusEffect(statusEffect)
             end
 
             target:delStatusEffect(effect)

--- a/scripts/commands/addabytime.lua
+++ b/scripts/commands/addabytime.lua
@@ -43,8 +43,8 @@ commandObj.onTrigger = function(player, minutes, target)
     end
 
     -- add time
-    local oldDuration = tonumber(effect:getDuration())
-    local newDuration = (oldDuration + (tonumber(minutes) * 60)) * 1000
+    local oldDuration = effect:getTimeRemaining()
+    local newDuration = oldDuration + tonumber(minutes) * 60 * 1000
 
     effect:setDuration(newDuration)
     effect:resetStartTime()

--- a/scripts/commands/adddynatime.lua
+++ b/scripts/commands/adddynatime.lua
@@ -46,7 +46,7 @@ commandObj.onTrigger = function(player, minutes, target)
     local zoneId = targ:getZoneID()
     local ID = zones[zoneId]
     local oldDuration = effect:getDuration()
-    effect:setDuration((oldDuration + (minutes * 60)) * 1000)
+    effect:setDuration(oldDuration + minutes * 60 * 1000)
     targ:setLocalVar('dynamis_lasttimeupdate', effect:getTimeRemaining() / 1000)
     targ:messageSpecial(ID.text.DYNAMIS_TIME_EXTEND, minutes)
 end

--- a/scripts/globals/abyssea/conflux_surveyor.lua
+++ b/scripts/globals/abyssea/conflux_surveyor.lua
@@ -55,7 +55,7 @@ xi.abyssea.surveyorOnEventFinish = function(player, csid, option, npc)
         -- At no point should we grant temporary visitant status, so we use
         -- CLuaStatusEffect::setIcon() to force an update.  Add the same 4
         -- seconds of buffer time for countdown, which is removed on saving
-        visitantEffect:setDuration(math.min(visitantTime * 1000 + 4, 7200 * 1000))
+        visitantEffect:setDuration(math.min((visitantTime + 4) * 1000, 7200 * 1000))
         visitantEffect:resetStartTime()
         visitantEffect:setIcon(xi.effect.VISITANT)
 

--- a/scripts/globals/assault/container.lua
+++ b/scripts/globals/assault/container.lua
@@ -354,7 +354,7 @@ xi.assault.afterInstanceRegistration = function(player, content)
 
     player:setCharVar('assaultEntered', assaultID)
     player:messageSpecial(ID.text.ASSAULT_START_OFFSET + assaultID, assaultID)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 
     local areaData = xi.assault.areaData[content.assaultArea]
     if areaData and areaData.firefly then

--- a/scripts/globals/hobbies/crafting/image_support.lua
+++ b/scripts/globals/hobbies/crafting/image_support.lua
@@ -98,7 +98,7 @@ xi.crafting.oldImageSupportOnTrigger = function(player, npc)
 
     -- Calculate effect Duration.
     if player:hasStatusEffect(effectId) then
-        imageDuration = player:getStatusEffect(effectId):getDuration()
+        imageDuration = math.floor(player:getStatusEffect(effectId):getDuration() / 1000)
     end
 
     -- Event handles everything with correct params.
@@ -201,7 +201,7 @@ xi.crafting.ahtUhrganImageSupportOnTrigger = function(player, npc)
 
     -- Calculate image support duration.
     if player:hasStatusEffect(effectId) then
-        imageDuration = player:getStatusEffect(effectId):getDuration()
+        imageDuration = math.floor(player:getStatusEffect(effectId):getDuration() / 1000)
     end
 
     -- Event handles everything with correct params.

--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -553,12 +553,12 @@ end
 
 xi.instance.updateInstanceTime = function(instance, elapsed, text)
     local players            = instance:getChars()
-    local remainingTimeLimit = instance:getTimeLimit() * 60 - (elapsed / 1000)
+    local remainingTimeLimit = instance:getTimeLimit() - elapsed
     local wipeTime           = instance:getWipeTime()
 
     if
         remainingTimeLimit < 0 or
-        (wipeTime ~= 0 and (elapsed - wipeTime) / 1000 > 180
+        (wipeTime ~= 0 and elapsed - wipeTime > 180
         )
     then
         instance:fail()

--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -548,7 +548,7 @@ local function applyCorsairEffect(caster, target, abilityId, power, subPower)
     -- Upgrading an existing roll: Preserve the existing effect's slot and remaining duration.
     if upgradeEffect then
         target:delStatusEffectSilent(effectId)
-        addDuration = upgradeEffect:getDuration() / 1000
+        addDuration = math.floor(upgradeEffect:getTimeRemaining() / 1000)
         addSlot     = upgradeEffect:getEffectSlot()
 
     -- New roll when there is a free slot: Use the lowest available slot and the full duration.

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -290,11 +290,8 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
         -- Handle Target Debuffs
         if debuffEffect then
             origDebuffStacks = debuffEffect:getPower()
-            debuffStacks     = debuffStacks + origDebuffStacks
-            debuffDuration   = debuffEffect:getDuration()
-
-            debuffStacks   = math.min(debuffStacks, maxSteps)
-            debuffDuration = math.min(debuffEffect:getDuration() + 30 + stepDurationGift, 120 + stepDurationGift)
+            debuffStacks     = math.min(debuffStacks + origDebuffStacks, maxSteps)
+            debuffDuration   = math.min(math.floor(debuffEffect:getTimeRemaining() / 1000) + 30 + stepDurationGift, 120 + stepDurationGift)
 
             if maxSteps >= origDebuffStacks then
                 target:delStatusEffectSilent(stepEffect)

--- a/scripts/globals/job_utils/thief.lua
+++ b/scripts/globals/job_utils/thief.lua
@@ -308,30 +308,21 @@ xi.job_utils.thief.useLarceny = function(player, target, ability, action)
     end
 
     -- Default is no SP Ability found
-    if effectStolen == nil then
+    if not effectStolen then
         effectID = player:stealStatusEffect(target)
 
-        local newStatus = player:getStatusEffect(effectID)
-
-        if newStatus then
-            newStatus:setDuration(newStatus:getDuration() + jpValue * 1000)
-        end
     -- Copy an SP Ability if found
     else
-        local newID       = effectStolen:getEffectType()
-        local newIcon     = effectStolen:getIcon()
-        local newPower    = effectStolen:getPower()
-        local newTick     = effectStolen:getTick()
-        local newDuration = effectStolen:getDuration() + jpValue
-        local newSubType  = effectStolen:getSubType()
-        local newSubPower = effectStolen:getSubPower()
-        local newTier     = effectStolen:getTier()
-        local newFlags    = effectStolen:getEffectFlags()
+        effectID = effectStolen:getEffectType()
 
-        player:addStatusEffect(newID, { power = newPower, duration = newDuration, origin = player, tick = newTick, icon = newIcon, subType = newSubType, subPower = newSubPower, tier = newTier, flag = newFlags })
-        target:delStatusEffect(newID)
+        player:copyStatusEffect(effectStolen)
+        target:delStatusEffect(effectID)
+    end
 
-        effectID = newID
+    local newStatus = player:getStatusEffect(effectID)
+
+    if newStatus then
+        newStatus:setDuration(newStatus:getDuration() + jpValue * 1000)
     end
 
     if effectID == 0 then

--- a/scripts/globals/nyzul/pathos.lua
+++ b/scripts/globals/nyzul/pathos.lua
@@ -66,9 +66,7 @@ local function addGearPenalty(mob)
 
     -- Time penalty.
     if penalty == xi.nyzul.penalty.TIME then
-        local timeLimit = instance:getTimeLimit() * 60
-
-        instance:setTimeLimit(timeLimit - 60)
+        instance:setTimeLimit(instance:getTimeLimit() - 60)
 
         for _, players in pairs(chars) do
             players:messageSpecial(ID.text.MALFUNCTION)

--- a/scripts/mixins/job_special.lua
+++ b/scripts/mixins/job_special.lua
@@ -318,7 +318,7 @@ g_mixins.job_special = function(jobSpecialMob)
                 if specialEffect then
                     local effect = mob:getStatusEffect(specialEffect)
                     if effect then
-                        effect:setDuration(customDuration)
+                        effect:setDuration(customDuration * 1000)
                     end
                 end
             end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2963,8 +2963,8 @@ end
 ---@class StatusEffectParams
 ---@field origin CBaseEntity
 ---@field power number?
----@field duration number?
----@field tick number?
+---@field duration number? Seconds
+---@field tick number? Seconds
 ---@field icon xi.effect? Defaults to effectId if not set
 ---@field subType integer?
 ---@field subPower number?

--- a/scripts/specs/core/CBattlefield.lua
+++ b/scripts/specs/core/CBattlefield.lua
@@ -36,17 +36,7 @@ end
 
 ---@nodiscard
 ---@return integer
-function CBattlefield:getFightTick()
-end
-
----@nodiscard
----@return integer
 function CBattlefield:getWipeTime()
-end
-
----@nodiscard
----@return integer
-function CBattlefield:getFightTime()
 end
 
 ---@nodiscard

--- a/scripts/specs/core/CInstance.lua
+++ b/scripts/specs/core/CInstance.lua
@@ -50,7 +50,7 @@ function CInstance:getPets()
 end
 
 ---@nodiscard
----@return integer
+---@return integer seconds
 function CInstance:getTimeLimit()
 end
 
@@ -65,7 +65,7 @@ function CInstance:getLevelCap()
 end
 
 ---@nodiscard
----@return integer
+---@return integer seconds
 function CInstance:getLastTimeUpdate()
 end
 
@@ -75,7 +75,7 @@ function CInstance:getProgress()
 end
 
 ---@nodiscard
----@return integer
+---@return integer seconds
 function CInstance:getWipeTime()
 end
 
@@ -102,9 +102,9 @@ end
 function CInstance:setLevelCap(cap)
 end
 
----@param ms integer
+---@param seconds integer
 ---@return nil
-function CInstance:setLastTimeUpdate(ms)
+function CInstance:setLastTimeUpdate(seconds)
 end
 
 ---@param seconds integer
@@ -117,9 +117,9 @@ end
 function CInstance:setProgress(progress)
 end
 
----@param ms integer
+---@param seconds integer
 ---@return nil
-function CInstance:setWipeTime(ms)
+function CInstance:setWipeTime(seconds)
 end
 
 ---@param stage integer

--- a/scripts/specs/core/CStatusEffect.lua
+++ b/scripts/specs/core/CStatusEffect.lua
@@ -30,7 +30,7 @@ function CStatusEffect:getTier()
 end
 
 ---@nodiscard
----@return integer
+---@return integer milliseconds
 function CStatusEffect:getDuration()
 end
 
@@ -45,7 +45,7 @@ function CStatusEffect:getLastTick()
 end
 
 ---@nodiscard
----@return integer
+---@return integer milliseconds
 function CStatusEffect:getTimeRemaining()
 end
 
@@ -55,7 +55,7 @@ function CStatusEffect:getTickCount()
 end
 
 ---@nodiscard
----@return integer
+---@return integer milliseconds
 function CStatusEffect:getTick()
 end
 
@@ -84,12 +84,12 @@ end
 function CStatusEffect:setTier(tier)
 end
 
----@param duration integer
+---@param duration integer milliseconds
 ---@return nil
 function CStatusEffect:setDuration(duration)
 end
 
----@param tick integer
+---@param tick integer milliseconds
 ---@return nil
 function CStatusEffect:setTick(tick)
 end

--- a/scripts/tests/jobs/cor/abilities/double_up.lua
+++ b/scripts/tests/jobs/cor/abilities/double_up.lua
@@ -1,0 +1,51 @@
+describe('Double-Up', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            zone  = xi.zone.WEST_RONFAURE,
+            job   = xi.job.COR,
+            level = 99,
+        })
+
+        player:addLearnedAbility(xi.jobAbility.FIGHTERS_ROLL)
+
+        -- Twelve or more busts the roll instead of upgrading it
+        stub('math.randomInt', 1)
+    end)
+
+    local function fightersRoll()
+        local roll = player:getStatusEffect(xi.effect.FIGHTERS_ROLL)
+        assert(roll, 'Fighters Roll is not active')
+
+        return roll
+    end
+
+    it('keeps the time remaining on the roll it upgrades', function()
+        player.actions:useAbility(player, xi.jobAbility.FIGHTERS_ROLL)
+        xi.test.world:tickEntity(player)
+
+        xi.test.world:skipTime(30)
+
+        player.actions:useAbility(player, xi.jobAbility.DOUBLE_UP)
+        xi.test.world:tickEntity(player)
+
+        -- Retail keeps counting down from the first roll rather than restarting it
+        local remaining = fightersRoll():getTimeRemaining() / 1000
+        assert(remaining > 265 and remaining <= 270, string.format('Expected 270s, got %.1fs', remaining))
+    end)
+
+    it('adds the second roll to the total', function()
+        player.actions:useAbility(player, xi.jobAbility.FIGHTERS_ROLL)
+        xi.test.world:tickEntity(player)
+
+        xi.test.world:skipTime(5)
+
+        player.actions:useAbility(player, xi.jobAbility.DOUBLE_UP)
+        xi.test.world:tickEntity(player)
+
+        assert(fightersRoll():getSubPower() == 2, 'Double-Up did not upgrade the roll')
+    end)
+end)

--- a/scripts/tests/jobs/dnc/abilities/steps.lua
+++ b/scripts/tests/jobs/dnc/abilities/steps.lua
@@ -1,0 +1,69 @@
+describe('Steps', function()
+    ---@type CClientEntityPair
+    local player
+
+    ---@type CTestEntity
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+        {
+            zone  = xi.zone.WEST_RONFAURE,
+            job   = xi.job.DNC,
+            level = 99,
+        })
+
+        -- A missed step applies no effect at all
+        stub('xi.combat.physicalHitRate.getPhysicalHitRate', 1.0)
+
+        mob = player.entities:moveTo('Wild_Rabbit')
+        mob:respawn()
+        mob:setUnkillable(true)
+
+        player.actions:engage(mob)
+        xi.test.world:tickEntity(player)
+    end)
+
+    local function useBoxStep()
+        player:setTP(3000)
+        player.actions:useAbility(mob, xi.jobAbility.BOX_STEP)
+        xi.test.world:tickEntity(player)
+    end
+
+    local function dazeTimeRemaining()
+        local daze = mob:getStatusEffect(xi.effect.SLUGGISH_DAZE_1)
+        assert(daze, 'Box Step applied no Sluggish Daze')
+
+        return daze:getTimeRemaining() / 1000
+    end
+
+    it('lasts one minute when first applied', function()
+        useBoxStep()
+
+        local remaining = dazeTimeRemaining()
+        assert(remaining > 55 and remaining <= 60, string.format('Expected 60s, got %.1fs', remaining))
+    end)
+
+    it('adds thirty seconds to the time remaining, not to the original duration', function()
+        useBoxStep()
+        xi.test.world:skipTime(30)
+        useBoxStep()
+
+        -- 30s left of the first minute, plus 30s for the second step
+        local remaining = dazeTimeRemaining()
+        assert(remaining > 55 and remaining <= 60, string.format('Expected 60s, got %.1fs', remaining))
+    end)
+
+    it('caps at two minutes', function()
+        useBoxStep()
+
+        -- Each step is worth +30s and the recast costs 5s, so this walks past the cap
+        for _ = 1, 5 do
+            xi.test.world:skipTime(5)
+            useBoxStep()
+        end
+
+        local remaining = dazeTimeRemaining()
+        assert(remaining > 115 and remaining <= 120, string.format('Expected the 120s cap, got %.1fs', remaining))
+    end)
+end)

--- a/scripts/tests/systems/effects/durations.lua
+++ b/scripts/tests/systems/effects/durations.lua
@@ -1,0 +1,44 @@
+describe('Status effect durations', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ job = xi.job.WHM, level = 99 })
+        player:addStatusEffect(xi.effect.POISON, { power = 5, duration = 60, tick = 3, origin = player })
+    end)
+
+    -- addStatusEffect takes seconds while the effect reports itself in milliseconds
+    it('are applied in seconds and reported in milliseconds', function()
+        local poison = player:getStatusEffect(xi.effect.POISON)
+        assert(poison, 'Poison was not applied')
+
+        assert(poison:getDuration() == 60000, string.format('Expected 60000ms, got %d', poison:getDuration()))
+        assert(poison:getTick() == 3000, string.format('Expected a 3000ms tick, got %d', poison:getTick()))
+    end)
+
+    it('count the time remaining down from the full duration', function()
+        xi.test.world:skipTime(20)
+
+        local poison = player:getStatusEffect(xi.effect.POISON)
+        assert(poison, 'Poison was not applied')
+
+        assert(poison:getDuration() == 60000, 'The full duration should not change as the effect runs')
+        assert(poison:getTimeRemaining() <= 40000, string.format('Expected 40000ms left, got %d', poison:getTimeRemaining()))
+    end)
+
+    it('are copied with the time remaining, not the full duration', function()
+        local other = xi.test.world:spawnPlayer({ job = xi.job.WHM, level = 99 })
+
+        xi.test.world:skipTime(20)
+
+        local poison = player:getStatusEffect(xi.effect.POISON)
+        assert(poison, 'Poison was not applied')
+
+        other:copyStatusEffect(poison)
+
+        local copied = other:getStatusEffect(xi.effect.POISON)
+        assert(copied, 'The effect was not copied')
+        assert(copied:getTimeRemaining() <= 40000, string.format('Expected 40000ms left, got %d', copied:getTimeRemaining()))
+        assert(copied:getTick() == 3000, string.format('Expected a 3000ms tick, got %d', copied:getTick()))
+    end)
+end)

--- a/scripts/zones/Arrapago_Remnants/instances/arrapago_remnants.lua
+++ b/scripts/zones/Arrapago_Remnants/instances/arrapago_remnants.lua
@@ -7,7 +7,7 @@ local instanceObject = {}
 
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
     player:messageSpecial(ID.text.SALVAGE_START, 1)
     player:addStatusEffect(xi.effect.ENCUMBRANCE_I, { power = 0xFFFF, duration = 6000, origin = player })
     player:addStatusEffect(xi.effect.OBLIVISCENCE, { duration = 6000, origin = player })

--- a/scripts/zones/Ilrusi_Atoll/instances/extermination.lua
+++ b/scripts/zones/Ilrusi_Atoll/instances/extermination.lua
@@ -9,7 +9,7 @@ instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
 
     player:messageSpecial(ID.text.ASSAULT_43_START, 43)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/Lebros_Cavern/instances/troll_fugitives.lua
+++ b/scripts/zones/Lebros_Cavern/instances/troll_fugitives.lua
@@ -8,7 +8,7 @@ local instanceObject = {}
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
     player:messageSpecial(ID.text.ASSAULT_23_START, 23)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
+++ b/scripts/zones/Lebros_Cavern/instances/wamoura_farm_raid.lua
@@ -8,7 +8,7 @@ local instanceObject = {}
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
     player:messageSpecial(ID.text.ASSAULT_27_START, 27)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/Mamool_Ja_Training_Grounds/instances/preemptive_strike.lua
+++ b/scripts/zones/Mamool_Ja_Training_Grounds/instances/preemptive_strike.lua
@@ -8,7 +8,7 @@ local instanceObject = {}
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
     player:messageSpecial(ID.text.ASSAULT_12_START, 12)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/Maquette_Abdhaljs-Legion_B/instances/ambuscade.lua
+++ b/scripts/zones/Maquette_Abdhaljs-Legion_B/instances/ambuscade.lua
@@ -24,7 +24,7 @@ end
 -- When the player zones into the instance
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
-    player:countdown(instance:getTimeLimit() * 60)
+    player:countdown(instance:getTimeLimit())
 end
 
 -- Instance 'tick'

--- a/scripts/zones/Nyzul_Isle/instances/nashmeiras_plea.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nashmeiras_plea.lua
@@ -34,7 +34,7 @@ end
 
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 
     player:delKeyItem(xi.ki.MYTHRIL_MIRROR)
 end

--- a/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
+++ b/scripts/zones/Nyzul_Isle/instances/nyzul_isle_investigation.lua
@@ -119,7 +119,7 @@ instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
 
     player:messageName(ID.text.COMMENCE, player, 51)
-    player:messageName(ID.text.TIME_TO_COMPLETE, player, instance:getTimeLimit())
+    player:messageName(ID.text.TIME_TO_COMPLETE, player, instance:getTimeLimit() / 60)
 
     player:addTempItem(xi.item.UNDERSEA_RUINS_FIREFLIES)
     player:setCharVar('assaultEntered', 1)

--- a/scripts/zones/Nyzul_Isle/instances/path_of_darkness.lua
+++ b/scripts/zones/Nyzul_Isle/instances/path_of_darkness.lua
@@ -42,7 +42,7 @@ instanceObject.afterInstanceRegister = function(player)
 
     -- NOTE: Time Limit observed in capture prior to KI fading.  This could be asyncronyous,
     -- but moving here from that reference.
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 
     if player:hasKeyItem(xi.ki.NYZUL_ISLE_ROUTE) then
         player:delKeyItem(xi.ki.NYZUL_ISLE_ROUTE)

--- a/scripts/zones/Nyzul_Isle/instances/waking_the_colossus.lua
+++ b/scripts/zones/Nyzul_Isle/instances/waking_the_colossus.lua
@@ -35,7 +35,7 @@ end
 
 instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 
     player:delKeyItem(xi.ki.LIGHTNING_CELL)
     player:messageSpecial(ID.text.LIGHTNING_CELL_SPARKS, xi.ki.LIGHTNING_CELL)

--- a/scripts/zones/Periqia/instances/requiem.lua
+++ b/scripts/zones/Periqia/instances/requiem.lua
@@ -10,7 +10,7 @@ instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
 
     player:messageSpecial(ID.text.ASSAULT_32_START, 32)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/Periqia/instances/shades_of_vengeance.lua
+++ b/scripts/zones/Periqia/instances/shades_of_vengeance.lua
@@ -25,7 +25,7 @@ instanceObject.afterInstanceRegister = function(player)
     end
 
     player:addTempItem(xi.item.CAGE_OF_DVUCCA_FIREFLIES)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceCreated = function(instance)

--- a/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/against_all_odds.lua
@@ -35,7 +35,7 @@ instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
     player:messageSpecial(ID.text.FADES_INTO_NOTHINGNESS, xi.ki.LIFE_FLOAT)
     player:delKeyItem(xi.ki.LIFE_FLOAT)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceTimeUpdate = function(instance, elapsed)

--- a/scripts/zones/The_Ashu_Talif/instances/the_black_coffin.lua
+++ b/scripts/zones/The_Ashu_Talif/instances/the_black_coffin.lua
@@ -55,7 +55,7 @@ instanceObject.afterInstanceRegister = function(player)
     local instance = player:getInstance()
     player:messageSpecial(ID.text.FADES_INTO_NOTHINGNESS, xi.ki.EPHRAMADIAN_GOLD_COIN)
     player:delKeyItem(xi.ki.EPHRAMADIAN_GOLD_COIN)
-    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit())
+    player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 end
 
 instanceObject.onInstanceTimeUpdate = function(instance, elapsed)

--- a/src/map/battlefield.cpp
+++ b/src/map/battlefield.cpp
@@ -134,11 +134,6 @@ timer::duration CBattlefield::GetTimeInside() const
     return m_Tick - m_StartTime;
 }
 
-timer::time_point CBattlefield::GetFightTime() const
-{
-    return m_FightTick;
-}
-
 timer::duration CBattlefield::GetTimeLimit() const
 {
     return m_TimeLimit;

--- a/src/map/battlefield.h
+++ b/src/map/battlefield.h
@@ -144,7 +144,6 @@ public:
     uint16                        GetRuleMask() const;
     timer::time_point             GetStartTime() const;
     timer::duration               GetTimeInside() const;
-    timer::time_point             GetFightTime() const;
     timer::duration               GetTimeLimit() const;
     timer::time_point             GetWipeTime() const;
     size_t                        GetMaxParticipants() const;

--- a/src/map/instance.cpp
+++ b/src/map/instance.cpp
@@ -259,7 +259,7 @@ void CInstance::CheckTime(timer::time_point tick)
     }
     if (m_lastTimeCheck + checkFrequency <= tick && !Failed())
     {
-        luautils::OnInstanceTimeUpdate(GetZone(), this, static_cast<uint32>(timer::count_milliseconds(GetElapsedTime(tick))));
+        luautils::OnInstanceTimeUpdate(GetZone(), this, static_cast<uint32>(timer::count_seconds(GetElapsedTime(tick))));
         m_lastTimeCheck = tick;
     }
 }

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -2703,7 +2703,7 @@ void CLuaBaseEntity::hideNPC(const sol::object& seconds)
 /************************************************************************
  *  Function: updateNPCHideTime()
  *  Purpose : Adds more time to an NPC being hidden
- *  Example : npc:updateNPCHideTime(50000) -- Hide-and-Seek World Champ
+ *  Example : npc:updateNPCHideTime(50) -- Hide for another 50 seconds
  *  Notes   : Default is 15 seconds
  ************************************************************************/
 

--- a/src/map/lua/lua_battlefield.cpp
+++ b/src/map/lua/lua_battlefield.cpp
@@ -73,19 +73,9 @@ uint32 CLuaBattlefield::getRemainingTime()
     return static_cast<uint32>(timer::count_seconds(m_PLuaBattlefield->GetRemainingTime()));
 }
 
-uint32 CLuaBattlefield::getFightTick()
-{
-    return static_cast<uint32>(timer::count_seconds(m_PLuaBattlefield->GetFightTime() - m_PLuaBattlefield->GetStartTime()));
-}
-
 uint32 CLuaBattlefield::getWipeTime()
 {
     return static_cast<uint32>(timer::count_seconds(m_PLuaBattlefield->GetWipeTime() - timer::start_time));
-}
-
-uint32 CLuaBattlefield::getFightTime()
-{
-    return static_cast<uint32>(timer::count_seconds(timer::start_time - m_PLuaBattlefield->GetFightTime()));
 }
 
 uint32 CLuaBattlefield::getMaxParticipants()
@@ -737,9 +727,7 @@ void CLuaBattlefield::Register()
     SOL_REGISTER("getTimeLimit", CLuaBattlefield::getTimeLimit);
     SOL_REGISTER("getRemainingTime", CLuaBattlefield::getRemainingTime);
     SOL_REGISTER("getTimeInside", CLuaBattlefield::getTimeInside);
-    SOL_REGISTER("getFightTick", CLuaBattlefield::getFightTick);
     SOL_REGISTER("getWipeTime", CLuaBattlefield::getWipeTime);
-    SOL_REGISTER("getFightTime", CLuaBattlefield::getFightTime);
     SOL_REGISTER("getMaxParticipants", CLuaBattlefield::getMaxParticipants);
     SOL_REGISTER("getPlayerCount", CLuaBattlefield::getPlayerCount);
     SOL_REGISTER("getPlayers", CLuaBattlefield::getPlayers);

--- a/src/map/lua/lua_battlefield.h
+++ b/src/map/lua/lua_battlefield.h
@@ -46,9 +46,7 @@ public:
     uint32   getTimeLimit();
     uint32   getTimeInside();
     uint32   getRemainingTime();
-    uint32   getFightTick();
     uint32   getWipeTime();
-    uint32   getFightTime();
     uint32   getMaxParticipants();
     uint32   getPlayerCount();
     auto     getPlayers() -> sol::table;

--- a/src/map/lua/lua_instance.cpp
+++ b/src/map/lua/lua_instance.cpp
@@ -122,8 +122,7 @@ sol::table CLuaInstance::getPets()
 
 uint32 CLuaInstance::getTimeLimit()
 {
-    uint32 limit = std::chrono::floor<std::chrono::minutes>(m_PLuaInstance->GetTimeLimit()).count();
-    return limit;
+    return static_cast<uint32>(timer::count_seconds(m_PLuaInstance->GetTimeLimit()));
 }
 
 sol::table CLuaInstance::getEntryPos()
@@ -146,8 +145,7 @@ uint8 CLuaInstance::getLevelCap()
 
 uint32 CLuaInstance::getLastTimeUpdate()
 {
-    auto time_ms = timer::count_milliseconds(m_PLuaInstance->GetLastTimeUpdate());
-    return static_cast<uint32>(time_ms);
+    return static_cast<uint32>(timer::count_seconds(m_PLuaInstance->GetLastTimeUpdate()));
 }
 
 uint32 CLuaInstance::getProgress()
@@ -157,8 +155,7 @@ uint32 CLuaInstance::getProgress()
 
 uint32 CLuaInstance::getWipeTime()
 {
-    auto time_ms = timer::count_milliseconds(m_PLuaInstance->GetWipeTime());
-    return static_cast<uint32>(time_ms);
+    return static_cast<uint32>(timer::count_seconds(m_PLuaInstance->GetWipeTime()));
 }
 
 auto CLuaInstance::getEntity(uint16 targid, const sol::object& filterObj) -> CBaseEntity*
@@ -187,9 +184,9 @@ void CLuaInstance::setLevelCap(uint8 cap)
     m_PLuaInstance->SetLevelCap(cap);
 }
 
-void CLuaInstance::setLastTimeUpdate(uint32 ms)
+void CLuaInstance::setLastTimeUpdate(uint32 seconds)
 {
-    m_PLuaInstance->SetLastTimeUpdate(std::chrono::milliseconds(ms));
+    m_PLuaInstance->SetLastTimeUpdate(std::chrono::seconds(seconds));
 }
 
 void CLuaInstance::setTimeLimit(uint32 seconds)
@@ -202,9 +199,9 @@ void CLuaInstance::setProgress(uint32 progress)
     m_PLuaInstance->SetProgress(progress);
 }
 
-void CLuaInstance::setWipeTime(uint32 ms)
+void CLuaInstance::setWipeTime(uint32 seconds)
 {
-    m_PLuaInstance->SetWipeTime(std::chrono::milliseconds(ms));
+    m_PLuaInstance->SetWipeTime(std::chrono::seconds(seconds));
 }
 
 void CLuaInstance::setStage(uint32 stage)

--- a/src/map/lua/lua_instance.h
+++ b/src/map/lua/lua_instance.h
@@ -63,10 +63,10 @@ public:
     auto   getLocalVar(const std::string& name) -> uint64_t;
 
     void setLevelCap(uint8 cap);
-    void setLastTimeUpdate(uint32 ms);
+    void setLastTimeUpdate(uint32 seconds);
     void setTimeLimit(uint32 seconds);
     void setProgress(uint32 progress);
-    void setWipeTime(uint32 ms);
+    void setWipeTime(uint32 seconds);
     void setStage(uint32 stage);
     void setLocalVar(const std::string& name, uint64_t value);
 

--- a/src/map/lua/lua_treasure_pool.cpp
+++ b/src/map/lua/lua_treasure_pool.cpp
@@ -151,10 +151,16 @@ auto CLuaTreasurePool::getItems() const -> sol::table
 
     for (const auto& item : m_PLuaTreasurePool->getItems())
     {
+        uint32 timestamp = 0;
+        if (item.TimeStamp.has_value())
+        {
+            timestamp = earth_time::timestamp(timer::to_utc(*item.TimeStamp));
+        }
+
         sol::table itemRow   = lua.create_table();
         itemRow["id"]        = item.ID;
         itemRow["slotId"]    = item.SlotID;
-        itemRow["timestamp"] = earth_time::timestamp(timer::to_utc(item.TimeStamp));
+        itemRow["timestamp"] = timestamp;
 
         sol::table lotters     = lua.create_table();
         int        lotterIndex = 1;

--- a/src/map/lua/luautils.cpp
+++ b/src/map/lua/luautils.cpp
@@ -5053,7 +5053,7 @@ auto OnInstanceLoadFailed(CZone* PZone) -> xi::ZoneId
     return result.get_type(0) == sol::type::number ? result.get<xi::ZoneId>(0) : xi::ZoneId::Unknown;
 }
 
-void OnInstanceTimeUpdate(CZone* PZone, CInstance* PInstance, uint32 time)
+void OnInstanceTimeUpdate(CZone* PZone, CInstance* PInstance, uint32 seconds)
 {
     TracyZoneScoped;
 
@@ -5065,7 +5065,7 @@ void OnInstanceTimeUpdate(CZone* PZone, CInstance* PInstance, uint32 time)
         return;
     }
 
-    auto result = onInstanceTimeUpdate(PInstance, time);
+    auto result = onInstanceTimeUpdate(PInstance, seconds);
     if (!result.valid())
     {
         sol::error err = result;

--- a/src/map/lua/luautils.h
+++ b/src/map/lua/luautils.h
@@ -482,12 +482,12 @@ bool OnCanUseSpell(CBattleEntity* PChar, CSpell* Spell); // triggers when CanUse
 auto GetCachedInstanceScript(uint16 instanceId) -> sol::table;
 
 void OnInstanceZoneIn(CCharEntity* PChar, CInstance* PInstance);
-void AfterInstanceRegister(CBaseEntity* PChar);                             // triggers after a character is registered and zoned into an instance (the first time)
-auto OnInstanceLoadFailed(CZone* PZone) -> xi::ZoneId;                      // triggers when an instance load is failed (ie. instance no longer exists)
-void OnInstanceTimeUpdate(CZone* PZone, CInstance* PInstance, uint32 time); // triggers every second for an instance
-void OnInstanceFailure(CInstance* PInstance);                               // triggers when an instance is failed
-void OnInstanceCreatedCallback(CCharEntity* PChar, CInstance* PInstance);   // triggers when an instance is created (per character - waiting outside for entry)
-void OnInstanceCreated(CInstance* PInstance);                               // triggers when an instance is created (instance setup)
+void AfterInstanceRegister(CBaseEntity* PChar);                                // triggers after a character is registered and zoned into an instance (the first time)
+auto OnInstanceLoadFailed(CZone* PZone) -> xi::ZoneId;                         // triggers when an instance load is failed (ie. instance no longer exists)
+void OnInstanceTimeUpdate(CZone* PZone, CInstance* PInstance, uint32 seconds); // triggers every second for an instance, with the elapsed seconds
+void OnInstanceFailure(CInstance* PInstance);                                  // triggers when an instance is failed
+void OnInstanceCreatedCallback(CCharEntity* PChar, CInstance* PInstance);      // triggers when an instance is created (per character - waiting outside for entry)
+void OnInstanceCreated(CInstance* PInstance);                                  // triggers when an instance is created (instance setup)
 void OnInstanceProgressUpdate(CInstance* PInstance);
 void OnInstanceStageChange(CInstance* PInstance);
 void OnInstanceComplete(CInstance* PInstance);

--- a/src/map/packets/s2c/0x0d2_trophy_list.cpp
+++ b/src/map/packets/s2c/0x0d2_trophy_list.cpp
@@ -29,12 +29,18 @@ GP_SERV_COMMAND_TROPHY_LIST::GP_SERV_COMMAND_TROPHY_LIST(const TreasurePoolItem*
 {
     auto& packet = this->data();
 
+    uint32_t startTime = 0;
+    if (PItem->TimeStamp.has_value())
+    {
+        startTime = static_cast<uint32_t>(timer::count_milliseconds(*PItem->TimeStamp - timer::start_time));
+    }
+
     packet.TrophyItemNum   = 1;                 // Item Quantity
     packet.Gold            = 0;                 // TODO: Gil Found
     packet.TrophyItemNo    = PItem->ID;         // Item ID
     packet.TrophyItemIndex = PItem->SlotID;     // Treasure Pool Slot
     packet.Entry           = isOldItem ? 1 : 0; // Old Item
-    packet.StartTime       = static_cast<uint32_t>(timer::count_milliseconds(PItem->TimeStamp - timer::start_time));
+    packet.StartTime       = startTime;
 
     if (PEntity != nullptr)
     {

--- a/src/map/treasure_pool.cpp
+++ b/src/map/treasure_pool.cpp
@@ -165,10 +165,10 @@ void CTreasurePool::delMember(CCharEntity* PChar)
 
 uint8 CTreasurePool::addItem(uint16 ItemID, CBaseEntity* PEntity)
 {
-    uint8             SlotID     = 0;
-    uint8             FreeSlotID = -1;
-    timer::time_point oldest     = timer::time_point::max();
-    const CItem*      PNewItem   = xi::items::lookup(ItemID);
+    uint8                    SlotID     = 0;
+    uint8                    FreeSlotID = -1;
+    Maybe<timer::time_point> oldest     = timer::time_point::max();
+    const CItem*             PNewItem   = xi::items::lookup(ItemID);
 
     if (!PNewItem)
     {
@@ -256,7 +256,7 @@ uint8 CTreasurePool::addItem(uint16 ItemID, CBaseEntity* PEntity)
 
     if (SlotID == 10)
     {
-        m_PoolItems[FreeSlotID].TimeStamp = timer::start_time;
+        m_PoolItems[FreeSlotID].TimeStamp = std::nullopt;
         checkTreasureItem(timer::now(), FreeSlotID);
     }
 
@@ -498,7 +498,7 @@ void CTreasurePool::checkTreasureItem(timer::time_point tick, uint8 SlotID)
         return;
     }
 
-    if ((tick - m_PoolItems[SlotID].TimeStamp) > treasure_livetime ||
+    if (!m_PoolItems[SlotID].TimeStamp.has_value() || (tick - *m_PoolItems[SlotID].TimeStamp) > treasure_livetime ||
         (memberCount() == 1 && m_Members[0]->getStorage(LOC_INVENTORY)->GetFreeSlotsCount() != 0) ||
         m_PoolItems[SlotID].Lotters.size() == memberCount())
     {
@@ -583,7 +583,7 @@ void CTreasurePool::treasureWon(CCharEntity* winner, uint8 SlotID)
         return;
     }
 
-    m_PoolItems[SlotID].TimeStamp = timer::start_time;
+    m_PoolItems[SlotID].TimeStamp = std::nullopt;
 
     for (const auto& member : m_Members)
     {
@@ -603,7 +603,7 @@ void CTreasurePool::treasureError(CCharEntity* winner, uint8 SlotID)
         return;
     }
 
-    m_PoolItems[SlotID].TimeStamp = timer::start_time;
+    m_PoolItems[SlotID].TimeStamp = std::nullopt;
 
     for (const auto& member : m_Members)
     {
@@ -623,7 +623,7 @@ void CTreasurePool::treasureLost(uint8 SlotID)
         return;
     }
 
-    m_PoolItems[SlotID].TimeStamp = timer::start_time;
+    m_PoolItems[SlotID].TimeStamp = std::nullopt;
 
     for (const auto& member : m_Members)
     {

--- a/src/map/treasure_pool.h
+++ b/src/map/treasure_pool.h
@@ -23,6 +23,7 @@
 #define _CTREASUREPOOL_H
 
 #include "common/cbasetypes.h"
+#include "common/types/maybe.h"
 
 #include <vector>
 
@@ -56,9 +57,9 @@ struct LotInfo
 
 struct TreasurePoolItem
 {
-    uint16            ID;
-    uint8             SlotID;
-    timer::time_point TimeStamp;
+    uint16                   ID;
+    uint8                    SlotID;
+    Maybe<timer::time_point> TimeStamp; // unset is treated as infinitely old, so the next check drops the item
 
     std::vector<LotInfo> Lotters;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Bunch of places mixing milliseconds and seconds.

Fixes:
- Modus Veritas not halving Helix duration
- Dancer Steps wrongly resetting debuff to full duration
- Corsair Double-Up wrongly resetting the roll to 5 minutes
- Larceny copying abnormaly long buffs
- Sacrifice copied effect not ticking
- Wanion/Emetic discharge copied effects not ticking
- A bug on treasure pool during the first 5 minutes of the process where treasure pool overflow would not work and new items would be discarded
- LLS cleanups here and there to specify and align the units involved
- Dropped 2 unused binding on battlefield

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
