### PR TITLE
[lua] Mission 4-1 Audits

### DIFF
--- a/scripts/missions/bastok/4_1_Magicite.lua
+++ b/scripts/missions/bastok/4_1_Magicite.lua
@@ -3,31 +3,22 @@
 -- Bastok M4-1
 -----------------------------------
 -- !addmission 1 13
--- Goggehn               : !pos -32 9 -49 243
--- _6r2 (Embassy)        : !pos -31.107 7.501 -65.061 243
+-- Goggehn               : !pos 3 9 -78 243
+-- _6r2 (Embassy)        : !pos 18 8 -74 243
 -- _6r9 (Audience Chmbr) : !pos 0 -5 66 243
 -- Aldo                  : !pos 20 3 -58 245
 -- Paya-Sabya            : !pos 9 1 70 244
--- Muckvix               : !pos -26.824 3.601 -137.082 245
+-- Geebeh                : !pos 11 1 68 244
+-- Muckvix               : !pos -26.824 4.601 -137.082 245
 -- Magicite (Orastone)   : !pos -344 25 43 152
--- Magicite (Opistone)   : !pos -160 -8 8 150
+-- Magicite (Optistone)  : !pos -160 -8 8 150
 -- Magicite (Aurastone)  : !pos 11 25 -81 148
 -----------------------------------
-local ruludeID = zones[xi.zone.RULUDE_GARDENS]
+local ruludeID     = zones[xi.zone.RULUDE_GARDENS]
+local upperJeunoID = zones[xi.zone.UPPER_JEUNO]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.BASTOK, xi.mission.id.bastok.MAGICITE)
-
-local function magiciteCounter(player)
-    local count = 0
-    for keyItem = xi.ki.MAGICITE_OPTISTONE, xi.ki.MAGICITE_ORASTONE do
-        if player:hasKeyItem(keyItem) then
-            count = count + 1
-        end
-    end
-
-    return count
-end
 
 mission.reward =
 {
@@ -71,19 +62,26 @@ mission.sections =
 
             onEventFinish =
             {
+                -- Both menu answers carry on into the rest of the scene.
+                -- Only a cancelled event leaves the mission unstarted.
                 [129] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
                     mission:begin(player)
+                    player:messageText(npc, ruludeID.text.YOU_ACCEPT_THE_MISSION, false, 6)
                     npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,
             },
         },
     },
 
-    -- Section 1: Mandatory pre-requisites. Necesary steps required even when having completed this mission for another nation.
+    -- Section 1: Mandatory pre-requisites. Necessary steps required even when having completed this mission for another nation.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
-                player:getMissionStatus(mission.areaId) <= 2
+                player:getMissionStatus(mission.areaId) <= 1
         end,
 
         [xi.zone.RULUDE_GARDENS] =
@@ -93,9 +91,9 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if player:getMissionStatus(mission.areaId) == 0 then
                         return mission:progressEvent(128)
-                    else
-                        return mission:event(138, 1)
                     end
+
+                    return mission:event(138, 1)
                 end,
             },
 
@@ -124,13 +122,15 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        if player:hasKeyItem(xi.ki.SILVER_BELL) then
-                            return mission:progressEvent(152, 1) -- CS without Verena nor Fickblix
-                        else
-                            return mission:progressEvent(152) -- Regular CS with Verena and Fickblix
-                        end
+                    if player:getMissionStatus(mission.areaId) ~= 1 then
+                        return
                     end
+
+                    if player:hasKeyItem(xi.ki.SILVER_BELL) then
+                        return mission:progressEvent(152, 1) -- CS without Verena nor Fickblix
+                    end
+
+                    return mission:progressEvent(152, 0, 1) -- Regular CS with Verena and Fickblix
                 end,
             },
 
@@ -160,15 +160,20 @@ mission.sections =
             ['_6r9'] =
             {
                 onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 3 then
-                        if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                            return mission:progressEvent(60, 1, 1)
-                        else
-                            return mission:progressEvent(60)
-                        end
-                    else
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
                         return mission:event(138, 1)
                     end
+
+                    -- Param 0 swaps the airship pass for gil, param 1 skips the Eald'narche and Wolfgang scene when set.
+                    if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
+                        return mission:progressEvent(60, 1, 0)
+                    end
+
+                    return mission:progressEvent(60, 0, 0)
                 end,
             },
 
@@ -203,11 +208,15 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 0 then
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
                         return mission:event(161)
-                    else
-                        return mission:event(183)
                     end
+
+                    return mission:event(183)
                 end,
             },
 
@@ -241,13 +250,31 @@ mission.sections =
 
         [xi.zone.UPPER_JEUNO] =
         {
-            ['Paya-Sabya'] =
+            ['Geebeh'] =
             {
                 onTrigger = function(player, npc)
                     if
                         not player:hasKeyItem(xi.ki.YAGUDO_TORCH) and
-                        mission:getVar(player, 'Option') == 0
+                        mission:getVar(player, 'Option') == 1
                     then
+                        return mission:messageText(upperJeunoID.text.WITHER_AND_DIE)
+                    end
+                end,
+            },
+
+            ['Paya-Sabya'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
+                        return
+                    end
+
+                    local option = mission:getVar(player, 'Option')
+
+                    -- Event 23 is the follow up once the garden scene has played.
+                    if option == 1 then
+                        return mission:event(23)
+                    elseif option == 0 then
                         return mission:progressEvent(80)
                     end
                 end,
@@ -266,14 +293,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(44, 152, 3, 1743, 3)
-                        else
-                            return mission:progressEvent(44)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(44, xi.zone.ALTAR_ROOM, 3)
+                    end
+
+                    return mission:progressEvent(44, xi.zone.ALTAR_ROOM)
                 end,
             },
 
@@ -289,7 +321,12 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.MAGICITE_ORASTONE)
                 end,
 
+                -- A cancelled event does not retire the Fickblix scene.
                 [10000] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
                     mission:setVar(player, 'Option', 0)
                 end,
             },
@@ -300,14 +337,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1, 1, 1, 1, 1, 1, 1, 1)
-                        else
-                            return mission:progressEvent(0)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(0, 1, 1, 1, 1, 1, 1, 1, 1)
+                    end
+
+                    return mission:progressEvent(0, xi.zone.MONASTIC_CAVERN)
                 end,
             },
 
@@ -324,14 +366,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1)
-                        else
-                            return mission:progressEvent(0)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(0, 1, 46, 47)
+                    end
+
+                    return mission:progressEvent(0, 0, 46, 47)
                 end,
             },
 

--- a/scripts/missions/sandoria/4_1_Magicite.lua
+++ b/scripts/missions/sandoria/4_1_Magicite.lua
@@ -8,24 +8,17 @@
 -- _6r9 (Audience Chmbr) : !pos 0 -5 66 243
 -- Aldo                  : !pos 20 3 -58 245
 -- Paya-Sabya            : !pos 9 1 70 244
--- Muckvix               : !pos -26.824 3.601 -137.082 245
+-- Geebeh                : !pos 11 1 68 244
+-- Muckvix               : !pos -26.824 4.601 -137.082 245
 -- Magicite (Orastone)   : !pos -344 25 43 152
