### PR TITLE
[lua] add default blue magic table func for phys/magic & LLS defs

### DIFF
--- a/scripts/actions/spells/blue/1000_needles.lua
+++ b/scripts/actions/spells/blue/1000_needles.lua
@@ -20,25 +20,23 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.MAGICAL
-    params.damageType = xi.damageType.LIGHT
-    params.skillType = xi.skill.BLUE_MAGIC
-    params.scattr = xi.skillchainType.COMPRESSION
-    params.diff = 0
-    params.bonus = -50 -- 50 magic accuracy penalty
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 1.5
-    params.tp300 = 1.5
-    params.azuretp = 1.5
-    params.duppercap = 49
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.PLANTOID
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.MAGICAL
+    params.damageType     = xi.damageType.LIGHT
+    params.skillchainType = xi.skillchainType.COMPRESSION
+
+    params.bonusMacc     = -50 -- 50 magic accuracy penalty
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 49
+
     params.str_wsc = 1.0
     params.dex_wsc = 1.5
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
     params.int_wsc = 2.0
     params.mnd_wsc = 1.0
     params.chr_wsc = 1.0

--- a/scripts/actions/spells/blue/actinic_burst.lua
+++ b/scripts/actions/spells/blue/actinic_burst.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.LUMINION
     params.effect          = xi.effect.FLASH
     params.power           = 0 -- Power is handled in hit rate calculations

--- a/scripts/actions/spells/blue/amorphic_spikes.lua
+++ b/scripts/actions/spells/blue/amorphic_spikes.lua
@@ -20,33 +20,30 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AMORPH
-    params.tpmod     = xi.spells.blue.tpMod.ATTACK
-    params.bonusacc  = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.AMORPH
+    params.tpModifier = xi.spells.blue.tpMod.ATTACK
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.PIERCING
-    params.scattr = xi.skillchainType.GRAVITATION
-    params.scattr2 = xi.skillchainType.TRANSFIXION
-    params.numhits = 5
-    params.multiplier = 1.0
-    params.tp150 = 1.375
-    params.tp300 = 1.750 -- as per https://wiki.ffo.jp/html/24665.html
-    params.azuretp = 2.125 -- guessing as no wiki has this info.
-    params.duppercap = 75
-    params.str_wsc = 0.0
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.PIERCING
+    params.skillchainType  = xi.skillchainType.GRAVITATION
+    params.skillchainType2 = xi.skillchainType.TRANSFIXION
+
+    params.numHits       = 5
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.375
+    params.ftp3000       = 1.750 -- as per https://wiki.ffo.jp/html/24665.html
+    params.ftpAzure      = 2.125 -- guessing as no wiki has this info.
+    params.baseDamageCap = 75
+
     params.dex_wsc = 0.20
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
     params.int_wsc = 0.20
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/amplification.lua
+++ b/scripts/actions/spells/blue/amplification.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 90)
+    local duration     = xi.spells.blue.calculateDurationWithDiffusion(caster, 90)
     local returnEffect = xi.effect.MAGIC_ATK_BOOST
 
     local actionOne = target:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, { power = 10, duration = duration, origin = caster })

--- a/scripts/actions/spells/blue/animating_wail.lua
+++ b/scripts/actions/spells/blue/animating_wail.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 1500 -- 15%
+    local power    = 1500 -- 15%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.HASTE, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/asuran_claws.lua
+++ b/scripts/actions/spells/blue/asuran_claws.lua
@@ -20,35 +20,32 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.bonusacc = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEAST
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.LIQUEFACTION
-    params.scattr2 = xi.skillchainType.IMPACTION
-    params.numhits = 6
-    params.multiplier = 0.625
-    params.tp150 = 0.625
-    params.tp300 = 0.625
-    params.azuretp = 0.625
-    params.duppercap = 21
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.HAND_TO_HAND
+    params.skillchainType  = xi.skillchainType.LIQUEFACTION
+    params.skillchainType2 = xi.skillchainType.IMPACTION
+
+    params.numHits       = 6
+    params.ftp0          = 0.625
+    params.ftp1500       = 0.625
+    params.ftp3000       = 0.625
+    params.ftpAzure      = 0.625
+    params.baseDamageCap = 21
+
     -- D seems low for its level, but the spell never did good damage, so a low D is a good way of keeping overall damage down.
     -- More discussion on https://ffxiclopedia.fandom.com/wiki/Talk:Asuran_Claws
     params.str_wsc = 0.1
     params.dex_wsc = 0.1
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/auroral_drape.lua
+++ b/scripts/actions/spells/blue/auroral_drape.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.EMPTY
     params.effect          = xi.effect.SILENCE
     params.power           = 1

--- a/scripts/actions/spells/blue/awful_eye.lua
+++ b/scripts/actions/spells/blue/awful_eye.lua
@@ -20,7 +20,8 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
+
     params.ecosystem       = xi.ecosystem.LIZARD
     params.effect          = xi.effect.STR_DOWN
     params.power           = 30

--- a/scripts/actions/spells/blue/bad_breath.lua
+++ b/scripts/actions/spells/blue/bad_breath.lua
@@ -21,11 +21,10 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
+
     params.ecosystem  = xi.ecosystem.PLANTOID
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.EARTH
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 8
     params.lvlMod     = 3
     params.isConal    = true

--- a/scripts/actions/spells/blue/battery_charge.lua
+++ b/scripts/actions/spells/blue/battery_charge.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 3 + caster:getMod(xi.mod.ENHANCES_REFRESH)
+    local power    = 3 + caster:getMod(xi.mod.ENHANCES_REFRESH)
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.REFRESH, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/battle_dance.lua
+++ b/scripts/actions/spells/blue/battle_dance.lua
@@ -20,25 +20,20 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.BEASTMEN
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr     = xi.skillchainType.IMPACTION
-    params.numhits    = 1
-    params.multiplier = 2.0
-    params.tp150      = 2.0
-    params.tp300      = 2.0
-    params.azuretp    = 2.0
-    params.duppercap  = 17
-    params.str_wsc    = 0.3
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 2.0
+    params.ftp1500       = 2.0
+    params.ftp3000       = 2.0
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 17
+    params.str_wsc       = 0.3
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/blastbomb.lua
+++ b/scripts/actions/spells/blue/blastbomb.lua
@@ -20,21 +20,16 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.BEASTMEN
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.FIRE
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 1.375
-    params.tMultiplier = 1.0
-    params.duppercap   = 30
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.2
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 1.375
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 30
+    params.int_wsc         = 0.2
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/blitzstrahl.lua
+++ b/scripts/actions/spells/blue/blitzstrahl.lua
@@ -20,21 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.ARCANA
-    params.attackType  = xi.damageType.ELEMENTAL
+    params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.THUNDER
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 1.5625
-    params.tMultiplier = 1.0
-    params.duppercap   = 61
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 1.5625
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 61
+
     params.int_wsc     = 0.3
     params.mnd_wsc     = 0.1
-    params.chr_wsc     = 0.0
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/blood_drain.lua
+++ b/scripts/actions/spells/blue/blood_drain.lua
@@ -20,12 +20,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
+    local params      = {}
+    params.ecosystem  = xi.ecosystem.BIRD
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.DARK
-    params.diff = 0 -- no stat increases magic accuracy
-    params.skillType = xi.skill.BLUE_MAGIC
+
     params.dmgMultiplier = 3
 
     return xi.spells.blue.useDrainSpell(caster, target, spell, params, 0, false)

--- a/scripts/actions/spells/blue/blood_saber.lua
+++ b/scripts/actions/spells/blue/blood_saber.lua
@@ -20,12 +20,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.UNDEAD
+    local params      = {}
+    params.ecosystem  = xi.ecosystem.UNDEAD
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.DARK
-    params.diff = 0 -- no stat increases magic accuracy
-    params.skillType = xi.skill.BLUE_MAGIC
+
     params.dmgMultiplier = 3.5
 
     return xi.spells.blue.useDrainSpell(caster, target, spell, params, 0, false)

--- a/scripts/actions/spells/blue/bludgeon.lua
+++ b/scripts/actions/spells/blue/bludgeon.lua
@@ -20,32 +20,27 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.ARCANA
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.bonusacc = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.ARCANA
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.LIQUEFACTION
-    params.numhits = 3
-    params.multiplier = 1.0
-    params.tp150 = 1.0
-    params.tp300 = 1.0
-    params.azuretp = 1.0
-    params.duppercap = 21
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.3
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.LIQUEFACTION
+
+    params.numHits       = 3
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.0
+    params.ftp3000       = 1.0
+    params.ftpAzure      = 1.0
+    params.baseDamageCap = 21
+    params.chr_wsc       = 0.3
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/body_slam.lua
+++ b/scripts/actions/spells/blue/body_slam.lua
@@ -20,25 +20,20 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.DRAGON
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.IMPACTION
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 1.5
-    params.tp300 = 1.5
-    params.azuretp = 1.5
-    params.duppercap = 75
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.4
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.DRAGON
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 75
+    params.vit_wsc       = 0.4
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/bomb_toss.lua
+++ b/scripts/actions/spells/blue/bomb_toss.lua
@@ -20,21 +20,16 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEASTMEN
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.FIRE
-    params.attribute = xi.mod.INT
-    params.multiplier = 1.625
-    params.tMultiplier = 1.0
-    params.duppercap = 40
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.2
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
+    params.dStat      = xi.mod.INT
+
+    params.ftp0            = 1.625
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 40
+    params.int_wsc         = 0.2
 
     return xi.spells.blue.useMagicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/cannonball.lua
+++ b/scripts/actions/spells/blue/cannonball.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.FUSION
-    params.numhits = 1
-    params.multiplier = 1.75
-    params.tp150 = 2.125
-    params.tp300 = 2.75
-    params.azuretp = 2.875
-    params.duppercap = 75
+    local params         = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem     = xi.ecosystem.VERMIN
+    params.tpModifier    = xi.spells.blue.tpMod.DAMAGE
+    params.attackType    = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.FUSION
+
+    params.numHits       = 1
+    params.ftp0          = 1.75
+    params.ftp1500       = 2.125
+    params.ftp3000       = 2.75
+    params.ftpAzure      = 2.875
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.5
-    params.dex_wsc = 0.0
     params.vit_wsc = 0.5
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
-    params.offcratiomod = caster:getStat(xi.mod.DEF) -- Cannonball uses Defense as its main modifier
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/chaotic_eye.lua
+++ b/scripts/actions/spells/blue/chaotic_eye.lua
@@ -20,9 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BEAST
     params.effect          = xi.effect.SILENCE
+
     params.power           = 1
     params.tick            = 0
     params.duration        = 120

