### PR TITLE
[core, lua] Parametrize Death State. No EXP loss on deaths while charmed

### DIFF
--- a/modules/era/lua/globals/job_utils/ninja.lua
+++ b/modules/era/lua/globals/job_utils/ninja.lua
@@ -44,9 +44,12 @@ m:addOverrideByEra('xi.effects.sange.onEffectGain', {
 
 -- Mijin Gakure: Now applies weakness and normal HP gain on raise
 -- Source: https://www.bg-wiki.com/ffxi/Version_Update_(07/20/2009)
-m:addOverrideByEra('xi.player.onPlayerDeath', {
-    [xi.expansion.WOTG] = function(player)
-        super(player)
-        player:setLocalVar('MijinGakure', 0)
+m:addOverrideByEra('xi.job_utils.ninja.useMijinGakure', {
+    [xi.expansion.WOTG] = function(player, target, ability, action)
+        local dmg = super(player, target, ability, action)
+
+        player:die({ mijin = false })
+
+        return dmg
     end,
 })

--- a/scripts/globals/job_utils/ninja.lua
+++ b/scripts/globals/job_utils/ninja.lua
@@ -56,8 +56,7 @@ xi.job_utils.ninja.useMijinGakure = function(player, target, ability, action)
     dmg = utils.handleStoneskin(target, dmg, xi.attackType.SPECIAL)
 
     target:takeDamage(dmg, player, xi.attackType.SPECIAL, xi.damageType.ELEMENTAL)
-    player:setLocalVar('MijinGakure', 1)
-    player:setHP(0)
+    player:die({ expLoss = false, mijin = true })
 
     return dmg
 end

--- a/scripts/specs/core/CBaseEntity.lua
+++ b/scripts/specs/core/CBaseEntity.lua
@@ -2199,6 +2199,15 @@ end
 function CBaseEntity:setHP(value)
 end
 
+---@class DeathParams
+---@field expLoss boolean? Whether the death costs experience points. Defaults to true
+---@field mijin boolean? Mijin Gakure: no weakness and half HP back on raise. Defaults to false
+
+---@param params DeathParams?
+---@return nil
+function CBaseEntity:die(params)
+end
+
 ---@param value integer
 ---@return nil
 function CBaseEntity:setMaxHP(value)

--- a/scripts/specs/test/CSimulation.lua
+++ b/scripts/specs/test/CSimulation.lua
@@ -45,6 +45,19 @@ end
 function CSimulation:seed()
 end
 
+---Read a server setting by its fully qualified key
+---@param key string Setting key, e.g. 'map.EXP_RETAIN'
+---@return boolean|number|string
+function CSimulation:getSetting(key)
+end
+
+---Override a server setting for the duration of the test, restored automatically afterwards
+---@param key string Setting key, e.g. 'map.EXP_RETAIN'
+---@param value boolean|number|string
+---@return nil
+function CSimulation:setSetting(key, value)
+end
+
 ---Advances the steady clock.
 ---@param seconds integer
 ---@return nil

--- a/scripts/tests/framework/settings.lua
+++ b/scripts/tests/framework/settings.lua
@@ -1,0 +1,23 @@
+describe('Setting overrides', function()
+    local originalRetain
+
+    setup(function()
+        originalRetain = xi.test.world:getSetting('map.EXP_RETAIN')
+    end)
+
+    it('setSetting applies the override', function()
+        xi.test.world:setSetting('map.EXP_RETAIN', 0.5)
+
+        assert(xi.test.world:getSetting('map.EXP_RETAIN') == 0.5, 'Expected the override to be readable')
+    end)
+
+    it('the override is restored once the test that set it ended', function()
+        assert(xi.test.world:getSetting('map.EXP_RETAIN') == originalRetain, 'Expected the original value to be restored')
+    end)
+
+    it('the override reaches Lua readers too', function()
+        xi.test.world:setSetting('map.EXP_RETAIN', 0.5)
+
+        assert(xi.settings.map.EXP_RETAIN == 0.5, 'Expected xi.settings to carry the override')
+    end)
+end)

--- a/scripts/tests/systems/death_exp_loss.lua
+++ b/scripts/tests/systems/death_exp_loss.lua
@@ -1,0 +1,50 @@
+-----------------------------------
+-- EXP loss is decided by the circumstances of the death
+-----------------------------------
+
+describe('EXP loss on death', function()
+    ---@type CClientEntityPair
+    local player
+
+    local function die(params)
+        player:die(params)
+        xi.test.world:tickEntity(player)
+
+        assert(player:isDead(), 'precondition: the player should be dead')
+    end
+
+    before_each(function()
+        -- An operator can switch EXP loss off entirely, which would make every assertion below pass for the wrong reason
+        xi.test.world:setSetting('map.EXP_RETAIN', 0)
+        xi.test.world:setSetting('map.EXP_LOSS_RATE', 1)
+        xi.test.world:setSetting('map.EXP_LOSS_LEVEL', 31)
+
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.IFRITS_CAULDRON, level = 50 })
+        player:setCharVar('expLost', 0)
+    end)
+
+    it('a normal death costs EXP', function()
+        die()
+
+        assert(player:getCharVar('expLost') > 0, 'a normal death should cost EXP')
+    end)
+
+    it('a death while charmed is free', function()
+        local mob = player.entities:get('Volcanic_Bomb')
+        mob:respawn()
+        mob:charm(player)
+
+        assert(player:isCharmed(), 'precondition: the player should be charmed')
+
+        die()
+
+        -- "Players will no longer lose experience points if KO'd while charmed." - June 2007 version update
+        assert(player:getCharVar('expLost') == 0, 'a death while charmed should not cost EXP')
+    end)
+
+    it('a death with expLoss off is free', function()
+        die({ expLoss = false })
+
+        assert(player:getCharVar('expLost') == 0, 'a death with expLoss = false should not cost EXP')
+    end)
+end)

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -341,12 +341,12 @@ auto CAIContainer::Internal_RangedAttack(const EntityId& target) -> bool
     return false;
 }
 
-auto CAIContainer::Internal_Die(timer::duration deathTime) -> bool
+auto CAIContainer::Internal_Die(timer::duration deathTime, DeathParams params) -> bool
 {
     auto* entity = dynamic_cast<CBattleEntity*>(PEntity);
     if (entity)
     {
-        return ChangeState<CDeathState>(entity, deathTime);
+        return ChangeState<CDeathState>(entity, deathTime, params);
     }
     return false;
 }

--- a/src/map/ai/ai_container.h
+++ b/src/map/ai/ai_container.h
@@ -31,6 +31,7 @@
 #include "helpers/event_handler.h"
 #include "helpers/pathfind.h"
 #include "helpers/targetfind.h"
+#include "states/death_state.h"
 #include "states/state.h"
 
 class CBaseEntity;
@@ -76,7 +77,7 @@ public:
     auto Internal_PetSkill(const EntityId& target, uint16 abilityid) -> bool;
     auto Internal_Ability(const EntityId& target, uint16 abilityid) -> bool;
     auto Internal_RangedAttack(const EntityId& target) -> bool;
-    auto Internal_Die(timer::duration) -> bool;
+    auto Internal_Die(timer::duration, DeathParams params = {}) -> bool;
     auto Internal_UseItem(const EntityId& target, uint8 loc, uint8 slotid) -> bool;
     auto Internal_Despawn(bool instantDespawn = false) -> bool;
     auto Internal_Synth(xi::SkillType synthSkill) -> bool;

--- a/src/map/ai/states/death_state.cpp
+++ b/src/map/ai/states/death_state.cpp
@@ -35,13 +35,19 @@ static constexpr timer::duration TIME_TO_SEND_RERAISE_MENU = 8s;
 
 }
 