--- Magicite (Opistone)   : !pos -160 -8 8 150
+-- Magicite (Optistone)  : !pos -160 -8 8 150
 -- Magicite (Aurastone)  : !pos 11 25 -81 148
+-----------------------------------
+local ruludeID     = zones[xi.zone.RULUDE_GARDENS]
+local upperJeunoID = zones[xi.zone.UPPER_JEUNO]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.MAGICITE)
-
-local function magiciteCounter(player)
-    local count = 0
-    for keyItem = xi.ki.MAGICITE_OPTISTONE, xi.ki.MAGICITE_ORASTONE do
-        if player:hasKeyItem(keyItem) then
-            count = count + 1
-        end
-    end
-
-    return count
-end
 
 mission.reward =
 {
@@ -51,18 +44,40 @@ mission.sections =
                 onTrigger = function(player, npc)
                     if xi.mission.getMissionRankPoints(player, xi.mission.id.sandoria.MAGICITE) then
                         return mission:progressEvent(45)
-                    else
-                        return mission:progressEvent(49)
                     end
+
+                    return mission:event(49)
+                end,
+            },
+
+            ['_6r5'] =
+            {
+                onTrigger = function(player, npc)
+                    if not xi.mission.getMissionRankPoints(player, xi.mission.id.sandoria.MAGICITE) then
+                        return
+                    end
+
+                    if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
+                        return mission:progressEvent(130, 1)
+                    end
+
+                    return mission:progressEvent(130, 0)
                 end,
             },
 
             onEventFinish =
             {
-                [45] = function(player, csid, option, npc)
-                    -- TODO: Verify that the mission is displayed in the logs here.  It may not officially be logged
-                    -- until talking to the Ambassador.
+                -- Both menu answers carry on into the rest of the scene.
+                -- Only a cancelled event leaves the mission unstarted.
+                [130] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
                     mission:begin(player)
+                    player:setMissionStatus(mission.areaId, 1)
+                    player:messageText(npc, ruludeID.text.YOU_ACCEPT_THE_MISSION, false, 6)
+                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,
             },
         },
@@ -77,16 +92,6 @@ mission.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            ['_6r5'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        local hasKIParam = player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and 1 or 0
-                        return mission:progressEvent(130, hasKIParam)
-                    end
-                end,
-            },
-
             ['_6r9'] =
             {
                 onTrigger = function(player, npc)
@@ -96,39 +101,14 @@ mission.sections =
                 end,
             },
 
-            ['High_Wind'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        -- Note: The event parameter below corresponds to having keyItem for Audience Permit.
-                        -- Currently have not captured a case where the negative answer is displayed.
-                        return mission:progressEvent(164, 1)
-                    end
-                end,
-            },
-
-            ['Rainhard'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        return mission:progressEvent(165, 1)
-                    end
-                end,
-            },
-
             ['Nelcabrit'] =
             {
                 onTrigger = function(player, npc)
-                    local missionStatus = player:getMissionStatus(mission.areaId)
-
-                    if missionStatus == 0 then
-                        -- Nelcabrit will display this message until talking to Jima (Door)
-                        return mission:progressEvent(45)
-                    elseif missionStatus == 1 then
-                        return mission:progressEvent(133)
-                    else
-                        return mission:progressEvent(136)
+                    if player:getMissionStatus(mission.areaId) == 1 then
+                        return mission:event(133)
                     end
+
+                    return mission:event(136)
                 end,
             },
 
@@ -138,12 +118,6 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 2)
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ALDO)
                 end,
-
-                [130] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 1)
-                    -- You Accept the Mission message here
-                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
-                end,
             },
         },
 
@@ -152,13 +126,15 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 2 then
-                        if player:hasKeyItem(xi.ki.SILVER_BELL) then
-                            return mission:progressEvent(152, 1)
-                        else
-                            return mission:progressEvent(152)
-                        end
+                    if player:getMissionStatus(mission.areaId) ~= 2 then
+                        return
                     end
+
+                    if player:hasKeyItem(xi.ki.SILVER_BELL) then
+                        return mission:progressEvent(152, 1)
+                    end
+
+                    return mission:progressEvent(152, 0, 1)
                 end,
             },
 
@@ -188,38 +164,26 @@ mission.sections =
             ['_6r9'] =
             {
                 onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 3 then
-                        if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                            return mission:progressEvent(60, 1, 1)
-                        else
-                            return mission:progressEvent(60)
-                        end
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return
                     end
-                end,
-            },
 
-            ['High_Wind'] =
-            {
-                onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 3 then
-                        return mission:progressEvent(164, 1)
+                    if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
+                        return mission:progressEvent(60, 1, 0)
                     end
-                end,
-            },
 
-            ['Rainhard'] =
-            {
-                onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 3 then
-                        return mission:progressEvent(165, 1)
-                    end
+                    return mission:progressEvent(60, 0, 0)
                 end,
             },
 
             ['Nelcabrit'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(136)
+                    return mission:event(136)
                 end,
             },
 
@@ -247,11 +211,15 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 0 then
-                        return mission:progressEvent(161)
-                    else
-                        return mission:progressEvent(183)
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return mission:event(161)
                     end
+
+                    return mission:event(183)
                 end,
             },
 
@@ -262,13 +230,13 @@ mission.sections =
                         if mission:getVar(player, 'Option') == 1 then
                             return mission:progressEvent(184)
                         else
-                            return mission:progressEvent(80)
+                            return mission:event(80)
                         end
                     else
                         if mission:getVar(player, 'Option') == 2 then
-                            return mission:progressEvent(81)
+                            return mission:event(81)
                         else
-                            return mission:progressEvent(79)
+                            return mission:event(79)
                         end
                     end
                 end,
@@ -285,13 +253,31 @@ mission.sections =
 
         [xi.zone.UPPER_JEUNO] =
         {
-            ['Paya-Sabya'] =
+            ['Geebeh'] =
             {
                 onTrigger = function(player, npc)
                     if
                         not player:hasKeyItem(xi.ki.YAGUDO_TORCH) and
-                        mission:getVar(player, 'Option') == 0
+                        mission:getVar(player, 'Option') == 1
                     then
+                        return mission:messageText(upperJeunoID.text.WITHER_AND_DIE)
+                    end
+                end,
+            },
+
+            ['Paya-Sabya'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
+                        return
+                    end
+
+                    local option = mission:getVar(player, 'Option')
+
+                    -- Event 23 is the follow up once the garden scene has played.
+                    if option == 1 then
+                        return mission:event(23)
+                    elseif option == 0 then
                         return mission:progressEvent(80)
                     end
                 end,
@@ -310,14 +296,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(44, 152, 3, 1743, 3)
-                        else
-                            return mission:progressEvent(44)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(44, xi.zone.ALTAR_ROOM, 3)
+                    end
+
+                    return mission:progressEvent(44, xi.zone.ALTAR_ROOM)
                 end,
             },
 
@@ -333,7 +324,12 @@ mission.sections =
                     npcUtil.giveKeyItem(player, xi.ki.MAGICITE_ORASTONE)
                 end,
 
+                -- A cancelled event does not retire the Fickblix scene.
                 [10000] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
                     mission:setVar(player, 'Option', 0)
                 end,
             },
