### PR TITLE
[core] Verify entities are live before executing lua bindings

### DIFF
--- a/scripts/tests/systems/stale_entity_handle.lua
+++ b/scripts/tests/systems/stale_entity_handle.lua
@@ -1,0 +1,42 @@
+describe('Stale entity handle', function()
+    ---@type CClientEntityPair
+    local player
+
+    local function staleHandle()
+        local handle = GetPlayerByID(player:getID())
+        assert(handle ~= nil, 'expected a handle to the player')
+        assert(handle:getID() == player:getID(), 'handle should work while the player is alive')
+
+        player:gotoZone(xi.zone.EAST_RONFAURE)
+
+        return handle
+    end
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.WEST_RONFAURE })
+    end)
+
+    it('raises when a stale handle is the receiver', function()
+        local handle = staleHandle()
+
+        local ok, err = pcall(function()
+            return handle:getID()
+        end)
+
+        assert(not ok, 'expected the stale handle to raise')
+        assert(tostring(err):find('getID'), 'error should name the binding, got: ' .. tostring(err))
+        assert(tostring(err):find('is gone'), 'error should say the entity is gone, got: ' .. tostring(err))
+    end)
+
+    it('raises when a stale handle is an argument', function()
+        local handle = staleHandle()
+
+        local ok, err = pcall(function()
+            player:facePlayer(handle)
+        end)
+
+        assert(not ok, 'expected the stale argument to raise')
+        assert(tostring(err):find('facePlayer'), 'error should name the binding, got: ' .. tostring(err))
+        assert(tostring(err):find('is gone'), 'error should say the entity is gone, got: ' .. tostring(err))
+    end)
+end)

--- a/src/map/entities/base_entity.h
+++ b/src/map/entities/base_entity.h
@@ -192,8 +192,14 @@ public:
 
     bool IsDynamicEntity() const;
 
-    auto           serial() const -> uint64;
-    auto           entityId() const -> EntityId;
+    auto serial() const -> uint64;
+    auto entityId() const -> EntityId;
+
+    auto lifetime() const -> std::weak_ptr<void>
+    {
+        return lifetime_;
+    }
+
     uint32         id;             // global identifier unique on the server
     uint16         targid;         // local identifier unique to the zone
     ENTITYTYPE     objtype;        // Type of entity
@@ -236,6 +242,8 @@ protected:
 
 private:
     uint64 serial_{ 0 };
+
+    std::shared_ptr<void> lifetime_{ std::make_shared<char>() };
 };
 
 #endif // _BASEENTITY_H

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -174,10 +174,27 @@
 
 CLuaBaseEntity::CLuaBaseEntity(CBaseEntity* PEntity)
 : m_PBaseEntity(PEntity)
+, id_(PEntity)
+, lifetime_(PEntity != nullptr ? PEntity->lifetime() : std::weak_ptr<void>())
 {
     if (PEntity == nullptr)
     {
         ShowError("CLuaBaseEntity created with nullptr instead of valid CBaseEntity*!");
+    }
+}
+
+void CLuaBaseEntity::ensureLive(std::string_view binding) const
+{
+    if (lifetime_.expired())
+    {
+        const auto message = fmt::format("{}: {} {} (targid {}, zone {}) is gone",
+                                         binding,
+                                         magic_enum::enum_name(id_.objtype),
+                                         id_.UniqueNo,
+                                         id_.ActIndex,
+                                         static_cast<uint16>(id_.zoneId));
+
+        luaL_error(lua.lua_state(), "%s", message.c_str());
     }
 }
 

--- a/src/map/lua/lua_base_entity.h
+++ b/src/map/lua/lua_base_entity.h
@@ -27,6 +27,7 @@
 #include "data/enums/fame_area.h"
 #include "data/enums/mob_mod.h"
 #include "data/enums/music_slot.h"
+#include "entities/entity_id.h"
 #include "enums/mission_log.h"
 #include "lua_trade_container.h"
 #include "luautils.h"
@@ -51,7 +52,9 @@ class CLuaZone;
 class CLuaBaseEntity
 {
 protected:
-    CBaseEntity* m_PBaseEntity;
+    CBaseEntity*        m_PBaseEntity;
+    EntityId            id_;       // what it pointed at, for the error message
+    std::weak_ptr<void> lifetime_; // expires when that entity is destroyed
 
 public:
     CLuaBaseEntity(CBaseEntity*);
@@ -60,6 +63,8 @@ public:
     {
         return m_PBaseEntity;
     }
+
+    void ensureLive(std::string_view binding) const; // raises a Lua error if the entity behind this handle is gone
 
     friend std::ostream& operator<<(std::ostream& out, const CLuaBaseEntity& entity);
 
@@ -998,5 +1003,59 @@ public:
 
     static void Register();
 };