--- a/scripts/actions/spells/blue/charged_whisker.lua
+++ b/scripts/actions/spells/blue/charged_whisker.lua
@@ -20,21 +20,16 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.BEAST
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.THUNDER
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 2.0
-    params.tMultiplier = 4.5
-    params.duppercap   = 100
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.5
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.0
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 2.0
+    params.dStatMultiplier = 4.5
+    params.baseDamageCap   = 100
+    params.dex_wsc         = 0.5
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/cimicine_discharge.lua
+++ b/scripts/actions/spells/blue/cimicine_discharge.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.VERMIN
     params.effect          = xi.effect.SLOW
     params.power           = 2000

--- a/scripts/actions/spells/blue/claw_cyclone.lua
+++ b/scripts/actions/spells/blue/claw_cyclone.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.SCISSION
-    params.numhits = 2
-    params.multiplier = 1.4375
-    params.tp150 = 1.4375
-    params.tp300 = 1.4375
-    params.azuretp = 1.4375
-    params.duppercap = 23
-    params.str_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEAST
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.SCISSION
+
+    params.numHits       = 2
+    params.ftp0          = 1.4375
+    params.ftp1500       = 1.4375
+    params.ftp3000       = 1.4375
+    params.ftpAzure      = 1.4375
+    params.baseDamageCap = 23
+
     params.dex_wsc = 0.3
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/cold_wave.lua
+++ b/scripts/actions/spells/blue/cold_wave.lua
@@ -20,13 +20,13 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params     = {}
     params.ecosystem = xi.ecosystem.ARCANA
     params.effect    = xi.effect.FROST
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.BLUE_MAGIC
-    local tick = 3
-    local duration = 60
+    params.dStat     = xi.mod.INT
+
+    local tick            = 3
+    local duration        = 60
     local resistThreshold = 0.5
 
     local maccParams =

--- a/scripts/actions/spells/blue/corrosive_ooze.lua
+++ b/scripts/actions/spells/blue/corrosive_ooze.lua
@@ -20,23 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AMORPH
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.AMORPH
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.WATER
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.BLUE_MAGIC
-    params.multiplier = 2.125
-    params.azureBonus = 0.5
-    params.tMultiplier = 2.0
-    params.duppercap = 69
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
+
+    params.dStat           = xi.mod.INT
+    params.ftp0            = 2.125
+    params.azureBonus      = 0.5
+    params.dStatMultiplier = 2.0
+    params.baseDamageCap   = 69
+
     params.int_wsc = 0.2
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)
     local maccParams =

--- a/scripts/actions/spells/blue/cursed_sphere.lua
+++ b/scripts/actions/spells/blue/cursed_sphere.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.VERMIN
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.WATER
-    params.attribute = xi.mod.INT
-    params.multiplier = 1.50
-    params.tMultiplier = 1.0
-    params.duppercap = 30
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
+    params.dStat      = xi.mod.INT
+
+    params.ftp0            = 1.50
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 30
+
     params.int_wsc = 0.3
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.useMagicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/death_ray.lua
+++ b/scripts/actions/spells/blue/death_ray.lua
@@ -20,22 +20,19 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AMORPH
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.AMORPH
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.DARK
-    params.attribute = xi.mod.INT
-    params.multiplier = 1.625
-    params.azureBonus = 2
-    params.tMultiplier = 1.0
-    params.duppercap = 51
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
+    params.dStat      = xi.mod.INT
+
+    params.ftp0            = 1.625
+    params.azureBonus      = 2
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 51
+
     params.int_wsc = 0.2
     params.mnd_wsc = 0.1
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.useMagicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/death_scissors.lua
+++ b/scripts/actions/spells/blue/death_scissors.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.COMPRESSION
-    params.scattr2 = xi.skillchainType.REVERBERATION
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 2.75
-    params.tp300 = 3.25
-    params.azuretp = 3.3
-    params.duppercap = 74
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.VERMIN
+    params.tpModifier      = xi.spells.blue.tpMod.DAMAGE
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.COMPRESSION
+    params.skillchainType2 = xi.skillchainType.REVERBERATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 2.75
+    params.ftp3000       = 3.25
+    params.ftpAzure      = 3.3
+    params.baseDamageCap = 74
+
     params.str_wsc = 0.6
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/delta_thrust.lua
+++ b/scripts/actions/spells/blue/delta_thrust.lua
@@ -20,32 +20,29 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params     = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem = xi.ecosystem.LIZARD
-    params.bonusacc  = 0
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.LIQUEFACTION
-    params.scattr2 = xi.skillchainType.DETONATION
-    params.numhits = 3
-    params.multiplier = 1.0
-    params.tp150 = 1.0
-    params.tp300 = 1.0
-    params.azuretp = 1.0
-    params.duppercap = 75
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.LIQUEFACTION
+    params.skillchainType2 = xi.skillchainType.DETONATION
+
+    params.numHits       = 3
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.0
+    params.ftp3000       = 1.0
+    params.ftpAzure      = 1.0
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.20
-    params.dex_wsc = 0.0
     params.vit_wsc = 0.50
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/diamondhide.lua
+++ b/scripts/actions/spells/blue/diamondhide.lua
@@ -22,8 +22,8 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local blueSkill = utils.clamp(caster:getSkillLevel(xi.skill.BLUE_MAGIC), 0, 500)
-    local power = (blueSkill / 3) * 2
-    local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
+    local power     = (blueSkill / 3) * 2
+    local duration  = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.STONESKIN, { power = power, duration = duration, origin = caster, tier = 2 }) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/actions/spells/blue/digest.lua
+++ b/scripts/actions/spells/blue/digest.lua
@@ -20,12 +20,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AMORPH
+    local params      = {}
+    params.ecosystem  = xi.ecosystem.AMORPH
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.DARK
-    params.diff = 0 -- no stat increases magic accuracy
-    params.skillType = xi.skill.BLUE_MAGIC
+
     params.dmgMultiplier = 5
 
     return xi.spells.blue.useDrainSpell(caster, target, spell, params, 0, false)

--- a/scripts/actions/spells/blue/dimensional_death.lua
+++ b/scripts/actions/spells/blue/dimensional_death.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.TRANSFIXION
-    params.scattr2 = xi.skillchainType.IMPACTION
-    params.numhits = 1
-    params.multiplier = 2.25
-    params.tp150 = 2.25
-    params.tp300 = 2.25
-    params.azuretp = 2.25
-    params.duppercap = 70
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem        = xi.ecosystem.UNDEAD
+    params.tpModifier      = xi.spells.blue.tpMod.ATTACK
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.HAND_TO_HAND
+    params.skillchainType  = xi.skillchainType.TRANSFIXION
+    params.skillchainType2 = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 2.25
+    params.ftp1500       = 2.25
+    params.ftp3000       = 2.25
+    params.ftpAzure      = 2.25
+    params.baseDamageCap = 70
+
     params.str_wsc = 0.5
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/disseverment.lua
+++ b/scripts/actions/spells/blue/disseverment.lua
@@ -20,32 +20,29 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.LUMINIAN
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.bonusacc = 0
+    local params       = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem   = xi.ecosystem.LUMINIAN
+    params.tpModifier  = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.PIERCING
-    params.scattr     = xi.skillchainType.DISTORTION
-    params.numhits    = 5
-    params.multiplier = 1.5
-    params.tp150      = 1.5
-    params.tp300      = 1.5
-    params.azuretp    = 1.5
-    params.duppercap  = 100
-    params.str_wsc    = 0.2
-    params.dex_wsc    = 0.2
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.PIERCING
+    params.skillchainType = xi.skillchainType.DISTORTION
+
+    params.numHits       = 5
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 100
+
+    params.str_wsc = 0.2
+    params.dex_wsc = 0.2
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/dream_flower.lua
+++ b/scripts/actions/spells/blue/dream_flower.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.PLANTOID
     params.effect          = xi.effect.SLEEP_I -- https://wiki.ffo.jp/html/5502.html
     params.power           = 1

--- a/scripts/actions/spells/blue/empty_thrash.lua
+++ b/scripts/actions/spells/blue/empty_thrash.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.EMPTY
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.COMPRESSION
-    params.scattr2 = xi.skillchainType.SCISSION
-    params.numhits = 1
-    params.multiplier = 2.0
-    params.tp150 = 2.0
-    params.tp300 = 2.0
-    params.azuretp = 2.0
-    params.duppercap = 33
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.EMPTY
+    params.tpModifier      = xi.spells.blue.tpMod.ACC
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.COMPRESSION
+    params.skillchainType2 = xi.skillchainType.SCISSION
+
+    params.numHits       = 1
+    params.ftp0          = 2.0
+    params.ftp1500       = 2.0
+    params.ftp3000       = 2.0
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 33
+
     params.str_wsc = 0.5
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/exuviation.lua
+++ b/scripts/actions/spells/blue/exuviation.lua
@@ -20,16 +20,16 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.minCure = 60
-    params.divisor0 = 0.6666
-    params.constant0 = -45
+    local params           = {}
+    params.minCure         = 60
+    params.divisor0        = 0.6666
+    params.constant0       = -45
     params.powerThreshold1 = 219
-    params.divisor1 = 2
-    params.constant1 = 65
+    params.divisor1        = 2
+    params.constant1       = 65
     params.powerThreshold2 = 459
-    params.divisor2 = 6.5
-    params.constant2 = 144.6666
+    params.divisor2        = 6.5
+    params.constant2       = 144.6666
 
     target:eraseStatusEffect()
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/eyes_on_me.lua
+++ b/scripts/actions/spells/blue/eyes_on_me.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.DEMON
-    params.attackType = xi.attackType.MAGICAL
-    params.damageType = xi.damageType.DARK
-    params.attribute = xi.mod.CHR
-    params.multiplier = 2.625
-    params.azureBonus = 2
-    params.tMultiplier = 1.5
-    params.duppercap = 69
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
+    local params       = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem   = xi.ecosystem.DEMON
+    params.attackType  = xi.attackType.MAGICAL
+    params.damageType  = xi.damageType.DARK
+    params.dStat       = xi.mod.CHR
+
+    params.ftp0            = 2.625
+    params.azureBonus      = 2
+    params.dStatMultiplier = 1.5
+    params.baseDamageCap    = 69
+
     params.chr_wsc = 0.4
 
     return xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/feather_barrier.lua