@@ -344,14 +340,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1, 1, 1, 1, 1, 1, 1, 1)
-                        else
-                            return mission:progressEvent(0)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(0, 1, 1, 1, 1, 1, 1, 1, 1)
+                    end
+
+                    return mission:progressEvent(0, xi.zone.MONASTIC_CAVERN)
                 end,
             },
 
@@ -368,14 +369,19 @@ mission.sections =
             ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1, 46, 47)
-                        else
-                            return mission:progressEvent(0, 0, 46, 47)
-                        end
+                    if player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
+                        return
                     end
+
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        -- Play Lion part of the CS (Last Magicite Received)
+                        return mission:progressEvent(0, 1, 46, 47)
+                    end
+
+                    return mission:progressEvent(0, 0, 46, 47)
                 end,
             },
 
@@ -397,14 +403,7 @@ mission.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            ['Nelcabrit'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 4 then
-                        return mission:progressEvent(36)
-                    end
-                end,
-            },
+            ['Nelcabrit'] = mission:progressEvent(36),
 
             onEventFinish =
             {
@@ -419,7 +418,7 @@ mission.sections =
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    return mission:progressEvent(183)
+                    return mission:event(183)
                 end,
             },
         },

--- a/scripts/missions/windurst/4_1_Magicite.lua
+++ b/scripts/missions/windurst/4_1_Magicite.lua
@@ -3,29 +3,22 @@
 -- Windurst M4-1
 -----------------------------------
 -- !addmission 2 13
--- Pakh Jatalfih         : !pos -32 9 -49 243
--- _6r8 (Embassy)        : !pos -31.107 7.501 -65.061 243
+-- Pakh Jatalfih         : !pos 34 8 -35 243
+-- _6r8 (Embassy)        : !pos 31 9 -22 243
 -- _6r9 (Audience Chmbr) : !pos 0 -5 66 243
 -- Aldo                  : !pos 20 3 -58 245
 -- Paya-Sabya            : !pos 9 1 70 244
--- Muckvix               : !pos -26.824 3.601 -137.082 245
+-- Geebeh                : !pos 11 1 68 244
+-- Muckvix               : !pos -26.824 4.601 -137.082 245
 -- Magicite (Orastone)   : !pos -344 25 43 152
--- Magicite (Opistone)   : !pos -160 -8 8 150
+-- Magicite (Optistone)  : !pos -160 -8 8 150
 -- Magicite (Aurastone)  : !pos 11 25 -81 148
+-----------------------------------
+local ruludeID     = zones[xi.zone.RULUDE_GARDENS]
+local upperJeunoID = zones[xi.zone.UPPER_JEUNO]
 -----------------------------------
 
 local mission = Mission:new(xi.mission.log_id.WINDURST, xi.mission.id.windurst.MAGICITE)
-
-local function magiciteCounter(player)
-    local count = 0
-    for keyItem = xi.ki.MAGICITE_OPTISTONE, xi.ki.MAGICITE_ORASTONE do
-        if player:hasKeyItem(keyItem) then
-            count = count + 1
-        end
-    end
-
-    return count
-end
 
 mission.reward =
 {
@@ -46,64 +39,63 @@ mission.sections =
 
         [xi.zone.RULUDE_GARDENS] =
         {
+            ['_6r8'] =
+            {
+                onTrigger = function(player, npc)
+                    if not xi.mission.getMissionRankPoints(player, xi.mission.id.windurst.MAGICITE) then
+                        return
+                    end
+
+                    if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
+                        return mission:progressEvent(131, 1)
+                    end
+
+                    return mission:progressEvent(131, 0)
+                end,
+            },
+
+            -- Event 50 points at the embassy door.
+            -- Progress priority keeps it ahead of the event 54 that 3-3 serves on this NPC.
             ['Pakh_Jatalfih'] =
             {
                 onTrigger = function(player, npc)
                     if xi.mission.getMissionRankPoints(player, xi.mission.id.windurst.MAGICITE) then
                         return mission:progressEvent(50)
-                    else
-                        return mission:progressEvent(54)
                     end
+
+                    return mission:event(54)
                 end,
             },
 
             onEventFinish =
             {
-                [50] = function(player, csid, option, npc)
+                -- Both menu answers carry on into the rest of the scene.
+                -- Only a cancelled event leaves the mission unstarted.
+                [131] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
                     mission:begin(player)
+                    player:setMissionStatus(mission.areaId, 1)
+                    player:messageText(npc, ruludeID.text.YOU_ACCEPT_THE_MISSION, false, 6)
+                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
                 end,
             },
         },
     },
 
-    -- Section 1: Mandatory pre-requisites. Necesary steps required even when having completed this mission for another nation.
+    -- Permit obtained. The archduke has not been seen.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
-                player:getMissionStatus(mission.areaId) <= 2
+                player:getMissionStatus(mission.areaId) == 1
         end,
 
         [xi.zone.RULUDE_GARDENS] =
         {
-            ['_6r8'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 0 then
-                        local hasKIParam = player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) and 1 or 0
-                        return mission:progressEvent(131, hasKIParam)
-                    end
-                end,
-            },
-
-            ['_6r9'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        return mission:progressEvent(128)
-                    end
-                end,
-            },
-
-            ['Pakh_Jatalfih'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 1 then
-                        return mission:progressEvent(134)
-                    else
-                        return mission:progressEvent(137)
-                    end
-                end,
-            },
+            ['_6r9']          = mission:progressEvent(128),
+            ['Pakh_Jatalfih'] = mission:event(134),
 
             onEventFinish =
             {
@@ -111,26 +103,27 @@ mission.sections =
                     player:setMissionStatus(mission.areaId, 2)
                     npcUtil.giveKeyItem(player, xi.ki.LETTER_TO_ALDO)
                 end,
-
-                [131] = function(player, csid, option, npc)
-                    player:setMissionStatus(mission.areaId, 1)
-                    npcUtil.giveKeyItem(player, xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
-                end,
             },
         },
+    },
+
+    -- Carrying the letter to Aldo.
+    {
+        check = function(player, currentMission, missionStatus, vars)
+            return currentMission == mission.missionId and
+                player:getMissionStatus(mission.areaId) == 2
+        end,
 
         [xi.zone.LOWER_JEUNO] =
         {
             ['Aldo'] =
             {
                 onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 2 then
-                        if player:hasKeyItem(xi.ki.SILVER_BELL) then
-                            return mission:progressEvent(152, 1)
-                        else
-                            return mission:progressEvent(152)
-                        end
+                    if player:hasKeyItem(xi.ki.SILVER_BELL) then
+                        return mission:progressEvent(152, 1, 1)
                     end
+
+                    return mission:progressEvent(152, 0, 1)
                 end,
             },
 
@@ -146,36 +139,190 @@ mission.sections =
                 end,
             },
         },
+
+        [xi.zone.RULUDE_GARDENS] =
+        {
+            ['Pakh_Jatalfih'] = mission:event(137),
+        },
     },
 
-    -- Section 2: Key Item hunt and Magicite obtention. Several steps aren't required or may have been already completed in another nation.
+    -- Key item hunt and magicite gathering.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
                 player:getMissionStatus(mission.areaId) == 3
         end,
 