-CDeathState::CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time)
+CDeathState::CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time, DeathParams params)
 : CState(PEntity, PEntity->entityId())
 , m_PEntity(PEntity)
+, params_(params)
 , m_deathTime(death_time)
 , m_raiseTime(GetEntryTime() + TIME_TO_SEND_RERAISE_MENU)
 {
     // Capture constructor arguments into members and nothing else. All other logic goes into init().
+}
+
+auto CDeathState::params() const -> const DeathParams&
+{
+    return params_;
 }
 
 auto CDeathState::init() -> StateErrorOr<void>

--- a/src/map/ai/states/death_state.h
+++ b/src/map/ai/states/death_state.h
@@ -23,10 +23,17 @@
 
 #include "state.h"
 
+// Circumstances of a death, decided by whatever caused it and carried for as long as the death lasts.
+struct DeathParams
+{
+    bool losesExp{ true };
+    bool mijin{ false }; // Mijin Gakure: no weakness, half HP back on raise
+};
+
 class CDeathState : public CState
 {
 public:
-    CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time);
+    CDeathState(xi::Badge<CState>, CBattleEntity* PEntity, timer::duration death_time, DeathParams params = {});
 
     auto init() -> StateErrorOr<void> override;
 
@@ -38,10 +45,13 @@ public:
     void allowSendRaise();
     void acceptRaise();
 