+++ b/scripts/actions/spells/blue/feather_barrier.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 20
+    local power    = 20
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 30)
 
     if not target:addStatusEffect(xi.effect.EVASION_BOOST, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/feather_storm.lua
+++ b/scripts/actions/spells/blue/feather_storm.lua
@@ -20,32 +20,28 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = xi.spells.blue.tpMod.CRITICAL
-    params.critchance = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEASTMEN
+    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critchance = 55
+        params.critChance = 55
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critchance = math.floor(caster:getTP() / 75)
+        params.critChance = math.floor(caster:getTP() / 75)
     end
 
-    params.attackType = xi.attackType.RANGED
-    params.damageType = xi.damageType.PIERCING
-    params.scattr     = xi.skillchainType.TRANSFIXION
-    params.numhits    = 1
-    params.multiplier = 2
-    params.tp150      = 2
-    params.tp300      = 2
-    params.azuretp    = 2
-    params.duppercap  = 17
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
+    params.attackType     = xi.attackType.RANGED
+    params.damageType     = xi.damageType.PIERCING
+    params.skillchainType = xi.skillchainType.TRANSFIXION
+
+    params.numHits       = 1
+    params.ftp0          = 2
+    params.ftp1500       = 2
+    params.ftp3000       = 2
+    params.ftpAzure      = 2
+    params.baseDamageCap = 17
+
     params.agi_wsc    = 0.3
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/filamented_hold.lua
+++ b/scripts/actions/spells/blue/filamented_hold.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.VERMIN
     params.effect          = xi.effect.SLOW
     params.power           = 2500

--- a/scripts/actions/spells/blue/firespit.lua
+++ b/scripts/actions/spells/blue/firespit.lua
@@ -20,21 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEASTMEN
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.FIRE
-    params.attribute = xi.mod.INT
-    params.multiplier = 3.0
-    params.tMultiplier = 1.5
-    params.duppercap = 69
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
+    params.dStat      = xi.mod.INT
+
+    params.ftp0            = 3.0
+    params.dStatMultiplier = 1.5
+    params.baseDamageCap   = 69
+
     params.int_wsc = 0.2
     params.mnd_wsc = 0.2
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.useMagicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/flying_hip_press.lua
+++ b/scripts/actions/spells/blue/flying_hip_press.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.BEASTMEN
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.WIND
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 3
     params.lvlMod     = 0
 

--- a/scripts/actions/spells/blue/foot_kick.lua
+++ b/scripts/actions/spells/blue/foot_kick.lua
@@ -20,32 +20,29 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = xi.spells.blue.tpMod.CRITICAL
-    params.critchance = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEAST
+    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critchance = 55
+        params.critChance = 55
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critchance = math.floor(caster:getTP() / 75)
+        params.critChance = math.floor(caster:getTP() / 75)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.DETONATION
-    params.numhits = 1
-    params.multiplier = 1.0
-    params.tp150 = 1.0
-    params.tp300 = 1.0
-    params.azuretp = 1.0
-    params.duppercap = 9
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.DETONATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.0
+    params.ftp3000       = 1.0
+    params.ftpAzure      = 1.0
+    params.baseDamageCap = 9
+
     params.str_wsc = 0.1
     params.dex_wsc = 0.1
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/frenetic_rip.lua
+++ b/scripts/actions/spells/blue/frenetic_rip.lua
@@ -20,25 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.DEMON
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.INDURATION
-    params.numhits = 3
-    params.multiplier = 1.36
-    params.tp150 = 2.08
-    params.tp300 = 2.36
-    params.azuretp = 2.61
-    params.duppercap = 75
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.DEMON
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.INDURATION
+
+    params.numHits       = 3
+    params.ftp0          = 1.36
+    params.ftp1500       = 2.08
+    params.ftp3000       = 2.36
+    params.ftpAzure      = 2.61
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.2
     params.dex_wsc = 0.2
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/frightful_roar.lua
+++ b/scripts/actions/spells/blue/frightful_roar.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.DEMON
     params.effect          = xi.effect.DEFENSE_DOWN
     params.power           = 10

--- a/scripts/actions/spells/blue/frost_breath.lua
+++ b/scripts/actions/spells/blue/frost_breath.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.LIZARD
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.ICE
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 3
     params.lvlMod     = 0.625
     params.isConal    = true

--- a/scripts/actions/spells/blue/frypan.lua
+++ b/scripts/actions/spells/blue/frypan.lua
@@ -20,32 +20,29 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod     = xi.spells.blue.tpMod.ACC
-    params.bonusacc  = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEASTMEN
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr     = xi.skillchainType.IMPACTION
-    params.numhits    = 1
-    params.multiplier = 1.78
-    params.tp150      = 1.78
-    params.tp300      = 1.78
-    params.azuretp    = 1.78
-    params.duppercap  = 75
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 1.78
+    params.ftp1500       = 1.78
+    params.ftp3000       = 1.78
+    params.ftpAzure      = 1.78
+    params.baseDamageCap = 75
+
     params.str_wsc    = 0.2
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
     params.mnd_wsc    = 0.2
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/goblin_rush.lua
+++ b/scripts/actions/spells/blue/goblin_rush.lua
@@ -20,33 +20,30 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod     = xi.spells.blue.tpMod.ACC
-    params.bonusacc  = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BEASTMEN
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.FUSION
-    params.scattr2 = xi.skillchainType.IMPACTION
-    params.numhits = 3
-    params.multiplier = 1.25
-    params.tp150 = 1.25
-    params.tp300 = 1.25
-    params.azuretp = 1.25
-    params.duppercap = 75
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.BLUNT
+    params.skillchainType  = xi.skillchainType.FUSION
+    params.skillchainType2 = xi.skillchainType.IMPACTION
+
+    params.numHits       = 3
+    params.ftp0          = 1.25
+    params.ftp1500       = 1.25
+    params.ftp3000       = 1.25
+    params.ftpAzure      = 1.25
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.30
     params.dex_wsc = 0.30
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/grand_slam.lua
+++ b/scripts/actions/spells/blue/grand_slam.lua
@@ -20,25 +20,20 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.INDURATION
-    params.numhits = 1
-    params.multiplier = 1.0
-    params.tp150 = 1.0
-    params.tp300 = 1.0
-    params.azuretp = 1.0
-    params.duppercap = 33
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.INDURATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.0
+    params.ftp3000       = 1.0
+    params.ftpAzure      = 1.0
+    params.baseDamageCap = 33
+
     params.vit_wsc = 0.3
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
-    params.ignorefstrcap = true -- Grand Slam doesn't have an fSTR cap
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/head_butt.lua
+++ b/scripts/actions/spells/blue/head_butt.lua
@@ -20,25 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.BEASTMEN
-    params.tpmod      = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr     = xi.skillchainType.IMPACTION
-    params.numhits    = 1
-    params.multiplier = 1.75
-    params.tp150      = 2.125
-    params.tp300      = 2.25
-    params.azuretp    = 2.375
-    params.duppercap  = 17
-    params.str_wsc    = 0.2
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.2
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 1.75
+    params.ftp1500       = 2.125
+    params.ftp3000       = 2.25
+    params.ftpAzure      = 2.375
+    params.baseDamageCap = 17
+
+    params.str_wsc = 0.2
+    params.int_wsc = 0.2
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/healing_breeze.lua
+++ b/scripts/actions/spells/blue/healing_breeze.lua
@@ -21,15 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.minCure = 60
-    params.divisor0 = 0.6666
-    params.constant0 = -45
+
+    params.minCure         = 60
+    params.divisor0        = 0.6666
+    params.constant0       = -45
     params.powerThreshold1 = 219
-    params.divisor1 = 2
-    params.constant1 = 65
+    params.divisor1        = 2
+    params.constant1       = 65
     params.powerThreshold2 = 459
-    params.divisor2 = 6.5
-    params.constant2 = 144.6666
+    params.divisor2        = 6.5
+    params.constant2       = 144.6666
 
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/heat_breath.lua
+++ b/scripts/actions/spells/blue/heat_breath.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.BEAST
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.FIRE
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 2
     params.lvlMod     = 0
     params.isConal    = true

--- a/scripts/actions/spells/blue/heavy_strike.lua
+++ b/scripts/actions/spells/blue/heavy_strike.lua
@@ -21,28 +21,24 @@ end
 
 -- Need to implement Automatic crit
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.ARCANA
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.FRAGMENTATION
-    params.scattr2 = xi.skillchainType.TRANSFIXION
-    params.numhits = 1
-    params.multiplier = 2.5 -- Using https://wiki.ffo.jp/html/24367.html over bg-wiki for this
-    params.tp150 = 3.5
-    params.tp300 = 4.0
-    params.azuretp = 4.0 -- This is a guess as blue gartr doesn't have this info
-    params.duppercap = 75
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.ARCANA
+    params.tpModifier      = xi.spells.blue.tpMod.ATTACK
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.HAND_TO_HAND
+    params.skillchainType  = xi.skillchainType.FRAGMENTATION
+    params.skillchainType2 = xi.skillchainType.TRANSFIXION
+
+    params.numHits       = 1
+    params.ftp0          = 2.5 -- Using https://wiki.ffo.jp/html/24367.html over bg-wiki for this
+    params.ftp1500       = 3.5
+    params.ftp3000       = 4.0
+    params.ftpAzure      = 4.0 -- This is a guess as blue gartr doesn't have this info
+    params.baseDamageCap = 75
+    params.bonusAcc      = -100
+    params.critChance    = 100 -- TODO: this should cap to 100%
+
     params.str_wsc = 0.5
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
-    params.bonusacc = -100
-    params.critchance = 100 -- TODO: this should cap to 100%
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/hecatomb_wave.lua
+++ b/scripts/actions/spells/blue/hecatomb_wave.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.DEMON
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.WIND
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 4
     params.lvlMod     = 1.5
     params.isConal    = true

--- a/scripts/actions/spells/blue/helldive.lua
+++ b/scripts/actions/spells/blue/helldive.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.TRANSFIXION
-    params.numhits = 1
-    params.multiplier = 1.25
-    params.tp150 = 1.625
-    params.tp300 = 2.00
-    params.azuretp = 2.125
-    params.duppercap = 19
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BIRD
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.TRANSFIXION
+
+    params.numHits       = 1
+    params.ftp0          = 1.25
+    params.ftp1500       = 1.625
+    params.ftp3000       = 2.00
+    params.ftpAzure      = 2.125
+    params.baseDamageCap = 19
+
     params.agi_wsc = 0.3
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/hydro_shot.lua
+++ b/scripts/actions/spells/blue/hydro_shot.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = xi.spells.blue.tpMod.EFFECT_CHANCE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.REVERBERATION
-    params.numhits = 1
-    params.multiplier = 1.25
-    params.tp150 = 1.25
-    params.tp300 = 1.25
-    params.azuretp = 1.25
-    params.duppercap = 75
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.EFFECT_CHANCE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.REVERBERATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.25
+    params.ftp1500       = 1.25
+    params.ftp3000       = 1.25
+    params.ftpAzure      = 1.25
+    params.baseDamageCap = 75
+
     params.agi_wsc = 0.3
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     -- Enmity Down amount is trivial, not worth implementing
     -- Sources: https://www.applySpellDamagethreads/37619-Blue-Mage-Best-thread-ever?p=4845494&viewfull=1#post4845494 and https://www.bg-wiki.com/ffxi/Hydro_Shot

--- a/scripts/actions/spells/blue/hysteric_barrage.lua
+++ b/scripts/actions/spells/blue/hysteric_barrage.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.DETONATION
-    params.numhits = 5
-    params.multiplier = 1.25
-    params.tp150 = 1.625
-    params.tp300 = 1.75
-    params.azuretp = 1.875
-    params.duppercap = 80
-    params.str_wsc = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.DETONATION
+
+    params.numHits       = 5
+    params.ftp0          = 1.25
+    params.ftp1500       = 1.625
+    params.ftp3000       = 1.75
+    params.ftpAzure      = 1.875
+    params.baseDamageCap = 80
+
     params.dex_wsc = 0.3
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/ice_break.lua
+++ b/scripts/actions/spells/blue/ice_break.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.ARCANA
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.ICE
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 2.25
-    params.tMultiplier = 1.0
-    params.duppercap   = 69
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.3
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 2.25
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 69
+
+    params.int_wsc = 0.3
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/infrasonics.lua
+++ b/scripts/actions/spells/blue/infrasonics.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.LIZARD
     params.effect          = xi.effect.EVASION_DOWN
     params.power           = 20

--- a/scripts/actions/spells/blue/jet_stream.lua
+++ b/scripts/actions/spells/blue/jet_stream.lua
@@ -20,32 +20,28 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BIRD
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.bonusacc = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.BIRD
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.IMPACTION
-    params.numhits = 3
-    params.multiplier = 1.125
-    params.tp150 = 1.125
-    params.tp300 = 1.125
-    params.azuretp = 1.125
-    params.duppercap = 39
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.IMPACTION
+
+    params.numHits       = 3
+    params.ftp0          = 1.125
+    params.ftp1500       = 1.125
+    params.ftp3000       = 1.125
+    params.ftpAzure      = 1.125
+    params.baseDamageCap = 39
+
     params.agi_wsc = 0.3
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/jettatura.lua
+++ b/scripts/actions/spells/blue/jettatura.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BIRD
     params.effect          = xi.effect.TERROR
     params.power           = 1

--- a/scripts/actions/spells/blue/lowing.lua
+++ b/scripts/actions/spells/blue/lowing.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BEAST
     params.effect          = xi.effect.PLAGUE
     params.power           = 5

--- a/scripts/actions/spells/blue/maelstrom.lua
+++ b/scripts/actions/spells/blue/maelstrom.lua
@@ -20,21 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.AQUAN
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.WATER
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 2.375
-    params.tMultiplier = 1.5
-    params.duppercap   = 69
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 2.375
+    params.dStatMultiplier = 1.5
+    params.baseDamageCap   = 69
+
     params.int_wsc     = 0.3
     params.mnd_wsc     = 0.1
-    params.chr_wsc     = 0.0
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/magic_fruit.lua
+++ b/scripts/actions/spells/blue/magic_fruit.lua
@@ -21,15 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.minCure = 250
-    params.divisor0 = 0.6666
-    params.constant0 = 130
+
+    params.minCure         = 250
+    params.divisor0        = 0.6666
+    params.constant0       = 130
     params.powerThreshold1 = 319
-    params.divisor1 = 1
-    params.constant1 = 210
+    params.divisor1        = 1
+    params.constant1       = 210
     params.powerThreshold2 = 559
-    params.divisor2 = 2.8333
-    params.constant2 = 391
+    params.divisor2        = 2.8333
+    params.constant2       = 391
 
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/magic_hammer.lua
+++ b/scripts/actions/spells/blue/magic_hammer.lua
@@ -27,22 +27,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEASTMEN
-    params.attackType = xi.attackType.MAGICAL
-    params.damageType = xi.damageType.LIGHT
-    params.attribute = xi.mod.MND
-    params.multiplier = 1.5
-    params.azureBonus = 0.5
-    params.tMultiplier = 1.0
-    params.duppercap = 35
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
+    local params        = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem    = xi.ecosystem.BEASTMEN
+    params.attackType   = xi.attackType.MAGICAL
+    params.damageType   = xi.damageType.LIGHT
+    params.dStat        = xi.mod.MND
+
+    params.ftp0            = 1.5
+    params.azureBonus      = 0.5
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 35
+
     params.mnd_wsc = 0.3
-    params.chr_wsc = 0.0
 
     local damage = 0
     if target:isUndead() then

--- a/scripts/actions/spells/blue/magnetite_cloud.lua
+++ b/scripts/actions/spells/blue/magnetite_cloud.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.BEASTMEN
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.EARTH
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 6
     params.lvlMod     = 1.875
     params.isConal    = true

--- a/scripts/actions/spells/blue/mandibular_bite.lua
+++ b/scripts/actions/spells/blue/mandibular_bite.lua
@@ -20,25 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.INDURATION
-    params.numhits = 1
-    params.multiplier = 2.0
-    params.tp150 = 2.0
-    params.tp300 = 2.0
-    params.azuretp = 2.0
-    params.duppercap = 45
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.VERMIN
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.INDURATION
+
+    params.numHits       = 1
+    params.ftp0          = 2.0
+    params.ftp1500       = 2.0
+    params.ftp3000       = 2.0
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 45
+
     params.str_wsc = 0.2
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
     params.int_wsc = 0.2
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/memento_mori.lua
+++ b/scripts/actions/spells/blue/memento_mori.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 20
+    local power    = 20
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
     if not target:addStatusEffect(xi.effect.MAGIC_ATK_BOOST, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/metallic_body.lua
+++ b/scripts/actions/spells/blue/metallic_body.lua
@@ -22,8 +22,8 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local blueSkill = utils.clamp(caster:getSkillLevel(xi.skill.BLUE_MAGIC), 0, 500)
-    local power = utils.clamp(0.375 * blueSkill + 12.5, 0, 150)
-    local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
+    local power     = utils.clamp(0.375 * blueSkill + 12.5, 0, 150)
+    local duration  = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.STONESKIN, { power = power, duration = duration, origin = caster, tier = 2 }) then
         spell:setMsg(xi.msg.basic.MAGIC_NO_EFFECT)

--- a/scripts/actions/spells/blue/mind_blast.lua
+++ b/scripts/actions/spells/blue/mind_blast.lua
@@ -20,22 +20,18 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.DEMON
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.THUNDER
-    params.attribute   = xi.mod.MND
-    params.multiplier  = 2.08
-    params.azureBonus  = 0.5
-    params.tMultiplier = 1.5
-    params.duppercap   = 69
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.0
-    params.mnd_wsc     = 0.3
-    params.chr_wsc     = 0.0
+    params.dStat       = xi.mod.MND
+
+    params.ftp0            = 2.08
+    params.azureBonus      = 0.5
+    params.dStatMultiplier = 1.5
+    params.baseDamageCap   = 69
+
+    params.mnd_wsc = 0.3
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/mp_drainkiss.lua
+++ b/scripts/actions/spells/blue/mp_drainkiss.lua
@@ -20,11 +20,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AMORPH
+    local params      = {}
+    params.ecosystem  = xi.ecosystem.AMORPH
     params.attackType = xi.attackType.MAGICAL
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.BLUE_MAGIC
+    params.dStat      = xi.mod.INT
+
     params.dmgMultiplier = 3.5
 
     return xi.spells.blue.useDrainSpell(caster, target, spell, params, 165, true)

--- a/scripts/actions/spells/blue/mysterious_light.lua
+++ b/scripts/actions/spells/blue/mysterious_light.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.ARCANA
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.WIND
-    params.attribute   = xi.mod.CHR
-    params.multiplier  = 2.0
-    params.tMultiplier = 1.0
-    params.duppercap   = 56
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.0
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.3
+    params.dStat       = xi.mod.CHR
+
+    params.ftp0            = 2.0
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 56
+
+    params.chr_wsc = 0.3
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/pinecone_bomb.lua
+++ b/scripts/actions/spells/blue/pinecone_bomb.lua
@@ -20,25 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.PLANTOID
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.RANGED
-    params.damageType = xi.damageType.PIERCING
-    params.scattr     = xi.skillchainType.LIQUEFACTION
-    params.numhits    = 1
-    params.multiplier = 2.25
-    params.tp150      = 2.25
-    params.tp300      = 2.25
-    params.azuretp    = 2.25
-    params.duppercap  = 37
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.PLANTOID
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.RANGED
+    params.damageType     = xi.damageType.PIERCING
+    params.skillchainType = xi.skillchainType.LIQUEFACTION
+
+    params.numHits       = 1
+    params.ftp0          = 2.25
+    params.ftp1500       = 2.25
+    params.ftp3000       = 2.25
+    params.ftpAzure      = 2.25
+    params.baseDamageCap = 37
+
     params.str_wsc    = 0.2
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
     params.agi_wsc    = 0.2
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/plasma_charge.lua
+++ b/scripts/actions/spells/blue/plasma_charge.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 5 -- 5 dmg
+    local power    = 5 -- 5 dmg
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
     if not target:addStatusEffect(xi.effect.SHOCK_SPIKES, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/plenilune_embrace.lua
+++ b/scripts/actions/spells/blue/plenilune_embrace.lua
@@ -13,7 +13,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = 90
+    local duration  = 90
     local moonCycle = getVanadielMoonCycle()
 
     local cycleBuffs =

--- a/scripts/actions/spells/blue/poison_breath.lua
+++ b/scripts/actions/spells/blue/poison_breath.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.UNDEAD
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.WATER
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 10
     params.lvlMod     = 1.25
     params.isConal    = true

--- a/scripts/actions/spells/blue/pollen.lua
+++ b/scripts/actions/spells/blue/pollen.lua
@@ -21,15 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.minCure = 14
-    params.divisor0 = 1
-    params.constant0 = -6
+
+    params.minCure         = 14
+    params.divisor0        = 1
+    params.constant0       = -6
     params.powerThreshold1 = 59
-    params.divisor1 = 2
-    params.constant1 = 9
+    params.divisor1        = 2
+    params.constant1       = 9
     params.powerThreshold2 = 99
-    params.divisor2 = 57
-    params.constant2 = 33.125
+    params.divisor2        = 57
+    params.constant2       = 33.125
 
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/power_attack.lua
+++ b/scripts/actions/spells/blue/power_attack.lua
@@ -20,32 +20,28 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = xi.spells.blue.tpMod.CRITICAL
-    params.critchance = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.VERMIN
+    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critchance = 55
+        params.critChance = 55
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critchance = math.floor(caster:getTP() / 75)
+        params.critChance = math.floor(caster:getTP() / 75)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.REVERBERATION
-    params.numhits = 1
-    params.multiplier = 1.125
-    params.tp150 = 1.125
-    params.tp300 = 1.125
-    params.azuretp = 1.125
-    params.duppercap = 11
-    params.str_wsc = 0.0
-    params.dex_wsc = 0.0
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.REVERBERATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.125
+    params.ftp1500       = 1.125
+    params.ftp3000       = 1.125
+    params.ftpAzure      = 1.125
+    params.baseDamageCap = 11
+
     params.vit_wsc = 0.3
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/quad_continuum.lua
+++ b/scripts/actions/spells/blue/quad_continuum.lua
@@ -20,26 +20,23 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.EMPTY
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.PIERCING
-    params.scattr = xi.skillchainType.DISTORTION
-    params.scattr2 = xi.skillchainType.SCISSION
-    params.numhits = 4
-    params.multiplier = 1.25
-    params.tp150 = 1.5
-    params.tp300 = 1.75
-    params.azuretp = 2.0
-    params.duppercap = 75
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.EMPTY
+    params.tpModifier      = xi.spells.blue.tpMod.DAMAGE
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.PIERCING
+    params.skillchainType  = xi.skillchainType.DISTORTION
+    params.skillchainType2 = xi.skillchainType.SCISSION
+
+    params.numHits       = 4
+    params.ftp0          = 1.25
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.75
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.32
-    params.dex_wsc = 0.0
     params.vit_wsc = 0.32
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/quadrastrike.lua
+++ b/scripts/actions/spells/blue/quadrastrike.lua
@@ -21,34 +21,31 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     -- Missing proper info and logic for crit.
-    local params = {}
-    params.ecosystem = xi.ecosystem.DEMON
-    params.tpmod = xi.spells.blue.tpMod.CRITHITRATE
-    params.bonusacc = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.DEMON
+    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.LIQUEFACTION
-    params.scattr2 = xi.skillchainType.SCISSION
-    params.numhits = 4
-    params.multiplier = 1.1875
-    params.tp150 = 1.1875
-    params.tp300 = 1.1875
-    params.azuretp = 1.1875
-    params.duppercap = 100
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.LIQUEFACTION
+    params.skillchainType2 = xi.skillchainType.SCISSION
+
+    params.numHits       = 4
+    params.ftp0          = 1.1875
+    params.ftp1500       = 1.1875
+    params.ftp3000       = 1.1875
+    params.ftpAzure      = 1.1875
+    params.baseDamageCap = 100
+
     params.str_wsc = 0.3
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
-    params.critchance = 30 -- Guessed, this probably scales with TP, BG wiki says 33% which likely includes base crit rate so we're reducing it a bit lower
+
+    params.critChance = 30 -- Guessed, this probably scales with TP, BG wiki says 33% which likely includes base crit rate so we're reducing it a bit lower
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/queasyshroom.lua
+++ b/scripts/actions/spells/blue/queasyshroom.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.PLANTOID
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.RANGED
-    params.damageType = xi.damageType.PIERCING
-    params.scattr     = xi.skillchainType.COMPRESSION
-    params.numhits    = 1
-    params.multiplier = 1.75
-    params.tp150      = 1.75
-    params.tp300      = 1.75
-    params.azuretp    = 1.75
-    params.duppercap  = 15
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.2
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.PLANTOID
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.RANGED
+    params.damageType     = xi.damageType.PIERCING
+    params.skillchainType = xi.skillchainType.COMPRESSION
+
+    params.numHits       = 1
+    params.ftp0          = 1.75
+    params.ftp1500       = 1.75
+    params.ftp3000       = 1.75
+    params.ftpAzure      = 1.75
+    params.baseDamageCap = 15
+
+    params.int_wsc = 0.2
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/radiant_breath.lua
+++ b/scripts/actions/spells/blue/radiant_breath.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.DRAGON
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.LIGHT
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 5
     params.lvlMod     = 0.75
     params.isConal    = true

--- a/scripts/actions/spells/blue/ram_charge.lua
+++ b/scripts/actions/spells/blue/ram_charge.lua
@@ -20,25 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.BEAST
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr = xi.skillchainType.FRAGMENTATION
-    params.numhits = 1
-    params.multiplier = 1.0
-    params.tp150 = 1.375
-    params.tp300 = 1.75
-    params.azuretp = 1.875
-    params.duppercap = 75
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEAST
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.FRAGMENTATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.0
+    params.ftp1500       = 1.375
+    params.ftp3000       = 1.75
+    params.ftpAzure      = 1.875
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.3
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
     params.mnd_wsc = 0.5
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/refueling.lua
+++ b/scripts/actions/spells/blue/refueling.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 1000 -- 10%
+    local power    = 1000 -- 10%
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.HASTE, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/regeneration.lua
+++ b/scripts/actions/spells/blue/regeneration.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 25
+    local power    = 25
     local duration = 90
 
     if caster:hasStatusEffect(xi.effect.DIFFUSION) then

--- a/scripts/actions/spells/blue/regurgitation.lua
+++ b/scripts/actions/spells/blue/regurgitation.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.LIZARD
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.WATER
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 1.83
-    params.tMultiplier = 2.0
-    params.duppercap   = 69
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 1.83
+    params.dStatMultiplier = 2.0
+    params.baseDamageCap   = 69
+
     params.mnd_wsc     = 0.3
-    params.chr_wsc     = 0.0
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/rending_deluge.lua
+++ b/scripts/actions/spells/blue/rending_deluge.lua
@@ -24,23 +24,18 @@ spellObject.onSpellCast = function(caster, target, spell)
         multi = multi + 1.50
     end
 
-    local params = {}
-    params.ecosystem = xi.ecosystem.AQUAN
-    params.attackType = xi.attackType.MAGICAL
-    params.damageType = xi.damageType.WATER
-    params.attribute = xi.mod.INT
-    params.skillType = xi.skill.BLUE_MAGIC
-    params.effect = xi.effect.NONE
-    params.multiplier = multi
-    params.tMultiplier = 3.5
-    params.duppercap = 100
+    local params       = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem   = xi.ecosystem.AQUAN
+    params.attackType  = xi.attackType.MAGICAL
+    params.damageType  = xi.damageType.WATER
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = multi
+    params.dStatMultiplier = 3.5
+    params.baseDamageCap   = 100
+
     params.str_wsc = 0.2
-    params.dex_wsc = 0.0
     params.vit_wsc = 0.2
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     local maccParams =
     {

--- a/scripts/actions/spells/blue/saline_coat.lua
+++ b/scripts/actions/spells/blue/saline_coat.lua
@@ -21,8 +21,8 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 50
-    local tick = 4 -- decay by 1 every 4 seconds
+    local power    = 50
+    local tick     = 4 -- decay by 1 every 4 seconds
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 180)
 
     if not target:addStatusEffect(xi.effect.MAGIC_DEF_BOOST, { power = power, duration = duration, origin = caster, tick = tick }) then

--- a/scripts/actions/spells/blue/sandspin.lua
+++ b/scripts/actions/spells/blue/sandspin.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.AMORPH
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.EARTH
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 1.0
-    params.tMultiplier = 1.0
-    params.duppercap   = 13
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.0
-    params.agi_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 1.0
+    params.dStatMultiplier = 1.0
+    params.baseDamageCap   = 13
+
     params.int_wsc     = 0.2
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.0
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/sandspray.lua
+++ b/scripts/actions/spells/blue/sandspray.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BEASTMEN
     params.effect          = xi.effect.BLINDNESS
     params.power           = 25

--- a/scripts/actions/spells/blue/screwdriver.lua
+++ b/scripts/actions/spells/blue/screwdriver.lua
@@ -20,33 +20,30 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.AQUAN
-    params.tpmod = xi.spells.blue.tpMod.CRITICAL
-    params.critchance = 0
+    local params        = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem    = xi.ecosystem.AQUAN
+    params.tpModifier   = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critchance = 55
+        params.critChance = 55
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critchance = math.floor(caster:getTP() / 75)
+        params.critChance = math.floor(caster:getTP() / 75)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.PIERCING
-    params.scattr = xi.skillchainType.TRANSFIXION
-    params.scattr2 = xi.skillchainType.SCISSION
-    params.numhits = 1
-    params.multiplier = 1.375
-    params.tp150 = 1.375
-    params.tp300 = 1.375
-    params.azuretp = 1.375
-    params.duppercap = 27
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.PIERCING
+    params.skillchainType  = xi.skillchainType.TRANSFIXION
+    params.skillchainType2 = xi.skillchainType.SCISSION
+
+    params.numHits       = 1
+    params.ftp0          = 1.375
+    params.ftp1500       = 1.375
+    params.ftp3000       = 1.375
+    params.ftpAzure      = 1.375
+    params.baseDamageCap = 27
+
     params.str_wsc = 0.2
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
     params.mnd_wsc = 0.2
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/seedspray.lua
+++ b/scripts/actions/spells/blue/seedspray.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.PLANTOID
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr     = xi.skillchainType.INDURATION
-    params.scattr2    = xi.skillchainType.DETONATION
-    params.numhits    = 3
-    params.multiplier = 0.875
-    params.tp150      = 0.875
-    params.tp300      = 0.875
-    params.azuretp    = 0.875
-    params.duppercap  = 69
-    params.str_wsc    = 0.0
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.PLANTOID
+    params.tpModifier      = xi.spells.blue.tpMod.DURATION
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.INDURATION
+    params.skillchainType2 = xi.skillchainType.DETONATION
+
+    params.numHits       = 3
+    params.ftp0          = 0.875
+    params.ftp1500       = 0.875
+    params.ftp3000       = 0.875
+    params.ftpAzure      = 0.875
+    params.baseDamageCap = 69
+
     params.dex_wsc    = 0.3
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/self-destruct.lua
+++ b/scripts/actions/spells/blue/self-destruct.lua
@@ -21,11 +21,11 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = xi.spells.blue.getDefaultParams(caster)
     params.attackType = xi.attackType.MAGICAL
     params.damageType = xi.damageType.FIRE
-    local playerHP = caster:getLocalVar('selfdestructHp')
-    local damage = playerHP - 1
+    local playerHP    = caster:getLocalVar('selfdestructHp')
+    local damage      = playerHP - 1
 
     if damage > 0 then
         damage = xi.spells.blue.applySpellDamage(caster, target, spell, damage, params)

--- a/scripts/actions/spells/blue/sheep_song.lua
+++ b/scripts/actions/spells/blue/sheep_song.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BEAST
     params.effect          = xi.effect.SLEEP_I
     params.power           = 1

--- a/scripts/actions/spells/blue/sickle_slash.lua
+++ b/scripts/actions/spells/blue/sickle_slash.lua
@@ -20,32 +20,28 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.VERMIN
-    params.tpmod = xi.spells.blue.tpMod.CRITICAL
-    params.critchance = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.VERMIN
+    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critchance = 55
+        params.critChance = 55
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critchance = math.floor(caster:getTP() / 75)
+        params.critChance = math.floor(caster:getTP() / 75)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.COMPRESSION
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 1.5
-    params.tp300 = 1.5
-    params.azuretp = 1.5
-    params.duppercap = 49
-    params.str_wsc = 0.0
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.COMPRESSION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 49
+
     params.dex_wsc = 0.5
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/smite_of_rage.lua
+++ b/scripts/actions/spells/blue/smite_of_rage.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.ARCANA
-    params.tpmod = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.DETONATION
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 2.25
-    params.tp300 = 2.5
-    params.azuretp = 2.53125
-    params.duppercap = 35
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.ARCANA
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.DETONATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 2.25
+    params.ftp3000       = 2.5
+    params.ftpAzure      = 2.53125
+    params.baseDamageCap = 35
+
     params.str_wsc = 0.2
     params.dex_wsc = 0.2
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
-    params.ignorefstrcap = true -- Smite of Rage doesn't have an fSTR cap
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/soporific.lua
+++ b/scripts/actions/spells/blue/soporific.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.PLANTOID
     params.effect          = xi.effect.SLEEP_I
     params.power           = 2

--- a/scripts/actions/spells/blue/sound_blast.lua
+++ b/scripts/actions/spells/blue/sound_blast.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BIRD
     params.effect          = xi.effect.INT_DOWN
     params.power           = 9

--- a/scripts/actions/spells/blue/spinal_cleave.lua
+++ b/scripts/actions/spells/blue/spinal_cleave.lua
@@ -20,33 +20,29 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod = xi.spells.blue.tpMod.ACC
-    params.bonusacc = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.UNDEAD
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.SCISSION
-    params.scattr2 = xi.skillchainType.DETONATION
-    params.numhits = 1
-    params.multiplier = 3.0
-    params.tp150 = 3.0
-    params.tp300 = 3.0
-    params.azuretp = 3.0
-    params.duppercap = 75
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.SCISSION
+    params.skillchainType2 = xi.skillchainType.DETONATION
+
+    params.numHits       = 1
+    params.ftp0          = 3.0
+    params.ftp1500       = 3.0
+    params.ftp3000       = 3.0
+    params.ftpAzure      = 3.0
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.3
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/spiral_spin.lua
+++ b/scripts/actions/spells/blue/spiral_spin.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.VERMIN
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr     = xi.skillchainType.TRANSFIXION
-    params.numhits    = 1
-    params.multiplier = 2.0
-    params.tp150      = 2.0
-    params.tp300      = 2.0
-    params.azuretp    = 2.0
-    params.duppercap  = 69
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.3
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.VERMIN
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.TRANSFIXION
+
+    params.numHits      = 1
+    params.ftp0         = 2.0
+    params.ftp1500      = 2.0
+    params.ftp3000      = 2.0
+    params.ftpAzure     = 2.0
+    params.baseDamageCap = 69
+
+    params.agi_wsc = 0.3
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/sprout_smack.lua
+++ b/scripts/actions/spells/blue/sprout_smack.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.PLANTOID
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr     = xi.skillchainType.REVERBERATION
-    params.numhits    = 1
-    params.multiplier = 1.5
-    params.tp150      = 1.5
-    params.tp300      = 1.5
-    params.azuretp    = 1.5
-    params.duppercap  = 11
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.3
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.PLANTOID
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.REVERBERATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 11
+
+    params.vit_wsc = 0.3
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/stinking_gas.lua
+++ b/scripts/actions/spells/blue/stinking_gas.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.UNDEAD
     params.effect          = xi.effect.VIT_DOWN
     params.power           = 10

--- a/scripts/actions/spells/blue/sub-zero_smash.lua
+++ b/scripts/actions/spells/blue/sub-zero_smash.lua
@@ -20,27 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.AQUAN
-    params.tpmod      = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.BLUNT
-    params.scattr     = xi.skillchainType.FRAGMENTATION
-    params.attribute  = xi.mod.INT
-    params.skillType  = xi.skill.BLUE_MAGIC
-    params.numhits    = 1
-    params.multiplier = 2.0
-    params.tp150      = 2.0
-    params.tp300      = 2.0
-    params.azuretp    = 2.0
-    params.duppercap  = 72
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.AQUAN
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.BLUNT
+    params.skillchainType = xi.skillchainType.FRAGMENTATION
+    params.dStat          = xi.mod.INT
+
+    params.numHits       = 1
+    params.ftp0          = 2.0
+    params.ftp1500       = 2.0
+    params.ftp3000       = 2.0
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 72
+
     params.vit_wsc    = 0.6
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/sudden_lunge.lua
+++ b/scripts/actions/spells/blue/sudden_lunge.lua
@@ -20,27 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.VERMIN
-    params.tpmod      = xi.spells.blue.tpMod.DAMAGE
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr     = xi.skillchainType.DETONATION
-    params.attribute  = xi.mod.INT
-    params.skillType  = xi.skill.BLUE_MAGIC
-    params.numhits    = 1
-    params.multiplier = 1.5
-    params.tp150      = 2.5
-    params.tp300      = 3
-    params.azuretp    = 3.5
-    params.duppercap  = 100
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.VERMIN
+    params.tpModifier     = xi.spells.blue.tpMod.DAMAGE
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.DETONATION
+    params.dStat          = xi.mod.INT
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 2.5
+    params.ftp3000       = 3
+    params.ftpAzure      = 3.5
+    params.baseDamageCap = 100
+
     params.agi_wsc    = 0.4
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/tail_slap.lua
+++ b/scripts/actions/spells/blue/tail_slap.lua
@@ -20,27 +20,23 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.BEASTMEN
-    params.tpmod      = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr     = xi.skillchainType.REVERBERATION
-    params.attribute  = xi.mod.INT
-    params.skillType  = xi.skill.BLUE_MAGIC
-    params.numhits    = 1
-    params.multiplier = 1.625
-    params.tp150      = 1.625
-    params.tp300      = 1.625
-    params.azuretp    = 1.625
-    params.duppercap  = 75
-    params.str_wsc    = 0.2
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.5
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.HAND_TO_HAND
+    params.skillchainType = xi.skillchainType.REVERBERATION
+    params.dStat          = xi.mod.INT
+
+    params.numHits       = 1
+    params.ftp0          = 1.625
+    params.ftp1500       = 1.625
+    params.ftp3000       = 1.625
+    params.ftpAzure      = 1.625
+    params.baseDamageCap = 75
+
+    params.str_wsc = 0.2
+    params.vit_wsc = 0.5
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/temporal_shift.lua
+++ b/scripts/actions/spells/blue/temporal_shift.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.LUMINIAN
     params.effect          = xi.effect.STUN
     params.power           = 1

--- a/scripts/actions/spells/blue/terror_touch.lua
+++ b/scripts/actions/spells/blue/terror_touch.lua
@@ -21,33 +21,30 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.UNDEAD
-    params.tpmod     = xi.spells.blue.tpMod.ACC
-    params.bonusacc  = 0
+    local params      = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem  = xi.ecosystem.UNDEAD
+    params.tpModifier = xi.spells.blue.tpMod.ACC
+
     if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.bonusacc = 70
+        params.bonusAcc = 70
     elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.bonusacc = math.floor(caster:getTP() / 50)
+        params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr     = xi.skillchainType.COMPRESSION
-    params.scattr2    = xi.skillchainType.REVERBERATION
-    params.numhits    = 1
-    params.multiplier = 1.5
-    params.tp150      = 1.5
-    params.tp300      = 1.5
-    params.azuretp    = 1.5
-    params.duppercap  = 41
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.2
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.2
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.HAND_TO_HAND
+    params.skillchainType  = xi.skillchainType.COMPRESSION
+    params.skillchainType2 = xi.skillchainType.REVERBERATION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 41
+
+    params.dex_wsc = 0.2
+    params.int_wsc = 0.2
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/thermal_pulse.lua
+++ b/scripts/actions/spells/blue/thermal_pulse.lua
@@ -20,21 +20,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.VERMIN
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.FIRE
-    params.attribute   = xi.mod.INT
-    params.multiplier  = 2.0
-    params.tMultiplier = 4.0 -- https://www.ffxiah.com/forum/topic/30626/the-beast-within-a-guide-to-blue-mage/#spells concurs with https://wiki.ffo.jp/html/22468.html on tp
-    params.duppercap   = 100
-    params.str_wsc     = 0.0
-    params.dex_wsc     = 0.0
-    params.vit_wsc     = 0.4
-    params.agi_wsc     = 0.0
-    params.int_wsc     = 0.0
-    params.mnd_wsc     = 0.0
-    params.chr_wsc     = 0.0
+    params.dStat       = xi.mod.INT
+
+    params.ftp0            = 2.0
+    params.dStatMultiplier = 4.0 -- https://www.ffxiah.com/forum/topic/30626/the-beast-within-a-guide-to-blue-mage/#spells concurs with https://wiki.ffo.jp/html/22468.html on tp
+    params.baseDamageCap   = 100
+
+    params.vit_wsc = 0.4
 
     -- Handle damage.
     local damage = xi.spells.blue.useMagicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/triumphant_roar.lua
+++ b/scripts/actions/spells/blue/triumphant_roar.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 15
+    local power    = 15
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 60)
 
     if not target:addStatusEffect(xi.effect.ATTACK_BOOST, { power = power, duration = duration, origin = caster }) then

--- a/scripts/actions/spells/blue/uppercut.lua
+++ b/scripts/actions/spells/blue/uppercut.lua
@@ -20,26 +20,22 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.PLANTOID
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.HAND_TO_HAND
-    params.scattr = xi.skillchainType.LIQUEFACTION
-    params.scattr2 = xi.skillchainType.IMPACTION
-    params.numhits = 1
-    params.multiplier = 1.5
-    params.tp150 = 1.5
-    params.tp300 = 1.5
-    params.azuretp = 1.5
-    params.duppercap = 39
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.PLANTOID
+    params.tpModifier      = xi.spells.blue.tpMod.ATTACK
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.HAND_TO_HAND
+    params.skillchainType  = xi.skillchainType.LIQUEFACTION
+    params.skillchainType2 = xi.skillchainType.IMPACTION
+
+    params.numHits       = 1
+    params.ftp0          = 1.5
+    params.ftp1500       = 1.5
+    params.ftp3000       = 1.5
+    params.ftpAzure      = 1.5
+    params.baseDamageCap = 39
+
     params.str_wsc = 0.35
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/venom_shell.lua
+++ b/scripts/actions/spells/blue/venom_shell.lua
@@ -20,7 +20,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.AQUAN
     params.effect          = xi.effect.POISON
     params.power           = 6

--- a/scripts/actions/spells/blue/vertical_cleave.lua
+++ b/scripts/actions/spells/blue/vertical_cleave.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem = xi.ecosystem.LUMINIAN
-    params.tpmod = xi.spells.blue.tpMod.ATTACK
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr = xi.skillchainType.GRAVITATION
-    params.numhits = 1
-    params.multiplier = 3.0
-    params.tp150 = 3.0
-    params.tp300 = 3.0
-    params.azuretp = 3.0
-    params.duppercap = 75
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.LUMINIAN
+    params.tpModifier     = xi.spells.blue.tpMod.ATTACK
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.SLASHING
+    params.skillchainType = xi.skillchainType.GRAVITATION
+
+    params.numHits       = 1
+    params.ftp0          = 3.0
+    params.ftp1500       = 3.0
+    params.ftp3000       = 3.0
+    params.ftpAzure      = 3.0
+    params.baseDamageCap = 75
+
     params.str_wsc = 0.5
-    params.dex_wsc = 0.0
-    params.vit_wsc = 0.0
-    params.agi_wsc = 0.0
-    params.int_wsc = 0.0
-    params.mnd_wsc = 0.0
-    params.chr_wsc = 0.0
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/warm-up.lua
+++ b/scripts/actions/spells/blue/warm-up.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 180)
+    local duration     = xi.spells.blue.calculateDurationWithDiffusion(caster, 180)
     local returnEffect = xi.effect.ACCURACY_BOOST
 
     local actionOne = target:addStatusEffect(xi.effect.ACCURACY_BOOST, { power = 10, duration = duration, origin = caster })

