### PR TITLE
[lua] Mission 5-1 Audits

### DIFF
--- a/data/zones/qubia_arena/mobs.yaml
+++ b/data/zones/qubia_arena/mobs.yaml
@@ -113,7 +113,7 @@ templates:
     id:            127
     species:       skeleton
     type:          [notorious, battlefield]
-    spell_list_id: 28
+    spell_list_id: 1
     skill_list_id: 227
     attributes:
       combat:
@@ -144,15 +144,19 @@ templates:
         look:
           type:  standard
           model: 564
-        model_size:  2
-        hitbox:     13
+        entity_flags: 1157
+        model_size:      2
+        hitbox:         13
       behaviors:
-        aggressive: true
-        links:      true
+        aggressive:     true
+        links:          true
+        true_detection: true
+      mob_mods:
+        always_aggro: 1
       spawn:
         type: [scripted]
       stats:
-        hp: 2000
+        hp: 1400
 
   Ancient_Warrior:
     id:            129
@@ -196,7 +200,7 @@ templates:
       spawn:
         type: [scripted]
       stats:
-        hp: 100
+        hp: 50
 
   Annihilated_Anthony:
     id:            160
@@ -252,7 +256,7 @@ templates:
     id:            223
     species:       skeleton
     type:          [notorious, battlefield]
-    spell_list_id: 28
+    spell_list_id: 1
     skill_list_id: 227
     attributes:
       combat:
@@ -283,16 +287,19 @@ templates:
         look:
           type:  standard
           model: 576
-        entity_flags: 1157
+        entity_flags: 1183
         model_size:      3
         hitbox:         16
       behaviors:
-        aggressive: true
-        links:      true
+        aggressive:     true
+        links:          true
+        true_detection: true
+      mob_mods:
+        always_aggro: 1
       spawn:
         type: [scripted]
       stats:
-        hp: 8300
+        hp: 10700
 
   Atori-Tutori_qm:
     id:            6642
@@ -2867,87 +2874,87 @@ templates:
 spawns:
   17620993:
     template: Archlich_Taberquoan
-    at:       [-399.908, -201.625, 386.934, 196]
+    at:       [-399.829, -202.125, 389.365, 192]
     level:    [45, 45]
   17620994:
     template: Ancient_Sorcerer
-    at:       [-416.616, -201.625, 409.581]
+    at:       [-410.826, -202.125, 407.049, 192]
     level:    [40, 40]
   17620995:
     template: Ancient_Sorcerer
-    at:       [-382.831, -201.625, 409.757, 128]
+    at:       [-389.476, -202.125, 407.588, 192]
     level:    [40, 40]
   17620996:
     template: Ancient_Warrior
-    at:       [-426.327, -199.125, 463.157]
+    at:       [-426.256, -199.625, 469.963, 128]
     level:    [40, 40]
   17620997:
     template: Ancient_Warrior
-    at:       [-426.188, -199.125, 476.989]
+    at:       [-373.739, -199.625, 469.963, 0]
     level:    [40, 40]
   17620998:
     template: Ancient_Warrior
-    at:       [-373.796, -199.125, 476.857]
+    at:       [-426.256, -199.625, 469.963, 128]
     level:    [40, 40]
   17620999:
     template: Ancient_Warrior
-    at:       [-373.951, -199.125, 463.279]
+    at:       [-373.739, -199.625, 469.963, 0]
     level:    [40, 40]
   17621000:
     template: Archlich_Taberquoan
-    at:       [0.165, -1.625, -12.967, 196]
+    at:       [0.048, -2.125, -10.925, 192]
     level:    [45, 45]
   17621001:
     template: Ancient_Sorcerer
-    at:       [-16.543, -1.625, 9.680]
+    at:       [-10.949, -2.125, 6.757, 192]
     level:    [40, 40]
   17621002:
     template: Ancient_Sorcerer
-    at:       [17.242, -1.625, 9.856, 128]
+    at:       [10.399, -2.125, 7.296, 192]
     level:    [40, 40]
   17621003:
     template: Ancient_Warrior