-        [xi.zone.RULUDE_GARDENS] =
+        [xi.zone.ALTAR_ROOM] =
         {
-            ['_6r9'] =
+            ['Magicite'] =
             {
                 onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 3 then
-                        if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-                            return mission:progressEvent(60, 1, 1)
+                    if player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
+                        return
+                    end
+
+                    -- Param 1 appends the Lion and Shadow of Darkness scene when this completes the set.
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE)
+                    then
+                        return mission:progressEvent(44, xi.zone.ALTAR_ROOM, 3)
+                    end
+
+                    return mission:progressEvent(44, xi.zone.ALTAR_ROOM)
+                end,
+            },
+
+            onZoneIn = function(player, prevZone)
+                if mission:getVar(player, 'Option') == 2 then -- Fickblix CS
+                    return 10000
+                end
+            end,
+
+            onEventFinish =
+            {
+                [44] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_ORASTONE)
+                end,
+
+                -- A cancelled event does not retire the Fickblix scene.
+                [10000] = function(player, csid, option, npc)
+                    if option == utils.EVENT_CANCELLED_OPTION then
+                        return
+                    end
+
+                    mission:setVar(player, 'Option', 0)
+                end,
+            },
+        },
+
+        [xi.zone.LOWER_JEUNO] =
+        {
+            ['Aldo'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return mission:event(161)
+                    end
+
+                    return mission:event(183)
+                end,
+            },
+
+            ['Muckvix'] =
+            {
+                onTrigger = function(player, npc)
+                    if not player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
+                        if mission:getVar(player, 'Option') == 1 then
+                            return mission:progressEvent(184)
                         else
-                            return mission:progressEvent(60)
+                            return mission:event(80)
+                        end
+                    else
+                        if mission:getVar(player, 'Option') == 2 then
+                            return mission:event(81)
+                        else
+                            return mission:event(79)
                         end
                     end
                 end,
             },
 
-            ['Pakh_Jatalfih'] =
+            onEventFinish =
             {
-                onTrigger = function(player, npc)
-                    return mission:progressEvent(137)
+                [184] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.YAGUDO_TORCH)
+                    mission:setVar(player, 'Option', 2) -- Fickblix CS
                 end,
             },
+        },
+
+        [xi.zone.MONASTIC_CAVERN] =
+        {
+            ['Magicite'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
+                        return
+                    end
+
+                    -- Param 2 appends the Lion and Shadow of Darkness scene when this completes the set.
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return mission:progressEvent(0, xi.zone.MONASTIC_CAVERN, 0, 1)
+                    end
+
+                    return mission:progressEvent(0, xi.zone.MONASTIC_CAVERN)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [0] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_OPTISTONE)
+                end,
+            },
+        },
+
+        [xi.zone.QULUN_DOME] =
+        {
+            ['Magicite'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
+                        return
+                    end
+
+                    -- Param 0 appends the Lion and Shadow of Darkness scene when this completes the set.
+                    if
+                        player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) and
+                        player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return mission:progressEvent(0, 1, xi.ki.CORUSCANT_ROSARY, xi.ki.BLACK_MATINEE_NECKLACE)
+                    end
+
+                    return mission:progressEvent(0, 0, xi.ki.CORUSCANT_ROSARY, xi.ki.BLACK_MATINEE_NECKLACE)
+                end,
+            },
+
+            onEventFinish =
+            {
+                [0] = function(player, csid, option, npc)
+                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_AURASTONE)
+                end,
+            },
+        },
+
+        [xi.zone.RULUDE_GARDENS] =
+        {
+            ['_6r9'] =
+            {
+                onTrigger = function(player, npc)
+                    if
+                        not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) or
+                        not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE)
+                    then
+                        return
+                    end
+
+                    -- Param 0 swaps the airship pass for gil, param 1 skips the Eald'narche and Wolfgang scene when set.
+                    if player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
+                        return mission:progressEvent(60, 1, 0)
+                    end
+
+                    return mission:progressEvent(60, 0, 0)
+                end,
+            },
+
+            ['Pakh_Jatalfih'] = mission:event(137),
 
             onEventFinish =
             {
@@ -196,58 +343,33 @@ mission.sections =
             },
         },
 
-        [xi.zone.LOWER_JEUNO] =
-        {
-            ['Aldo'] =
-            {
-                onTrigger = function(player, npc)
-                    if magiciteCounter(player) == 0 then
-                        return mission:progressEvent(161)
-                    else
-                        return mission:progressEvent(183)
-                    end
-                end,
-            },
-
-            ['Muckvix'] =
-            {
-                onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
-                        if mission:getVar(player, 'Option') == 1 then
-                            return mission:progressEvent(184)
-                        else
-                            return mission:progressEvent(80)
-                        end
-                    else
-                        if mission:getVar(player, 'Option') == 2 then
-                            return mission:progressEvent(81)
-                        else
-                            return mission:progressEvent(79)
-                        end
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [184] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.YAGUDO_TORCH)
-                    mission:setVar(player, 'Option', 2) -- Fickbix CS
-                end,
-            },
-        },
-
         [xi.zone.UPPER_JEUNO] =
         {
-            ['Paya-Sabya'] =
+            ['Geebeh'] =
             {
                 onTrigger = function(player, npc)
                     if
                         not player:hasKeyItem(xi.ki.YAGUDO_TORCH) and
-                        mission:getVar(player, 'Option') == 0
+                        mission:getVar(player, 'Option') == 1
                     then
-                        return mission:progressEvent(80)
+                        return mission:messageText(upperJeunoID.text.WITHER_AND_DIE)
                     end
+                end,
+            },
+
+            ['Paya-Sabya'] =
+            {
+                onTrigger = function(player, npc)
+                    if player:hasKeyItem(xi.ki.YAGUDO_TORCH) then
+                        return
+                    end
+
+                    -- Event 23 is the follow up once the garden scene has played.
+                    if mission:getVar(player, 'Option') == 1 then
+                        return mission:event(23)
+                    end
+
+                    return mission:progressEvent(80)
                 end,
             },
 
@@ -258,122 +380,28 @@ mission.sections =
                 end,
             },
         },
-
-        [xi.zone.ALTAR_ROOM] =
-        {
-            ['Magicite'] =
-            {
-                onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_ORASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(44, 152, 3, 1743, 3)
-                        else
-                            return mission:progressEvent(44)
-                        end
-                    end
-                end,
-            },
-
-            onZoneIn = function(player, prevZone)
-                if mission:getVar(player, 'Option') == 2 then -- Fickbix CS
-                    return 10000
-                end
-            end,
-
-            onEventFinish =
-            {
-                [44] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_ORASTONE)
-                end,
-
-                [10000] = function(player, csid, option, npc)
-                    mission:setVar(player, 'Option', 0)
-                end,
-            },
-        },
-
-        [xi.zone.MONASTIC_CAVERN] =
-        {
-            ['Magicite'] =
-            {
-                onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_OPTISTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1, 1, 1, 1, 1, 1, 1, 1)
-                        else
-                            return mission:progressEvent(0)
-                        end
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [0] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_OPTISTONE)
-                end,
-            },
-        },
-
-        [xi.zone.QULUN_DOME] =
-        {
-            ['Magicite'] =
-            {
-                onTrigger = function(player, npc)
-                    if not player:hasKeyItem(xi.ki.MAGICITE_AURASTONE) then
-                        if magiciteCounter(player) == 2 then
-                            -- Play Lion part of the CS (Last Magicite Received)
-                            return mission:progressEvent(0, 1)
-                        else
-                            return mission:progressEvent(0)
-                        end
-                    end
-                end,
-            },
-
-            onEventFinish =
-            {
-                [0] = function(player, csid, option, npc)
-                    npcUtil.giveKeyItem(player, xi.ki.MAGICITE_AURASTONE)
-                end,
-            },
-        },
     },
 
