### PR TITLE
[lua] Fix Assault Point Reward Handling

### DIFF
--- a/scripts/globals/assault/container.lua
+++ b/scripts/globals/assault/container.lua
@@ -354,6 +354,13 @@ xi.assault.afterInstanceRegistration = function(player, content)
     local ID        = zones[content.zoneID]
 
     player:setCharVar('assaultEntered', assaultID)
+
+    -- Players are awarded 100 Assault points for this area upon entering. This is credited immediately without any message.
+    local pointsArea = xi.assault.missionToArea[assaultID]
+    if pointsArea then
+        player:addAssaultPoint(pointsArea, 100)
+    end
+
     player:messageSpecial(ID.text.ASSAULT_START_OFFSET + assaultID, assaultID)
     player:messageSpecial(ID.text.TIME_TO_COMPLETE, instance:getTimeLimit() / 60)
 
@@ -396,24 +403,12 @@ xi.assault.onInstanceFailure = function(instance)
     local chars     = instance:getChars()
     local mobs      = instance:getMobs()
     local zoneID    = instance:getZone():getID()
-    local _, player = next(chars)
-    if not player then
-        return
-    end
-
-    local assaultID = player:getCurrentAssault()
-    local area      = xi.assault.missionToArea[assaultID]
 
     for _, entity in pairs(mobs) do
         DespawnMob(entity:getID(), instance)
     end
 
     for _, entity in pairs(chars) do
-        if area then
-            entity:addAssaultPoint(area, 100)
-            entity:messageSpecial(zones[zoneID].text.ASSAULT_POINTS_OBTAINED, 100)
-        end
-
         entity:messageSpecial(zones[zoneID].text.MISSION_FAILED, 10, 10)
         entity:setCharVar('assaultEntered', 0)
         entity:setCharVar('AssaultFailed', 1)
@@ -458,8 +453,11 @@ local function awardCompletionPoints(player, instance)
             end
 
             if pointsArea then
-                member:addAssaultPoint(pointsArea, math.floor(points))
-                member:messageSpecial(zoneText.ASSAULT_POINTS_OBTAINED, math.floor(points))
+                local assaultPointsEarned = math.floor(points)
+
+                -- Players earn the displayed points, minus the 100 points already awarded on entry.
+                member:addAssaultPoint(pointsArea, math.max(assaultPointsEarned - 100, 0))
+                member:messageSpecial(zoneText.ASSAULT_POINTS_OBTAINED, assaultPointsEarned)
             end
 
             member:setVar('AssaultPromotion', member:getCharVar('AssaultPromotion') + promotionBonus)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Changes how Assault Points are awarded for retail accuracy. 

* Players are awarded 100 Assault points upon entry of the Assault, these are your "consolation" points. - and they are added silently with no message.
* Upon victory, players are awarded the amount displayed in the chat, minus the 100 they got upon entering.
* When losing, players get nothing, since they already got 100 for entering the Assault.

Packet verified in this capture : 
[2026-8-31_23_57.zip](https://github.com/user-attachments/files/31674310/2026-8-31_23_57.zip)


## Steps to test these changes

Run an Assault, get 100 points upon entering, get the points it says you got - 100 upon victory
