### PR TITLE
[C++] CP multiplier and conquest alliance condition fix

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -511,11 +511,12 @@ uint8 GetBalance()
     return GetBalance(sandoria, bastok, windurst, sandoria_prev, bastok_prev, windurst_prev);
 }
 
+// TODO: Retail returns 0, 0b011, 0b101, or 0b110. Bits are nations allied: Sandoria, Bastok, Windurst
 uint8 GetAlliance(uint8 sandoria, uint8 bastok, uint8 windurst)
 {
-    if (((sandoria > (bastok + windurst) && sandoria > bastok && sandoria > windurst) && sandoria > 9) ||
-        ((bastok > (sandoria + windurst) && bastok > sandoria && bastok > windurst) && bastok > 9) ||
-        ((windurst > (sandoria + bastok) && windurst > bastok && windurst > sandoria) && windurst > 9))
+    if (sandoria > bastok + windurst ||
+        bastok > sandoria + windurst ||
+        windurst > sandoria + bastok)
     {
         return 1;
     }
@@ -605,16 +606,31 @@ uint32 AddConquestPoints(CCharEntity* PChar, uint32 exp)
     // NOTE: No need to send CConquestPacket,
     // The client itself requests this packet after a fixed period of time
 
-    REGION_TYPE region = PChar->loc.zone->GetRegionID();
+    const REGION_TYPE region = PChar->loc.zone->GetRegionID();
 
     if (region != REGION_TYPE::UNKNOWN)
     {
-        // 10% if region control is player's nation
-        // 15% otherwise
+        // Follows the CP multiplier in https://www.playonline.com/comnews/200302052327.html
+        const uint8 owner      = GetRegionOwner(region);
+        const uint8 nationRank = luautils::GetNationRank(PChar->profile.nation);
 
-        double percentage = PChar->profile.nation == GetRegionOwner(region) ? 0.1 : 0.15;
+        double percentage = 0.15;
+
+        // Only different multiplier if region is not owned by beastmen and nation is not rank 1
+        if (owner <= NATION_WINDURST && nationRank > 1)
+        {
+            if (IsAlliance()) // In alliance and owner of the region is rank 1 or not.
+            {
+                percentage = luautils::GetNationRank(owner) == 1 ? 0.2 : 0.1;
+            }
+            else if (owner == PChar->profile.nation) // Player's nation owns the region
+            {
+                percentage = 0.1;
+            }
+        }
+
         percentage += PChar->getMod(xi::Mod::CONQUEST_BONUS) / 100.0;
-        uint32 points = (uint32)(exp * percentage);
+        const uint32 points = static_cast<uint32>(static_cast<double>(exp) * percentage);
 
         charutils::AddPoints(PChar, charutils::GetConquestPointsName(PChar).c_str(), points);
         GainInfluencePoints(PChar, points / 2);
@@ -636,5 +652,7 @@ uint32 AddConquestPoints(CCharEntity* PChar, uint32 exp)
 // 1: bastok
 // 2: windurst
 // 3: beastmen
+// 4: other
+// 5: neutral
 
 }; // namespace conquest


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- CP rates are incorrect. They should be set to those on these patch notes. Data below to prove it. https://www.playonline.com/comnews/200302052327.html
- Alliance formation requirement (> 9 regions owned) is wrong. The only requirement is for one nation to hold more regions than the other 2 combined. Here's a capture where an alliance formed and the number 1 nation owned 9 regions, not > 9. https://wiki.ffo.jp/html/579.html

### Data For CP Change

<img width="1402" height="877" alt="image" src="https://github.com/user-attachments/assets/88f23d2d-a33e-4e5b-80c4-7e79e7c6d673" />

Capture Alliance: https://drive.google.com/file/d/1zUQIAwYx5wItd5eU5fF1Omvu4d9fu3oa/view?usp=drive_link
Capture Non-Alliance: https://drive.google.com/file/d/1LhMrHemfG_m0_Ki5BfjX-Fn7aJuFCL9t/view?usp=drive_link

## Steps to test these changes
Set nation to different values, sometimes with alliance, sometimes without. Make sure you have signet.

!updateconquest 0
!setplayernation #

## Note
I noticed in the conquest packet, it's currently 1/0 that is sent for alliance information and it's supposed to be 0, 3, 5, or 6. Changing it requires several other changes that are out of scope for this PR so I added a TODO.