+    auto params() const -> const DeathParams&;
+
 private:
     // Shadows CState::m_PEntity
     CBattleEntity* const m_PEntity;
 
+    DeathParams       params_;
     timer::duration   m_deathTime;
     bool              m_raiseSent{ false };
     bool              m_raiseAccepted{ false };

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -2427,7 +2427,11 @@ void CCharEntity::Die()
     const auto staged = nextDeath_.value_or(DeathParams{});
     nextDeath_.reset();
 
-    const DeathParams params = staged;
+    // Retail stopped charging EXP for a KO while charmed in June 2007
+    const DeathParams params{
+        .losesExp = staged.losesExp && !isCharmed,
+        .mijin    = staged.mijin,
+    };
 
     Die(death_duration, params);
     SetDeathTime(timer::now());

--- a/src/map/entities/char_entity.cpp
+++ b/src/map/entities/char_entity.cpp
@@ -57,6 +57,7 @@
 #include "ai/helpers/targetfind.h"
 #include "ai/states/ability_state.h"
 #include "ai/states/attack_state.h"
+#include "ai/states/death_state.h"
 #include "ai/states/item_state.h"
 #include "ai/states/magic_state.h"
 #include "ai/states/weaponskill_state.h"
@@ -2156,8 +2157,11 @@ void CCharEntity::OnRaise()
             m_weaknessLvl = 1;
         }
 
+        const auto* PDeathState = dynamic_cast<CDeathState*>(PAI->GetCurrentState());
+        const bool  mijin       = PDeathState && PDeathState->params().mijin;
+
         // add weakness effect (75% reduction in HP/MP)
-        if (GetLocalVar("MijinGakure") == 0)
+        if (!mijin)
         {
             auto weaknessTime = 5min;
 
@@ -2182,7 +2186,7 @@ void CCharEntity::OnRaise()
         auto& actionResult = actionTarget.addResult();
 
         // Mijin Gakure used with MIJIN_RERAISE MOD
-        if (GetLocalVar("MijinGakure") != 0 && getMod(xi::Mod::MIJIN_RERAISE) != 0)
+        if (mijin && getMod(xi::Mod::MIJIN_RERAISE) != 0)
         {
             actionResult.animation = ActionAnimation::Raise;
             hpReturned             = (uint16)(GetMaxHP());
@@ -2190,13 +2194,13 @@ void CCharEntity::OnRaise()
         else if (m_hasRaise == 1)
         {
             actionResult.animation = ActionAnimation::Raise;
-            hpReturned             = static_cast<uint16>((GetLocalVar("MijinGakure") != 0) ? GetMaxHP() * 0.5 : GetMaxHP() * 0.1);
+            hpReturned             = static_cast<uint16>(mijin ? GetMaxHP() * 0.5 : GetMaxHP() * 0.1);
             ratioReturned          = 0.50f * static_cast<double>(1 - settings::get<uint8>("map.EXP_RETAIN"));
         }
         else if (m_hasRaise == 2)
         {
             actionResult.animation = ActionAnimation::Raise2;
-            hpReturned             = static_cast<uint16>((GetLocalVar("MijinGakure") != 0) ? GetMaxHP() * 0.5 : GetMaxHP() * 0.25);
+            hpReturned             = static_cast<uint16>(mijin ? GetMaxHP() * 0.5 : GetMaxHP() * 0.25);
             ratioReturned          = ((GetMLevel() <= 50) ? 0.50f : 0.75f) * static_cast<double>(1 - settings::get<uint8>("map.EXP_RETAIN"));
         }
         else if (m_hasRaise == 3)
@@ -2234,7 +2238,6 @@ void CCharEntity::OnRaise()
             StatusEffectContainer->AddStatusEffect(xi::StatusEffect::Reraise, static_cast<uint16>(xi::StatusEffect::Reraise), 3, 0s, 1h);
         }
 
-        SetLocalVar("MijinGakure", 0);
         m_hasArise = false;
         m_hasRaise = 0;
     }