+
+namespace xi::lua
+{
+
+inline void ensureLive(std::string_view binding, const CLuaBaseEntity* entity)
+{
+    if (entity != nullptr)
+    {
+        entity->ensureLive(binding);
+    }
+}
+
+// Keep both spellings. With only the const one, a CLuaBaseEntity* argument prefers the catch-all and is never checked.
+inline void ensureLive(std::string_view binding, CLuaBaseEntity* entity)
+{
+    if (entity != nullptr)
+    {
+        entity->ensureLive(binding);
+    }
+}
+
+// Anything that is not an entity handle has no lifetime to check.
+template <typename T>
+void ensureLive(std::string_view, const T&)
+{
+}
+
+// Wraps an entity binding in a lambda of the same signature, with the handle it is called on as
+// the first parameter, which is how sol passes the receiver of `entity:method(...)`.
+template <typename Ret, typename... Args>
+auto guarded(std::string_view binding, Ret (CLuaBaseEntity::*func)(Args...))
+{
+    return [binding, func](CLuaBaseEntity& self, Args... args) -> Ret
+    {
+        self.ensureLive(binding);         // the receiver
+        (ensureLive(binding, args), ...); // each argument, of which only the entities are checked
+
+        return (self.*func)(std::forward<Args>(args)...);
+    };
+}
+
+template <typename Ret, typename... Args>
+auto guarded(std::string_view binding, Ret (CLuaBaseEntity::*func)(Args...) const)
+{
+    return [binding, func](const CLuaBaseEntity& self, Args... args) -> Ret
+    {
+        self.ensureLive(binding);         // the receiver
+        (ensureLive(binding, args), ...); // each argument, of which only the entities are checked
+
+        return (self.*func)(std::forward<Args>(args)...);
+    };
+}
+
+} // namespace xi::lua
 
 #endif

--- a/src/map/lua/sol_bindings.h
+++ b/src/map/lua/sol_bindings.h
@@ -23,6 +23,8 @@
 
 #include "sol/sol.hpp"
 
+#include <string_view>
+
 // sol changes this behavior to return 0 rather than truncating
 // we rely on that, so change it back
 // clang-format off
@@ -39,7 +41,7 @@
                                                                 sol::no_constructor, \
                                                                 sol::base_classes, sol::bases<__VA_ARGS__>())
 
-#define SOL_REGISTER(FuncName, Func) lua[className][FuncName] = &Func
+#define SOL_REGISTER(FuncName, Func) lua[className][FuncName] = xi::lua::guarded(#Func, &Func)
 
 #define SOL_READONLY(PropName, Func) typeBuilder[PropName] = sol::readonly_property(&Func)
 
@@ -92,6 +94,24 @@
         return obj ? sol::stack::push<LuaType>(L, obj) : sol::stack::push(L, sol::lua_nil); \
     }
 // clang-format on
+
+namespace xi::lua
+{
+
+// Binds the member pointer unchanged, for usertypes with no guarded overload of their own.
+template <typename Ret, typename Class, typename... Args>
+auto guarded(std::string_view, Ret (Class::*func)(Args...))
+{
+    return func;
+}
+
+template <typename Ret, typename Class, typename... Args>
+auto guarded(std::string_view, Ret (Class::*func)(Args...) const)
+{
+    return func;
+}
+
+} // namespace xi::lua
 
 //
 // Class bindings

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -385,6 +385,7 @@ void CParty::DelMember(CBattleEntity* PEntity)
 {
     if (PEntity == nullptr || PEntity->PParty != this)
     {
+        std::erase(members, PEntity);
         ShowWarning("CParty::DelMember() - PEntity was null, or PParty mismatch.");
         return;
     }
@@ -462,17 +463,12 @@ void CParty::DelMember(CBattleEntity* PEntity)
 
 void CParty::PopMember(CBattleEntity* PEntity)
 {
+    std::erase(members, PEntity);
+
     if (PEntity == nullptr || PEntity->PParty != this)
     {
         ShowWarning("CParty::PopMember() - PEntity was null, or PParty mismatch.");
         return;
-    }
-
-    auto memberToDelete = std::find(members.begin(), members.end(), PEntity);
-
-    if (memberToDelete != members.end())
-    {
-        members.erase(memberToDelete);
     }
 
     // free memory, party will re reinsatiated when they zone back in

--- a/src/test/lua/lua_test_entity.cpp
+++ b/src/test/lua/lua_test_entity.cpp
@@ -44,6 +44,8 @@ CLuaTestEntity::~CLuaTestEntity() = default;
 void CLuaTestEntity::setEntity(CBaseEntity* entity)
 {
     m_PBaseEntity = entity;
+    id_           = EntityId(entity);
+    lifetime_     = entity != nullptr ? entity->lifetime() : std::weak_ptr<void>();
 }
 
 /************************************************************************


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Trying to get rid of an entire class of crashes/corruption: lua scripts capturing entities usertypes in timers and other delayed callbacks and not regrabbing them by ID (about 20 of them are live today in this codebase)

This collects serials on creation into a set and pops them on destruction. 

At the sol layer, I insert a templated wrapper that's no-op for most bindings but short-circuits anything that's either a CLuaBaseEntity method or takes one as parameter and resolves against the set of serials. 

If the serial is not found, a lua error is pushed and the binding is not consumed.

It's kind of a hack stemming from poor lifecycle tracking but not having compiler enforcement at the lua layer makes this sort of bug all too easy to push through leading to subtle corruption or outright crashes.

Other alternatives include: 
- Not storing a pointer in CLuaBaseEntity and resolving EntityId everywhere
- Enforcing the check of known bad patterns in CI?

## Steps to test these changes
Testing it some more but the test cases speak for themselves.

<!-- Clear and detailed steps to test your changes here -->