-    -- Section 3: Magicite given to Jeuno totally-not-evil leader. Finish quest.
+    -- The stones are handed over. The embassy closes the mission.
     {
         check = function(player, currentMission, missionStatus, vars)
             return currentMission == mission.missionId and
                 player:getMissionStatus(mission.areaId) == 4
         end,
 
+        [xi.zone.LOWER_JEUNO] =
+        {
+            ['Aldo'] = mission:event(183),
+        },
+
         [xi.zone.RULUDE_GARDENS] =
         {
-            ['Pakh_Jatalfih'] =
-            {
-                onTrigger = function(player, npc)
-                    if player:getMissionStatus(mission.areaId) == 4 then
-                        return mission:progressEvent(37)
-                    end
-                end,
-            },
+            ['Pakh_Jatalfih'] = mission:progressEvent(37),
 
             onEventFinish =
             {
                 [37] = function(player, csid, option, npc)
                     mission:complete(player)
-                end,
-            },
-        },
-
-        [xi.zone.LOWER_JEUNO] =
-        {
-            ['Aldo'] =
-            {
-                onTrigger = function(player, npc)
-                    return mission:progressEvent(183)
                 end,
             },
         },

--- a/scripts/quests/jeuno/Mysteries_of_Beadeaux_I.lua
+++ b/scripts/quests/jeuno/Mysteries_of_Beadeaux_I.lua
@@ -4,13 +4,10 @@
 -- Log ID: 3, Quest ID: 31
 -- Sattal-Mansal : !pos 40 3 -53 245
 -----------------------------------
+local lowerJeunoID = zones[xi.zone.LOWER_JEUNO]
+-----------------------------------
 
 local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.MYSTERIES_OF_BEADEAUX_I)
-
-quest.reward =
-{
-    keyItem = xi.ki.CORUSCANT_ROSARY,
-}
 
 quest.sections =
 {
@@ -25,7 +22,7 @@ quest.sections =
             ['Sattal-Mansal'] =
             {
                 onTrigger = function(player, npc)
-                    return quest:progressEvent(89)
+                    return quest:progressEvent(89, 0)
                 end,
             },
 
@@ -49,26 +46,34 @@ quest.sections =
         {
             ['Sattal-Mansal'] =
             {
+                -- Retail hands over the reward as the event starts. The message prints when it ends.
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.QUADAV_CHARM) then
-                        return quest:progressEvent(91)
+                    if not npcUtil.tradeMatches(trade, { { xi.item.QUADAV_CHARM, 1 } }) then
+                        return
                     end
+
+                    player:addKeyItem(xi.ki.CORUSCANT_ROSARY)
+                    player:addFame(xi.fameArea.SANDORIA, 7)
+                    player:addFame(xi.fameArea.BASTOK, 7)
+                    player:addFame(xi.fameArea.WINDURST, 7)
+                    player:tradeComplete()
+
+                    return quest:progressEvent(91)
                 end,
+
+                -- Param 0 flags the offer as already taken.
+                onTrigger = quest:event(89, 1),
             },
 
             onEventFinish =
             {
                 [91] = function(player, csid, option, npc)
-                    if quest:complete(player) then
-                        player:addFame(xi.fameArea.SANDORIA, 7)
-                        player:addFame(xi.fameArea.BASTOK, 7)
-                        player:addFame(xi.fameArea.WINDURST, 7)
-                        player:confirmTrade()
-                    end
+                    player:completeQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.MYSTERIES_OF_BEADEAUX_I)
+                    player:messageSpecial(lowerJeunoID.text.KEYITEM_OBTAINED, xi.ki.CORUSCANT_ROSARY)
                 end,
             },
         },
-    }
+    },
 }
 
 return quest

--- a/scripts/quests/jeuno/Mysteries_of_Beadeaux_II.lua
+++ b/scripts/quests/jeuno/Mysteries_of_Beadeaux_II.lua
@@ -4,13 +4,10 @@
 -- Log ID: 3, Quest ID: 32
 -- Sattal-Mansal : !pos 40 3 -53 245
 -----------------------------------
+local lowerJeunoID = zones[xi.zone.LOWER_JEUNO]
+-----------------------------------
 
 local quest = Quest:new(xi.questLog.JEUNO, xi.quest.id.jeuno.MYSTERIES_OF_BEADEAUX_II)
-
-quest.reward =
-{
-    keyItem = xi.ki.BLACK_MATINEE_NECKLACE,
-}
 
 quest.sections =
 {
@@ -24,26 +21,31 @@ quest.sections =
         {
             ['Sattal-Mansal'] =
             {
+                -- Retail hands over the reward as the event starts. The message prints when it ends.
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, xi.item.QUADAV_AUGURY_SHELL) then
-                        return quest:progressEvent(92)
+                    if not npcUtil.tradeMatches(trade, { { xi.item.QUADAV_AUGURY_SHELL, 1 } }) then
+                        return
                     end
+
+                    player:addKeyItem(xi.ki.BLACK_MATINEE_NECKLACE)
+                    player:addFame(xi.fameArea.SANDORIA, 7)
+                    player:addFame(xi.fameArea.BASTOK, 7)
+                    player:addFame(xi.fameArea.WINDURST, 7)
+                    player:tradeComplete()
+
+                    return quest:progressEvent(92)
                 end,
             },
 
             onEventFinish =
             {
                 [92] = function(player, csid, option, npc)
-                    if quest:complete(player) then
-                        player:addFame(xi.fameArea.SANDORIA, 7)
-                        player:addFame(xi.fameArea.BASTOK, 7)
-                        player:addFame(xi.fameArea.WINDURST, 7)
-                        player:confirmTrade()
-                    end
+                    player:completeQuest(xi.questLog.JEUNO, xi.quest.id.jeuno.MYSTERIES_OF_BEADEAUX_II)
+                    player:messageSpecial(lowerJeunoID.text.KEYITEM_OBTAINED, xi.ki.BLACK_MATINEE_NECKLACE)
                 end,
             },
         },
-    }
+    },
 }
 
 return quest

--- a/scripts/quests/jeuno/Save_My_Sister.lua
+++ b/scripts/quests/jeuno/Save_My_Sister.lua
@@ -47,7 +47,9 @@ quest.sections =
                 onTrigger = function(player, npc)
                     local questProgress = quest:getVar(player, 'Prog')
 