--- a/scripts/actions/spells/blue/whirl_of_rage.lua
+++ b/scripts/actions/spells/blue/whirl_of_rage.lua
@@ -20,26 +20,23 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.ARCANA
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.SLASHING
-    params.scattr     = xi.skillchainType.SCISSION
-    params.scattr2    = xi.skillchainType.DETONATION
-    params.numhits    = 1
-    params.multiplier = 3.0
-    params.tp150      = 3.5
-    params.tp300      = 4.0
-    params.azuretp    = 4.25
-    params.duppercap  = 83
-    params.str_wsc    = 0.3
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.0
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.3
-    params.chr_wsc    = 0.0
+    local params           = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem       = xi.ecosystem.ARCANA
+    params.tpModifier      = xi.spells.blue.tpMod.DURATION
+    params.attackType      = xi.attackType.PHYSICAL
+    params.damageType      = xi.damageType.SLASHING
+    params.skillchainType  = xi.skillchainType.SCISSION
+    params.skillchainType2 = xi.skillchainType.DETONATION
+
+    params.numHits       = 1
+    params.ftp0          = 3.0
+    params.ftp1500       = 3.5
+    params.ftp3000       = 4.0
+    params.ftpAzure      = 4.25
+    params.baseDamageCap = 83
+
+    params.str_wsc = 0.3
+    params.mnd_wsc = 0.3
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/white_wind.lua
+++ b/scripts/actions/spells/blue/white_wind.lua
@@ -22,15 +22,16 @@ end
 spellObject.onSpellCast = function(caster, target, spell)
     -- Need to confirm increases by Divine Seal and Cure Potency equipment
     local params = {}
