### PR TITLE
[lua] Sandy 7-2 Bug Fixes

### DIFF
--- a/scripts/battlefields/Horlais_Peak/the_secret_weapon.lua
+++ b/scripts/battlefields/Horlais_Peak/the_secret_weapon.lua
@@ -53,7 +53,8 @@ content.groups =
             },
         },
 
-        allDeath = function(battlefield, mob)
+        superlink = true,
+        allDeath  = function(battlefield, mob)
             battlefield:setStatus(xi.battlefield.status.WON)
         end,
     },

--- a/scripts/zones/Horlais_Peak/mobs/Darokbok_of_Clan_Reaper.lua
+++ b/scripts/zones/Horlais_Peak/mobs/Darokbok_of_Clan_Reaper.lua
@@ -10,6 +10,13 @@ local entity = {}
 entity.onMobSpawn = function(mob)
     mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
     mob:setMobMod(xi.mobMod.MAGIC_COOL, 20)
+
+    -- Return to normal facing after turning to buff his party.
+    mob:addListener('MAGIC_STATE_EXIT', 'RESTORE_FACING', function(mobArg, spell)
+        if not mobArg:isEngaged() then
+            mobArg:setRotation(mobArg:getSpawnPos().rot)
+        end
+    end)
 end
 
 entity.onMobSpellChoose = function(mob, target, spellId)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes two bugs with Sandy Mission 7-2:

- The mobs should superlink.
- The main boss should turn back to face normally after buffing one of his allies.

## Steps to test these changes

Run the mission, see the above.

## Captures

Capture file included in video description.

https://www.youtube.com/watch?v=P_yCueKAVTc