-                    if questProgress == 1 then
+                    if questProgress == 0 then
+                        return quest:progressEvent(172)
+                    elseif questProgress == 1 then
                         return quest:progressEvent(105)
                     elseif questProgress == 3 then
                         return quest:event(27)
@@ -102,7 +104,7 @@ quest.sections =
                     if questProgress == 2 then
                         return quest:progressEvent(98)
                     elseif questProgress >= 3 then
-                        return quest:progressEvent(99)
+                        return quest:event(99)
                     end
                 end,
             },

--- a/scripts/tests/missions/bastok.lua
+++ b/scripts/tests/missions/bastok.lua
@@ -171,4 +171,88 @@ describe('Bastok Missions', function()
             player.assert:hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.WADING_BEASTS)
         end)
     end)
+
+    describe('Magicite', function()
+        before_each(function()
+            player:setRank(4)
+            player:setRankPoints(4000)
+        end)
+
+        it('should not start the mission from the embassy attendant', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('Goggehn', { eventId = 0 })
+
+            player.assert:hasMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should not start the mission when the door event is cancelled', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r2', { eventId = 129, finishOption = utils.EVENT_CANCELLED_OPTION })
+
+            player.assert:hasMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should start the mission at the embassy door', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r2', { eventId = 129, finishOption = 1 })
+
+            player.assert:hasMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.MAGICITE)
+            player.assert:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should give Paya-Sabya a follow up line once the garden scene has played', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r2', { eventId = 129, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+
+            player:gotoZone(xi.zone.UPPER_JEUNO)
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 80 })
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 23 })
+        end)
+
+        it('should complete the mission', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r2', { eventId = 129, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+            player.assert:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            -- Aldo trades the letter for the silver bell.
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+            player.assert:hasKI(xi.ki.SILVER_BELL)
+            player.assert.no:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            player:gotoZone(xi.zone.MONASTIC_CAVERN)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_OPTISTONE)
+
+            player:gotoZone(xi.zone.ALTAR_ROOM)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 44 })
+            player.assert:hasKI(xi.ki.MAGICITE_ORASTONE)
+
+            -- The last stone appends the Lion and Shadow of Darkness scene to the same event.
+            player:gotoZone(xi.zone.QULUN_DOME)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            -- The archduke takes all three stones and issues the airship pass.
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r9', { eventId = 60 })
+            player.assert:hasKI(xi.ki.AIRSHIP_PASS)
+            player.assert.no:hasKI(xi.ki.MAGICITE_OPTISTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_ORASTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            player.entities:gotoAndTrigger('Goggehn', { eventId = 35 })
+            player.assert
+                :hasMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.NONE)
+                :hasCompletedMission(xi.mission.log_id.BASTOK, xi.mission.id.bastok.MAGICITE)
+                :hasKI(xi.ki.MESSAGE_TO_JEUNO_BASTOK)
+        end)
+    end)
 end)

--- a/scripts/tests/missions/sandoria.lua
+++ b/scripts/tests/missions/sandoria.lua
@@ -98,4 +98,88 @@ describe('San d\'Oria', function()
             player.entities:gotoAndTrigger('Arnau', { eventId = 694 })
         end)
     end)
+
+    describe('Magicite', function()
+        before_each(function()
+            player:setRank(4)
+            player:setRankPoints(4000)
+        end)
+
+        it('should not start the mission from the embassy attendant', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('Nelcabrit', { eventId = 45 })
+
+            player.assert:hasMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should not start the mission when the door event is cancelled', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r5', { eventId = 130, finishOption = utils.EVENT_CANCELLED_OPTION })
+
+            player.assert:hasMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should start the mission at the embassy door', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r5', { eventId = 130, finishOption = 1 })
+
+            player.assert:hasMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.MAGICITE)
+            player.assert:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should give Paya-Sabya a follow up line once the garden scene has played', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r5', { eventId = 130, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+
+            player:gotoZone(xi.zone.UPPER_JEUNO)
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 80 })
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 23 })
+        end)
+
+        it('should complete the mission', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r5', { eventId = 130, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+            player.assert:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            -- Aldo trades the letter for the silver bell.
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+            player.assert:hasKI(xi.ki.SILVER_BELL)
+            player.assert.no:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            player:gotoZone(xi.zone.MONASTIC_CAVERN)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_OPTISTONE)
+
+            player:gotoZone(xi.zone.ALTAR_ROOM)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 44 })
+            player.assert:hasKI(xi.ki.MAGICITE_ORASTONE)
+
+            -- The last stone appends the Lion and Shadow of Darkness scene to the same event.
+            player:gotoZone(xi.zone.QULUN_DOME)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            -- The archduke takes all three stones and issues the airship pass.
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r9', { eventId = 60 })
+            player.assert:hasKI(xi.ki.AIRSHIP_PASS)
+            player.assert.no:hasKI(xi.ki.MAGICITE_OPTISTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_ORASTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            player.entities:gotoAndTrigger('Nelcabrit', { eventId = 36 })
+            player.assert
+                :hasMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.NONE)
+                :hasCompletedMission(xi.mission.log_id.SANDORIA, xi.mission.id.sandoria.MAGICITE)
+                :hasKI(xi.ki.MESSAGE_TO_JEUNO_SANDORIA)
+        end)
+    end)
 end)

--- a/scripts/tests/missions/windurst.lua
+++ b/scripts/tests/missions/windurst.lua
@@ -1,0 +1,91 @@
+describe('Windurst', function()
+    ---@type CClientEntityPair
+    local player
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer()
+
+        player:setNation(xi.nation.WINDURST)
+        player:setRank(4)
+        player:setRankPoints(4000)
+    end)
+
+    describe('Magicite', function()
+        it('should not start the mission from the embassy attendant', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('Pakh_Jatalfih', { eventId = 50 })
+
+            player.assert:hasMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should not start the mission when the door event is cancelled', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r8', { eventId = 131, finishOption = utils.EVENT_CANCELLED_OPTION })
+
+            player.assert:hasMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.NONE)
+            player.assert.no:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should start the mission at the embassy door', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r8', { eventId = 131, finishOption = 1 })
+
+            player.assert:hasMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.MAGICITE)
+            player.assert:hasKI(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT)
+        end)
+
+        it('should give Paya-Sabya a follow up line once the garden scene has played', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r8', { eventId = 131, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+
+            player:gotoZone(xi.zone.UPPER_JEUNO)
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 80 })
+            player.entities:gotoAndTrigger('Paya-Sabya', { eventId = 23 })
+        end)
+
+        it('should complete the mission', function()
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r8', { eventId = 131, finishOption = 1 })
+            player.entities:gotoAndTrigger('_6r9', { eventId = 128 })
+            player.assert:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            -- Aldo trades the letter for the silver bell.
+            player:gotoZone(xi.zone.LOWER_JEUNO)
+            player.entities:gotoAndTrigger('Aldo', { eventId = 152 })
+            player.assert:hasKI(xi.ki.SILVER_BELL)
+            player.assert.no:hasKI(xi.ki.LETTER_TO_ALDO)
+
+            player:gotoZone(xi.zone.MONASTIC_CAVERN)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_OPTISTONE)
+
+            player:gotoZone(xi.zone.ALTAR_ROOM)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 44 })
+            player.assert:hasKI(xi.ki.MAGICITE_ORASTONE)
+
+            -- The last stone appends the Lion and Shadow of Darkness scene to the same event.
+            player:gotoZone(xi.zone.QULUN_DOME)
+            player.entities:gotoAndTrigger('Magicite', { eventId = 0 })
+            player.assert:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            -- The archduke takes all three stones and issues the airship pass.
+            player:gotoZone(xi.zone.RULUDE_GARDENS)
+            player.entities:gotoAndTrigger('_6r9', { eventId = 60 })
+            player.assert:hasKI(xi.ki.AIRSHIP_PASS)
+            player.assert.no:hasKI(xi.ki.MAGICITE_OPTISTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_ORASTONE)
+            player.assert.no:hasKI(xi.ki.MAGICITE_AURASTONE)
+
+            player.entities:gotoAndTrigger('Pakh_Jatalfih', { eventId = 37 })
+            player.assert
+                :hasMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.NONE)
+                :hasCompletedMission(xi.mission.log_id.WINDURST, xi.mission.id.windurst.MAGICITE)
+                :hasKI(xi.ki.MESSAGE_TO_JEUNO_WINDURST)
+        end)
+    end)
+end)