-    params.minCure = math.floor(caster:getMaxHP() / 7) * 2
-    params.divisor0 = 0.6666
-    params.constant0 = -45
+
+    params.minCure         = math.floor(caster:getMaxHP() / 7) * 2
+    params.divisor0        = 0.6666
+    params.constant0       = -45
     params.powerThreshold1 = 0
-    params.divisor1 = 2
-    params.constant1 = 65
+    params.divisor1        = 2
+    params.constant1       = 65
     params.powerThreshold2 = 0
-    params.divisor2 = 6.5
-    params.constant2 = 144.6666
+    params.divisor2        = 6.5
+    params.constant2       = 144.6666
 
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/wild_carrot.lua
+++ b/scripts/actions/spells/blue/wild_carrot.lua
@@ -21,15 +21,16 @@ end
 
 spellObject.onSpellCast = function(caster, target, spell)
     local params = {}
-    params.minCure = 120
-    params.divisor0 = 1
-    params.constant0 = 60
+
+    params.minCure         = 120
+    params.divisor0        = 1
+    params.constant0       = 60
     params.powerThreshold1 = 179
-    params.divisor1 = 2
-    params.constant1 = 105
+    params.divisor1        = 2
+    params.constant1       = 105
     params.powerThreshold2 = 299
-    params.divisor2 = 15.6666
-    params.constant2 = 170.43
+    params.divisor2        = 15.6666
+    params.constant2       = 170.43
 
     return xi.spells.blue.useCuringSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/wild_oats.lua
