### PR TITLE
[C++][lua] Expeditionary Force reduces Beastmen Influence

### DIFF
--- a/scripts/globals/expeditionary_force.lua
+++ b/scripts/globals/expeditionary_force.lua
@@ -976,6 +976,10 @@ xi.expeditionaryForce.onMobDeath = function(mob, player)
     -- Award Influence
     player:gainConquestInfluence(regionPointsEarned[GetNationRank(creditNation)])
 
+    -- Award mob kills for Conquest
+    -- TODO: Get a more accurate number and check per region values.
+    player:addConquestMobKills(25)
+
     -- SEND ZONE MESSAGE
     for _, person in pairs(mob:getZone():getPlayers()) do
         person:messageText(person, ID.text.EXP_FORCE_KILL_SANDORIA + creditNation, 5) -- 5 = Grey: messageText event

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -10074,6 +10074,24 @@ void CLuaBaseEntity::gainConquestInfluence(int32 points)
 }
 
 /************************************************************************
+ *  Function: addConquestMobKills()
+ *  Purpose : Adds mob kills to the player's current region
+ *  Example : player:addConquestMobKills(25)
+ *  Notes   :
+ ************************************************************************/
+
+void CLuaBaseEntity::addConquestMobKills(int32 count)
+{
+    if (m_PBaseEntity->objtype != TYPE_PC)
+    {
+        ShowWarning("Invalid entity type calling function (%s).", m_PBaseEntity->getName());
+        return;
+    }
+
+    conquest::AddMobKills(count, zoneutils::GetCurrentRegion(m_PBaseEntity->getZone()));
+}
+
+/************************************************************************
  *  Function: getSeals()
  *  Purpose : Returns the current seal balance for a player
  *  Example : player:getSeals(type)
@@ -20886,6 +20904,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("addCP", CLuaBaseEntity::addCP);
     SOL_REGISTER("delCP", CLuaBaseEntity::delCP);
     SOL_REGISTER("gainConquestInfluence", CLuaBaseEntity::gainConquestInfluence);
+    SOL_REGISTER("addConquestMobKills", CLuaBaseEntity::addConquestMobKills);
 
     SOL_REGISTER("getSeals", CLuaBaseEntity::getSeals);
     SOL_REGISTER("addSeals", CLuaBaseEntity::addSeals);

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -500,6 +500,7 @@ public:
     void  addCP(int32 cp);
     void  delCP(int32 cp);
     void  gainConquestInfluence(int32 points);
+    void  addConquestMobKills(int32 count);
 
     int32 getSeals(uint8 sealType);
     void  addSeals(int32 points, uint8 sealType);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Reduces Beastmen Influence during an EF kill by adding mob kills to the region per NM kill.

Data is from PR #10720
25 mob kills per region is too low for regions like Valdeaunia but seems to be appropriate for the Dunes region. I suspect the impact may be dependent based on the region, but more data is necessary. Kept it at 25 for all regions to balance against the player.

## Steps to test these changes

Go to Xarcabard, die, go back, !addkeyitem 309, !gotoname Beastmens_Banner, then test killing EF NMs.