-    at:       [-26.254, 0.875, 63.256]
+    at:       [-26.194, 0.375, 70.031, 128]
     level:    [40, 40]
   17621004:
     template: Ancient_Warrior
-    at:       [-26.115, 0.875, 77.088]
+    at:       [26.320, 0.375, 70.032, 0]
     level:    [40, 40]
   17621005:
     template: Ancient_Warrior
-    at:       [26.277, 0.875, 76.956]
+    at:       [-26.194, 0.375, 70.031, 128]
     level:    [40, 40]
   17621006:
     template: Ancient_Warrior
-    at:       [26.122, 0.875, 63.378]
+    at:       [26.320, 0.375, 70.032, 0]
     level:    [40, 40]
   17621007:
     template: Archlich_Taberquoan
-    at:       [400.120, 198.375, -412.743, 196]
+    at:       [400.096, 197.875, -411.016, 192]
     level:    [45, 45]
   17621008:
     template: Ancient_Sorcerer
-    at:       [383.412, 198.375, -390.096]
+    at:       [389.096, 197.875, -393.334, 192]
     level:    [40, 40]
   17621009:
     template: Ancient_Sorcerer
-    at:       [417.197, 198.375, -389.920, 128]
+    at:       [410.446, 197.875, -392.794, 192]
     level:    [40, 40]
   17621010:
     template: Ancient_Warrior
-    at:       [373.701, 200.875, -336.520]
+    at:       [373.806, 200.375, -329.969, 0]
     level:    [40, 40]
   17621011:
     template: Ancient_Warrior
-    at:       [373.840, 200.875, -322.688]
+    at:       [426.320, 200.375, -329.968, 128]
     level:    [40, 40]
   17621012:
     template: Ancient_Warrior
-    at:       [426.232, 200.875, -322.820]
+    at:       [373.806, 200.375, -329.969, 0]
     level:    [40, 40]
   17621013:
     template: Ancient_Warrior
-    at:       [426.077, 200.875, -336.398]
+    at:       [426.320, 200.375, -329.968, 128]
     level:    [40, 40]
   17621014:
     template: Warlord_Rojgnoj

--- a/modules/era/lua/battlefields/mission_level_caps.lua
+++ b/modules/era/lua/battlefields/mission_level_caps.lua
@@ -1,12 +1,19 @@
 -----------------------------------
--- CoP Mission Battlefield Level Caps Module
--- Implements era-appropriate level caps for all CoP mission battlefields
+-- Mission Battlefield Level Caps Module
+-- Implements era-appropriate level caps for the Rank 5 and CoP mission battlefields
 -----------------------------------