+++ b/scripts/actions/spells/blue/wild_oats.lua
@@ -20,25 +20,21 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
-    params.ecosystem  = xi.ecosystem.PLANTOID
-    params.tpmod      = xi.spells.blue.tpMod.DURATION
-    params.attackType = xi.attackType.PHYSICAL
-    params.damageType = xi.damageType.PIERCING
-    params.scattr     = xi.skillchainType.TRANSFIXION
-    params.numhits    = 1
-    params.multiplier = 1.84
-    params.tp150      = 1.84
-    params.tp300      = 1.84
-    params.azuretp    = 1.84
-    params.duppercap  = 11
-    params.str_wsc    = 0.0
-    params.dex_wsc    = 0.0
-    params.vit_wsc    = 0.0
-    params.agi_wsc    = 0.3
-    params.int_wsc    = 0.0
-    params.mnd_wsc    = 0.0
-    params.chr_wsc    = 0.0
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.PLANTOID
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
+    params.attackType     = xi.attackType.PHYSICAL
+    params.damageType     = xi.damageType.PIERCING
+    params.skillchainType = xi.skillchainType.TRANSFIXION
+
+    params.numHits       = 1
+    params.ftp0          = 1.84
+    params.ftp1500       = 1.84
+    params.ftp3000       = 1.84
+    params.ftpAzure      = 1.84
+    params.baseDamageCap = 11
+
+    params.agi_wsc = 0.3
 
     -- Handle damage.
     local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)

