### PR TITLE
[lua] Changes minimum level to enter assaults to 50

### DIFF
--- a/scripts/globals/assault/container.lua
+++ b/scripts/globals/assault/container.lua
@@ -12,6 +12,7 @@ xi.assault.contentsByZone = xi.assault.contentsByZone or {}
 ---@field assaultID                integer
 ---@field instanceID               integer
 ---@field zoneID                   integer
+---@field suggestedLevel           integer
 ---@field loot                     table
 ---@field releasePos               table
 ---@field requiredProgress         integer?
@@ -40,7 +41,7 @@ end
 --  - requiredOrders:   (required) Key item orders needed to enter the assault
 --  - zoneID:           (required) ID of the zone
 --  - assaultArea:      (required) Area used for assault point currency
---  - suggestedLevel:   (required) Minimum level to enter; affects points rewarded
+--  - suggestedLevel:   (required) Recommended level; determines unappraised item eligibility
 --  - entranceParams:   (required) Table of zone-in event parameters
 --      - instanceID:   instanceID of the assault
 --      - entryEvent:   { csid, ... } args unpacked into player:startEvent() at the Runic Portal
@@ -214,7 +215,7 @@ xi.assault.checkRequirements = function(player, content)
         player:getCurrentAssault() == content.assaultID and
         player:getCharVar('assaultEntered') == 0 and
         player:getCharVar('AssaultFailed') == 0 and
-        player:getMainLvl() >= content.suggestedLevel
+        player:getMainLvl() >= 50
 end
 
 xi.assault.hasOrders = function(player)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes the minimum level you must be to enter an assault to level 50 and not based off of "recommended level"
Recommended level as far as we know only determines eligibility for ??? items, which is already supported by the framework.

<img width="1417" height="304" alt="image" src="https://github.com/user-attachments/assets/4ee58d0d-0963-4837-a70a-4bfc47db2416" />

## Steps to test these changes

None for now, need some assaults with a higher recommended level