### PR TITLE
[lua] Event to cutscene for ZM14, COR, and Windurst 9-1 and 9-2

### DIFF
--- a/scripts/missions/rotz/14_Ark_Angels.lua
+++ b/scripts/missions/rotz/14_Ark_Angels.lua
@@ -51,7 +51,7 @@ mission.sections =
 
         [xi.zone.THE_SHRINE_OF_RUAVITAU] =
         {
-            ['blank_divine_might'] = mission:progressEvent(53, 917, 1408, 1550),
+            ['blank_divine_might'] = mission:progressCutscene(53, 917, 1408, 1550),
 
             onEventFinish =
             {

--- a/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
+++ b/scripts/missions/windurst/9_1_Doll_of_the_Dead.lua
@@ -132,7 +132,7 @@ mission.sections =
                         (missionStatus == 4 or missionStatus == 5) and
                         npcUtil.tradeMatches(trade, { { xi.item.CLUMP_OF_GOOBBUE_HUMUS, 1 } })
                     then
-                        return mission:progressEvent(13)
+                        return mission:progressCutscene(13)
                     end
                 end,
 

--- a/scripts/missions/windurst/9_2_Moon_Reading.lua
+++ b/scripts/missions/windurst/9_2_Moon_Reading.lua
@@ -190,7 +190,7 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 1 and
                         not player:hasKeyItem(xi.ki.ANCIENT_VERSE_OF_ROMAEVE)
                     then
-                        return mission:progressEvent(4)
+                        return mission:progressCutscene(4)
                     end
                 end,
             },
@@ -212,7 +212,7 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 1 and
                         not player:hasKeyItem(xi.ki.ANCIENT_VERSE_OF_UGGALEPIH)
                     then
-                        return mission:progressEvent(68)
+                        return mission:progressCutscene(68)
                     end
                 end,
             },

--- a/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
+++ b/scripts/quests/ahtUrhgan/Luck_of_the_Draw.lua
@@ -83,7 +83,7 @@ quest.sections =
             {
                 onTrigger = function(player, npc)
                     if quest:getVar(player, 'Prog') == 2 then
-                        return quest:progressEvent(211)
+                        return quest:progressCutscene(211)
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes many events to cutscenes.

ZM 14, event 53: https://youtu.be/YT-kvjKeBC8 from Valentine
Corsair Unlock - Luck of the Draw, event 211: https://www.youtube.com/watch?v=gNIOv3UmKWw from Renala
Windurst 9-1, event 13: https://youtu.be/lTvFCUIVCSk?t=2071 from Valentine
Windurst 9-2 - Video thanks to Valentine
     event 4: https://youtu.be/s54IMysaksw?t=1236
     event 68: https://youtu.be/s54IMysaksw?t=1502

## Steps to test these changes

!addmission 3 26
!pos -40 0 -151 178

!addmission 2 22
!setmissionstatus name 4 2
!additem 1181
!pos 82 7 139 153
Trade

!addmission 2 23
!setmissionstatus name 1 2
!pos 0 -29 64 122
!pos -239 -1 -19 159

!addquest 6 6
!setquestvar name 6 6 Prog 2
!pos 469 -12 112 54