@@ -2421,12 +2424,17 @@ void CCharEntity::Die()
         petutils::DespawnPet(this);
     }
 
-    Die(death_duration);
+    const auto staged = nextDeath_.value_or(DeathParams{});
+    nextDeath_.reset();
+
+    const DeathParams params = staged;
+
+    Die(death_duration, params);
     SetDeathTime(timer::now());
 
     setBlockingAid(false);
 
-    if (GetLocalVar("MijinGakure") == 0 &&
+    if (params.losesExp &&
         (PBattlefield == nullptr || (PBattlefield->GetRuleMask() & RULES_LOSE_EXP) == RULES_LOSE_EXP) &&
         GetMLevel() >= settings::get<uint8>("map.EXP_LOSS_LEVEL"))
     {
@@ -2437,7 +2445,17 @@ void CCharEntity::Die()
     luautils::OnPlayerDeath(this);
 }
 
-void CCharEntity::Die(timer::duration _duration)
+auto CCharEntity::nextDeath() const -> const Maybe<DeathParams>&
+{
+    return nextDeath_;
+}
+
+void CCharEntity::setNextDeath(Maybe<DeathParams> params)
+{
+    nextDeath_ = params;
+}
+
+void CCharEntity::Die(timer::duration _duration, DeathParams params)
 {
     TracyZoneScoped;
 
@@ -2458,7 +2476,7 @@ void CCharEntity::Die(timer::duration _duration)
 
     m_deathSyncTime = timer::now() + death_update_frequency;
     PAI->ClearStateStack();
-    PAI->Internal_Die(_duration);
+    PAI->Internal_Die(_duration, params);
 
     // If player allegiance is not reset on death they will auto-homepoint
     allegiance = xi::Allegiance::Player;

--- a/src/map/entities/char_entity.h
+++ b/src/map/entities/char_entity.h
@@ -47,6 +47,7 @@
 
 #include "persist_batch.h"
 
+#include "ai/states/death_state.h"
 #include "battle_entity.h"
 #include "linkshell.h"
 #include "maze.h"
@@ -710,8 +711,11 @@ public:
     bool IsMobOwner(CBattleEntity* PTarget);
 
     void Die() override;
-    void Die(timer::duration _duration);
+    void Die(timer::duration _duration, DeathParams params = {});
     void Raise();
+
+    auto nextDeath() const -> const Maybe<DeathParams>&;
+    void setNextDeath(Maybe<DeathParams> params);
 
     static constexpr timer::duration death_duration         = 60min;
     static constexpr timer::duration death_update_frequency = 16s;
@@ -783,6 +787,8 @@ protected:
 
 private:
     auto applyTargetRestrictions(CBaseEntity* PResolved, uint16 validTargetFlags, std::unique_ptr<CBasicPacket>& errMsg) -> CBattleEntity*;
+
+    Maybe<DeathParams> nextDeath_;
 
     CCraftState                               craftState_{};
     std::vector<std::unique_ptr<Transaction>> transactions_;

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -10490,6 +10490,36 @@ void CLuaBaseEntity::setHP(int32 value)
 }
 
 /************************************************************************
+ *  Function: die()
+ *  Purpose : Kills a player, describing the circumstances of the death
+ *  Example : player:die({ expLoss = false, mijin = true })
+ *  Notes   : Only the given keys are changed. Death will occur on the next tick.
+ ************************************************************************/
+
+void CLuaBaseEntity::die(const sol::object& params)
+{
+    auto* PChar = dynamic_cast<CCharEntity*>(m_PBaseEntity);
+    if (!PChar)
+    {
+        ShowWarning("Invalid Entity (%s) calling function.", m_PBaseEntity->getName());
+        return;
+    }
+
+    if (params.is<sol::table>())
+    {
+        const auto table  = params.as<sol::table>();
+        auto       staged = PChar->nextDeath().value_or(DeathParams{});
+
+        staged.losesExp = table.get_or("expLoss", staged.losesExp);
+        staged.mijin    = table.get_or("mijin", staged.mijin);
+
+        PChar->setNextDeath(staged);
+    }
+
+    setHP(0);
+}
+
+/************************************************************************
  *  Function: setMaxHP()
  *  Purpose : Sets the Maximum Hit Points of an Entity
  *  Example : player:setMaxHP(100)
@@ -20911,6 +20941,7 @@ void CLuaBaseEntity::Register()
     SOL_REGISTER("addHPLeaveSleeping", CLuaBaseEntity::addHPLeaveSleeping);
 
     SOL_REGISTER("setHP", CLuaBaseEntity::setHP);
+    SOL_REGISTER("die", CLuaBaseEntity::die);
     SOL_REGISTER("setMaxHP", CLuaBaseEntity::setMaxHP);
     SOL_REGISTER("restoreHP", CLuaBaseEntity::restoreHP);
     SOL_REGISTER("delHP", CLuaBaseEntity::delHP);

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -519,6 +519,7 @@ public:
     int32 addHP(int32 hpAdd);                                                                                                                      // Increase hp of Entity
     int32 addHPLeaveSleeping(int32 hpAdd);                                                                                                         // Increase hp of Entity but do not awaken the Entity
     void  setHP(int32 value);                                                                                                                      // Set hp of Entity to value
+    void  die(const sol::object& params);                                                                                                          // Kill a player, describing the circumstances of the death
     void  setMaxHP(int32 value);                                                                                                                   // Set max hp of Entity to value
     int32 restoreHP(int32 restoreAmt);                                                                                                             // Modify hp of Entity, but check if alive first
     void  delHP(int32 delAmt);                                                                                                                     // Decrease hp of Entity

--- a/src/test/lua/lua_simulation.cpp
+++ b/src/test/lua/lua_simulation.cpp
@@ -21,6 +21,8 @@
 
 #include "lua_simulation.h"
 
+#include "common/settings.h"
+#include "common/utils.h"
 #include "common/vana_time.h"
 #include "enums/tick_type.h"
 #include "helpers/lua_client_entity_pair_packets.h"
@@ -51,6 +53,18 @@
 
 namespace
 {
+
+// settings::set only writes the C++ map, while Lua reads xi.settings directly, so both have to move together
+void applySetting(const std::string& key, const settings::SettingsVariant& value)
+{
+    value.visit([&](const auto& held)
+                {
+                    settings::set(key, held);
+
+                    const auto parts                                              = split(key, ".");
+                    lua["xi"]["settings"][to_lower(parts[0])][to_upper(parts[1])] = held;
+                });
+}
 
 auto durationToVanaTime = [](const uint8 vanaHour, const uint8 vanaMinute) -> earth_time::duration
 {
@@ -131,6 +145,78 @@ void CLuaSimulation::skipTime(uint32 seconds) const
     // Advance time by the requested amount
     timer::add_offset(std::chrono::seconds(seconds));
     tick();
+}
+
+/************************************************************************
+ *  Function: getSetting()
+ *  Purpose : Reads a server setting by its fully qualified key.
+ *  Example : local retain = sim:getSetting('map.EXP_RETAIN')
+ ************************************************************************/
+
+auto CLuaSimulation::getSetting(const std::string& key) const -> sol::object
+{
+    const auto entry = settings::settingsMap.find(key);
+    if (entry == settings::settingsMap.end())
+    {
+        TestError("Unknown setting: {}", key);
+        return sol::lua_nil;
+    }
+
+    sol::object out = sol::lua_nil;
+    entry->second.visit([&](const auto& held)
+                        {
+                            out = sol::make_object(lua, held);
+                        });
+
+    return out;
+}
+
+/************************************************************************
+ *  Function: setSetting()
+ *  Purpose : Overrides a server setting for the duration of the test.
+ *  Example : sim:setSetting('map.EXP_RETAIN', 0)
+ *  Notes   : The engine puts the original value back after each test, the
+ *            same way it restores stubs and spies.
+ ************************************************************************/
+
+void CLuaSimulation::setSetting(const std::string& key, const sol::object& value)
+{
+    const auto entry = settings::settingsMap.find(key);
+    if (entry == settings::settingsMap.end())
+    {
+        TestError("Unknown setting: {}", key);
+        return;
+    }
+
+    // Only the first override of a test records the value to go back to
+    settingOverrides_.try_emplace(key, entry->second);
+
+    if (value.is<bool>())
+    {
+        applySetting(key, value.as<bool>());
+    }
+    else if (value.is<double>())
+    {
+        applySetting(key, value.as<double>());
+    }
+    else if (value.is<std::string>())
+    {
+        applySetting(key, value.as<std::string>());
+    }
+    else
+    {
+        TestError("Unsupported value type for setting: {}", key);
+    }
+}
+
+void CLuaSimulation::restoreSettings()
+{
+    for (const auto& [key, value] : settingOverrides_)
+    {
+        applySetting(key, value);
+    }
+
+    settingOverrides_.clear();
 }
 
 /************************************************************************
@@ -645,6 +731,8 @@ void CLuaSimulation::Register()
     SOL_REGISTER("skipVanaDays", CLuaSimulation::skipVanaDays);
     SOL_REGISTER("setRegionOwner", CLuaSimulation::setRegionOwner);
     SOL_REGISTER("setSeed", CLuaSimulation::setSeed);
+    SOL_REGISTER("getSetting", CLuaSimulation::getSetting);
+    SOL_REGISTER("setSetting", CLuaSimulation::setSetting);
     SOL_REGISTER("seed", CLuaSimulation::seed);
     SOL_REGISTER("spawnPlayer", CLuaSimulation::spawnPlayer);
     SOL_REGISTER("getSpawnSlot", CLuaSimulation::getSpawnSlot);

--- a/src/test/lua/lua_simulation.h
+++ b/src/test/lua/lua_simulation.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "common/cbasetypes.h"
+#include "common/settings.h"
 #include "lua_client_entity_pair.h"
 
 #include "data/enums/zone.h"
@@ -69,6 +70,9 @@ public:
     void skipVanaDays(uint32 days) const;
     void setRegionOwner(REGION_TYPE region, NATION_TYPE nation) const;
     void setSeed(uint64 seed) const;
+    auto getSetting(const std::string& key) const -> sol::object;
+    void setSetting(const std::string& key, const sol::object& value);
+    void restoreSettings();
     void seed() const;
     void resetWeather() const;
     void setSetupContext(bool inSetup);
@@ -79,6 +83,7 @@ public:
 
 private:
     std::vector<ClientInfo>       clients_;
+    settings::SettingsMap         settingOverrides_;
     bool                          inSetupContext_{ false };
     MapEngine*                    engine_{ nullptr };
     std::shared_ptr<InMemorySink> sink_{ nullptr };

--- a/src/test/test_engine.cpp
+++ b/src/test/test_engine.cpp
@@ -333,8 +333,9 @@ auto TestEngine::runTestCaseOnce(const TestCase& testCase, const HookContext& co
             status       = TestStatus::Failed;
         }
 
-        // Restore all mocks and spies after test execution
+        // Restore all mocks, spies and setting overrides after test execution
         mockManager_->restoreAll();
+        simulation_->restoreSettings();
     }
 
     // Run all after hooks (even if test failed)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

> Players will no longer lose experience points if KO'd while charmed.
https://www.playonline.com/pcd/update/ff11us/20070606TsVPr1/detail.html

- Pass a set of params to the DeathState (or more precisely, have it collect it from the CCharEntity)
- Replace existing Mijin Gakure localvar hack with it
- Add the charm guard

Also:
- Add the ability to override process settings for the duration of a test (auto reverted)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