--- Source: https://www.bg-wiki.com/ffxi/Version_Update_(06/21/2010)
+-- CoP caps removed June 21, 2010:
+-- Source: https://www.playonline.com/pcd/verup/ff11us/detail/5571/detail.html
+-- Nation mission caps removed February 15, 2011:
+-- Sources:
+--  https://www.playonline.com/pcd/verup/ff11us/detail/6240/detail.html
+--  https://www.playonline.com/pcd/verup/ff11/detail/6233/detail.html
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
-local m = Module:new('cop_level_caps', xi.pre(xi.expansion.ABYSSEA))
+-- Expansion gates cannot represent the February 2011 removal exactly. Pre-Abyssea is the
+-- nearest supported boundary and preserves the original caps for 75-cap configurations.
+local m = Module:new('mission_level_caps', xi.pre(xi.expansion.ABYSSEA))
 
 -- Apply level caps after server initialization when all battlefields are loaded
 m:addOverride('xi.server.onServerStart', function()
@@ -14,6 +21,9 @@ m:addOverride('xi.server.onServerStart', function()
 
     local battlefields =
     {
+        -- Nation Rank 5-1 Battlefield
+        { xi.battlefield.id.RANK_5_MISSION,                         50 },
+
         -- Level 30 Battlefields
         { xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_HOLLA, 30 },
         { xi.battlefield.id.ANCIENT_FLAMES_BECKON_SPIRE_OF_DEM,   30 },

--- a/scripts/battlefields/QuBia_Arena/rank_5_mission.lua
+++ b/scripts/battlefields/QuBia_Arena/rank_5_mission.lua
@@ -5,6 +5,9 @@
 local qubiaID = zones[xi.zone.QUBIA_ARENA]
 -----------------------------------
 
+-- Each pair shares a home point and produces at most one Warrior per pulse.
+local warriorOffsetsBySpawnPoint = { { 3, 5 }, { 4, 6 } }
+
 local content = BattlefieldMission:new({
     zoneId                = xi.zone.QUBIA_ARENA,
     battlefieldId         = xi.battlefield.id.RANK_5_MISSION,
@@ -12,8 +15,7 @@ local content = BattlefieldMission:new({
     isMission             = true,
     allowTrusts           = true,
     maxPlayers            = 6,
-    levelCap              = 50,
-    timeLimit             = utils.minutes(30),
+    timeLimit             = utils.minutes(15),
     index                 = 0,
     entryNpc              = 'BC_Entrance',
     exitNpc               = 'Burning_Circle',
@@ -21,6 +23,11 @@ local content = BattlefieldMission:new({
     requiredMissionStatus = 11,
     title                 = xi.title.ARCHMAGE_ASSASSIN,
 })
+
+function content:entryRequirement(player, npc, isRegistrant, trade)
+    return player:hasCompletedMission(player:getNation(), self.mission) or
+        player:hasKeyItem(xi.ki.NEW_FEIYIN_SEAL)
+end
 
 content.groups =
 {
@@ -32,7 +39,20 @@ content.groups =
             { qubiaID.mob.ARCHLICH_TABERQUOAN + 14 },
         },
 
-        allDeath = function(battlefield, mob)
+        allDeath = function(battlefield, archlich)
+            for offset = 1, 6 do
+                local add = GetMobByID(archlich:getID() + offset)
+
+                if add and add:isSpawned() then
+                    -- Retail removes remaining add models and nameplates in the Archlich death frame.
+                    for _, player in pairs(battlefield:getPlayers()) do
+                        player:sendEntityUpdateToPlayer(add, xi.entityUpdate.ENTITY_DESPAWN, xi.updateType.UPDATE_NONE)
+                    end
+
+                    DespawnMob(add:getID())
+                end
+            end
+
             battlefield:setStatus(xi.battlefield.status.WON)
         end,
 
@@ -92,5 +112,45 @@ content.groups =
         superlinkGroup = 1,
     },
 }
+
+function content:onBattlefieldTick(battlefield, tick)
+    Battlefield.onBattlefieldTick(self, battlefield, tick)
+
+    if battlefield:getStatus() ~= xi.battlefield.status.LOCKED then
+        return
+    end
+
+    local currentTime = GetSystemTime()
+    if currentTime < battlefield:getLocalVar('nextWarriorRespawn') then
+        return
+    end
+
+    local mobBaseId = qubiaID.mob.ARCHLICH_TABERQUOAN + (battlefield:getArea() - 1) * 7
+    local archlich  = GetMobByID(mobBaseId)
+    if not archlich then
+        return
+    end
+
+    local archlichTarget = archlich:getTarget()
+    if not archlichTarget then
+        return
+    end
+
+    battlefield:setLocalVar('nextWarriorRespawn', currentTime + 10)
+
+    for _, spawnPointOffsets in ipairs(warriorOffsetsBySpawnPoint) do
+        for _, offset in ipairs(spawnPointOffsets) do
+            local warrior = GetMobByID(mobBaseId + offset)
+
+            if warrior and not warrior:isSpawned() then
+                warrior:spawn()
+                -- Seed threat before directly entering the attack state.
+                warrior:addEnmity(archlichTarget, 1, 0)
+                warrior:engage(archlichTarget:getTargID())
+                break
+            end
+        end
+    end
+end
 
 return content:register()

--- a/scripts/zones/QuBia_Arena/mobs/Ancient_Sorcerer.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Ancient_Sorcerer.lua
@@ -1,25 +1,28 @@
 -----------------------------------
 -- Area: Qu'Bia Arena
---   NM: Archlich Taber'quoan
+--  Mob: Ancient Sorcerer
 -- Mission 5-1 BCNM Fight
 -----------------------------------
 ---@type TMobEntity
 local entity = {}
 
 entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+    mob:setMobMod(xi.mobMod.MAGIC_COOL, 45)
+    mob:setMobMod(xi.mobMod.NO_STANDBACK, 1)
     mob:setMobMod(xi.mobMod.SOUND_RANGE, 15)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)
     local spellList =
     {
-        [ 1] = { xi.magic.spell.BLIZZARD_II, target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
+        [ 1] = { xi.magic.spell.THUNDER,     target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
         [ 2] = { xi.magic.spell.WATER_II,    target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
         [ 3] = { xi.magic.spell.BLIZZAGA,    target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
-        [ 4] = { xi.magic.spell.STONEGA_II,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
-        [ 5] = { xi.magic.spell.THUNDAGA,    target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
-        [ 6] = { xi.magic.spell.WATERGA_II,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
-        [ 7] = { xi.magic.spell.POISON_II,   target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.POISON,     0, 100 },
+        [ 4] = { xi.magic.spell.AEROGA,      target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
+        [ 5] = { xi.magic.spell.STONEGA_II,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
+        [ 6] = { xi.magic.spell.THUNDAGA,    target, false, xi.action.type.DAMAGE_TARGET,        nil,                  0, 100 },
+        [ 7] = { xi.magic.spell.POISONGA,    target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.POISON,     0, 100 },
         [ 8] = { xi.magic.spell.BIO_II,      target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BIO,        4, 100 },
         [ 9] = { xi.magic.spell.FROST,       target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.FROST,      0, 100 },
         [10] = { xi.magic.spell.CHOKE,       target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.CHOKE,      0, 100 },
@@ -32,8 +35,7 @@ entity.onMobSpellChoose = function(mob, target, spellId)
         [17] = { xi.magic.spell.SLEEP,       target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,    1, 100 },
         [18] = { xi.magic.spell.BLIND,       target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BLINDNESS,  0, 100 },
         [19] = { xi.magic.spell.BIND,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BIND,       0, 100 },
-        [20] = { xi.magic.spell.SLEEP_II,    target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,    2, 100 },
-        [21] = { xi.magic.spell.SLEEPGA,     target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,    1, 100 },
+        [20] = { xi.magic.spell.SLEEPGA,     target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,    1, 100 },
     }
 
     return xi.combat.behavior.chooseAction(mob, target, nil, spellList)

--- a/scripts/zones/QuBia_Arena/mobs/Ancient_Warrior.lua
+++ b/scripts/zones/QuBia_Arena/mobs/Ancient_Warrior.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Area: Qu'Bia Arena
+--  Mob: Ancient Warrior
+-- Mission 5-1 BCNM Fight
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+entity.onMobSpawn = function(mob)
+    mob:setMod(xi.mod.DOUBLE_ATTACK, 0)
+end
+
+return entity


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR audits the Mission 5-1 battlefield in multiple ways against retail captures, including:

- Builds appropriate spawn behavior for Ancient Warriors.
- Audits all mob stats, spell lists, and behaviors.
- Adjusts aggro behavior and immunities.
- The mission now requires either completing the mission or the New Fei'Yin Seal for mission entry.
- Removes the level cap and sets the time limit to 15 minutes, per retail. Accordingly, adjusts the era module to add the level cap back in.

## Steps to test these changes

Run the mission and see you can still complete it and all of the above behavior is fixed.

## Captures

Capture file in video description.

https://youtu.be/ZLnlBCvhmT8

**Siknoz**

[Windurst 5-1 The Final Seal.zip](https://github.com/user-attachments/files/31634179/Windurst.5-1.The.Final.Seal.zip)