--- a/scripts/zones/Altar_Room/DefaultActions.lua
+++ b/scripts/zones/Altar_Room/DefaultActions.lua
@@ -1,6 +1,3 @@
-local ID = zones[xi.zone.ALTAR_ROOM]
-
 return {
-    ['Hooknox']  = { event = 46 },
-    ['Magicite'] = { messageSpecial = ID.text.THE_MAGICITE_GLOWS_OMINOUSLY },
+    ['Hooknox'] = { event = 46 },
 }

--- a/scripts/zones/Altar_Room/npcs/Magicite.lua
+++ b/scripts/zones/Altar_Room/npcs/Magicite.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Altar Room
+--  NPC: Magicite
+-- Involved in Mission: Magicite
+-- !pos -346.776 21.833 46.173 152
+-----------------------------------
+local ID = zones[xi.zone.ALTAR_ROOM]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:messageText(npc, ID.text.THE_MAGICITE_GLOWS_OMINOUSLY, false, 6)
+end
+
+return entity

--- a/scripts/zones/Castle_Oztroja/npcs/_47c.lua
+++ b/scripts/zones/Castle_Oztroja/npcs/_47c.lua
@@ -47,7 +47,7 @@ entity.onTrigger = function(player, npc)
             end
         end
     else
-        player:messageSpecial(ID.text.CANNOT_REACH_TARGET)
+        player:messageText(npc, ID.text.CANNOT_REACH_TARGET, false, 6)
     end
 end
 

--- a/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
+++ b/scripts/zones/Lower_Jeuno/npcs/Derrick.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if not player:hasKeyItem(xi.ki.AIRSHIP_PASS) then
-        player:startEvent(230, 12)
+        player:startEvent(230, utils.MAX_UINT32 - 2, 10)
     else
         player:startEvent(230, 14)
     end
@@ -21,6 +21,7 @@ entity.onEventUpdate = function(player, csid, option, npc)
     if csid == 230 and option == 10 then
         if player:delGil(500000) then
             player:addKeyItem(xi.ki.AIRSHIP_PASS)
+            player:addTitle(xi.title.HAVE_WINGS_WILL_FLY)
             player:updateEvent(0, 1)
         else
             player:updateEvent(0, 0)

--- a/scripts/zones/Monastic_Cavern/DefaultActions.lua
+++ b/scripts/zones/Monastic_Cavern/DefaultActions.lua
@@ -3,6 +3,5 @@ local ID = zones[xi.zone.MONASTIC_CAVERN]
 return {
     ['Altar']     = { messageSpecial = ID.text.ALTAR },
     ['Loo_Kohor'] = { event = 5 },
-    ['Magicite']  = { messageSpecial = ID.text.THE_MAGICITE_GLOWS_OMINOUSLY },
     ['qm1']       = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
 }

--- a/scripts/zones/Monastic_Cavern/npcs/Magicite.lua
+++ b/scripts/zones/Monastic_Cavern/npcs/Magicite.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Monastic Cavern
+--  NPC: Magicite
+-- Involved in Mission: Magicite
+-- !pos -160.899 -8.437 7.800 150
+-----------------------------------
+local ID = zones[xi.zone.MONASTIC_CAVERN]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:messageText(npc, ID.text.THE_MAGICITE_GLOWS_OMINOUSLY, false, 6)
+end
+
+return entity

--- a/scripts/zones/Qulun_Dome/DefaultActions.lua
+++ b/scripts/zones/Qulun_Dome/DefaultActions.lua
@@ -1,7 +1,5 @@
 local ID = zones[xi.zone.QULUN_DOME]
 
 return {
-    ['_440']     = { messageSpecial = ID.text.IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC },
-    ['Magicite'] = { messageSpecial = ID.text.THE_MAGICITE_GLOWS_OMINOUSLY },
-    ['qm1']      = { messageSpecial = ID.text.YOU_FIND_NOTHING },
+    ['qm1'] = { messageSpecial = ID.text.YOU_FIND_NOTHING },
 }

--- a/scripts/zones/Qulun_Dome/npcs/Magicite.lua
+++ b/scripts/zones/Qulun_Dome/npcs/Magicite.lua
@@ -1,0 +1,16 @@
+-----------------------------------
+-- Area: Qulun Dome
+--  NPC: Magicite
+-- Involved in Mission: Magicite
+-- !pos 9.182 22.554 -84.158 148
+-----------------------------------
+local ID = zones[xi.zone.QULUN_DOME]
+-----------------------------------
+---@type TNpcEntity
+local entity = {}
+
+entity.onTrigger = function(player, npc)
+    player:messageText(npc, ID.text.THE_MAGICITE_GLOWS_OMINOUSLY, false, 6)
+end
+
+return entity

--- a/scripts/zones/Qulun_Dome/npcs/_440.lua
+++ b/scripts/zones/Qulun_Dome/npcs/_440.lua
@@ -11,16 +11,19 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if
-        player:hasKeyItem(xi.ki.SILVER_BELL) and
-        player:hasKeyItem(xi.ki.CORUSCANT_ROSARY) and
-        player:hasKeyItem(xi.ki.BLACK_MATINEE_NECKLACE)
+        not player:hasKeyItem(xi.ki.SILVER_BELL) or
+        not player:hasKeyItem(xi.ki.CORUSCANT_ROSARY) or
+        not player:hasKeyItem(xi.ki.BLACK_MATINEE_NECKLACE)
     then
-        if player:getZPos() < -7.2 then
-            player:startEvent(51)
-        else
-            -- This event automatically handles the distance check
-            player:startEvent(50)
-        end
+        player:messageSpecial(ID.text.IT_SEEMS_TO_BE_LOCKED_BY_POWERFUL_MAGIC)
+        return
+    end
+
+    if player:getZPos() < -7.2 then
+        player:startEvent(51)
+    else
+        -- This event automatically handles the distance check
+        player:startEvent(50)
     end
 end
 