--- a/scripts/actions/spells/blue/wind_breath.lua
+++ b/scripts/actions/spells/blue/wind_breath.lua
@@ -20,12 +20,10 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params      = {}
     params.ecosystem  = xi.ecosystem.DRAGON
     params.attackType = xi.attackType.BREATH
     params.damageType = xi.damageType.WIND
-    params.diff       = 0 -- no stat increases magic accuracy
-    params.skillType  = xi.skill.BLUE_MAGIC
     params.hpMod      = 4
     params.lvlMod     = 0
     params.isConal    = true

--- a/scripts/actions/spells/blue/yawn.lua
+++ b/scripts/actions/spells/blue/yawn.lua
@@ -21,7 +21,7 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params = {}
+    local params           = {}
     params.ecosystem       = xi.ecosystem.BIRD
     params.effect          = xi.effect.SLEEP_I
     params.power           = 2

--- a/scripts/actions/spells/blue/zephyr_mantle.lua
+++ b/scripts/actions/spells/blue/zephyr_mantle.lua
@@ -21,8 +21,8 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local power = 4
-    local tick = 0
+    local power    = 4
+    local tick     = 0
     local duration = xi.spells.blue.calculateDurationWithDiffusion(caster, 300)
 
     if not target:addStatusEffect(xi.effect.BLINK, { power = power, duration = duration, origin = caster, tick = tick }) then

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -744,11 +744,6 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
 
     target:takeSpellDamage(caster, spell, dmg, attackType, damageType)
 
-    -- Handle TP
-    local tpHits        = params.tphitslanded or 0
-    local extraTPGained = xi.combat.tp.calculateTPGainOnMagicalDamage(caster, target, dmg) * math.max(tpHits - 1, 0) -- Calculate extra TP gained from multihits. takeSpellDamage accounts for one already.
-    target:addTP(extraTPGained)
-
     -- Handle Afflatus Misery.
     target:handleAfflatusMiseryDamage(dmg)
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -12,6 +12,7 @@ xi.spells.blue = xi.spells.blue or {}
 -----------------------------------
 
 -- The TP modifier (currently unused)
+---@enum xi.spells.blue.tpMod
 xi.spells.blue.tpMod =
 {
     NONE          = 0,
@@ -186,11 +187,11 @@ end
 
 ---@param caster CBaseEntity
 ---@param target CBaseEntity
----@param params table
+---@param params blueSkillParams
 ---@return number
 local calculateCritChance = function(caster, target, params)
     if
-        params.critchance ~= nil and
+        params.critChance ~= nil and
         (caster:hasStatusEffect(xi.effect.AZURE_LORE) or
         caster:hasStatusEffect(xi.effect.EFFLUX) or
         caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY))
@@ -199,7 +200,7 @@ local calculateCritChance = function(caster, target, params)
         -- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S8:Y8
         local nativecrit = xi.combat.physical.calculateSwingCriticalRate(caster, target, 0, xi.slot.MAIN) - 0.05
 
-        return utils.clamp(params.critchance / 100 + nativecrit, 0.00, 1.0)
+        return utils.clamp(params.critChance / 100 + nativecrit, 0.00, 1.0)
     end
 
     return 0
@@ -245,18 +246,99 @@ end
 -- Global functions
 -----------------------------------
 
+---@class blueSkillParams
+---@field numHits          number
+---@field ftp0             number
+---@field ftp1500          number
+---@field ftp3000          number
+---@field ftpAzure         number
+---@field azureBonus       number
+---@field baseDamageCap    number
+---@field critChance       number
+---@field bonusAcc         number
+---@field bonusMacc        number
+---@field attackMod        number
+---@field ecosystem        xi.ecosystem
+---@field attackType       xi.attackType
+---@field damageType       xi.damageType
+---@field dStat            xi.mod
+---@field dStatMultiplier  number
+---@field tpModifier       xi.spells.blue.tpMod
+---@field skillchainType   xi.skillchainType
+---@field skillchainType2  xi.skillchainType
+---@field str_wsc          number
+---@field dex_wsc          number
+---@field vit_wsc          number
+---@field agi_wsc          number
+---@field int_wsc          number
+---@field mnd_wsc          number
+---@field chr_wsc          number
+---@field hasEfflux        boolean
+---@field hasAzureLore     boolean
+---@field hasBurstAffinity boolean
+---@field hasChainAffinity boolean
+---@field hasSneakAttack   boolean
+---@field tpHitsLanded     number
+---@field hitsLanded       number
+
+---@param caster CBaseEntity
+---@return blueSkillParams
+xi.spells.blue.getDefaultParams = function(caster)
+    local params = {}
+
+    params.numHits       = 1
+    params.ftp0          = 0
+    params.ftp1500       = 0
+    params.ftp3000       = 0
+    params.ftpAzure      = 0
+    params.azureBonus    = 0
+    params.baseDamageCap = 0
+    params.critChance    = 0
+    params.bonusAcc      = 0
+    params.bonusMacc     = 0
+    params.attackMod     = 1.0
+
+    params.ecosystem       = xi.ecosystem.UNCLASSIFIED
+    params.attackType      = xi.attackType.NONE
+    params.damageType      = xi.damageType.NONE
+    params.dStat           = xi.mod.INT
+    params.dStatMultiplier = 1
+    params.tpModifier      = xi.spells.blue.tpMod.NONE
+    params.skillchainType  = xi.skillchainType.NONE
+    params.skillchainType2 = xi.skillchainType.NONE
+
+    params.str_wsc = 0.0
+    params.dex_wsc = 0.0
+    params.vit_wsc = 0.0
+    params.agi_wsc = 0.0
+    params.int_wsc = 0.0
+    params.mnd_wsc = 0.0
+    params.chr_wsc = 0.0
+
+    params.hasEfflux        = caster:hasStatusEffect(xi.effect.EFFLUX)
+    params.hasAzureLore     = caster:hasStatusEffect(xi.effect.AZURE_LORE)
+    params.hasBurstAffinity = caster:hasStatusEffect(xi.effect.BURST_AFFINITY)
+    params.hasChainAffinity = caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY)
+    params.hasSneakAttack   = caster:hasStatusEffect(xi.effect.SNEAK_ATTACK)
+
+    params.tpHitsLanded = 0
+    params.hitsLanded   = 0
+
+    return params
+end
+
 -- Get the damage for a physical Blue Magic spell
 ---@param caster CBaseEntity
 ---@param target CBaseEntity
 ---@param spell CSpell
