### PR TITLE
[lua] Quest The Prankster fix Ahaadah dialog

### DIFF
--- a/scripts/quests/ahtUrhgan/The_Prankster.lua
+++ b/scripts/quests/ahtUrhgan/The_Prankster.lua
@@ -128,10 +128,13 @@ quest.sections =
             vars.Prog == 3
         end,
 
-        [xi.zone.BHAFLAU_THICKETS] =
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
         {
             ['Ahaadah'] = quest:event(17),
+        },
 
+        [xi.zone.BHAFLAU_THICKETS] =
+        {
             ['qm3'] = quest:progressCutscene(2),
 
             onEventFinish =
@@ -140,6 +143,16 @@ quest.sections =
                     quest:complete(player)
                 end,
             },
+        },
+    },
+    {
+        check = function(player, status, vars)
+            return status == xi.questStatus.QUEST_COMPLETED
+        end,
+
+        [xi.zone.AHT_URHGAN_WHITEGATE] =
+        {
+            ['Ahaadah'] = quest:event(18):replaceDefault(),
         },
     },
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes dialog with Ahaadah during The Prankster.
Captures by Siknoz: https://1drv.ms/u/c/87e665e10555c452/IQCWItMfKYmKS7jJkCw6bVliAV-o2JuskstgfBfY3yUidOM?e=MNZbnc
https://youtu.be/ZI2kfa6MRt8

## Steps to test these changes

!quest AHT_URHGAN THE_PRANKSTER
!setquestvar name 6 60 Prog 3
!pos -70 -6 105 50
Talk to him
Complete quest and talk to him again