--- a/scripts/zones/RuLude_Gardens/DefaultActions.lua
+++ b/scripts/zones/RuLude_Gardens/DefaultActions.lua
@@ -4,7 +4,6 @@ return {
     ['_6r2']                 = { messageSpecial = ID.text.RESTRICTED }, -- Door:Bastokan Emb.
     ['_6r5']                 = { messageSpecial = ID.text.RESTRICTED }, -- Door:San d'Orian Emb.
     ['_6r8']                 = { messageSpecial = ID.text.RESTRICTED }, -- Door:Windurstian Emb.
-    ['_6r9']                 = { event = 138 }, -- Door:Audience Chamber
     ['Adolie']               = { event = 158 },
     ['Ajahkeem']             = { event = 10106 },
     ['Akta']                 = { event = 116 },
@@ -23,7 +22,6 @@ return {
     ['Enigmatic_Footprints'] = { messageSpecial = ID.text.TEAR_IN_FABRIC_OF_SPACE },
     ['Falreze']              = { event = 121 },
     ['Harith']               = { event = 111 },
-    ['High_Wind']            = { event = 164 },
     ['Jamal']                = { event = 10237 },
     ['Kayle']                = { event = 125 },
     ['Leis']                 = { event = 119 },
@@ -41,7 +39,6 @@ return {
     ['Pursuivant']           = { event = 69 },
     ['qm1']                  = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY },
     ['Radeivepart']          = { event = 159 },
-    ['Rainhard']             = { event = 165 },
     ['relic']                = { messageSpecial = ID.text.NOTHING_OUT_OF_ORDINARY }, -- Blank QM at base of the fountain next to Radeivepart
     ['Sitting_Ram']          = { event = 115 },
     ['Splintery_Chest']      = { messageSpecial = ID.text.SIGNIFICANTLY_SHOPWORN },

--- a/scripts/zones/RuLude_Gardens/IDs.lua
+++ b/scripts/zones/RuLude_Gardens/IDs.lua
@@ -33,6 +33,7 @@ zones[xi.zone.RULUDE_GARDENS] =
         HUNT_RECORDED                    = 6910,  -- You record your hunt.
         OBTAIN_SCYLDS                    = 6912,  -- You obtain <number> [scyld/scylds]! Current balance: <number> [scyld/scylds].
         HUNT_CANCELED                    = 6916,  -- Hunt canceled.
+        YOU_ACCEPT_THE_MISSION           = 9990,  -- You accept the mission.
         RESTRICTED                       = 10123, -- It reads, Restricted Area.
         THE_CONSULATE_IS_AWAY            = 10125, -- The consulate is away.
         SOVEREIGN_WITHOUT_AN_APPOINTMENT = 10196, -- Nobody sees the sovereign without an appointment!

--- a/scripts/zones/RuLude_Gardens/npcs/High_Wind.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/High_Wind.lua
@@ -1,18 +1,18 @@
 -----------------------------------
 -- Area: Ru'Lude Gardens
---  NPC: Audience Chamber
+--  NPC: High Wind
 -- Involved in Mission: Magicite
--- !pos 0 -5 66 243
+-- !pos 2.397 -4.999 68.749 243
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    -- Param 0 picks between the guards turning the player away and the no permit line.
+    -- Param 0 picks between waving the player through and asking for the permit.
     if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
-        player:startEvent(138, 1)
+        player:startEvent(164, 1)
     else
-        player:startEvent(138, 0)
+        player:startEvent(164, 0)
     end
 end
 

--- a/scripts/zones/RuLude_Gardens/npcs/Rainhard.lua
+++ b/scripts/zones/RuLude_Gardens/npcs/Rainhard.lua
@@ -1,18 +1,18 @@
 -----------------------------------
 -- Area: Ru'Lude Gardens
---  NPC: Audience Chamber
+--  NPC: Rainhard
 -- Involved in Mission: Magicite
--- !pos 0 -5 66 243
+-- !pos -2.397 -4.999 68.749 243
 -----------------------------------
 ---@type TNpcEntity
 local entity = {}
 
 entity.onTrigger = function(player, npc)
-    -- Param 0 picks between the guards turning the player away and the no permit line.
+    -- Param 0 picks between waving the player through and asking for the permit.
     if player:hasKeyItem(xi.ki.ARCHDUCAL_AUDIENCE_PERMIT) then
-        player:startEvent(138, 1)
+        player:startEvent(165, 1)
     else
-        player:startEvent(138, 0)
+        player:startEvent(165, 0)
     end
 end
 

--- a/scripts/zones/Upper_Jeuno/IDs.lua
+++ b/scripts/zones/Upper_Jeuno/IDs.lua
@@ -35,6 +35,7 @@ zones[xi.zone.UPPER_JEUNO] =
         YOU_CAN_NOW_BECOME_A_BEASTMASTER = 7211,  -- You can now become a beastmaster.
         NO_ONES_HOME                     = 7214,  -- Looks like no one's home.
         WASTING_YOUR_TIME                = 7453,  -- Hah! You're wasting your time!
+        WITHER_AND_DIE                   = 7461,  -- Just you watch them wither and die.
         YOU_ARE_GIVEN_THREE_SPRIGS       = 7738,  -- You are given three sprigs of <item>.
         CONQUEST                         = 7767,  -- You've earned conquest points!
         ITEM_DELIVERY_DIALOG             = 8100,  -- Delivering goods to residences everywhere!


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits Mission 4-1 "Magicite" for Windurst and San d'Oria based on retail captures. It also makes a few changes to the Bastok version, but ideally Bastok needs a full capture to verify some remaining items. Specifically, this PR does the following things:

**All three nations**

- The mission starts at the embassy door instead of the attendant outside it.
- Both answers to the door menu start the mission.
- The door prints "You accept the mission." the way retail does.
- Event parameters match what the captures show.
- Tidies the three mission files up to match LSB conventions.

**Ru'Lude Gardens**

- High Wind and Rainhard get their own NPC files. They answer differently depending on whether you carry the Archducal permit.
- The Audience Chamber door plays its event in both cases instead of a chat message in one of them.

**Magicite**

- The three magicite get their own NPC files. Their message goes through the NPC the way retail sends it.
- The Qulun Dome door keeps its locked message in the NPC file.

**Castle Oztroja**

- The cannot reach message for the bottom floor door levers goes through the NPC the way retail sends it.

**Quests**

- Mysteries of Beadeaux I and II hand the key item over when the scene starts, not when it ends - per retail.
- Mysteries of Beadeaux I has a separate line once you have already accepted.
- Save My Sister has Baudin's opening line back. It went missing.
- Derrick now grants the Have Wings, Will Fly title when you buy the airship pass. Previously if someone bought the airship pass and then did Mission 4-1 they would never get the title.

**Tests**

- Adds Magicite tests for all three nations, five cases each, covering the door and a full run to completion. San d'Oria and Bastok already had test files, Windurst did not.

## Steps to test these changes

Run all 3 missions and see they all still work but with the above fixes in place.

## Captures

Capture file in video description.

https://youtu.be/kP6IGiMKKRQ

**SIknoz**

[Mission - Sandoria - 4-1 Magicite.zip](https://github.com/user-attachments/files/31622536/Mission.-.Sandoria.-.4-1.Magicite.zip)