----@param params table
+---@param params blueSkillParams
 ---@return number, number
 xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     spell:setCritical(false)
 
     -- Initial D value
     local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell)
-    initialD       = utils.clamp(initialD, 0, params.duppercap)
+    initialD       = utils.clamp(initialD, 0, params.baseDamageCap)
 
     -- fSTR
     local dSTR = caster:getStat(xi.mod.STR) - target:getStat(xi.mod.VIT)
@@ -268,13 +350,13 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         fStr = calculatefSTR(dSTR, caster:getMainLvl())
     end
 
-    -- Multiplier, bonus WSC
-    local multiplier = params.multiplier or 1
+    -- ftp, bonus WSC
+    local ftp        = params.ftp0 or 1
     local bonusWSC   = getWSCBonuses(caster)
     local tp         = getTPBonus(caster)
 
     if tp > 0 then
-        multiplier = calculatefTP(tp, params.multiplier, params.tp150, params.tp300)
+        ftp = calculatefTP(tp, params.ftp0, params.ftp1500, params.ftp3000)
     end
 
     -- WSC
@@ -285,8 +367,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     local correlationBonus = xi.combat.damage.ecosystemMultiplier(caster, target, params.ecosystem or 0) - 1
 
     -- Azure Lore
-    if caster:getStatusEffect(xi.effect.AZURE_LORE) then
-        multiplier = params.azuretp
+    if params.hasAzureLore then
+        ftp = params.ftpAzure
     end
 
     -- Final D
@@ -296,22 +378,21 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     -- Get the possible pDIF range and hit rate --
     ----------------------------------------------
 
-    params.bonusacc     = params.bonusacc == nil and 0 or params.bonusacc
-    params.critchance   = calculateCritChance(caster, target, params)
+    params.bonusAcc     = params.bonusAcc or 0
+    params.critChance   = calculateCritChance(caster, target, params)
 
     local isCannonball         = spell:getID() == xi.magic.spell.CANNONBALL
     local potencyAttackMod     = 1 + (caster:getMerit(xi.merit.PHYSICAL_POTENCY) * 2) / 256 -- Each merit value is 2, but SE uses 4/256 for attack merit values.
-    local spellAttackMod       = 1 -- TODO: implement
+    local spellAttackMod       = params.attackMod -- TODO: implement
     local attackMultiplier     = spellAttackMod * potencyAttackMod
     local applyLevelCorrection = xi.data.levelCorrection.isLevelCorrectedZone(caster)
-    local hitrate              = calculateHitrate(caster, target, params.bonusacc)
+    local hitrate              = calculateHitrate(caster, target, params.bonusAcc)
 
     -------------------------
     -- Perform the attacks --
     -------------------------
 
     local hitsdone          = 0
-    local hitslanded        = 0
     local finaldmg          = 0
     local anyCrit           = false
     local sneakIsApplicable = false
@@ -330,9 +411,10 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         end
     end
 
-    params.tphitslanded = 0
+    params.tpHitsLanded = 0
+    params.hitsLanded   = 0
 
-    while hitsdone < params.numhits do
+    while hitsdone < params.numHits do
         local chance = math.randomFloat(0, 1)
 
         if
@@ -341,24 +423,24 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         then
             -- TODO: Check for shadow absorbs. Right now the whole spell will be absorbed by one shadow before it even gets here.
 
-            local isCritical = sneakIsApplicable or math.randomFloat(0, 1) < params.critchance
+            local isCritical = sneakIsApplicable or math.randomFloat(0, 1) < params.critChance
             local pdif       = xi.combat.physical.calculateMeleePDIF(caster, target, xi.skill.BLUE_MAGIC, attackMultiplier, isCritical, applyLevelCorrection, false, 0, false, xi.slot.MAIN, isCannonball)
 
             anyCrit = anyCrit or isCritical
 
             -- Add it to our final damage
             if hitsdone == 0 then
-                finaldmg = finaldmg + finalD * (multiplier + correlationBonus) * pdif -- first hit gets full multiplier
+                finaldmg = finaldmg + finalD * (ftp + correlationBonus) * pdif -- first hit gets full ftp bonus
             else
                 finaldmg = finaldmg + finalD * (1 + correlationBonus) * pdif
             end
 
-            hitslanded        = hitslanded + 1
+            params.hitsLanded = params.hitsLanded + 1
             sneakIsApplicable = false
 
             -- Store number of hits that did > 0 damage
             if finaldmg > 0 then
-                params.tphitslanded = params.tphitslanded + 1
+                params.tpHitsLanded = params.tpHitsLanded + 1
             end
         end
 
@@ -372,11 +454,11 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     finaldmg = math.floor(finaldmg * xi.combat.damage.calculateDamageAdjustment(target, true, false, false, false))
 
-    if hitslanded == 0 then
+    if params.hitsLanded == 0 then
         spell:setMsg(xi.msg.basic.MAGIC_FAIL)
     end
 
-    if anyCrit and hitslanded > 0 then
+    if anyCrit and params.hitsLanded > 0 then
         target:triggerListener('CRITICAL_TAKE', target, caster)
     end
 
@@ -384,10 +466,15 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     caster:delStatusEffectSilent(xi.effect.EFFLUX)
 
-    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget), hitslanded
+    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget), params.hitsLanded
 end
 
 -- Get the damage for a magical Blue Magic spell. Called from spell scripts.
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param spell CSpell
+---@param params blueSkillParams
+---@return number
 xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     -- In individual magical spells, don't use params.effect for the added effect
     -- This would affect the resistance check for damage here
@@ -395,8 +482,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     -- Use params.addedEffect instead
 
     -- Initial values
-    local initialD   = utils.clamp(caster:getMainLvl() + 2, 0, params.duppercap)
-    params.skillType = xi.skill.BLUE_MAGIC
+    local initialD   = utils.clamp(caster:getMainLvl() + 2, 0, params.baseDamageCap)
 
     -- WSC
     local wsc           = calculateWSC(caster, params)
@@ -414,8 +500,8 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     wsc = wsc * wscMultiplier -- Bonus WSC from AF3/BA
 
     -- INT/MND/CHR dmg bonuses
-    params.diff     = caster:getStat(params.attribute) - target:getStat(params.attribute)
-    local statBonus = params.diff * params.tMultiplier
+    local statDiff  = caster:getStat(params.dStat) - target:getStat(params.dStat)
+    local statBonus = statDiff * params.dStatMultiplier
 
     -- Azure Lore
     local azureBonus = 0
@@ -434,13 +520,13 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     local skillchainCount = xi.combat.magicBurst.getMagicBurstTier(target, spellElement)
 
     -- Final D value
-    local finalDamage    = (initialD + wsc) * (params.multiplier + azureBonus + correlationBonus) + statBonus
+    local finalDamage    = (initialD + wsc) * (params.ftp0 + azureBonus + correlationBonus) + statBonus
 
     local maccParams =
     {
         magicalElement = spellElement,
         magicBurstTier = skillchainCount,
-        actorStat      = params.attribute,
+        actorStat      = params.dStat,
         skillType      = skillType,
         spellGroup     = spellGroup,
     }
@@ -507,7 +593,7 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     {
         magicalElement = spellElement,
         magicBurstTier = skillchainCount,
-        actorStat      = params.attribute,
+        actorStat      = params.dStat,
         skillType      = skillType,
         spellGroup     = spellGroup,
     }
@@ -673,11 +759,17 @@ xi.spells.blue.useBreathSpell = function(caster, target, spell, params)
 end
 
 -- Apply spell damage
+---@param caster CBaseEntity
+---@param target CBaseEntity
+---@param spell CSpell
+---@param dmg number
+---@param params blueSkillParams
+---@param trickAttackTarget CBaseEntity?
 xi.spells.blue.applySpellDamage = function(caster, target, spell, dmg, params, trickAttackTarget)
     dmg                 = math.floor(dmg * xi.settings.main.BLUE_POWER)
     local attackType    = params.attackType or xi.attackType.NONE
     local damageType    = params.damageType or xi.damageType.NONE
-    local tpHits        = params.tphitslanded or 0
+    local tpHits        = params.tpHitsLanded or 0
     local extraTPGained = xi.combat.tp.calculateTPGainOnMagicalDamage(caster, target, dmg) * math.max(tpHits - 1, 0) -- Calculate extra TP gained from multihits. takeSpellDamage accounts for one already.
 
     -- handle MDT, One For All, Liement
@@ -842,7 +934,7 @@ end
 xi.spells.blue.applyBlueAdditionalEffect = function(caster, target, params, effectTable)
     -- Sanitize parameters.
     local element = params.damageType and params.damageType - 5 or 0
-    local stat    = params.attribute and params.attribute or xi.mod.INT
+    local stat    = params.dStat or xi.mod.INT
     if params.attackType == xi.attackType.BREATH then
         stat = 0
     end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -3233,7 +3233,7 @@ function CBaseEntity:setStatDebilitation(statDebil)
 end
 
 ---@nodiscard
----@param statId integer
+---@param statId integer|xi.mod
 ---@param optSlot integer?
 ---@return integer
 function CBaseEntity:getStat(statId, optSlot)
@@ -3395,8 +3395,8 @@ end
 ---@param caster CBaseEntity
 ---@param spell CSpell
 ---@param damage integer
----@param atkType integer
----@param dmgType integer
+---@param atkType integer|xi.attackType
+---@param dmgType integer|xi.damageType
 ---@return nil
 function CBaseEntity:takeSpellDamage(caster, spell, damage, atkType, dmgType)
 end


### PR DESCRIPTION


<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

use LLS definitions with a new table definition
generate a default table of params for phys/magic (others like enfeeb/breath etc not done yet)

Rename a bunch of stuff to make more sense... but maybe sometimes less sense depending on your perspective.
Whole lot of alignment
## Steps to test these changes

Cast junk and see stuff work
