### PR TITLE
[yaml] Corrects species res ranks, DT mods and removes non-NM template overrides

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -211,7 +211,7 @@ ecosystems:
                   piercing: -2500
                   blunt:    -3750
                 dmg_magic:
-                  all: 2500
+                  all: 1250
                 rank_element:
                   fire:    0
                   ice:     2
@@ -234,6 +234,7 @@ ecosystems:
                   gravity:     2
               mods:
                 udmgbreath: 2500
+                mdef:         40
           flan:
             id: 5
             attributes:
@@ -551,6 +552,8 @@ ecosystems:
                   blind:        4
                   stun:         4
                   gravity:      1
+              mods:
+                mdef: 50
           sandworm:
             id: 14
             attributes:
@@ -601,6 +604,8 @@ ecosystems:
                   slashing: -5000
                   piercing: -5000
                   blunt:    -7500
+                dmg_magic:
+                  all: -2500
                 rank_element:
                   fire:    -3
                   ice:     -2
@@ -621,6 +626,8 @@ ecosystems:
                   blind:       -2
                   stun:        -2
                   gravity:     -2
+              mods:
+                mdef: 20
           clot:
             id: 16
             attributes:
@@ -1196,6 +1203,7 @@ ecosystems:
                   gravity:      0
               mods:
                 udmgbreath: -1250
+                mdef:          50
           orobon:
             id: 34
             attributes:
@@ -1293,6 +1301,8 @@ ecosystems:
                   blind:       6
                   stun:        2
                   gravity:     2
+              mods:
+                mdef: 10
       pugil:
         id: 16
         attributes:
@@ -1375,6 +1385,8 @@ ecosystems:
               detects:
                 - hearing
               resists:
+                dmg_magic:
+                  all: 3500
                 rank_element:
                   fire:    9
                   ice:     4
@@ -2333,7 +2345,7 @@ ecosystems:
             attributes:
               resists:
                 dmg_magic:
-                  all: -2500
+                  all: -625
                 rank_element:
                   fire:     5
                   ice:      3
@@ -2356,6 +2368,7 @@ ecosystems:
                   gravity:      5
               mods:
                 udmgbreath: -5000
+                mdef:          60
       magic_pot:
         id: 31
         attributes:
@@ -2491,6 +2504,8 @@ ecosystems:
                   blind:       -2
                   stun:        -2
                   gravity:      4
+              mods:
+                mdef: 30
       mimic:
         id: 33
         species:
@@ -2673,7 +2688,7 @@ ecosystems:
                   piercing: -1250
                   blunt:    -1250
                 dmg_magic:
-                  all: -1250
+                  all: -3450
                 rank_element:
                   fire:    2
                   ice:     3
@@ -2704,8 +2719,6 @@ ecosystems:
                   slashing: -1250
                   piercing: -1250
                   blunt:    -1250
-                dmg_magic:
-                  all: -1250
                 rank_element:
                   fire:    2
                   ice:     2
@@ -2747,6 +2760,8 @@ ecosystems:
             id: 78
             attributes:
               resists:
+                dmg_physical:
+                  piercing: 2500
                 rank_element:
                   fire:     0
                   ice:      1
@@ -2799,6 +2814,8 @@ ecosystems:
             id: 80
             attributes:
               resists:
+                dmg_physical:
+                  piercing: 2500
                 rank_element:
                   fire:     0
                   ice:      1
@@ -2884,7 +2901,7 @@ ecosystems:
                   stun:        0
                   gravity:     4
               mods:
-                udmgbreath: -1250
+                mdef: 60
           metal_head:
             id: 83
             attributes:
@@ -2912,7 +2929,7 @@ ecosystems:
                   stun:        0
                   gravity:     4
               mods:
-                udmgbreath: -1250
+                mdef: 60
       rampart:
         id: 38
         species:
@@ -3017,6 +3034,8 @@ ecosystems:
                   blind:       2
                   stun:        2
                   gravity:     2
+              mods:
+                mdef: 90
           skormoth:
             id: 87
             attributes:
@@ -3853,6 +3872,8 @@ ecosystems:
                   blind:       -2
                   stun:        -1
                   gravity:     -2
+              mods:
+                mdef: 22
           sheep:
             id: 111
             attributes:
@@ -4236,6 +4257,8 @@ ecosystems:
             id: 122
             attributes:
               resists:
+                dmg_magic:
+                  all: -5000
                 rank_element:
                   fire:    0
                   ice:     0
@@ -5463,6 +5486,8 @@ ecosystems:
                   blind:        0
                   stun:        -2
                   gravity:     -1
+              mods:
+                mdef: 30
       troll:
         id: 72
         attributes:
@@ -6062,6 +6087,8 @@ ecosystems:
                   blind:       -1
                   stun:         2
                   gravity:     -2
+              mods:
+                mdef: -10
       colibri:
         id: 80
         attributes:
@@ -6119,6 +6146,8 @@ ecosystems:
               resists:
                 dmg_physical:
                   piercing: 2500
+                dmg_magic:
+                  all: -9000
                 rank_element:
                   fire:     2
                   ice:      0
@@ -6285,6 +6314,8 @@ ecosystems:
                 dmg_physical:
                   slashing: -1250
                   blunt:     -625
+                dmg_magic:
+                  all: -1250
                 rank_element:
                   fire:    1
                   ice:     0
@@ -6307,7 +6338,7 @@ ecosystems:
                   gravity:     9
               mods:
                 udmgbreath: -2500
-                mdef:          80
+                mdef:          40
           white_harpeia:
             id: 186
             attributes:
@@ -6315,6 +6346,8 @@ ecosystems:
                 dmg_physical:
                   slashing: -1250
                   blunt:     -625
+                dmg_magic:
+                  all: -1250
                 rank_element:
                   fire:    1
                   ice:     0
@@ -6337,7 +6370,7 @@ ecosystems:
                   gravity:     9
               mods:
                 udmgbreath: -2500
-                mdef:          80
+                mdef:          40
       hippogryph:
         id: 83
         species:
@@ -6522,6 +6555,8 @@ ecosystems:
                   blind:        1
                   stun:         6
                   gravity:      6
+              mods:
+                mdef: 24
           tulfaire:
             id: 192
             attributes:
@@ -6677,8 +6712,6 @@ ecosystems:
             id: 196
             attributes:
               resists:
-                dmg_magic:
-                  all: -2500
                 rank_element:
                   fire:     0
                   ice:      0
@@ -6699,6 +6732,8 @@ ecosystems:
                   blind:        6
                   stun:         0
                   gravity:      0
+              mods:
+                mdef: 20
           shadow_eyes:
             id: 197
             attributes:
@@ -6886,6 +6921,8 @@ ecosystems:
                   blind:        1
                   stun:         1
                   gravity:      1
+              mods:
+                mdef: 10
       dvergr:
         id: 89
         attributes:
@@ -7043,8 +7080,6 @@ ecosystems:
             id: 207
             attributes:
               resists:
-                dmg_magic:
-                  all: -3750
                 rank_element:
                   fire:     3
                   ice:      4
@@ -7067,7 +7102,7 @@ ecosystems:
                   gravity:      3
               mods:
                 udmgbreath: -6250
-                mdef:          30
+                mdef:          14
       gargouille:
         id: 91
         attributes:
@@ -7285,14 +7320,13 @@ ecosystems:
             - magic
             - ability
             - scent
-          mods:
-            mdef:         20
-            udmgmagic: -2500
         species:
           black_robe_flayer:
             id: 214
             attributes:
               resists:
+                dmg_magic:
+                  all: -2500
                 rank_element:
                   fire:     0
                   ice:      2
@@ -7313,10 +7347,14 @@ ecosystems:
                   blind:       11
                   stun:         0
                   gravity:      0
+              mods:
+                mdef: 20
           soulflayer:
             id: 215
             attributes:
               resists:
+                dmg_magic:
+                  all: -2500
                 rank_element:
                   fire:     0
                   ice:      2
@@ -7337,6 +7375,8 @@ ecosystems:
                   blind:       11
                   stun:         0
                   gravity:      0
+              mods:
+                mdef: 20
               mob_mods:
                 sublink:    11
                 roam_cool:  50
@@ -7481,6 +7521,8 @@ ecosystems:
             id: 220
             attributes:
               resists:
+                dmg_magic:
+                  all: 8000
                 rank_element:
                   fire:     6
                   ice:      3
@@ -7501,6 +7543,8 @@ ecosystems:
                   blind:        3
                   stun:         3
                   gravity:      6
+              mods:
+                mdef: 50
       hydra:
         id: 96
         attributes:
@@ -7520,8 +7564,6 @@ ecosystems:
                 dmg_physical:
                   piercing: -5000
                   blunt:    -5000
-                dmg_magic:
-                  all: -2500
                 rank_element:
                   fire:    6
                   ice:     6
@@ -7544,7 +7586,7 @@ ecosystems:
                   gravity:     6
               mods:
                 udmgbreath: -10000
-                mdef:           30
+                mdef:           50
           hydra:
             id: 222
             attributes:
@@ -7754,6 +7796,8 @@ ecosystems:
                 - sight
                 - hearing
               resists:
+                dmg_magic:
+                  all: -4000
                 rank_element:
                   fire:     0
                   ice:      0
@@ -7947,6 +7991,8 @@ ecosystems:
                   blind:       -3
                   stun:        -2
                   gravity:      4
+              mods:
+                mdef: 20
           wyvern:
             id: 235
             attributes:
@@ -8555,6 +8601,10 @@ ecosystems:
                 - sight
                 - magic
               resists:
+                dmg_physical:
+                  slashing: -7500
+                  piercing: -5000
+                  blunt:    -6250
                 rank_element:
                   fire:    11 # absorbs on retail
                   ice:     11
@@ -8575,6 +8625,8 @@ ecosystems:
                   blind:       11
                   stun:        11
                   gravity:     11
+              mods:
+                udmgbreath: -2500
           titan:
             id: 255
             attributes:
@@ -9154,7 +9206,7 @@ ecosystems:
                   stun:         3
                   gravity:      3
               mods:
-                mdef: 40
+                mdef: 90
           monoceros:
             id: 272
             attributes:
@@ -9224,6 +9276,8 @@ ecosystems:
                   blind:        3
                   stun:         3
                   gravity:     11
+              mods:
+                mdef: 20
           pixie:
             id: 274
             attributes:
@@ -9250,6 +9304,8 @@ ecosystems:
                   blind:        1
                   stun:         1
                   gravity:     11
+              mods:
+                mdef: 16
           undeen:
             id: 275
             attributes:
@@ -9302,6 +9358,8 @@ ecosystems:
                   blind:        3
                   stun:         3
                   gravity:     11
+              mods:
+                mdef: 30
       porxie:
         id: 108
         species:
@@ -9370,7 +9428,7 @@ ecosystems:
                   piercing: -5000
                   blunt:    -2500
                 dmg_magic:
-                  all: -3750
+                  all: -1250
                 rank_element:
                   fire:    -2
                   ice:      4
@@ -9400,7 +9458,7 @@ ecosystems:
                   piercing: -5000
                   blunt:    -2500
                 dmg_magic:
-                  all: -3750
+                  all: -1250
                 rank_element:
                   fire:    -2
                   ice:      4
@@ -9613,8 +9671,6 @@ ecosystems:
             id: 285
             attributes:
               resists:
-                dmg_magic:
-                  all: -5000
                 rank_element:
                   fire:    11
                   ice:     11
@@ -9635,12 +9691,12 @@ ecosystems:
                   blind:        2
                   stun:         4
                   gravity:      4
+              mods:
+                mdef: 14
           seether:
             id: 286
             attributes:
               resists:
-                dmg_magic:
-                  all: -5000
                 rank_element:
                   fire:    11
                   ice:     11
@@ -9661,6 +9717,8 @@ ecosystems:
                   blind:        0
                   stun:         0
                   gravity:      0
+              mods:
+                mdef: 12
       thinker:
         id: 114
         attributes:
@@ -9766,7 +9824,7 @@ ecosystems:
                   stun:         4
                   gravity:      4
               mods:
-                mdef: 12
+                mdef: 14
           wanderer:
             id: 290
             attributes:
@@ -9793,7 +9851,7 @@ ecosystems:
                   gravity:      0
               mods:
                 hpp:  -10
-                mdef:  14
+                mdef:  12
               mob_mods:
                 mp_base: 50
       weeper:
@@ -9835,7 +9893,7 @@ ecosystems:
                   stun:         4
                   gravity:      4
               mods:
-                mdef: 12
+                mdef: 14
           weeper:
             id: 292
             attributes:
@@ -9862,7 +9920,7 @@ ecosystems:
                   gravity:      0
               mods:
                 hpp:  10
-                mdef: 14
+                mdef: 12
   humanoid:
     id: 12
     families:
@@ -10126,6 +10184,8 @@ ecosystems:
                   blind:        4
                   stun:        11
                   gravity:      4
+              mods:
+                mdef: 30
           legendary_adamantoise:
             id: 300
             attributes:
@@ -10598,6 +10658,8 @@ ecosystems:
                   blind:       2
                   stun:        2
                   gravity:     2
+              mods:
+                mdef: 22
       raptor:
         id: 129
         attributes:
@@ -11318,7 +11380,7 @@ ecosystems:
                   stun:        6
                   gravity:     2
               mods:
-                mdef: 60
+                mdef: 10
       cactaur:
         id: 141
         attributes:
@@ -11385,6 +11447,8 @@ ecosystems:
                   blind:        0
                   stun:         0
                   gravity:      2
+              mods:
+                mdef: 30
               mob_mods:
                 sublink: 7
       flytrap:
@@ -11829,6 +11893,8 @@ ecosystems:
             id: 350
             attributes:
               resists:
+                dmg_physical:
+                  piercing: 2500
                 rank_element:
                   fire:    -3
                   ice:     -3
@@ -11965,6 +12031,8 @@ ecosystems:
                   blind:        4
                   stun:        -1
                   gravity:     -1
+              mods:
+                mdef: 10
           purbol:
             id: 355
             attributes:
@@ -11989,6 +12057,8 @@ ecosystems:
                   blind:        9
                   stun:         0
                   gravity:      4
+              mods:
+                mdef: 20
           scarce_morbol:
             id: 356
             attributes:
@@ -12091,6 +12161,8 @@ ecosystems:
                   blind:       2
                   stun:        3
                   gravity:     1
+              mods:
+                mdef: 24
           rafflesia:
             id: 359
             attributes:
@@ -13073,7 +13145,6 @@ ecosystems:
                   slashing: -1250
                   piercing: -5000
                   blunt:     1250
-                  h2h:       1250
                 dmg_magic:
                   all: -2500
                 rank_element:
@@ -13098,6 +13169,7 @@ ecosystems:
                   gravity:     0
               mods:
                 udmgbreath: -5000
+                mdef:          52
       defiant:
         id: 169
         species:
@@ -13481,7 +13553,6 @@ ecosystems:
                   slashing: -2500
                   piercing: -2500
                   blunt:    -5000
-                  h2h:      -5000
                 dmg_magic:
                   all: -2500
                 rank_element:
@@ -13506,6 +13577,7 @@ ecosystems:
                   gravity:     -1
               mods:
                 paralyzeres: 20
+                mdef:        20
           ghost:
             id: 408
             attributes:
@@ -13656,6 +13728,8 @@ ecosystems:
                   slashing: -1250
                   piercing: -5000
                   blunt:     2500
+                dmg_magic:
+                  all: 1000
                 rank_element:
                   fire:    0
                   ice:     5
@@ -13676,6 +13750,8 @@ ecosystems:
                   blind:       9
                   stun:        2
                   gravity:     2
+              mods:
+                mdef: 30
       qutrub:
         id: 176
         attributes:
@@ -13897,8 +13973,6 @@ ecosystems:
                   slashing: -1250
                   piercing: -5000
                   blunt:     2500
-                dmg_magic:
-                  all: -1250
                 rank_element:
                   fire:    -3
                   ice:      0
@@ -13981,7 +14055,7 @@ ecosystems:
             attributes:
               resists:
                 dmg_magic:
-                  all: -2500
+                  all: -3750
                 rank_element:
                   fire:     3
                   ice:      6
@@ -14004,6 +14078,7 @@ ecosystems:
                   gravity:      5
               mods:
                 udmgbreath: -1250
+                mdef:          30
           vampyr:
             id: 421
             attributes:
@@ -14111,6 +14186,8 @@ ecosystems:
                   blind:        3
                   stun:         0
                   gravity:     -2
+              mods:
+                mdef: 20
           pitlion:
             id: 424
             attributes:
@@ -14366,6 +14443,8 @@ ecosystems:
               detects:
                 - hearing
               resists:
+                dmg_magic:
+                  all: -400
                 rank_element:
                   fire:    2
                   ice:     2
@@ -14682,6 +14761,8 @@ ecosystems:
                   blind:        4
                   stun:         0
                   gravity:      0
+              mods:
+                mdef: 40
           diremite:
             id: 442
             attributes:
@@ -15230,6 +15311,8 @@ ecosystems:
             id: 459
             attributes:
               resists:
+                dmg_physical:
+                  blunt: 1250
                 rank_element:
                   fire:     1
                   ice:     -2
@@ -15443,7 +15526,7 @@ ecosystems:
             attributes:
               resists:
                 dmg_physical:
-                  piercing: 2500
+                  piercing: -2500
                 dmg_magic:
                   all: -1250
                 rank_element:
@@ -15573,6 +15656,8 @@ ecosystems:
                   blind:       2
                   stun:        2
                   gravity:     4
+              mods:
+                mdef: 40
           wamoura:
             id: 470
             attributes:
@@ -15695,7 +15780,7 @@ ecosystems:
                 - lowhp
               resists:
                 dmg_magic:
-                  all: 2500
+                  all: -2500
                 rank_element:
                   fire:    0
                   ice:     4
@@ -15998,7 +16083,7 @@ ecosystems:
                   stun:        0
                   gravity:     0
               mods:
-                mdef: 60
+                mdef: 300
           rocks:
             id: 377
             attributes:

--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -213,25 +213,25 @@ ecosystems:
                 dmg_magic:
                   all: 2500
                 rank_element:
-                  fire:    -1
-                  ice:      1
-                  wind:     1
-                  earth:    1
-                  thunder: -1
-                  water:    3
-                  light:   -1
-                  dark:     2
+                  fire:    0
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 0
+                  water:   4
+                  light:   4
+                  dark:    3
                 rank_status:
-                  paralyze:     1
-                  bind:         1
-                  silence:      1
-                  slow:         1
-                  poison:       3
-                  light_sleep: -1
-                  dark_sleep:   2
-                  blind:        2
-                  stun:        -1
-                  gravity:      1
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        0
+                  gravity:     2
               mods:
                 udmgbreath: 2500
           flan:
@@ -282,25 +282,25 @@ ecosystems:
                 dmg_magic:
                   all: 2500
                 rank_element:
-                  fire:    -1
-                  ice:      1
-                  wind:     1
-                  earth:    1
-                  thunder: -1
-                  water:    3
-                  light:   -1
-                  dark:     2
+                  fire:    0
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 0
+                  water:   4
+                  light:   0
+                  dark:    3
                 rank_status:
-                  paralyze:     1
-                  bind:         1
-                  silence:      1
-                  slow:         1
-                  poison:       3
-                  light_sleep: -1
-                  dark_sleep:   2
-                  blind:        2
-                  stun:        -1
-                  gravity:      1
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      4
+                  light_sleep: 0
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        0
+                  gravity:     2
               mods:
                 udmgbreath: 2500
       hecteyes:
@@ -1175,25 +1175,25 @@ ecosystems:
                 dmg_magic:
                   all: -1250
                 rank_element:
-                  fire:    -1
-                  ice:      1
-                  wind:    -1
-                  earth:   -1
-                  thunder: -2
-                  water:    6
-                  light:   -2
-                  dark:     3
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    0
+                  thunder: -1
+                  water:    7
+                  light:   -1
+                  dark:     4
                 rank_status:
-                  paralyze:     1
-                  bind:         1
-                  silence:     -1
-                  slow:        -1
-                  poison:       6
-                  light_sleep: -2
-                  dark_sleep:   3
-                  blind:        3
-                  stun:        -2
-                  gravity:     -1
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         0
+                  poison:       7
+                  light_sleep: -1
+                  dark_sleep:   4
+                  blind:        4
+                  stun:        -1
+                  gravity:      0
               mods:
                 udmgbreath: -1250
           orobon:
@@ -1274,25 +1274,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    1
-                  ice:     3
-                  wind:    3
-                  earth:   1
+                  fire:    2
+                  ice:     4
+                  wind:    2
+                  earth:   4
                   thunder: 2
-                  water:   2
-                  light:   4
-                  dark:    2
+                  water:   4
+                  light:   1
+                  dark:    6
                 rank_status:
-                  paralyze:    3
-                  bind:        3
-                  silence:     3
-                  slow:        1
-                  poison:      2
-                  light_sleep: 4
-                  dark_sleep:  2
-                  blind:       2
+                  paralyze:    4
+                  bind:        4
+                  silence:     2
+                  slow:        4
+                  poison:      4
+                  light_sleep: 1
+                  dark_sleep:  6
+                  blind:       6
                   stun:        2
-                  gravity:     3
+                  gravity:     2
       pugil:
         id: 16
         attributes:
@@ -2335,25 +2335,25 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:    8
-                  ice:     5
-                  wind:    8
-                  earth:   7
-                  thunder: 9
-                  water:   5
-                  light:   7
-                  dark:    5
+                  fire:     5
+                  ice:      3
+                  wind:     5
+                  earth:    4
+                  thunder: 11
+                  water:    3
+                  light:    4
+                  dark:     3
                 rank_status:
-                  paralyze:    7
-                  bind:        7
-                  silence:     7
-                  slow:        7
-                  poison:      7
-                  light_sleep: 7
-                  dark_sleep:  7
-                  blind:       7
-                  stun:        9
-                  gravity:     8
+                  paralyze:     7
+                  bind:         7
+                  silence:      7
+                  slow:         4
+                  poison:       7
+                  light_sleep:  4
+                  dark_sleep:   7
+                  blind:        7
+                  stun:        11
+                  gravity:      5
               mods:
                 udmgbreath: -5000
       magic_pot:
@@ -2472,25 +2472,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:     2
-                  ice:      2
-                  wind:     2
-                  earth:    3
-                  thunder: -3
-                  water:    2
-                  light:    2
-                  dark:     2
+                  fire:     4
+                  ice:      4
+                  wind:     4
+                  earth:    4
+                  thunder: -2
+                  water:    4
+                  light:    6
+                  dark:    -2
                 rank_status:
-                  paralyze:     2
-                  bind:         2
-                  silence:      2
-                  slow:         3
-                  poison:       2
-                  light_sleep:  2
-                  dark_sleep:   2
-                  blind:        2
-                  stun:        -3
-                  gravity:      2
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:         4
+                  poison:       4
+                  light_sleep:  6
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:      4
       mimic:
         id: 33
         species:
@@ -2708,7 +2708,7 @@ ecosystems:
                   all: -1250
                 rank_element:
                   fire:    2
-                  ice:     3
+                  ice:     2
                   wind:    3
                   earth:   3
                   thunder: 7
@@ -2716,8 +2716,8 @@ ecosystems:
                   light:   5
                   dark:    3
                 rank_status:
-                  paralyze:    3
-                  bind:        3
+                  paralyze:    2
+                  bind:        2
                   silence:     3
                   slow:        3
                   poison:      0
@@ -2748,25 +2748,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     3
-                  wind:    3
-                  earth:   3
-                  thunder: 6
-                  water:   1
-                  light:   6
-                  dark:    3
+                  fire:     0
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  4
+                  water:   -1
+                  light:    4
+                  dark:     1
                 rank_status:
-                  paralyze:    3
-                  bind:        3
-                  silence:     3
-                  slow:        3
-                  poison:      1
-                  light_sleep: 6
-                  dark_sleep:  3
-                  blind:       3
-                  stun:        6
-                  gravity:     3
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  4
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         4
+                  gravity:      1
           gear:
             id: 79
             attributes:
@@ -2800,25 +2800,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     3
-                  wind:    3
-                  earth:   3
-                  thunder: 6
-                  water:   1
-                  light:   6
-                  dark:    3
+                  fire:     0
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  4
+                  water:   -1
+                  light:    4
+                  dark:     1
                 rank_status:
-                  paralyze:    3
-                  bind:        3
-                  silence:     3
-                  slow:        3
-                  poison:      1
-                  light_sleep: 6
-                  dark_sleep:  3
-                  blind:       3
-                  stun:        6
-                  gravity:     3
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  4
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         4
+                  gravity:      1
           triple_gear:
             id: 81
             attributes:
@@ -3739,23 +3739,23 @@ ecosystems:
               resists:
                 rank_element:
                   fire:    -1
-                  ice:      1
+                  ice:      2
                   wind:    -1
                   earth:   -1
-                  thunder: -2
+                  thunder:  0
                   water:   -2
                   light:   -1
                   dark:    -1
                 rank_status:
-                  paralyze:     1
-                  bind:         1
+                  paralyze:     2
+                  bind:         2
                   silence:     -1
                   slow:        -1
                   poison:      -2
                   light_sleep: -1
                   dark_sleep:  -1
                   blind:       -1
-                  stun:        -2
+                  stun:         0
                   gravity:     -1
           ram:
             id: 108
@@ -3835,23 +3835,23 @@ ecosystems:
               resists:
                 rank_element:
                   fire:    -2
-                  ice:      0
+                  ice:      1
                   wind:    -2
                   earth:   -2
-                  thunder: -3
-                  water:   -3
+                  thunder: -1
+                  water:   -2
                   light:   -2
                   dark:    -2
                 rank_status:
-                  paralyze:     0
-                  bind:         0
+                  paralyze:     1
+                  bind:         1
                   silence:     -2
                   slow:        -2
-                  poison:      -3
+                  poison:      -2
                   light_sleep: -2
                   dark_sleep:  -2
                   blind:       -2
-                  stun:        -3
+                  stun:        -1
                   gravity:     -2
           sheep:
             id: 111
@@ -3939,25 +3939,25 @@ ecosystems:
                 - scent
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:      0
-                  wind:     0
-                  earth:    0
-                  thunder: -3
-                  water:   -2
-                  light:    0
-                  dark:     0
+                  fire:    -2
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder: -2
+                  water:   -1
+                  light:    1
+                  dark:     1
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:      0
-                  slow:         0
-                  poison:      -2
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:        -3
-                  gravity:      0
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -2
+                  gravity:      1
           tiger:
             id: 114
             attributes:
@@ -4007,25 +4007,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     0
-                  wind:    2
-                  earth:   7
-                  thunder: 2
-                  water:   1
-                  light:   1
-                  dark:    1
+                  fire:     7
+                  ice:      0
+                  wind:     2
+                  earth:    4
+                  thunder:  2
+                  water:   -2
+                  light:    1
+                  dark:     1
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     2
-                  slow:        7
-                  poison:      1
-                  light_sleep: 1
-                  dark_sleep:  1
-                  blind:       1
-                  stun:        2
-                  gravity:     2
+                  paralyze:     0
+                  bind:         0
+                  silence:      2
+                  slow:         4
+                  poison:      -2
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         2
+                  gravity:      2
           yztarg:
             id: 116
             attributes:
@@ -4159,49 +4159,49 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:     0
-                  ice:      0
-                  wind:     0
-                  earth:   -2
-                  thunder:  4
-                  water:    0
-                  light:    0
-                  dark:     0
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   2
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    2
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:      0
-                  slow:        -2
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         4
-                  gravity:      0
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        2
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
           giants:
             id: 120
             attributes:
               resists:
                 rank_element:
-                  fire:     0
-                  ice:      0
+                  fire:    -2
+                  ice:      4
                   wind:     0
-                  earth:   -2
-                  thunder:  4
+                  earth:    0
+                  thunder:  0
                   water:    0
                   light:    0
                   dark:     0
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:      0
-                  slow:        -2
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         4
-                  gravity:      0
+                  paralyze:    4
+                  bind:        4
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           gigas:
             id: 121
             attributes:
@@ -4237,25 +4237,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:     0
-                  ice:      0
-                  wind:     0
-                  earth:   -2
-                  thunder:  4
-                  water:    0
-                  light:    0
-                  dark:     0
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:      0
-                  slow:        -2
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         4
-                  gravity:      0
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
           jotunn:
             id: 123
             attributes:
@@ -5725,24 +5725,24 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:    8
-                  ice:     8
+                  fire:    2
+                  ice:     1
                   wind:    8
-                  earth:   8
-                  thunder: 8
-                  water:   8
-                  light:   8
-                  dark:    8
+                  earth:   0
+                  thunder: 2
+                  water:   2
+                  light:   2
+                  dark:    4
                 rank_status:
-                  paralyze:    8
-                  bind:        8
+                  paralyze:    1
+                  bind:        1
                   silence:     8
-                  slow:        8
-                  poison:      8
-                  light_sleep: 8
-                  dark_sleep:  8
-                  blind:       8
-                  stun:        8
+                  slow:        0
+                  poison:      2
+                  light_sleep: 2
+                  dark_sleep:  4
+                  blind:       4
+                  stun:        2
                   gravity:     8
               mods:
                 mdef: 20
@@ -6043,25 +6043,25 @@ ecosystems:
                 eva: e
               resists:
                 rank_element:
-                  fire:    -2
-                  ice:     -2
-                  wind:    -3
+                  fire:    -1
+                  ice:     -1
+                  wind:    -2
                   earth:    2
                   thunder:  2
-                  water:   -2
-                  light:   -2
-                  dark:    -2
+                  water:   -1
+                  light:   -1
+                  dark:    -1
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -3
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -2
                   slow:         2
-                  poison:      -2
-                  light_sleep: -2
-                  dark_sleep:  -2
-                  blind:       -2
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
                   stun:         2
-                  gravity:     -3
+                  gravity:     -2
       colibri:
         id: 80
         attributes:
@@ -6120,25 +6120,25 @@ ecosystems:
                 dmg_physical:
                   piercing: 2500
                 rank_element:
-                  fire:    -1
-                  ice:     -2
-                  wind:     6
-                  earth:    0
-                  thunder: -1
-                  water:   -1
-                  light:    0
-                  dark:    -2
+                  fire:     2
+                  ice:      0
+                  wind:     2
+                  earth:   -2
+                  thunder:  6
+                  water:    2
+                  light:    1
+                  dark:     2
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:      6
-                  slow:         0
-                  poison:      -1
-                  light_sleep:  0
-                  dark_sleep:  -2
-                  blind:       -2
-                  stun:        -1
-                  gravity:      6
+                  paralyze:     0
+                  bind:         0
+                  silence:      2
+                  slow:        -2
+                  poison:       2
+                  light_sleep:  1
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         6
+                  gravity:      2
               mods:
                 mdef: 14
       flock_bat:
@@ -6286,25 +6286,25 @@ ecosystems:
                   slashing: -1250
                   blunt:     -625
                 rank_element:
-                  fire:     6
-                  ice:      4
-                  wind:    11 # absorbs on retail
-                  earth:   11
-                  thunder:  6
-                  water:    6
-                  light:   11
-                  dark:     4
+                  fire:    1
+                  ice:     0
+                  wind:    9
+                  earth:   5
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
                 rank_status:
-                  paralyze:     4
-                  bind:         4
-                  silence:     11 # absorbs on retail
-                  slow:        11
-                  poison:       6
-                  light_sleep: 11
-                  dark_sleep:   4
-                  blind:        4
-                  stun:         6
-                  gravity:     11 # absorbs on retail
+                  paralyze:    0
+                  bind:        0
+                  silence:     9
+                  slow:        5
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     9
               mods:
                 udmgbreath: -2500
                 mdef:          80
@@ -6316,25 +6316,25 @@ ecosystems:
                   slashing: -1250
                   blunt:     -625
                 rank_element:
-                  fire:     6
-                  ice:      4
-                  wind:    11 # absorbs on retail
-                  earth:   11
-                  thunder:  6
-                  water:    6
-                  light:   11
-                  dark:     4
+                  fire:    1
+                  ice:     0
+                  wind:    9
+                  earth:   5
+                  thunder: 1
+                  water:   1
+                  light:   1
+                  dark:    1
                 rank_status:
-                  paralyze:     4
-                  bind:         4
-                  silence:     11 # absorbs on retail
-                  slow:        11
-                  poison:       6
-                  light_sleep: 11
-                  dark_sleep:   4
-                  blind:        4
-                  stun:         6
-                  gravity:     11 # absorbs on retail
+                  paralyze:    0
+                  bind:        0
+                  silence:     9
+                  slow:        5
+                  poison:      1
+                  light_sleep: 1
+                  dark_sleep:  1
+                  blind:       1
+                  stun:        1
+                  gravity:     9
               mods:
                 udmgbreath: -2500
                 mdef:          80
@@ -6503,25 +6503,25 @@ ecosystems:
                   slashing: -5000
                   piercing:  5000
                 rank_element:
-                  fire:     4
-                  ice:     -2
-                  wind:     4
+                  fire:     2
+                  ice:      6
+                  wind:     6
                   earth:   -2
-                  thunder:  2
+                  thunder:  6
                   water:    2
-                  light:    2
-                  dark:     2
+                  light:    1
+                  dark:     1
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:      4
+                  paralyze:     6
+                  bind:         6
+                  silence:      6
                   slow:        -2
                   poison:       2
-                  light_sleep:  2
-                  dark_sleep:   2
-                  blind:        2
-                  stun:         2
-                  gravity:      4
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         6
+                  gravity:      6
           tulfaire:
             id: 192
             attributes:
@@ -6567,25 +6567,25 @@ ecosystems:
                 dmg_magic:
                   all: 1250
                 rank_element:
-                  fire:    4
-                  ice:     2
-                  wind:    9
-                  earth:   2
-                  thunder: 9
-                  water:   4
-                  light:   4
-                  dark:    6
+                  fire:     6
+                  ice:      4
+                  wind:    11
+                  earth:   -1
+                  thunder: 11
+                  water:    8
+                  light:    6
+                  dark:     8
                 rank_status:
-                  paralyze:    2
-                  bind:        2
-                  silence:     9
-                  slow:        2
-                  poison:      4
-                  light_sleep: 4
-                  dark_sleep:  6
-                  blind:       6
-                  stun:        9
-                  gravity:     9
+                  paralyze:     4
+                  bind:         4
+                  silence:     11
+                  slow:        -1
+                  poison:       8
+                  light_sleep:  6
+                  dark_sleep:   8
+                  blind:        8
+                  stun:        11
+                  gravity:     11
               mods:
                 udmgbreath: -3750
                 mdef:          10
@@ -6867,25 +6867,25 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:     0
-                  ice:      0
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:    0
-                  light:   -2
-                  dark:     0
+                  fire:     1
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  1
+                  water:    1
+                  light:   -1
+                  dark:     1
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:      0
-                  slow:         0
-                  poison:       0
-                  light_sleep: -2
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
+                  poison:       1
+                  light_sleep: -1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:         1
+                  gravity:      1
       dvergr:
         id: 89
         attributes:
@@ -7294,49 +7294,49 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -3
-                  wind:    -3
-                  earth:   -3
-                  thunder: -3
-                  water:   -3
-                  light:   -3
-                  dark:    -3
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    9
+                  light:   -1
+                  dark:    11
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -3
-                  slow:        -3
-                  poison:      -3
-                  light_sleep: -3
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -3
-                  gravity:     -3
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         0
+                  poison:       9
+                  light_sleep: -1
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         0
+                  gravity:      0
           soulflayer:
             id: 215
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -3
-                  wind:    -3
-                  earth:   -3
-                  thunder: -3
-                  water:   -3
-                  light:   -3
-                  dark:    -3
+                  fire:     0
+                  ice:      2
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    9
+                  light:   -1
+                  dark:    11
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -3
-                  slow:        -3
-                  poison:      -3
-                  light_sleep: -3
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -3
-                  gravity:     -3
+                  paralyze:     2
+                  bind:         2
+                  silence:      0
+                  slow:         0
+                  poison:       9
+                  light_sleep: -1
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         0
+                  gravity:      0
               mob_mods:
                 sublink:    11
                 roam_cool:  50
@@ -7482,25 +7482,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     2
-                  wind:    2
-                  earth:   2
-                  thunder: 2
-                  water:   2
-                  light:   2
-                  dark:    2
+                  fire:     6
+                  ice:      3
+                  wind:     6
+                  earth:    3
+                  thunder:  3
+                  water:   10
+                  light:    3
+                  dark:     3
                 rank_status:
-                  paralyze:    2
-                  bind:        2
-                  silence:     2
-                  slow:        2
-                  poison:      2
-                  light_sleep: 2
-                  dark_sleep:  2
-                  blind:       2
-                  stun:        2
-                  gravity:     2
+                  paralyze:     3
+                  bind:         3
+                  silence:      6
+                  slow:         3
+                  poison:      10
+                  light_sleep:  3
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         3
+                  gravity:      6
       hydra:
         id: 96
         attributes:
@@ -7523,25 +7523,25 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:    9
-                  ice:     9
-                  wind:    9
-                  earth:   6
-                  thunder: 6
-                  water:   6
-                  light:   6
-                  dark:    6
+                  fire:    6
+                  ice:     6
+                  wind:    6
+                  earth:   3
+                  thunder: 3
+                  water:   3
+                  light:   3
+                  dark:    3
                 rank_status:
-                  paralyze:    9
-                  bind:        9
-                  silence:     9
-                  slow:        6
-                  poison:      6
-                  light_sleep: 6
-                  dark_sleep:  6
-                  blind:       6
-                  stun:        6
-                  gravity:     9
+                  paralyze:    6
+                  bind:        6
+                  silence:     6
+                  slow:        3
+                  poison:      3
+                  light_sleep: 3
+                  dark_sleep:  3
+                  blind:       3
+                  stun:        3
+                  gravity:     6
               mods:
                 udmgbreath: -10000
                 mdef:           30
@@ -7755,23 +7755,23 @@ ecosystems:
                 - hearing
               resists:
                 rank_element:
-                  fire:    11
-                  ice:     11
+                  fire:     0
+                  ice:      0
                   wind:     0
                   earth:    0
                   thunder:  0
-                  water:   -2
-                  light:    0
-                  dark:     0
+                  water:    0
+                  light:   -2
+                  dark:    11
                 rank_status:
-                  paralyze:    11
-                  bind:        11
+                  paralyze:     0
+                  bind:         0
                   silence:      0
                   slow:         0
-                  poison:      -2
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
+                  poison:       0
+                  light_sleep: -2
+                  dark_sleep:  11
+                  blind:       11
                   stun:         0
                   gravity:      0
           earth_wyrm:
@@ -7904,24 +7904,24 @@ ecosystems:
               resists:
                 rank_element:
                   fire:     4
-                  ice:      1
-                  wind:     0
-                  earth:    0
-                  thunder: -2
-                  water:   -2
-                  light:   -2
-                  dark:    -3
+                  ice:     -2
+                  wind:    10
+                  earth:   10
+                  thunder:  4
+                  water:    4
+                  light:    4
+                  dark:     4
                 rank_status:
-                  paralyze:     1
-                  bind:         1
-                  silence:      0
-                  slow:         0
-                  poison:      -2
-                  light_sleep: -2
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -2
-                  gravity:      0
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     10
+                  slow:        10
+                  poison:       4
+                  light_sleep:  4
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         4
+                  gravity:     10
           red_wyvern:
             id: 234
             attributes:
@@ -7929,24 +7929,24 @@ ecosystems:
               resists:
                 rank_element:
                   fire:     4
-                  ice:      1
-                  wind:     0
+                  ice:      0
+                  wind:     4
                   earth:    0
                   thunder: -2
                   water:   -2
                   light:   -2
                   dark:    -3
                 rank_status:
-                  paralyze:     1
-                  bind:         1
-                  silence:      0
+                  paralyze:     0
+                  bind:         0
+                  silence:      4
                   slow:         0
                   poison:      -2
                   light_sleep: -2
                   dark_sleep:  -3
                   blind:       -3
                   stun:        -2
-                  gravity:      0
+                  gravity:      4
           wyvern:
             id: 235
             attributes:
@@ -8633,25 +8633,25 @@ ecosystems:
                   blunt:    -7500
                   h2h:      -7500
                 rank_element:
-                  fire:    11
-                  ice:     11
-                  wind:     0
-                  earth:    0
+                  fire:     0
+                  ice:     -3
+                  wind:    11
+                  earth:   11
                   thunder:  0
-                  water:   -3
+                  water:    0
                   light:    0
                   dark:     0
                 rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     11
+                  slow:        11
+                  poison:       0
                   light_sleep:  0
                   dark_sleep:   0
                   blind:        0
                   stun:         0
-                  gravity:      0
+                  gravity:     11
               mob_mods:
                 roam_turns:    3
                 hp_standback: -1
@@ -8665,24 +8665,24 @@ ecosystems:
                   blunt:    -7500
                 rank_element:
                   fire:    11
-                  ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
+                  ice:      1
+                  wind:     1
+                  earth:    1
+                  thunder:  1
                   water:   -3
-                  light:    0
-                  dark:     0
+                  light:   11
+                  dark:    -3
                 rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
+                  paralyze:     1
+                  bind:         1
+                  silence:      1
+                  slow:         1
                   poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
+                  light_sleep: 11
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:         1
+                  gravity:      1
               mob_mods:
                 roam_turns: 3
           byrgen:
@@ -8694,25 +8694,25 @@ ecosystems:
                   piercing: -7500
                   blunt:    -7500
                 rank_element:
-                  fire:    11
-                  ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:   -3
-                  light:    0
-                  dark:     0
+                  fire:     1
+                  ice:      1
+                  wind:    -3
+                  earth:   11
+                  thunder:  1
+                  water:    1
+                  light:   -3
+                  dark:    11
                 rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
+                  paralyze:     1
+                  bind:         1
+                  silence:     -3
+                  slow:        11
+                  poison:       1
+                  light_sleep: -3
+                  dark_sleep:  11
+                  blind:       11
+                  stun:         1
+                  gravity:     -3
               mob_mods:
                 roam_turns: 3
           dark_elemental:
@@ -8823,25 +8823,25 @@ ecosystems:
                   piercing: -7500
                   blunt:    -7500
                 rank_element:
-                  fire:    11
+                  fire:    -3
                   ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:   -3
-                  light:    0
-                  dark:     0
+                  wind:     1
+                  earth:    1
+                  thunder: -3
+                  water:   11
+                  light:    1
+                  dark:     1
                 rank_status:
                   paralyze:    11
                   bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
+                  silence:      1
+                  slow:         1
+                  poison:      11
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -3
+                  gravity:      1
               mob_mods:
                 roam_turns: 3
           ice_elemental:
@@ -8952,25 +8952,25 @@ ecosystems:
                   piercing: -7500
                   blunt:    -7500
                 rank_element:
-                  fire:    11
-                  ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:   -3
-                  light:    0
-                  dark:     0
+                  fire:     1
+                  ice:     -3
+                  wind:    11
+                  earth:   -3
+                  thunder: 11
+                  water:    1
+                  light:    1
+                  dark:     1
                 rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     11
+                  slow:        -3
+                  poison:       1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        11
+                  gravity:     11
               mob_mods:
                 roam_turns: 3
           water_elemental:
@@ -9134,25 +9134,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:     2
-                  ice:      2
-                  wind:     2
-                  earth:   -2
-                  thunder:  6
-                  water:    2
-                  light:    0
-                  dark:     4
+                  fire:     3
+                  ice:      1
+                  wind:     3
+                  earth:    1
+                  thunder:  3
+                  water:    1
+                  light:    6
+                  dark:    -2
                 rank_status:
-                  paralyze:     2
-                  bind:         2
-                  silence:      2
-                  slow:        -2
-                  poison:       2
-                  light_sleep:  0
-                  dark_sleep:   4
-                  blind:        4
-                  stun:         6
-                  gravity:      2
+                  paralyze:     1
+                  bind:         1
+                  silence:      3
+                  slow:         1
+                  poison:       1
+                  light_sleep:  6
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:         3
+                  gravity:      3
               mods:
                 mdef: 40
           monoceros:
@@ -9205,24 +9205,24 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:     1
-                  ice:      1
+                  fire:     3
+                  ice:      3
                   wind:    11
-                  earth:    1
-                  thunder:  1
-                  water:    1
-                  light:    1
-                  dark:     8
+                  earth:    3
+                  thunder:  3
+                  water:    3
+                  light:    9
+                  dark:     3
                 rank_status:
-                  paralyze:     1
-                  bind:         1
+                  paralyze:     3
+                  bind:         3
                   silence:     11
-                  slow:         1
-                  poison:       1
-                  light_sleep:  1
-                  dark_sleep:   8
-                  blind:        8
-                  stun:         1
+                  slow:         3
+                  poison:       3
+                  light_sleep:  9
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         3
                   gravity:     11
           pixie:
             id: 274
@@ -9237,17 +9237,17 @@ ecosystems:
                   earth:    1
                   thunder:  1
                   water:    1
-                  light:    1
-                  dark:     8
+                  light:    8
+                  dark:     1
                 rank_status:
                   paralyze:     1
                   bind:         1
                   silence:     11
                   slow:         1
                   poison:       1
-                  light_sleep:  1
-                  dark_sleep:   8
-                  blind:        8
+                  light_sleep:  8
+                  dark_sleep:   1
+                  blind:        1
                   stun:         1
                   gravity:     11
           undeen:
@@ -9283,24 +9283,24 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:     1
-                  ice:      1
+                  fire:     3
+                  ice:      3
                   wind:    11
-                  earth:    1
-                  thunder:  1
-                  water:    1
-                  light:    1
-                  dark:     8
+                  earth:    3
+                  thunder:  3
+                  water:    3
+                  light:    9
+                  dark:     3
                 rank_status:
-                  paralyze:     1
-                  bind:         1
+                  paralyze:     3
+                  bind:         3
                   silence:     11
-                  slow:         1
-                  poison:       1
-                  light_sleep:  1
-                  dark_sleep:   8
-                  blind:        8
-                  stun:         1
+                  slow:         3
+                  poison:       3
+                  light_sleep:  9
+                  dark_sleep:   3
+                  blind:        3
+                  stun:         3
                   gravity:     11
       porxie:
         id: 108
@@ -9616,25 +9616,25 @@ ecosystems:
                 dmg_magic:
                   all: -5000
                 rank_element:
-                  fire:    0
-                  ice:     0
-                  wind:    0
-                  earth:   0
-                  thunder: 0
-                  water:   0
-                  light:   0
-                  dark:    0
+                  fire:    11
+                  ice:     11
+                  wind:     4
+                  earth:    2
+                  thunder:  4
+                  water:    0
+                  light:    4
+                  dark:     2
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     0
-                  slow:        0
-                  poison:      0
-                  light_sleep: 0
-                  dark_sleep:  0
-                  blind:       0
-                  stun:        0
-                  gravity:     0
+                  paralyze:    11
+                  bind:        11
+                  silence:      4
+                  slow:         2
+                  poison:       0
+                  light_sleep:  4
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         4
+                  gravity:      4
           seether:
             id: 286
             attributes:
@@ -9642,25 +9642,25 @@ ecosystems:
                 dmg_magic:
                   all: -5000
                 rank_element:
-                  fire:    0
-                  ice:     0
-                  wind:    0
-                  earth:   0
-                  thunder: 0
-                  water:   0
-                  light:   0
-                  dark:    0
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     0
-                  slow:        0
-                  poison:      0
-                  light_sleep: 0
-                  dark_sleep:  0
-                  blind:       0
-                  stun:        0
-                  gravity:     0
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
       thinker:
         id: 114
         attributes:
@@ -9748,32 +9748,6 @@ ecosystems:
                 rank_element:
                   fire:    11
                   ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:   -3
-                  light:    0
-                  dark:     0
-                rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
-              mods:
-                mdef: 12
-          wanderer:
-            id: 290
-            attributes:
-              resists:
-                rank_element:
-                  fire:    11
-                  ice:     11
                   wind:     4
                   earth:    2
                   thunder:  4
@@ -9791,6 +9765,32 @@ ecosystems:
                   blind:        2
                   stun:         4
                   gravity:      4
+              mods:
+                mdef: 12
+          wanderer:
+            id: 290
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mods:
                 hpp:  -10
                 mdef:  14
@@ -9817,32 +9817,6 @@ ecosystems:
                 rank_element:
                   fire:    11
                   ice:     11
-                  wind:     0
-                  earth:    0
-                  thunder:  0
-                  water:   -3
-                  light:    0
-                  dark:     0
-                rank_status:
-                  paralyze:    11
-                  bind:        11
-                  silence:      0
-                  slow:         0
-                  poison:      -3
-                  light_sleep:  0
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         0
-                  gravity:      0
-              mods:
-                mdef: 12
-          weeper:
-            id: 292
-            attributes:
-              resists:
-                rank_element:
-                  fire:    11
-                  ice:     11
                   wind:     4
                   earth:    2
                   thunder:  4
@@ -9860,6 +9834,32 @@ ecosystems:
                   blind:        2
                   stun:         4
                   gravity:      4
+              mods:
+                mdef: 12
+          weeper:
+            id: 292
+            attributes:
+              resists:
+                rank_element:
+                  fire:    11
+                  ice:     11
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -3
+                  light:    0
+                  dark:     0
+                rank_status:
+                  paralyze:    11
+                  bind:        11
+                  silence:      0
+                  slow:         0
+                  poison:      -3
+                  light_sleep:  0
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
               mods:
                 hpp:  10
                 mdef: 14
@@ -10579,25 +10579,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    0
-                  ice:     0
-                  wind:    0
-                  earth:   2
-                  thunder: 0
-                  water:   3
-                  light:   0
-                  dark:    0
+                  fire:    2
+                  ice:     2
+                  wind:    2
+                  earth:   4
+                  thunder: 2
+                  water:   5
+                  light:   2
+                  dark:    2
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     0
-                  slow:        2
-                  poison:      3
-                  light_sleep: 0
-                  dark_sleep:  0
-                  blind:       0
-                  stun:        0
-                  gravity:     0
+                  paralyze:    2
+                  bind:        2
+                  silence:     2
+                  slow:        4
+                  poison:      5
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     2
       raptor:
         id: 129
         attributes:
@@ -11298,25 +11298,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    0
-                  ice:     2
-                  wind:    1
-                  earth:   7
-                  thunder: 1
-                  water:   6
-                  light:   4
-                  dark:    6
+                  fire:    -1
+                  ice:      4
+                  wind:     2
+                  earth:    9
+                  thunder:  6
+                  water:    8
+                  light:    4
+                  dark:     6
                 rank_status:
-                  paralyze:    2
-                  bind:        2
-                  silence:     1
-                  slow:        7
-                  poison:      6
+                  paralyze:    4
+                  bind:        4
+                  silence:     2
+                  slow:        9
+                  poison:      8
                   light_sleep: 4
                   dark_sleep:  6
                   blind:       6
-                  stun:        1
-                  gravity:     1
+                  stun:        6
+                  gravity:     2
               mods:
                 mdef: 60
       cactaur:
@@ -11366,25 +11366,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -2
-                  ice:     -3
-                  wind:     0
-                  earth:    0
-                  thunder: -2
-                  water:    4
-                  light:    4
-                  dark:    -3
+                  fire:     0
+                  ice:     -2
+                  wind:     2
+                  earth:    2
+                  thunder:  0
+                  water:    6
+                  light:    6
+                  dark:     0
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:      0
-                  slow:         0
-                  poison:       4
-                  light_sleep:  4
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -2
-                  gravity:      0
+                  paralyze:    -2
+                  bind:        -2
+                  silence:      2
+                  slow:         2
+                  poison:       6
+                  light_sleep:  6
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      2
               mob_mods:
                 sublink: 7
       flytrap:
@@ -11446,25 +11446,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -2
-                  ice:     -2
-                  wind:    -2
-                  earth:   -2
-                  thunder: -2
-                  water:    4
-                  light:   -3
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
+                  water:    5
+                  light:   -2
                   dark:     4
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -2
-                  poison:       4
-                  light_sleep: -3
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
+                  poison:       5
+                  light_sleep: -2
                   dark_sleep:   4
                   blind:        6
-                  stun:        -2
-                  gravity:     -2
+                  stun:        -1
+                  gravity:     -1
           funguar:
             id: 338
             attributes:
@@ -11498,25 +11498,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    0
-                  ice:     0
-                  wind:    0
-                  earth:   0
-                  thunder: 0
-                  water:   6
-                  light:   0
-                  dark:    6
+                  fire:    -2
+                  ice:     -2
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:    4
+                  light:   -3
+                  dark:     4
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     0
-                  slow:        0
-                  poison:      6
-                  light_sleep: 0
-                  dark_sleep:  6
-                  blind:       6
-                  stun:        0
-                  gravity:     0
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -2
+                  slow:        -2
+                  poison:       4
+                  light_sleep: -3
+                  dark_sleep:   4
+                  blind:        6
+                  stun:        -2
+                  gravity:     -2
       goobbue:
         id: 144
         species:
@@ -11634,25 +11634,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:      4
-                  wind:     2
-                  earth:    4
-                  thunder:  2
-                  water:    8
+                  fire:     0
+                  ice:      6
+                  wind:     3
+                  earth:    6
+                  thunder:  3
+                  water:    9
                   light:   11
-                  dark:     4
+                  dark:     6
                 rank_status:
-                  paralyze:     4
-                  bind:         4
-                  silence:      2
-                  slow:         4
-                  poison:       8
+                  paralyze:     6
+                  bind:         6
+                  silence:      3
+                  slow:         6
+                  poison:       9
                   light_sleep: 11
-                  dark_sleep:   4
-                  blind:        4
-                  stun:         2
-                  gravity:      2
+                  dark_sleep:   6
+                  blind:        6
+                  stun:         3
+                  gravity:      3
           tulittia:
             id: 344
             attributes:
@@ -11700,25 +11700,25 @@ ecosystems:
                 dmg_physical:
                   piercing: 2500
                 rank_element:
-                  fire:    -3
-                  ice:     -3
-                  wind:    -3
-                  earth:    0
-                  thunder: -3
-                  water:    0
-                  light:    0
-                  dark:    -3
+                  fire:    0
+                  ice:     0
+                  wind:    1
+                  earth:   5
+                  thunder: 0
+                  water:   4
+                  light:   4
+                  dark:    0
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -3
-                  slow:         0
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -3
-                  gravity:     -3
+                  paralyze:    0
+                  bind:        0
+                  silence:     1
+                  slow:        5
+                  poison:      4
+                  light_sleep: 4
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     1
           ake_ome:
             id: 346
             attributes:
@@ -11806,25 +11806,25 @@ ecosystems:
                 dmg_physical:
                   piercing: 2500
                 rank_element:
-                  fire:    -3
-                  ice:     -3
-                  wind:    -3
-                  earth:    0
-                  thunder: -3
-                  water:    0
-                  light:    0
-                  dark:    -3
+                  fire:    -2
+                  ice:     -2
+                  wind:    -1
+                  earth:    3
+                  thunder: -2
+                  water:    2
+                  light:    2
+                  dark:    -2
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -3
-                  slow:         0
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -3
-                  gravity:     -3
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:         3
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -1
           mandragora:
             id: 350
             attributes:
@@ -11856,25 +11856,25 @@ ecosystems:
                 dmg_physical:
                   piercing: 2500
                 rank_element:
-                  fire:    -3
-                  ice:     -3
-                  wind:    -3
-                  earth:    0
-                  thunder: -3
-                  water:    0
-                  light:    0
-                  dark:    -3
+                  fire:    -2
+                  ice:     -2
+                  wind:    -1
+                  earth:    3
+                  thunder: -2
+                  water:    2
+                  light:    2
+                  dark:    -2
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -3
-                  slow:         0
-                  poison:       0
-                  light_sleep:  0
-                  dark_sleep:  -3
-                  blind:       -3
-                  stun:        -3
-                  gravity:     -3
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:         3
+                  poison:       2
+                  light_sleep:  2
+                  dark_sleep:  -2
+                  blind:       -2
+                  stun:        -2
+                  gravity:     -1
       morbol:
         id: 147
         attributes:
@@ -11895,25 +11895,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -2
-                  wind:    -2
-                  earth:   -2
-                  thunder: -2
-                  water:    4
-                  light:   -2
+                  fire:    -1
+                  ice:     -1
+                  wind:    -1
+                  earth:    3
+                  thunder: -1
+                  water:    3
+                  light:   -1
                   dark:     4
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -2
-                  poison:       4
-                  light_sleep: -2
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:         3
+                  poison:       3
+                  light_sleep: -1
                   dark_sleep:   4
                   blind:        4
-                  stun:        -2
-                  gravity:     -2
+                  stun:        -1
+                  gravity:     -1
           morbol:
             id: 353
             attributes:
@@ -11946,73 +11946,73 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -2
-                  wind:    -2
-                  earth:   -2
-                  thunder: -2
+                  fire:    -2
+                  ice:     -1
+                  wind:    -1
+                  earth:   -1
+                  thunder: -1
                   water:    4
-                  light:   -2
+                  light:   -1
                   dark:     4
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -2
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -1
                   poison:       4
-                  light_sleep: -2
+                  light_sleep: -1
                   dark_sleep:   4
                   blind:        4
-                  stun:        -2
-                  gravity:     -2
+                  stun:        -1
+                  gravity:     -1
           purbol:
             id: 355
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -2
-                  wind:    -2
-                  earth:   -2
-                  thunder: -2
-                  water:    4
-                  light:   -2
-                  dark:     4
+                  fire:     0
+                  ice:      4
+                  wind:     4
+                  earth:   11
+                  thunder:  0
+                  water:   11
+                  light:    4
+                  dark:     9
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -2
-                  poison:       4
-                  light_sleep: -2
-                  dark_sleep:   4
-                  blind:        4
-                  stun:        -2
-                  gravity:     -2
+                  paralyze:     4
+                  bind:         4
+                  silence:      4
+                  slow:        11
+                  poison:      11
+                  light_sleep:  4
+                  dark_sleep:   9
+                  blind:        9
+                  stun:         0
+                  gravity:      4
           scarce_morbol:
             id: 356
             attributes:
               resists:
                 rank_element:
-                  fire:    -3
-                  ice:     -2
-                  wind:    -2
-                  earth:   -2
-                  thunder: -2
+                  fire:    -2
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
                   water:    4
                   light:   -2
                   dark:     4
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -2
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
                   poison:       4
                   light_sleep: -2
                   dark_sleep:   4
                   blind:        4
-                  stun:        -2
-                  gravity:     -2
+                  stun:         0
+                  gravity:      0
       panopt:
         id: 148
         species:
@@ -12072,25 +12072,25 @@ ecosystems:
                 dmg_physical:
                   slashing: 1250
                 rank_element:
-                  fire:    -2
-                  ice:      0
-                  wind:    -1
-                  earth:    3
-                  thunder:  1
-                  water:    0
-                  light:    2
-                  dark:     0
+                  fire:    0
+                  ice:     2
+                  wind:    1
+                  earth:   5
+                  thunder: 3
+                  water:   2
+                  light:   4
+                  dark:    2
                 rank_status:
-                  paralyze:     0
-                  bind:         0
-                  silence:     -1
-                  slow:         3
-                  poison:       0
-                  light_sleep:  2
-                  dark_sleep:   0
-                  blind:        0
-                  stun:         1
-                  gravity:     -1
+                  paralyze:    2
+                  bind:        2
+                  silence:     1
+                  slow:        5
+                  poison:      2
+                  light_sleep: 4
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        3
+                  gravity:     1
           rafflesia:
             id: 359
             attributes:
@@ -13077,25 +13077,25 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:    -2
-                  ice:      2
-                  wind:    -1
-                  earth:    2
-                  thunder: -1
-                  water:   -1
-                  light:   -3
-                  dark:     3
+                  fire:    -1
+                  ice:      6
+                  wind:     0
+                  earth:    4
+                  thunder:  0
+                  water:    1
+                  light:    4
+                  dark:     6
                 rank_status:
-                  paralyze:     2
-                  bind:         2
-                  silence:     -1
-                  slow:         2
-                  poison:      -1
-                  light_sleep: -3
-                  dark_sleep:   3
-                  blind:        3
-                  stun:        -1
-                  gravity:     -1
+                  paralyze:    6
+                  bind:        6
+                  silence:     0
+                  slow:        4
+                  poison:      1
+                  light_sleep: 4
+                  dark_sleep:  6
+                  blind:       6
+                  stun:        0
+                  gravity:     0
               mods:
                 udmgbreath: -5000
       defiant:
@@ -13489,7 +13489,7 @@ ecosystems:
                   ice:      5
                   wind:    -1
                   earth:    0
-                  thunder: -1
+                  thunder: -2
                   water:   -1
                   light:   -2
                   dark:     5
@@ -13502,7 +13502,7 @@ ecosystems:
                   light_sleep: -2
                   dark_sleep:   5
                   blind:        5
-                  stun:        -1
+                  stun:        -2
                   gravity:     -1
               mods:
                 paralyzeres: 20
@@ -13900,25 +13900,25 @@ ecosystems:
                 dmg_magic:
                   all: -1250
                 rank_element:
-                  fire:    -2
-                  ice:      2
-                  wind:    -1
-                  earth:   -1
-                  thunder: -1
-                  water:   -1
-                  light:   -2
+                  fire:    -3
+                  ice:      0
+                  wind:    -2
+                  earth:   -2
+                  thunder: -2
+                  water:   -2
+                  light:   -3
                   dark:     4
                 rank_status:
-                  paralyze:     2
-                  bind:         2
-                  silence:     -1
-                  slow:        -1
-                  poison:      -1
-                  light_sleep: -2
+                  paralyze:     0
+                  bind:         0
+                  silence:     -2
+                  slow:        -2
+                  poison:      -2
+                  light_sleep: -3
                   dark_sleep:  11
                   blind:        4
-                  stun:        -1
-                  gravity:     -1
+                  stun:        -2
+                  gravity:     -2
           skeleton:
             id: 419
             attributes:
@@ -13983,25 +13983,25 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:     1
-                  ice:      4
-                  wind:     3
-                  earth:    3
-                  thunder:  1
-                  water:    1
-                  light:   -1
+                  fire:     3
+                  ice:      6
+                  wind:     5
+                  earth:    5
+                  thunder:  3
+                  water:    3
+                  light:    4
                   dark:    11
                 rank_status:
-                  paralyze:     4
-                  bind:         4
-                  silence:      3
-                  slow:         3
-                  poison:       1
-                  light_sleep: -1
+                  paralyze:     6
+                  bind:         6
+                  silence:      5
+                  slow:         5
+                  poison:       3
+                  light_sleep:  4
                   dark_sleep:  11
                   blind:       11
-                  stun:         1
-                  gravity:      3
+                  stun:         3
+                  gravity:      5
               mods:
                 udmgbreath: -1250
           vampyr:
@@ -14330,25 +14330,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     0
-                  wind:    2
-                  earth:   2
-                  thunder: 2
-                  water:   2
-                  light:   0
-                  dark:    2
+                  fire:     0
+                  ice:     -3
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:    0
+                  light:   -3
+                  dark:     0
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     2
-                  slow:        2
-                  poison:      2
-                  light_sleep: 0
-                  dark_sleep:  2
-                  blind:       2
-                  stun:        2
-                  gravity:     2
+                  paralyze:    -3
+                  bind:        -3
+                  silence:      0
+                  slow:         0
+                  poison:       0
+                  light_sleep: -3
+                  dark_sleep:   0
+                  blind:        0
+                  stun:         0
+                  gravity:      0
       bztavian:
         id: 183
         species:
@@ -14501,7 +14501,7 @@ ecosystems:
                   fire:    -1
                   ice:      1
                   wind:     1
-                  earth:    2
+                  earth:    3
                   thunder:  1
                   water:   -1
                   light:    1
@@ -14510,7 +14510,7 @@ ecosystems:
                   paralyze:     1
                   bind:         1
                   silence:      1
-                  slow:         2
+                  slow:         3
                   poison:      -1
                   light_sleep:  1
                   dark_sleep:   1
@@ -14623,25 +14623,25 @@ ecosystems:
                 - hearing
               resists:
                 rank_element:
-                  fire:    2
-                  ice:     0
-                  wind:    2
-                  earth:   6
-                  thunder: 0
-                  water:   2
-                  light:   6
-                  dark:    0
+                  fire:    -2
+                  ice:     -3
+                  wind:    -2
+                  earth:    0
+                  thunder: -3
+                  water:   -2
+                  light:    0
+                  dark:    -3
                 rank_status:
-                  paralyze:    0
-                  bind:        0
-                  silence:     2
-                  slow:        6
-                  poison:      2
-                  light_sleep: 6
-                  dark_sleep:  0
-                  blind:       0
-                  stun:        0
-                  gravity:     2
+                  paralyze:    -3
+                  bind:        -3
+                  silence:     -2
+                  slow:         0
+                  poison:      -2
+                  light_sleep:  0
+                  dark_sleep:  -3
+                  blind:       -3
+                  stun:        -3
+                  gravity:     -2
       diremite:
         id: 187
         attributes:
@@ -14663,25 +14663,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -1
-                  ice:     -1
-                  wind:    -1
-                  earth:   -1
-                  thunder: -1
-                  water:   -3
-                  light:   -2
-                  dark:     3
+                  fire:     0
+                  ice:      0
+                  wind:     0
+                  earth:    0
+                  thunder:  0
+                  water:   -2
+                  light:   -1
+                  dark:     4
                 rank_status:
-                  paralyze:    -1
-                  bind:        -1
-                  silence:     -1
-                  slow:        -1
-                  poison:      -3
-                  light_sleep: -2
-                  dark_sleep:   3
-                  blind:        3
-                  stun:        -1
-                  gravity:     -1
+                  paralyze:     0
+                  bind:         0
+                  silence:      0
+                  slow:         0
+                  poison:      -2
+                  light_sleep: -1
+                  dark_sleep:   4
+                  blind:        4
+                  stun:         0
+                  gravity:      0
           diremite:
             id: 442
             attributes:
@@ -15231,24 +15231,24 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:     0
-                  ice:     -3
+                  fire:     1
+                  ice:     -2
                   wind:     0
-                  earth:    0
-                  thunder: -2
-                  water:   -2
-                  light:   -3
-                  dark:     0
+                  earth:    1
+                  thunder: -1
+                  water:   -1
+                  light:   -2
+                  dark:     1
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
+                  paralyze:    -2
+                  bind:        -2
                   silence:      0
-                  slow:         0
-                  poison:      -2
-                  light_sleep: -3
-                  dark_sleep:   0
-                  blind:        0
-                  stun:        -2
+                  slow:         1
+                  poison:      -1
+                  light_sleep: -2
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -1
                   gravity:      0
           scorpion:
             id: 460
@@ -15348,24 +15348,24 @@ ecosystems:
               resists:
                 rank_element:
                   fire:     0
-                  ice:     -3
-                  wind:     0
-                  earth:    0
+                  ice:     -2
+                  wind:    -1
+                  earth:    1
                   thunder: -1
                   water:   -1
                   light:    0
                   dark:     0
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:      0
-                  slow:         0
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:         1
                   poison:      -1
                   light_sleep:  0
                   dark_sleep:   0
                   blind:        0
                   stun:        -1
-                  gravity:      0
+                  gravity:     -1
           spider:
             id: 464
             attributes:
@@ -15555,24 +15555,24 @@ ecosystems:
                   piercing: 1250
                 rank_element:
                   fire:    11
-                  ice:     -2
-                  wind:     2
-                  earth:   -1
-                  thunder:  0
-                  water:   -2
-                  light:    0
-                  dark:    -1
+                  ice:      0
+                  wind:     4
+                  earth:    1
+                  thunder:  2
+                  water:    0
+                  light:    2
+                  dark:     2
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:      2
-                  slow:        -1
-                  poison:      -2
-                  light_sleep:  0
-                  dark_sleep:  -1
-                  blind:       -1
-                  stun:         0
-                  gravity:      2
+                  paralyze:    0
+                  bind:        0
+                  silence:     4
+                  slow:        1
+                  poison:      0
+                  light_sleep: 2
+                  dark_sleep:  2
+                  blind:       2
+                  stun:        2
+                  gravity:     4
           wamoura:
             id: 470
             attributes:

--- a/data/zones/abyssea_altepa/mobs.yaml
+++ b/data/zones/abyssea_altepa/mobs.yaml
@@ -367,9 +367,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -771,9 +768,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_altepa/mobs.yaml
+++ b/data/zones/abyssea_altepa/mobs.yaml
@@ -1071,14 +1071,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_attohwa/mobs.yaml
+++ b/data/zones/abyssea_attohwa/mobs.yaml
@@ -783,9 +783,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1171,9 +1168,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_attohwa/mobs.yaml
+++ b/data/zones/abyssea_attohwa/mobs.yaml
@@ -432,9 +432,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -756,17 +753,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -862,24 +848,6 @@ templates:
     species:       chariot
     skill_list_id: 63
     attributes:
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1234,24 +1202,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_grauberg/mobs.yaml
+++ b/data/zones/abyssea_grauberg/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -408,21 +399,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -508,13 +484,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -899,13 +868,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1291,13 +1253,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1533,13 +1488,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1594,13 +1542,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_konschtat/mobs.yaml
+++ b/data/zones/abyssea_konschtat/mobs.yaml
@@ -99,19 +99,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -913,9 +900,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -2571,21 +2555,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_la_theine/mobs.yaml
+++ b/data/zones/abyssea_la_theine/mobs.yaml
@@ -95,13 +95,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -325,13 +318,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -783,13 +769,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1329,15 +1308,6 @@ templates:
       combat:
         skill: great_axe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_misareaux/mobs.yaml
+++ b/data/zones/abyssea_misareaux/mobs.yaml
@@ -1326,9 +1326,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1425,9 +1422,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_misareaux/mobs.yaml
+++ b/data/zones/abyssea_misareaux/mobs.yaml
@@ -69,21 +69,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -968,24 +953,6 @@ templates:
     species:       chariot
     skill_list_id: 63
     attributes:
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1439,24 +1406,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_tahrongi/mobs.yaml
+++ b/data/zones/abyssea_tahrongi/mobs.yaml
@@ -1151,14 +1151,6 @@ templates:
       combat:
         skill: sword
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -1343,9 +1335,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_tahrongi/mobs.yaml
+++ b/data/zones/abyssea_tahrongi/mobs.yaml
@@ -344,9 +344,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -744,9 +741,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1414,9 +1408,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1498,9 +1489,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_uleguerand/mobs.yaml
+++ b/data/zones/abyssea_uleguerand/mobs.yaml
@@ -1262,16 +1262,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        rank_element:
-          fire:  4
-          ice:   1
-          dark: -3
-        rank_status:
-          paralyze:    1
-          bind:        1
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_vunkerl/mobs.yaml
+++ b/data/zones/abyssea_vunkerl/mobs.yaml
@@ -288,14 +288,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -909,24 +901,6 @@ templates:
     species:       chariot
     skill_list_id: 63
     attributes:
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1012,19 +986,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -1203,24 +1164,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1313,19 +1256,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/al_zahbi/mobs.yaml
+++ b/data/zones/al_zahbi/mobs.yaml
@@ -102,9 +102,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -128,9 +125,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -358,9 +352,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1054,15 +1045,6 @@ templates:
         skill: scythe
         delay: 380
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:  11
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -1405,24 +1387,6 @@ templates:
       resists:
         dmg_physical:
           blunt: -1250
-        rank_element:
-          fire:    6
-          ice:     6
-          wind:    6
-          earth:   3
-          thunder: 3
-          water:   3
-          light:   3
-          dark:    3
-        rank_status:
-          paralyze:    6
-          bind:        6
-          silence:     6
-          slow:        3
-          poison:      3
-          light_sleep: 3
-          dark_sleep:  3
-          blind:       3
       render:
         look:
           type:  standard
@@ -2082,18 +2046,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -2115,18 +2067,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -2389,19 +2329,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2426,19 +2353,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2460,19 +2374,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2498,19 +2399,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2536,19 +2424,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2573,19 +2448,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2607,19 +2469,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2643,19 +2492,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -3139,18 +2975,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -3762,17 +3586,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -3797,17 +3610,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/altar_room/mobs.yaml
+++ b/data/zones/altar_room/mobs.yaml
@@ -211,16 +211,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/alzadaal_undersea_ruins/mobs.yaml
+++ b/data/zones/alzadaal_undersea_ruins/mobs.yaml
@@ -37,24 +37,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  4
-          water:   -1
-          light:    4
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  4
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -80,24 +62,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  4
-          water:   -1
-          light:    4
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  4
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -258,19 +222,6 @@ templates:
         skill: axe
         delay: 220
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/arrapago_reef/mobs.yaml
+++ b/data/zones/arrapago_reef/mobs.yaml
@@ -171,9 +171,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -261,23 +258,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -869,9 +849,6 @@ templates:
           slashing:  1250
           blunt:    -1250
           h2h:      -1250
-        rank_status:
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -1889,19 +1866,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -1935,19 +1899,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -1982,19 +1933,6 @@ templates:
       combat:
         skill: sword
       jobs: [cor, cor]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2030,19 +1968,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2078,19 +2003,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  standard
@@ -2161,19 +2073,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2209,19 +2108,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2254,19 +2140,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2300,19 +2173,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2344,19 +2204,6 @@ templates:
       combat:
         skill: sword
       jobs: [cor, cor]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2487,19 +2334,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2533,19 +2367,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2579,19 +2400,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2624,19 +2432,6 @@ templates:
       combat:
         skill: sword
       jobs: [cor, cor]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -3189,19 +2984,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/arrapago_remnants/mobs.yaml
+++ b/data/zones/arrapago_remnants/mobs.yaml
@@ -426,9 +426,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -736,9 +733,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/arrapago_remnants/mobs.yaml
+++ b/data/zones/arrapago_remnants/mobs.yaml
@@ -292,9 +292,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -596,19 +593,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -637,19 +621,6 @@ templates:
       combat:
         skill: sword
       jobs: [cor, cor]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -678,19 +649,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -720,19 +678,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -905,19 +850,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -1312,19 +1244,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/attohwa_chasm/mobs.yaml
+++ b/data/zones/attohwa_chasm/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/aydeewa_subterrane/mobs.yaml
+++ b/data/zones/aydeewa_subterrane/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/balgas_dais/mobs.yaml
+++ b/data/zones/balgas_dais/mobs.yaml
@@ -1533,16 +1533,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/balgas_dais/mobs.yaml
+++ b/data/zones/balgas_dais/mobs.yaml
@@ -316,9 +316,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -345,9 +342,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -394,9 +388,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -425,9 +416,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/bastok_markets_s/mobs.yaml
+++ b/data/zones/bastok_markets_s/mobs.yaml
@@ -581,9 +581,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/bastok_markets_s/mobs.yaml
+++ b/data/zones/bastok_markets_s/mobs.yaml
@@ -628,13 +628,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -741,13 +734,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1054,13 +1040,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1221,13 +1200,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1427,13 +1399,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1596,13 +1561,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1857,9 +1815,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2014,13 +1969,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2418,13 +2366,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2485,21 +2426,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -2521,13 +2447,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/batallia_downs/mobs.yaml
+++ b/data/zones/batallia_downs/mobs.yaml
@@ -42,16 +42,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1419,13 +1409,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1523,13 +1506,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1763,13 +1739,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1823,13 +1792,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/batallia_downs_s/mobs.yaml
+++ b/data/zones/batallia_downs_s/mobs.yaml
@@ -54,16 +54,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1178,13 +1168,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2316,9 +2299,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2575,23 +2555,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -2638,13 +2601,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3356,13 +3312,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3564,13 +3513,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3668,13 +3610,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3743,13 +3678,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/batallia_downs_s/mobs.yaml
+++ b/data/zones/batallia_downs_s/mobs.yaml
@@ -363,9 +363,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -508,8 +505,6 @@ templates:
       jobs: [mnk, mnk]
       resists:
         immune_status: [gravity, bind, light_sleep, dark_sleep]
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2109,9 +2104,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/beadeaux/mobs.yaml
+++ b/data/zones/beadeaux/mobs.yaml
@@ -10,13 +10,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -155,13 +148,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -203,13 +189,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -364,13 +343,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -446,13 +418,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -527,13 +492,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -573,13 +531,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -661,13 +612,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -853,13 +797,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -897,13 +834,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1088,13 +1018,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1167,13 +1090,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1231,13 +1147,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1273,13 +1182,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1328,13 +1230,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1374,13 +1269,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1420,13 +1308,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1499,13 +1380,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1579,13 +1453,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/beadeaux_s/mobs.yaml
+++ b/data/zones/beadeaux_s/mobs.yaml
@@ -544,9 +544,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/beadeaux_s/mobs.yaml
+++ b/data/zones/beadeaux_s/mobs.yaml
@@ -262,13 +262,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -372,13 +365,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -578,13 +564,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -652,13 +631,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -797,13 +769,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -932,13 +897,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1086,13 +1044,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1238,13 +1189,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1266,13 +1210,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1336,13 +1273,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [rdm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1365,13 +1295,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1608,13 +1531,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1662,13 +1578,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1773,13 +1682,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1875,13 +1777,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1979,13 +1874,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2007,13 +1895,6 @@ templates:
       combat:
         skill: sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2039,13 +1920,6 @@ templates:
         skill: club
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2109,13 +1983,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2194,13 +2061,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2307,13 +2167,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2486,13 +2339,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2554,13 +2400,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2699,13 +2538,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2762,9 +2594,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2883,13 +2712,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2988,13 +2810,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3410,13 +3225,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3448,13 +3256,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3522,13 +3323,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3645,13 +3439,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3687,24 +3474,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3751,21 +3520,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -3820,13 +3574,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3884,13 +3631,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3913,13 +3653,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3940,13 +3673,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3969,13 +3695,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/beaucedine_glacier_s/mobs.yaml
+++ b/data/zones/beaucedine_glacier_s/mobs.yaml
@@ -229,21 +229,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -930,13 +915,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1166,13 +1144,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2369,9 +2340,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3185,23 +3153,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3353,13 +3304,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3486,16 +3430,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3520,13 +3454,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/beaucedine_glacier_s/mobs.yaml
+++ b/data/zones/beaucedine_glacier_s/mobs.yaml
@@ -446,9 +446,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/bhaflau_remnants/mobs.yaml
+++ b/data/zones/bhaflau_remnants/mobs.yaml
@@ -497,12 +497,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          fire:  2
-          water: 2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -524,19 +518,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -1634,17 +1615,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -1667,17 +1637,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/bhaflau_thickets/mobs.yaml
+++ b/data/zones/bhaflau_thickets/mobs.yaml
@@ -65,15 +65,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -160,9 +151,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -186,9 +174,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1988,19 +1973,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2025,19 +1997,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2059,19 +2018,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2097,19 +2043,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2135,19 +2068,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2172,19 +2092,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2206,19 +2113,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2242,19 +2136,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2620,16 +2501,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:  4
-          ice:   1
-          dark: -3
-        rank_status:
-          paralyze:    1
-          bind:        1
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard

--- a/data/zones/bibiki_bay/mobs.yaml
+++ b/data/zones/bibiki_bay/mobs.yaml
@@ -11,9 +11,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1181,9 +1178,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/bibiki_bay/mobs.yaml
+++ b/data/zones/bibiki_bay/mobs.yaml
@@ -1573,23 +1573,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/buburimu_peninsula/mobs.yaml
+++ b/data/zones/buburimu_peninsula/mobs.yaml
@@ -34,15 +34,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1054,13 +1045,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1609,16 +1593,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/buburimu_peninsula/mobs.yaml
+++ b/data/zones/buburimu_peninsula/mobs.yaml
@@ -66,9 +66,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1285,9 +1282,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/caedarva_mire/mobs.yaml
+++ b/data/zones/caedarva_mire/mobs.yaml
@@ -12,19 +12,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -465,19 +452,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -843,9 +817,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1002,9 +973,6 @@ templates:
           slashing:  1250
           blunt:    -1250
           h2h:      -1250
-        rank_status:
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -1412,7 +1380,6 @@ templates:
           thunder:  2
           water:   10
           light:    1
-          dark:    11
         rank_status:
           paralyze:     4
           bind:         4
@@ -1420,8 +1387,6 @@ templates:
           slow:         2
           poison:      10
           light_sleep:  1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -1529,19 +1494,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -1564,19 +1516,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -2043,19 +1982,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/cape_teriggan/mobs.yaml
+++ b/data/zones/cape_teriggan/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/castle_oztroja/mobs.yaml
+++ b/data/zones/castle_oztroja/mobs.yaml
@@ -1495,16 +1495,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/castle_oztroja_s/mobs.yaml
+++ b/data/zones/castle_oztroja_s/mobs.yaml
@@ -357,9 +357,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/castle_oztroja_s/mobs.yaml
+++ b/data/zones/castle_oztroja_s/mobs.yaml
@@ -1177,13 +1177,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2061,9 +2054,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2728,13 +2718,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2780,16 +2763,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -2990,16 +2963,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3050,16 +3013,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3733,25 +3686,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3808,16 +3742,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_baileys/mobs.yaml
+++ b/data/zones/castle_zvahl_baileys/mobs.yaml
@@ -654,13 +654,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -698,13 +691,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1044,13 +1030,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1526,13 +1505,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_baileys_s/mobs.yaml
+++ b/data/zones/castle_zvahl_baileys_s/mobs.yaml
@@ -162,13 +162,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -320,13 +313,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -544,13 +530,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1657,13 +1636,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1872,13 +1844,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1950,13 +1915,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2095,13 +2053,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2503,13 +2454,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2646,9 +2590,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3095,13 +3036,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3589,23 +3523,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3707,13 +3624,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3746,13 +3656,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3815,13 +3718,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_baileys_s/mobs.yaml
+++ b/data/zones/castle_zvahl_baileys_s/mobs.yaml
@@ -510,9 +510,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_keep/mobs.yaml
+++ b/data/zones/castle_zvahl_keep/mobs.yaml
@@ -324,13 +324,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -368,13 +361,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -739,13 +725,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -785,13 +764,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -868,13 +840,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1234,13 +1199,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1278,13 +1236,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1326,13 +1277,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_keep_s/mobs.yaml
+++ b/data/zones/castle_zvahl_keep_s/mobs.yaml
@@ -480,9 +480,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_keep_s/mobs.yaml
+++ b/data/zones/castle_zvahl_keep_s/mobs.yaml
@@ -500,13 +500,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -542,13 +535,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -732,13 +718,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1558,13 +1537,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1796,13 +1768,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1883,13 +1848,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2071,13 +2029,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2687,13 +2638,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2829,9 +2773,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3178,13 +3119,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3333,13 +3267,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3873,23 +3800,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3949,13 +3859,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3992,13 +3895,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/ceizak_battlegrounds/mobs.yaml
+++ b/data/zones/ceizak_battlegrounds/mobs.yaml
@@ -109,9 +109,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/ceizak_battlegrounds/mobs.yaml
+++ b/data/zones/ceizak_battlegrounds/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -248,14 +242,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -712,14 +698,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard

--- a/data/zones/cirdas_caverns/mobs.yaml
+++ b/data/zones/cirdas_caverns/mobs.yaml
@@ -14,12 +14,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -165,12 +159,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -191,25 +179,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      4
-          wind:     1
-          earth:   11
-          thunder:  4
-          water:    4
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          silence:      1
-          slow:        11
-          poison:       4
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -274,12 +243,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -424,23 +387,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -718,12 +664,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -791,12 +731,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -1020,12 +954,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -1051,19 +979,6 @@ templates:
       combat:
         skill: axe
         delay: 150
-      resists:
-        rank_element:
-          ice:      2
-          earth:    1
-          thunder: -1
-          water:    8
-          light:    6
-        rank_status:
-          paralyze:    2
-          bind:        2
-          slow:        1
-          poison:      8
-          light_sleep: 6
       render:
         look:
           type:  standard

--- a/data/zones/cirdas_caverns/mobs.yaml
+++ b/data/zones/cirdas_caverns/mobs.yaml
@@ -305,9 +305,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -753,9 +750,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/cloister_of_gales/mobs.yaml
+++ b/data/zones/cloister_of_gales/mobs.yaml
@@ -16,15 +16,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/crawlers_nest_s/mobs.yaml
+++ b/data/zones/crawlers_nest_s/mobs.yaml
@@ -882,9 +882,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/crawlers_nest_s/mobs.yaml
+++ b/data/zones/crawlers_nest_s/mobs.yaml
@@ -411,14 +411,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:   -3
-          light: -3
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -469,21 +461,6 @@ templates:
     attributes:
       combat:
         skill: polearm
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -539,14 +516,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:   -3
-          light: -3
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -572,21 +541,6 @@ templates:
     attributes:
       combat:
         skill: polearm
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -612,21 +566,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -651,21 +590,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -717,24 +641,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, whm]
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -2
-          wind:    -2
-          earth:   -2
-          thunder: -2
-          water:    4
-          light:   -3
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:     -2
-          slow:        -2
-          poison:       4
-          light_sleep: -3
-          dark_sleep:   4
       render:
         look:
           type:  standard
@@ -761,14 +667,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:   -3
-          light: -3
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -794,21 +692,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -833,21 +716,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -900,21 +768,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -1076,13 +929,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1168,13 +1014,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1221,13 +1060,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1279,13 +1111,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1573,13 +1398,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1775,13 +1593,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1841,13 +1652,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2052,13 +1856,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2080,13 +1877,6 @@ templates:
       combat:
         skill: sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2112,13 +1902,6 @@ templates:
         skill: club
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2205,13 +1988,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2360,13 +2136,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2523,14 +2292,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:   -3
-          light: -3
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -2606,21 +2367,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -2646,14 +2392,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:   -3
-          light: -3
-        rank_status:
-          paralyze:    -3
-          bind:        -3
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -2679,21 +2417,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -2718,21 +2441,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -2
-          ice:     -3
-          wind:    -2
-          thunder: -3
-          water:   -2
-          dark:    -3
-        rank_status:
-          paralyze:   -3
-          bind:       -3
-          silence:    -2
-          poison:     -2
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -2986,9 +2694,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3035,13 +2740,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3193,13 +2891,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3221,13 +2912,6 @@ templates:
       combat:
         skill: axe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3272,13 +2956,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3421,13 +3098,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3673,13 +3343,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3714,13 +3377,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3780,21 +3436,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -3849,13 +3490,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/den_of_rancor/mobs.yaml
+++ b/data/zones/den_of_rancor/mobs.yaml
@@ -750,9 +750,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dho_gates/mobs.yaml
+++ b/data/zones/dho_gates/mobs.yaml
@@ -214,12 +214,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -241,12 +235,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -375,12 +363,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -463,12 +445,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_bastok/mobs.yaml
+++ b/data/zones/dynamis_bastok/mobs.yaml
@@ -557,24 +557,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -622,24 +604,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -689,24 +653,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -754,24 +700,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -818,24 +746,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -884,24 +794,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -949,24 +841,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1015,24 +889,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1083,24 +939,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1146,24 +984,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1210,24 +1030,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1276,24 +1078,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1340,24 +1124,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1405,24 +1171,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1472,24 +1220,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1537,24 +1267,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1603,24 +1315,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1671,24 +1365,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1735,24 +1411,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1798,24 +1456,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1863,24 +1503,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1926,24 +1548,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1988,24 +1592,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2052,24 +1638,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2117,24 +1685,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2183,24 +1733,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2251,24 +1783,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2316,24 +1830,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2382,24 +1878,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2450,24 +1928,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2513,24 +1973,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2577,24 +2019,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2643,24 +2067,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2707,24 +2113,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2770,24 +2158,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2835,24 +2205,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2899,24 +2251,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2962,24 +2296,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3027,24 +2343,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3092,24 +2390,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3158,24 +2438,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3226,24 +2488,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3289,24 +2533,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3353,24 +2579,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3419,24 +2627,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_beaucedine/mobs.yaml
+++ b/data/zones/dynamis_beaucedine/mobs.yaml
@@ -5028,25 +5028,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5083,25 +5064,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5180,25 +5142,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5325,24 +5268,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5472,24 +5397,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5533,24 +5440,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5632,25 +5521,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5692,24 +5562,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5751,25 +5603,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6012,24 +5845,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6113,25 +5928,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6259,24 +6055,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6358,25 +6136,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6419,24 +6178,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6519,24 +6260,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6580,24 +6303,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6682,25 +6387,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6857,25 +6543,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6996,25 +6663,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7174,24 +6822,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7235,24 +6865,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7293,25 +6905,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7428,25 +7021,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7521,25 +7095,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7582,24 +7137,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7639,25 +7176,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7743,24 +7261,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7847,24 +7347,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7908,24 +7390,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8007,25 +7471,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_buburimu/mobs.yaml
+++ b/data/zones/dynamis_buburimu/mobs.yaml
@@ -2007,25 +2007,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2060,25 +2041,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2113,25 +2075,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2164,25 +2107,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2216,25 +2140,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2268,25 +2173,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2421,25 +2307,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2476,25 +2343,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2531,25 +2379,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2796,24 +2625,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2853,24 +2664,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2910,24 +2703,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3175,24 +2950,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3231,24 +2988,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3287,24 +3026,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3342,24 +3063,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3400,24 +3103,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3458,24 +3143,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3609,25 +3276,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3663,25 +3311,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3717,25 +3346,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3771,24 +3381,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3827,24 +3419,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3883,24 +3457,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3934,25 +3490,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3989,25 +3526,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4044,25 +3562,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4506,24 +4005,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4563,24 +4044,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4620,24 +4083,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4773,25 +4218,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4828,25 +4254,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4883,25 +4290,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5149,24 +4537,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5207,24 +4577,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5265,24 +4617,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5418,25 +4752,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5473,25 +4788,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5528,25 +4824,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5583,24 +4860,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5638,24 +4897,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5693,24 +4934,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5847,24 +5070,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5901,24 +5106,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5955,24 +5142,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6010,24 +5179,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6068,24 +5219,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6126,24 +5259,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6282,25 +5397,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6335,25 +5431,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6388,25 +5465,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6712,25 +5770,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6766,25 +5805,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6820,25 +5840,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7075,25 +6076,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7127,25 +6109,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7179,25 +6142,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7535,24 +6479,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7593,24 +6519,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7651,24 +6559,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7704,24 +6594,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7760,24 +6632,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7816,24 +6670,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7866,25 +6702,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7920,25 +6737,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7974,25 +6772,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8225,25 +7004,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8278,25 +7038,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8331,25 +7072,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8480,25 +7202,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8533,25 +7236,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8586,25 +7270,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8641,24 +7306,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8696,24 +7343,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8751,24 +7380,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8802,25 +7413,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8857,25 +7449,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8912,25 +7485,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -9072,24 +7626,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9127,24 +7663,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9182,24 +7700,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9342,24 +7842,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9400,24 +7882,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9458,24 +7922,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9511,24 +7957,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9567,24 +7995,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9623,24 +8033,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -9778,25 +8170,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -9832,25 +8205,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -9886,25 +8240,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_buburimu/mobs.yaml
+++ b/data/zones/dynamis_buburimu/mobs.yaml
@@ -1366,9 +1366,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1407,9 +1404,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_jeuno/mobs.yaml
+++ b/data/zones/dynamis_jeuno/mobs.yaml
@@ -2399,25 +2399,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2458,25 +2439,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2519,25 +2481,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2578,25 +2521,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2636,25 +2560,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2696,25 +2601,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2756,25 +2642,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2817,25 +2684,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2880,25 +2728,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2939,25 +2768,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2997,25 +2807,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3057,25 +2848,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3115,25 +2887,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3176,25 +2929,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3239,25 +2973,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3299,25 +3014,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3360,25 +3056,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3423,25 +3100,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3483,25 +3141,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3544,25 +3183,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3607,25 +3227,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3667,25 +3268,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3726,25 +3308,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3787,25 +3350,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3846,25 +3390,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3906,25 +3431,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3968,25 +3474,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4027,25 +3514,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4085,25 +3553,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4145,25 +3594,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4204,25 +3634,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4264,25 +3675,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4326,25 +3718,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4386,25 +3759,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4445,25 +3799,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4506,25 +3841,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4564,25 +3880,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4623,25 +3920,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4684,25 +3962,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4744,25 +4003,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4805,25 +4045,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4868,25 +4089,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4927,25 +4129,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4987,25 +4170,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5049,25 +4213,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_qufim/mobs.yaml
+++ b/data/zones/dynamis_qufim/mobs.yaml
@@ -1215,25 +1215,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1268,25 +1249,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1319,25 +1281,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1371,25 +1314,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1524,25 +1448,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1579,25 +1484,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1846,24 +1732,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1903,24 +1771,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1960,24 +1810,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2225,24 +2057,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2281,24 +2095,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2337,24 +2133,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2392,24 +2170,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2450,24 +2210,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2508,24 +2250,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2659,25 +2383,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2713,25 +2418,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2767,25 +2453,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2821,24 +2488,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2877,24 +2526,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2933,24 +2564,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2984,25 +2597,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3039,25 +2633,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3469,24 +3044,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3526,24 +3083,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3583,24 +3122,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3736,25 +3257,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3791,25 +3293,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3846,25 +3329,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4078,24 +3542,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4136,24 +3582,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4194,24 +3622,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4347,25 +3757,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4402,25 +3793,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4457,25 +3829,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4512,24 +3865,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4567,24 +3902,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4622,24 +3939,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4776,24 +4075,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4830,24 +4111,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4884,24 +4147,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4939,24 +4184,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4997,24 +4224,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5055,24 +4264,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5211,25 +4402,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5264,25 +4436,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5317,25 +4470,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5676,25 +4810,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5730,25 +4845,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5784,25 +4880,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6039,25 +5116,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6091,25 +5149,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6143,25 +5182,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6499,24 +5519,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6557,24 +5559,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6615,24 +5599,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6668,24 +5634,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6724,24 +5672,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6780,24 +5710,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6830,25 +5742,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6884,25 +5777,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6938,25 +5812,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7155,25 +6010,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7208,25 +6044,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7261,25 +6078,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7378,25 +6176,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7431,25 +6210,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7484,25 +6244,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7539,24 +6280,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7594,24 +6317,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7649,24 +6354,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7700,25 +6387,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7755,25 +6423,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7917,24 +6566,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7972,24 +6603,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8027,24 +6640,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8187,24 +6782,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8245,24 +6822,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8303,24 +6862,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8356,24 +6897,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8412,24 +6935,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8468,24 +6973,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8623,25 +7110,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8677,25 +7145,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_valkurm/mobs.yaml
+++ b/data/zones/dynamis_valkurm/mobs.yaml
@@ -784,10 +784,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -826,10 +822,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -1232,25 +1224,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1285,25 +1258,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1338,25 +1292,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1389,25 +1324,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1441,25 +1357,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1493,25 +1390,6 @@ templates:
       combat:
         skill: dagger
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1646,25 +1524,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1701,25 +1560,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -1756,25 +1596,6 @@ templates:
       combat:
         skill: sword
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2021,24 +1842,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2078,24 +1881,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2135,24 +1920,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2366,24 +2133,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2422,24 +2171,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2478,24 +2209,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2533,24 +2246,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2591,24 +2286,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2649,24 +2326,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -2800,25 +2459,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2854,25 +2494,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2908,25 +2529,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -2962,24 +2564,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3018,24 +2602,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3074,24 +2640,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3125,25 +2673,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3180,25 +2709,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3235,25 +2745,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3664,24 +3155,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3721,24 +3194,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3778,24 +3233,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3931,25 +3368,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -3986,25 +3404,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4041,25 +3440,6 @@ templates:
       combat:
         skill: dagger
       jobs: [nin, nin]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4273,24 +3653,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4331,24 +3693,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4389,24 +3733,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4542,25 +3868,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4597,25 +3904,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4652,25 +3940,6 @@ templates:
       combat:
         skill: dagger
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -4707,24 +3976,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4762,24 +4013,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4817,24 +4050,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4971,24 +4186,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5025,24 +4222,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5079,24 +4258,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5134,24 +4295,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5192,24 +4335,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5250,24 +4375,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -5406,25 +4513,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5459,25 +4547,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5512,25 +4581,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5836,25 +4886,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5890,25 +4921,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -5944,25 +4956,6 @@ templates:
       combat:
         skill: axe
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6199,25 +5192,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6251,25 +5225,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6303,25 +5258,6 @@ templates:
       combat:
         skill: dagger
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6659,24 +5595,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6717,24 +5635,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6775,24 +5675,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6828,24 +5710,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6884,24 +5748,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6940,24 +5786,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -6990,25 +5818,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7044,25 +5853,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7098,25 +5888,6 @@ templates:
       combat:
         skill: sword
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7349,25 +6120,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7402,25 +6154,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7455,25 +6188,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7572,25 +6286,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7625,25 +6320,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7678,25 +6354,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7733,24 +6390,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7788,24 +6427,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7843,24 +6464,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -7894,25 +6497,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -7949,25 +6533,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8004,25 +6569,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8164,24 +6710,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8219,24 +6747,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8274,24 +6784,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8434,24 +6926,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8492,24 +6966,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8550,24 +7006,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8603,24 +7041,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8659,24 +7079,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8715,24 +7117,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -8836,25 +7220,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8890,25 +7255,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -8944,25 +7290,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:    -1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -2
-          dark:     1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -2
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard

--- a/data/zones/east_ronfaure/mobs.yaml
+++ b/data/zones/east_ronfaure/mobs.yaml
@@ -978,13 +978,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/east_ronfaure_s/mobs.yaml
+++ b/data/zones/east_ronfaure_s/mobs.yaml
@@ -1109,13 +1109,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1637,14 +1630,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -2058,14 +2043,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -2192,13 +2169,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2388,9 +2358,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2646,23 +2613,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -2709,13 +2659,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2887,14 +2830,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -3639,13 +3574,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/east_ronfaure_s/mobs.yaml
+++ b/data/zones/east_ronfaure_s/mobs.yaml
@@ -361,9 +361,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/east_sarutabaruta/mobs.yaml
+++ b/data/zones/east_sarutabaruta/mobs.yaml
@@ -636,9 +636,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1033,9 +1030,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/east_sarutabaruta/mobs.yaml
+++ b/data/zones/east_sarutabaruta/mobs.yaml
@@ -736,13 +736,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/empyreal_paradox/mobs.yaml
+++ b/data/zones/empyreal_paradox/mobs.yaml
@@ -134,25 +134,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, whm]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          light:   1
-          dark:    1
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     1
-          slow:        1
-          poison:      1
-          light_sleep: 1
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/escha_ruaun/mobs.yaml
+++ b/data/zones/escha_ruaun/mobs.yaml
@@ -704,24 +704,6 @@ templates:
         delay: 200
       resists:
         immune_status: [light_sleep, dark_sleep]
-        rank_element:
-          fire:    -2
-          ice:     -2
-          wind:    -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:     -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -799,25 +781,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        rank_element:
-          fire:     3
-          ice:      9
-          wind:     3
-          earth:    9
-          thunder:  3
-          water:    9
-          light:    2
-          dark:    11
-        rank_status:
-          paralyze:     9
-          bind:         9
-          silence:      3
-          slow:         9
-          poison:       9
-          light_sleep:  2
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -2533,24 +2496,6 @@ templates:
         delay: 200
       resists:
         immune_status: [light_sleep, dark_sleep]
-        rank_element:
-          fire:    -2
-          ice:     -2
-          wind:    -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:     -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/escha_zitah/mobs.yaml
+++ b/data/zones/escha_zitah/mobs.yaml
@@ -56,13 +56,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -234,13 +227,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1111,13 +1097,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/everbloom_hollow/mobs.yaml
+++ b/data/zones/everbloom_hollow/mobs.yaml
@@ -947,13 +947,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/feiyin/mobs.yaml
+++ b/data/zones/feiyin/mobs.yaml
@@ -935,18 +935,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -976,18 +964,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1017,18 +993,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1057,18 +1021,6 @@ templates:
       combat:
         skill: sword
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1172,18 +1124,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1218,18 +1158,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1264,18 +1192,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1309,18 +1225,6 @@ templates:
       combat:
         skill: sword
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard

--- a/data/zones/foret_de_hennetiel/mobs.yaml
+++ b/data/zones/foret_de_hennetiel/mobs.yaml
@@ -11,14 +11,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -523,12 +515,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -750,21 +736,6 @@ templates:
     attributes:
       combat:
         skill: polearm
-      resists:
-        rank_element:
-          ice:   9
-          earth: 4
-          water: 2
-          light: 6
-          dark:  4
-        rank_status:
-          paralyze:    9
-          bind:        9
-          slow:        4
-          poison:      2
-          light_sleep: 6
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/fort_karugo_narugo_s/mobs.yaml
+++ b/data/zones/fort_karugo_narugo_s/mobs.yaml
@@ -55,15 +55,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1077,13 +1068,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1972,9 +1956,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2115,13 +2096,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2705,13 +2679,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2797,16 +2764,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3261,25 +3218,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard

--- a/data/zones/fort_karugo_narugo_s/mobs.yaml
+++ b/data/zones/fort_karugo_narugo_s/mobs.yaml
@@ -312,9 +312,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1799,9 +1796,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/garlaige_citadel_s/mobs.yaml
+++ b/data/zones/garlaige_citadel_s/mobs.yaml
@@ -286,9 +286,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/garlaige_citadel_s/mobs.yaml
+++ b/data/zones/garlaige_citadel_s/mobs.yaml
@@ -1030,13 +1030,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1825,9 +1818,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2447,13 +2437,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2539,16 +2522,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -2599,16 +2572,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3004,25 +2967,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3080,16 +3024,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/ghoyus_reverie/mobs.yaml
+++ b/data/zones/ghoyus_reverie/mobs.yaml
@@ -297,13 +297,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -973,13 +966,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2072,13 +2058,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2195,13 +2174,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2401,23 +2373,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -2742,13 +2697,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2954,13 +2902,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3960,13 +3901,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/giddeus/mobs.yaml
+++ b/data/zones/giddeus/mobs.yaml
@@ -923,16 +923,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/grauberg_s/mobs.yaml
+++ b/data/zones/grauberg_s/mobs.yaml
@@ -318,15 +318,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -361,15 +352,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -529,13 +511,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -731,13 +706,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -903,13 +871,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -957,13 +918,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1044,13 +998,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1267,13 +1214,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1464,13 +1404,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1661,13 +1594,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1918,13 +1844,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2165,10 +2084,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -2205,13 +2120,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2246,13 +2154,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2423,13 +2324,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2799,13 +2693,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2855,9 +2742,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2904,13 +2788,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2946,13 +2823,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3057,13 +2927,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3160,13 +3023,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3188,13 +3044,6 @@ templates:
       combat:
         skill: axe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3239,13 +3088,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3456,24 +3298,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -3493,13 +3317,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3847,13 +3664,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3899,13 +3709,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3936,21 +3739,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -4028,13 +3816,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4153,13 +3934,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4223,21 +3997,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -4290,13 +4049,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4377,13 +4129,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/grauberg_s/mobs.yaml
+++ b/data/zones/grauberg_s/mobs.yaml
@@ -659,9 +659,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/halvung/mobs.yaml
+++ b/data/zones/halvung/mobs.yaml
@@ -286,12 +286,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          fire:  2
-          water: 2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -423,8 +417,6 @@ templates:
           slashing: -1250
           blunt:    -2500
           h2h:      -2500
-        rank_status:
-          silence: 7
       render:
         look:
           type:  standard
@@ -1681,17 +1673,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -1720,17 +1701,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -1757,17 +1727,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/hazhalm_testing_grounds/mobs.yaml
+++ b/data/zones/hazhalm_testing_grounds/mobs.yaml
@@ -140,19 +140,6 @@ templates:
         skill: axe
         delay: 180
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -539,13 +526,12 @@ templates:
       jobs: [blm, blm]
       resists:
         rank_element:
-          fire:    -3
-          ice:      4
-          wind:    -2
-          thunder: -2
-          water:   -2
-          light:   -3
-          dark:     4
+          fire:  -3
+          ice:    4
+          wind:  -2
+          water: -2
+          light: -3
+          dark:   4
         rank_status:
           silence:     -2
           poison:      -2
@@ -1456,9 +1442,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1876,11 +1859,6 @@ templates:
       combat:
         skill: hand_to_hand
       jobs: [drk, blm]
-      resists:
-        rank_element:
-          light: -3
-        rank_status:
-          light_sleep: -3
       render:
         look:
           type:  standard
@@ -2387,19 +2365,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/ilrusi_atoll/mobs.yaml
+++ b/data/zones/ilrusi_atoll/mobs.yaml
@@ -160,19 +160,6 @@ templates:
       combat:
         skill: axe
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -197,19 +184,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -233,19 +207,6 @@ templates:
       combat:
         skill: axe
       jobs: [sam, sam]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton

--- a/data/zones/jade_sepulcher/mobs.yaml
+++ b/data/zones/jade_sepulcher/mobs.yaml
@@ -167,18 +167,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/jugner_forest/mobs.yaml
+++ b/data/zones/jugner_forest/mobs.yaml
@@ -18,13 +18,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -434,18 +427,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  misc
@@ -2094,13 +2075,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/jugner_forest_s/mobs.yaml
+++ b/data/zones/jugner_forest_s/mobs.yaml
@@ -315,9 +315,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/jugner_forest_s/mobs.yaml
+++ b/data/zones/jugner_forest_s/mobs.yaml
@@ -337,14 +337,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -1028,13 +1020,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2407,9 +2392,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2772,23 +2754,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3720,13 +3685,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3758,13 +3716,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4029,13 +3980,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/kamihr_drifts/mobs.yaml
+++ b/data/zones/kamihr_drifts/mobs.yaml
@@ -505,14 +505,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -653,12 +645,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/konschtat_highlands/mobs.yaml
+++ b/data/zones/konschtat_highlands/mobs.yaml
@@ -12,13 +12,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -51,13 +44,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -715,13 +701,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -956,13 +935,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1020,13 +992,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1462,13 +1427,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1697,13 +1655,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/kuftal_tunnel/mobs.yaml
+++ b/data/zones/kuftal_tunnel/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/la_theine_plateau/mobs.yaml
+++ b/data/zones/la_theine_plateau/mobs.yaml
@@ -40,15 +40,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1216,13 +1207,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/la_vaule_s/mobs.yaml
+++ b/data/zones/la_vaule_s/mobs.yaml
@@ -414,9 +414,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/la_vaule_s/mobs.yaml
+++ b/data/zones/la_vaule_s/mobs.yaml
@@ -1174,13 +1174,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2037,14 +2030,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -2180,9 +2165,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2695,23 +2677,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3701,13 +3666,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/labyrinth_of_onzozo/mobs.yaml
+++ b/data/zones/labyrinth_of_onzozo/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/laloff_amphitheater/mobs.yaml
+++ b/data/zones/laloff_amphitheater/mobs.yaml
@@ -393,9 +393,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -424,9 +421,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/lebros_cavern/mobs.yaml
+++ b/data/zones/lebros_cavern/mobs.yaml
@@ -182,12 +182,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          fire:  2
-          water: 2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -446,17 +440,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -543,17 +526,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/leujaoam_sanctum/mobs.yaml
+++ b/data/zones/leujaoam_sanctum/mobs.yaml
@@ -236,9 +236,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -417,9 +414,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard

--- a/data/zones/lufaise_meadows/mobs.yaml
+++ b/data/zones/lufaise_meadows/mobs.yaml
@@ -30,12 +30,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          ice: -3
-        rank_status:
-          paralyze: -3
-          bind:     -3
       render:
         look:
           type:  standard
@@ -128,15 +122,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/mamook/mobs.yaml
+++ b/data/zones/mamook/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1937,16 +1928,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:  4
-          ice:   1
-          dark: -3
-        rank_status:
-          paralyze:    1
-          bind:        1
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard

--- a/data/zones/mamool_ja_training_grounds/mobs.yaml
+++ b/data/zones/mamool_ja_training_grounds/mobs.yaml
@@ -609,24 +609,6 @@ templates:
       resists:
         dmg_physical:
           blunt: -1250
-        rank_element:
-          fire:    6
-          ice:     6
-          wind:    6
-          earth:   3
-          thunder: 3
-          water:   3
-          light:   3
-          dark:    3
-        rank_status:
-          paralyze:    6
-          bind:        6
-          silence:     6
-          slow:        3
-          poison:      3
-          light_sleep: 3
-          dark_sleep:  3
-          blind:       3
       render:
         look:
           type:  standard

--- a/data/zones/manaclipper/mobs.yaml
+++ b/data/zones/manaclipper/mobs.yaml
@@ -9,23 +9,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/maquette_abdhaljs_legion_a/mobs.yaml
+++ b/data/zones/maquette_abdhaljs_legion_a/mobs.yaml
@@ -85,15 +85,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -966,21 +957,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -1084,21 +1060,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/maquette_abdhaljs_legion_b/mobs.yaml
+++ b/data/zones/maquette_abdhaljs_legion_b/mobs.yaml
@@ -753,21 +753,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -856,21 +841,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/marjami_ravine/mobs.yaml
+++ b/data/zones/marjami_ravine/mobs.yaml
@@ -86,14 +86,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -558,23 +550,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -593,12 +568,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/maze_of_shakhrami/mobs.yaml
+++ b/data/zones/maze_of_shakhrami/mobs.yaml
@@ -54,15 +54,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/meriphataud_mountains/mobs.yaml
+++ b/data/zones/meriphataud_mountains/mobs.yaml
@@ -1279,13 +1279,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2063,16 +2056,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/meriphataud_mountains_s/mobs.yaml
+++ b/data/zones/meriphataud_mountains_s/mobs.yaml
@@ -316,9 +316,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1991,9 +1988,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/meriphataud_mountains_s/mobs.yaml
+++ b/data/zones/meriphataud_mountains_s/mobs.yaml
@@ -1076,13 +1076,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2331,9 +2324,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3178,13 +3168,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3261,13 +3244,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3429,16 +3405,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3907,25 +3873,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3948,16 +3895,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/misareaux_coast/mobs.yaml
+++ b/data/zones/misareaux_coast/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/moh_gates/mobs.yaml
+++ b/data/zones/moh_gates/mobs.yaml
@@ -48,24 +48,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -230,24 +212,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -393,24 +357,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -718,23 +664,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -753,24 +682,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -796,12 +707,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard

--- a/data/zones/moh_gates/mobs.yaml
+++ b/data/zones/moh_gates/mobs.yaml
@@ -507,9 +507,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/morimar_basalt_fields/mobs.yaml
+++ b/data/zones/morimar_basalt_fields/mobs.yaml
@@ -224,24 +224,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -591,24 +573,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -652,12 +616,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -758,14 +716,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -784,24 +734,6 @@ templates:
       combat:
         skill: great_axe
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     4
-          earth:   11
-          thunder: 11
-          water:   11
-          light:    4
-          dark:     4
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:      4
-          slow:        11
-          poison:      11
-          light_sleep:  4
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard

--- a/data/zones/morimar_basalt_fields/mobs.yaml
+++ b/data/zones/morimar_basalt_fields/mobs.yaml
@@ -371,9 +371,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/mount_zhayolm/mobs.yaml
+++ b/data/zones/mount_zhayolm/mobs.yaml
@@ -305,12 +305,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          fire:  2
-          water: 2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -445,8 +439,6 @@ templates:
           slashing: -1250
           blunt:    -2500
           h2h:      -2500
-        rank_status:
-          silence: 7
       render:
         look:
           type:  standard
@@ -1102,23 +1094,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -1627,23 +1602,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard
@@ -1744,17 +1702,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -1815,23 +1762,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/navukgo_execution_chamber/mobs.yaml
+++ b/data/zones/navukgo_execution_chamber/mobs.yaml
@@ -13,25 +13,6 @@ templates:
         delay:    480
         dmg_mult: 125
       jobs: [mnk, mnk]
-      resists:
-        rank_element:
-          fire:    7
-          ice:     7
-          wind:    2
-          earth:   7
-          thunder: 7
-          water:   2
-          light:   4
-          dark:    4
-        rank_status:
-          paralyze:    7
-          bind:        7
-          silence:     2
-          slow:        7
-          poison:      2
-          light_sleep: 4
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -267,17 +248,6 @@ templates:
         skill: scythe
         delay: 170
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/north_gustaberg/mobs.yaml
+++ b/data/zones/north_gustaberg/mobs.yaml
@@ -12,13 +12,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -51,13 +44,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -316,13 +302,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -993,13 +972,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1111,13 +1083,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1203,13 +1168,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1276,13 +1234,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1498,13 +1449,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1967,13 +1911,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/north_gustaberg_s/mobs.yaml
+++ b/data/zones/north_gustaberg_s/mobs.yaml
@@ -561,9 +561,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/north_gustaberg_s/mobs.yaml
+++ b/data/zones/north_gustaberg_s/mobs.yaml
@@ -360,13 +360,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -397,13 +390,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -622,13 +608,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -903,13 +882,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1086,13 +1058,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1153,13 +1118,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1305,13 +1263,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1362,13 +1313,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [rdm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1592,13 +1536,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1623,13 +1560,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1656,13 +1586,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1937,13 +1860,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2372,13 +2288,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2609,13 +2518,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2960,9 +2862,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3041,13 +2940,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3137,13 +3029,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3176,13 +3061,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3296,13 +3174,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3324,13 +3195,6 @@ templates:
       combat:
         skill: axe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3375,13 +3239,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4071,13 +3928,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4199,13 +4049,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4292,21 +4135,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -4328,13 +4156,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4505,13 +4326,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/nyzul_isle/mobs.yaml
+++ b/data/zones/nyzul_isle/mobs.yaml
@@ -242,19 +242,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -551,19 +538,6 @@ templates:
         skill: axe
         delay: 180
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -696,9 +670,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1478,12 +1449,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          fire:  2
-          water: 2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1922,8 +1887,6 @@ templates:
           slashing: -1250
           blunt:    -2500
           h2h:      -2500
-        rank_status:
-          silence: 7
       render:
         look:
           type:  standard
@@ -2093,19 +2056,6 @@ templates:
         skill: axe
         delay: 150
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:      2
-          earth:    1
-          thunder: -1
-          water:    8
-          light:    6
-        rank_status:
-          paralyze:    2
-          bind:        2
-          slow:        1
-          poison:      8
-          light_sleep: 6
       render:
         look:
           type:  standard
@@ -4387,19 +4337,6 @@ templates:
         skill: axe
         delay: 150
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:      2
-          earth:    1
-          thunder: -1
-          water:    8
-          light:    6
-        rank_status:
-          paralyze:    2
-          bind:        2
-          slow:        1
-          poison:      8
-          light_sleep: 6
       render:
         look:
           type:  standard
@@ -4684,19 +4621,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -4912,24 +4836,6 @@ templates:
       combat:
         skill: staff
         delay: 320
-      resists:
-        rank_element:
-          ice:      1
-          wind:     1
-          earth:    1
-          thunder:  5
-          water:   -1
-          light:    6
-          dark:     1
-        rank_status:
-          paralyze:     1
-          bind:         1
-          silence:      1
-          slow:         1
-          poison:      -1
-          light_sleep:  6
-          dark_sleep:   1
-          blind:        1
       render:
         look:
           type:  standard
@@ -6394,19 +6300,6 @@ templates:
         skill: axe
         delay: 150
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:      2
-          earth:    1
-          thunder: -1
-          water:    8
-          light:    6
-        rank_status:
-          paralyze:    2
-          bind:        2
-          slow:        1
-          poison:      8
-          light_sleep: 6
       render:
         look:
           type:  standard
@@ -6480,19 +6373,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -6514,19 +6394,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -6550,19 +6417,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -6716,17 +6570,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -6981,24 +6824,6 @@ templates:
       resists:
         dmg_physical:
           blunt: -1250
-        rank_element:
-          fire:    6
-          ice:     6
-          wind:    6
-          earth:   3
-          thunder: 3
-          water:   3
-          light:   3
-          dark:    3
-        rank_status:
-          paralyze:    6
-          bind:        6
-          silence:     6
-          slow:        3
-          poison:      3
-          light_sleep: 3
-          dark_sleep:  3
-          blind:       3
       render:
         look:
           type:  standard

--- a/data/zones/nyzul_isle/mobs.yaml
+++ b/data/zones/nyzul_isle/mobs.yaml
@@ -3110,9 +3110,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6103,9 +6100,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/ordelles_caves/mobs.yaml
+++ b/data/zones/ordelles_caves/mobs.yaml
@@ -39,15 +39,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -85,15 +76,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/outer_rakaznar/mobs.yaml
+++ b/data/zones/outer_rakaznar/mobs.yaml
@@ -92,12 +92,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -142,13 +136,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -305,9 +292,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -737,12 +721,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/palborough_mines/mobs.yaml
+++ b/data/zones/palborough_mines/mobs.yaml
@@ -12,13 +12,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -53,13 +46,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -180,13 +166,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -325,13 +304,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -408,13 +380,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -640,13 +605,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -694,13 +652,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -918,13 +869,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -964,13 +908,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/pashhow_marshlands/mobs.yaml
+++ b/data/zones/pashhow_marshlands/mobs.yaml
@@ -396,13 +396,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -439,13 +432,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -476,13 +462,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -579,13 +558,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1035,13 +1007,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1096,13 +1061,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1779,13 +1737,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1818,13 +1769,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1854,13 +1798,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1895,13 +1832,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1935,13 +1865,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2062,13 +1985,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2304,13 +2220,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/pashhow_marshlands_s/mobs.yaml
+++ b/data/zones/pashhow_marshlands_s/mobs.yaml
@@ -474,9 +474,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/pashhow_marshlands_s/mobs.yaml
+++ b/data/zones/pashhow_marshlands_s/mobs.yaml
@@ -331,13 +331,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -528,13 +521,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -781,13 +767,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1174,13 +1153,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1256,13 +1228,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1379,13 +1344,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1559,13 +1517,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1656,13 +1607,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [bst, bst]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1780,13 +1724,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1808,12 +1745,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2029,13 +1960,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2226,13 +2150,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2637,13 +2554,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2694,13 +2604,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2791,9 +2694,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2948,13 +2848,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2976,13 +2869,6 @@ templates:
       combat:
         skill: axe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3027,13 +2913,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3177,13 +3056,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3504,13 +3376,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3632,13 +3497,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3884,13 +3742,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3953,13 +3804,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4018,21 +3862,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -4087,13 +3916,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -4266,13 +4088,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/periqia/mobs.yaml
+++ b/data/zones/periqia/mobs.yaml
@@ -55,9 +55,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -733,19 +730,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton
@@ -767,19 +751,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          ice:   -2
-          water:  3
-          light: -2
-          dark:   2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  automaton

--- a/data/zones/phomiuna_aqueducts/mobs.yaml
+++ b/data/zones/phomiuna_aqueducts/mobs.yaml
@@ -44,15 +44,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/promyvion_dem/mobs.yaml
+++ b/data/zones/promyvion_dem/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: club
       jobs: [war, drk]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -41,15 +35,6 @@ templates:
       combat:
         skill: scythe
         delay: 0
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -75,14 +60,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -239,15 +216,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -301,12 +269,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -336,12 +298,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -371,14 +327,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -408,14 +356,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/promyvion_holla/mobs.yaml
+++ b/data/zones/promyvion_holla/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: club
       jobs: [war, drk]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -41,15 +35,6 @@ templates:
       combat:
         skill: scythe
         delay: 0
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -79,14 +64,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -181,15 +158,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -309,12 +277,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -344,12 +306,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -379,14 +335,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -416,14 +364,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/promyvion_mea/mobs.yaml
+++ b/data/zones/promyvion_mea/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: club
       jobs: [war, drk]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -41,15 +35,6 @@ templates:
       combat:
         skill: scythe
         delay: 0
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -75,14 +60,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -239,15 +216,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -301,12 +269,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -336,12 +298,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -371,14 +327,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -408,14 +356,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/promyvion_vahzl/mobs.yaml
+++ b/data/zones/promyvion_vahzl/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: club
       jobs: [war, drk]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -41,15 +35,6 @@ templates:
       combat:
         skill: scythe
         delay: 0
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -75,14 +60,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -321,15 +298,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -366,15 +334,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard
@@ -581,12 +540,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard
@@ -616,14 +569,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/psoxja/mobs.yaml
+++ b/data/zones/psoxja/mobs.yaml
@@ -1520,25 +1520,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:    -2
-          ice:      2
-          wind:    -1
-          earth:   -1
-          thunder: -1
-          water:   -1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:     2
-          bind:         2
-          silence:     -1
-          slow:        -1
-          poison:      -1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard

--- a/data/zones/qubia_arena/mobs.yaml
+++ b/data/zones/qubia_arena/mobs.yaml
@@ -438,18 +438,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [thf, mnk]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -476,18 +464,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [thf, mnk]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -903,18 +879,6 @@ templates:
         skill: katana
         delay: 360
       jobs: [rng, war]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -941,18 +905,6 @@ templates:
         skill: katana
         delay: 360
       jobs: [rng, war]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1085,18 +1037,6 @@ templates:
         skill: club
         delay: 360
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1125,18 +1065,6 @@ templates:
         skill: club
         delay: 360
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1711,18 +1639,6 @@ templates:
       combat:
         skill: dagger
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1748,18 +1664,6 @@ templates:
       combat:
         skill: dagger
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard

--- a/data/zones/qufim_island/mobs.yaml
+++ b/data/zones/qufim_island/mobs.yaml
@@ -1300,9 +1300,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/qulun_dome/mobs.yaml
+++ b/data/zones/qulun_dome/mobs.yaml
@@ -54,13 +54,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -100,13 +93,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -138,13 +124,6 @@ templates:
       combat:
         skill: great_sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -220,13 +199,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -248,13 +220,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -277,13 +242,6 @@ templates:
         skill: club
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -306,13 +264,6 @@ templates:
         skill: hand_to_hand
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -334,13 +285,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -417,13 +361,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -471,13 +408,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/rakaznar_inner_court/mobs.yaml
+++ b/data/zones/rakaznar_inner_court/mobs.yaml
@@ -31,9 +31,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -170,12 +167,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -226,12 +217,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -251,12 +236,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -288,13 +267,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -857,22 +829,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     6
-          wind:    4
-          earth:   6
-          thunder: 4
-          water:   6
-          light:   2
-        rank_status:
-          paralyze:    6
-          bind:        6
-          silence:     4
-          slow:        6
-          poison:      6
-          light_sleep: 2
       render:
         look:
           type:  standard
@@ -1191,9 +1147,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          thunder: -2
       render:
         look:
           type:  standard
@@ -1237,12 +1190,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/rala_waterways/mobs.yaml
+++ b/data/zones/rala_waterways/mobs.yaml
@@ -148,23 +148,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/rala_waterways_u/mobs.yaml
+++ b/data/zones/rala_waterways_u/mobs.yaml
@@ -31,22 +31,6 @@ templates:
       combat:
         skill: sword
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          ice:     11
-          wind:     2
-          earth:   11
-          thunder:  2
-          water:   11
-          light:    2
-        rank_status:
-          paralyze:    11
-          bind:        11
-          silence:      2
-          slow:        11
-          poison:      11
-          light_sleep:  2
       render:
         look:
           type:  standard
@@ -241,12 +225,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        rank_element:
-          dark: -3
-        rank_status:
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -290,21 +268,6 @@ templates:
     attributes:
       combat:
         skill: polearm
-      resists:
-        rank_element:
-          ice:   9
-          earth: 4
-          water: 2
-          light: 6
-          dark:  4
-        rank_status:
-          paralyze:    9
-          bind:        9
-          slow:        4
-          poison:      2
-          light_sleep: 6
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/reisenjima/mobs.yaml
+++ b/data/zones/reisenjima/mobs.yaml
@@ -29,9 +29,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -55,9 +52,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -84,8 +78,6 @@ templates:
       jobs: [mnk, mnk]
       resists:
         immune_status: [light_sleep, dark_sleep]
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -106,9 +98,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -133,9 +122,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/reisenjima/mobs.yaml
+++ b/data/zones/reisenjima/mobs.yaml
@@ -516,13 +516,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -722,21 +715,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -829,21 +807,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -893,14 +856,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -954,13 +909,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1046,13 +994,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1144,14 +1085,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -1298,13 +1231,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1460,13 +1386,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1492,10 +1411,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -1860,7 +1775,6 @@ templates:
           thunder:  2
           water:   10
           light:    1
-          dark:    11
         rank_status:
           paralyze:     4
           bind:         4
@@ -1868,8 +1782,6 @@ templates:
           slow:         2
           poison:      10
           light_sleep:  1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -2059,13 +1971,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/riverne_site_a01/mobs.yaml
+++ b/data/zones/riverne_site_a01/mobs.yaml
@@ -55,15 +55,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -182,10 +173,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -277,16 +264,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:  4
-          ice:   1
-          dark: -3
-        rank_status:
-          paralyze:    1
-          bind:        1
-          dark_sleep: -3
-          blind:      -3
       render:
         look:
           type:  standard
@@ -442,10 +419,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard

--- a/data/zones/riverne_site_b01/mobs.yaml
+++ b/data/zones/riverne_site_b01/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -505,10 +496,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -680,10 +667,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard

--- a/data/zones/rolanberry_fields/mobs.yaml
+++ b/data/zones/rolanberry_fields/mobs.yaml
@@ -12,16 +12,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -177,13 +167,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -217,13 +200,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -304,13 +280,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -566,13 +535,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1172,13 +1134,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1340,13 +1295,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1421,13 +1369,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1493,13 +1434,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1596,13 +1530,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1634,13 +1561,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2059,13 +1979,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/rolanberry_fields_s/mobs.yaml
+++ b/data/zones/rolanberry_fields_s/mobs.yaml
@@ -323,21 +323,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -362,16 +347,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -619,13 +594,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -804,13 +772,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -834,24 +795,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -892,13 +835,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -950,13 +886,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1522,13 +1451,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1577,24 +1499,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -1694,12 +1598,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1746,13 +1644,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1890,13 +1781,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2049,13 +1933,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2080,12 +1957,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2154,13 +2025,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2560,12 +2424,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2583,13 +2441,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -2743,13 +2594,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3158,9 +3002,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3207,13 +3048,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3381,13 +3215,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3409,13 +3236,6 @@ templates:
       combat:
         skill: axe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3460,13 +3280,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3630,13 +3443,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3905,13 +3711,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3952,13 +3751,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4023,13 +3815,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4103,13 +3888,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4162,13 +3940,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4216,13 +3987,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -4370,24 +4134,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          fire:     1
-          ice:     -1
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    1
-          light:   -1
-          dark:    -1
-        rank_status:
-          paralyze:    -1
-          bind:        -1
-          silence:     -1
-          slow:        -1
-          poison:       1
-          light_sleep: -1
-          dark_sleep:  -1
-          blind:       -1
       render:
         look:
           type:  standard
@@ -4406,21 +4152,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        rank_element:
-          fire:     4
-          ice:      1
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -3
-        rank_status:
-          paralyze:     1
-          bind:         1
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -3
-          blind:       -3
       render:
         look:
           type:  standard
@@ -4475,13 +4206,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/rolanberry_fields_s/mobs.yaml
+++ b/data/zones/rolanberry_fields_s/mobs.yaml
@@ -547,9 +547,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2711,9 +2708,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2810,9 +2804,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/ruaun_gardens/mobs.yaml
+++ b/data/zones/ruaun_gardens/mobs.yaml
@@ -49,13 +49,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -84,15 +77,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/ruhotz_silvermines/mobs.yaml
+++ b/data/zones/ruhotz_silvermines/mobs.yaml
@@ -221,13 +221,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -303,13 +296,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -333,13 +319,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -548,13 +527,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -900,13 +872,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1093,13 +1058,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1211,13 +1169,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1505,13 +1456,6 @@ templates:
       combat:
         skill: great_sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1530,13 +1474,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1558,13 +1495,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1709,13 +1639,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1740,13 +1663,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1846,13 +1762,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [pld, war]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/sacrarium/mobs.yaml
+++ b/data/zones/sacrarium/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/sauromugue_champaign/mobs.yaml
+++ b/data/zones/sauromugue_champaign/mobs.yaml
@@ -12,16 +12,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1264,13 +1254,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1336,13 +1319,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1490,13 +1466,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1528,13 +1497,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2011,16 +1973,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/sauromugue_champaign_s/mobs.yaml
+++ b/data/zones/sauromugue_champaign_s/mobs.yaml
@@ -280,9 +280,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1617,8 +1614,6 @@ templates:
       jobs: [mnk, mnk]
       resists:
         immune_status: [gravity, bind, paralyze, light_sleep, dark_sleep]
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2006,9 +2001,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/sauromugue_champaign_s/mobs.yaml
+++ b/data/zones/sauromugue_champaign_s/mobs.yaml
@@ -54,16 +54,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1056,13 +1046,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2241,9 +2224,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2924,13 +2904,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2961,13 +2934,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3085,13 +3051,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3144,13 +3103,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3214,16 +3166,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3257,13 +3199,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3830,25 +3765,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3906,16 +3822,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/sih_gates/mobs.yaml
+++ b/data/zones/sih_gates/mobs.yaml
@@ -66,9 +66,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -115,9 +112,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/sih_gates/mobs.yaml
+++ b/data/zones/sih_gates/mobs.yaml
@@ -93,12 +93,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -160,12 +154,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -752,12 +740,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_remnants/mobs.yaml
+++ b/data/zones/silver_sea_remnants/mobs.yaml
@@ -483,19 +483,6 @@ templates:
         skill: axe
         delay: 150
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:      2
-          earth:    1
-          thunder: -1
-          water:    8
-          light:    6
-        rank_status:
-          paralyze:    2
-          bind:        2
-          slow:        1
-          poison:      8
-          light_sleep: 6
       render:
         look:
           type:  standard
@@ -955,19 +942,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_route_to_al_zahbi/mobs.yaml
+++ b/data/zones/silver_sea_route_to_al_zahbi/mobs.yaml
@@ -32,15 +32,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_route_to_nashmau/mobs.yaml
+++ b/data/zones/silver_sea_route_to_nashmau/mobs.yaml
@@ -40,15 +40,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/south_gustaberg/mobs.yaml
+++ b/data/zones/south_gustaberg/mobs.yaml
@@ -12,13 +12,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -51,13 +44,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -100,13 +86,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -923,13 +902,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1253,13 +1225,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/southern_san_doria_s/mobs.yaml
+++ b/data/zones/southern_san_doria_s/mobs.yaml
@@ -798,13 +798,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1469,9 +1462,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -1566,23 +1556,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -2279,13 +2252,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/southern_san_doria_s/mobs.yaml
+++ b/data/zones/southern_san_doria_s/mobs.yaml
@@ -343,9 +343,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/spire_of_dem/mobs.yaml
+++ b/data/zones/spire_of_dem/mobs.yaml
@@ -146,15 +146,6 @@ templates:
       jobs: [war, rdm]
       resists:
         immune_status: [bind, light_sleep, dark_sleep]
-        rank_element:
-          fire:    2
-          ice:     2
-          wind:    2
-          earth:   2
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
       render:
         look:
           type:  standard
@@ -180,12 +171,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire: -3
-          wind: 11
-        rank_status:
-          silence: 11
       render:
         look:
           type:  standard

--- a/data/zones/spire_of_holla/mobs.yaml
+++ b/data/zones/spire_of_holla/mobs.yaml
@@ -36,14 +36,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          light: -3
-          dark:  11
-        rank_status:
-          light_sleep: -3
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -72,15 +64,6 @@ templates:
       jobs: [war, rdm]
       resists:
         immune_status: [bind, light_sleep, dark_sleep]
-        rank_element:
-          fire:    2
-          ice:     2
-          wind:    2
-          earth:   2
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
       render:
         look:
           type:  standard

--- a/data/zones/spire_of_mea/mobs.yaml
+++ b/data/zones/spire_of_mea/mobs.yaml
@@ -14,15 +14,6 @@ templates:
       jobs: [war, rdm]
       resists:
         immune_status: [bind, light_sleep, dark_sleep]
-        rank_element:
-          fire:    2
-          ice:     2
-          wind:    2
-          earth:   2
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
       render:
         look:
           type:  standard
@@ -72,15 +63,6 @@ templates:
       combat:
         skill: scythe
       jobs: [war, rdm]
-      resists:
-        rank_element:
-          fire:  11
-          ice:   11
-          water: -3
-        rank_status:
-          paralyze: 11
-          bind:     11
-          poison:   -3
       render:
         look:
           type:  standard

--- a/data/zones/stellar_fulcrum/mobs.yaml
+++ b/data/zones/stellar_fulcrum/mobs.yaml
@@ -341,25 +341,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, whm]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          light:   1
-          dark:    1
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     1
-          slow:        1
-          poison:      1
-          light_sleep: 1
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/tahrongi_canyon/mobs.yaml
+++ b/data/zones/tahrongi_canyon/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -853,13 +844,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1466,16 +1450,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/tahrongi_canyon/mobs.yaml
+++ b/data/zones/tahrongi_canyon/mobs.yaml
@@ -907,9 +907,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/talacca_cove/mobs.yaml
+++ b/data/zones/talacca_cove/mobs.yaml
@@ -298,24 +298,6 @@ templates:
       jobs: [rng, rng]
       resists:
         immune_status: [gravity, poison, light_sleep, dark_sleep]
-        rank_element:
-          fire:    -1
-          ice:     -2
-          wind:    -1
-          earth:   -1
-          thunder: -2
-          water:    3
-          light:   -2
-          dark:     2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:     -1
-          slow:        -1
-          poison:       3
-          light_sleep: -2
-          dark_sleep:   2
-          blind:        2
       render:
         look:
           type:  standard
@@ -362,23 +344,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire:    -3
-          ice:     -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/the_boyahda_tree/mobs.yaml
+++ b/data/zones/the_boyahda_tree/mobs.yaml
@@ -572,9 +572,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -781,9 +778,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/the_celestial_nexus/mobs.yaml
+++ b/data/zones/the_celestial_nexus/mobs.yaml
@@ -40,23 +40,6 @@ templates:
         skill:    great_katana
         dmg_mult: 125
       jobs: [sam, drg]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   2
-          thunder: 1
-          water:   1
-          dark:    2
-        rank_status:
-          paralyze:   1
-          bind:       1
-          silence:    1
-          slow:       2
-          poison:     1
-          dark_sleep: 2
-          blind:      2
       render:
         look:
           type:  standard
@@ -84,23 +67,6 @@ templates:
         skill:    sword
         dmg_mult: 125
       jobs: [war, nin]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          dark:    2
-        rank_status:
-          paralyze:   1
-          bind:       1
-          silence:    1
-          slow:       1
-          poison:     1
-          dark_sleep: 2
-          blind:      2
       render:
         look:
           type:  standard
@@ -127,23 +93,6 @@ templates:
         skill:    dagger
         dmg_mult: 125
       jobs: [bst, thf]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    2
-          earth:   1
-          thunder: 1
-          water:   1
-          dark:    2
-        rank_status:
-          paralyze:   1
-          bind:       1
-          silence:    2
-          slow:       1
-          poison:     1
-          dark_sleep: 2
-          blind:      2
       render:
         look:
           type:  standard
@@ -319,25 +268,6 @@ templates:
         delay:    170
         dmg_mult: 125
       jobs: [blm, war]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          light:   1
-          dark:    1
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     1
-          slow:        1
-          poison:      1
-          light_sleep: 1
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -362,25 +292,6 @@ templates:
         delay:    170
         dmg_mult: 125
       jobs: [blm, war]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          light:   1
-          dark:    1
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     1
-          slow:        1
-          poison:      1
-          light_sleep: 1
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -408,25 +319,6 @@ templates:
         delay:    170
         dmg_mult: 125
       jobs: [blm, war]
-      resists:
-        rank_element:
-          fire:    1
-          ice:     1
-          wind:    1
-          earth:   1
-          thunder: 1
-          water:   1
-          light:   1
-          dark:    1
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     1
-          slow:        1
-          poison:      1
-          light_sleep: 1
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -502,24 +394,6 @@ templates:
       jobs: [rdm, rdm]
       resists:
         immune_status: [silence, light_sleep, dark_sleep]
-        rank_element:
-          fire:    3
-          ice:     3
-          wind:    3
-          earth:   3
-          thunder: 3
-          water:   3
-          light:   3
-          dark:    3
-        rank_status:
-          paralyze:    3
-          bind:        3
-          silence:     3
-          slow:        3
-          poison:      3
-          light_sleep: 3
-          dark_sleep:  3
-          blind:       3
       render:
         look:
           type:  standard

--- a/data/zones/the_eldieme_necropolis/mobs.yaml
+++ b/data/zones/the_eldieme_necropolis/mobs.yaml
@@ -134,18 +134,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -182,18 +170,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -228,18 +204,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -268,18 +232,6 @@ templates:
       combat:
         skill: sword
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -636,18 +588,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -684,18 +624,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -730,18 +658,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -775,18 +691,6 @@ templates:
       combat:
         skill: sword
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1164,18 +1068,6 @@ templates:
         skill: dagger
         delay: 360
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1209,18 +1101,6 @@ templates:
         skill: dagger
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1254,18 +1134,6 @@ templates:
         skill: dagger
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1300,18 +1168,6 @@ templates:
       combat:
         skill: dagger
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1552,18 +1408,6 @@ templates:
         skill: axe
         delay: 360
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1594,18 +1438,6 @@ templates:
         skill: axe
         delay: 360
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1634,18 +1466,6 @@ templates:
         skill: axe
         delay: 360
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1673,18 +1493,6 @@ templates:
       combat:
         skill: axe
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard

--- a/data/zones/the_eldieme_necropolis_s/mobs.yaml
+++ b/data/zones/the_eldieme_necropolis_s/mobs.yaml
@@ -315,9 +315,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/the_eldieme_necropolis_s/mobs.yaml
+++ b/data/zones/the_eldieme_necropolis_s/mobs.yaml
@@ -786,18 +786,6 @@ templates:
         skill: dagger
         delay: 360
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -945,13 +933,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1911,18 +1892,6 @@ templates:
         skill: polearm
         delay: 360
       jobs: [drg, drg]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -1973,9 +1942,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2233,23 +2199,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -2937,18 +2886,6 @@ templates:
         skill: sword
         delay: 360
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard
@@ -3101,13 +3038,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3238,18 +3168,6 @@ templates:
       combat:
         skill: great_sword
         delay: 360
-      resists:
-        rank_element:
-          fire:  -2
-          ice:    4
-          light: -2
-          dark:   4
-        rank_status:
-          paralyze:     4
-          bind:         4
-          light_sleep: -2
-          dark_sleep:   4
-          blind:        4
       render:
         look:
           type:  standard

--- a/data/zones/the_garden_of_ruhmet/mobs.yaml
+++ b/data/zones/the_garden_of_ruhmet/mobs.yaml
@@ -813,24 +813,6 @@ templates:
       jobs: [brd, war]
       resists:
         immune_status: [light_sleep, dark_sleep]
-        rank_element:
-          fire:    -2
-          ice:     -2
-          wind:    -2
-          earth:   -2
-          thunder: -2
-          water:   -2
-          light:   -2
-          dark:    -2
-        rank_status:
-          paralyze:    -2
-          bind:        -2
-          silence:     -2
-          slow:        -2
-          poison:      -2
-          light_sleep: -2
-          dark_sleep:  -2
-          blind:       -2
       render:
         look:
           type:  standard

--- a/data/zones/the_shrine_of_ruavitau/mobs.yaml
+++ b/data/zones/the_shrine_of_ruavitau/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/throne_room/mobs.yaml
+++ b/data/zones/throne_room/mobs.yaml
@@ -319,23 +319,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          fire:    11
-          ice:     11
-          wind:    11
-          thunder: 11
-          water:   11
-          light:   11
-          dark:    11
-        rank_status:
-          paralyze:    11
-          bind:        11
-          silence:     11
-          poison:      11
-          light_sleep: 11
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard

--- a/data/zones/uleguerand_range/mobs.yaml
+++ b/data/zones/uleguerand_range/mobs.yaml
@@ -1172,12 +1172,6 @@ templates:
       combat:
         skill: scythe
         delay: 220
-      resists:
-        rank_element:
-          fire:  -3
-          water: -2
-        rank_status:
-          poison: -2
       render:
         look:
           type:  standard

--- a/data/zones/valkurm_dunes/mobs.yaml
+++ b/data/zones/valkurm_dunes/mobs.yaml
@@ -1739,13 +1739,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/valley_of_sorrows/mobs.yaml
+++ b/data/zones/valley_of_sorrows/mobs.yaml
@@ -54,15 +54,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/velugannon_palace/mobs.yaml
+++ b/data/zones/velugannon_palace/mobs.yaml
@@ -13,15 +13,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/vunkerl_inlet_s/mobs.yaml
+++ b/data/zones/vunkerl_inlet_s/mobs.yaml
@@ -82,15 +82,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1141,13 +1132,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2313,9 +2297,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2539,23 +2520,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3364,13 +3328,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3586,13 +3543,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/vunkerl_inlet_s/mobs.yaml
+++ b/data/zones/vunkerl_inlet_s/mobs.yaml
@@ -394,9 +394,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/wajaom_woodlands/mobs.yaml
+++ b/data/zones/wajaom_woodlands/mobs.yaml
@@ -42,15 +42,6 @@ templates:
       jobs: [blm, rdm]
       resists:
         immune_status: [gravity, silence, slow, elegy]
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -1877,18 +1868,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -1910,18 +1889,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -2533,19 +2500,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:    2
-          water:  9
-          light: -1
-          dark:  11
-        rank_status:
-          paralyze:     2
-          bind:         2
-          poison:       9
-          light_sleep: -1
-          dark_sleep:  11
-          blind:       11
       render:
         look:
           type:  standard
@@ -2669,18 +2623,6 @@ templates:
         skill: great_katana
         delay: 280
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          ice:     -2
-          wind:     2
-          thunder: -1
-          dark:    -1
-        rank_status:
-          paralyze:   -2
-          bind:       -2
-          silence:     2
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -3461,17 +3403,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard
@@ -3496,17 +3427,6 @@ templates:
       combat:
         skill: scythe
         delay: 265
-      resists:
-        rank_element:
-          fire:  11
-          wind:   2
-          earth: -1
-          dark:  -1
-        rank_status:
-          silence:     2
-          slow:       -1
-          dark_sleep: -1
-          blind:      -1
       render:
         look:
           type:  standard

--- a/data/zones/walk_of_echoes/mobs.yaml
+++ b/data/zones/walk_of_echoes/mobs.yaml
@@ -78,9 +78,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -745,9 +742,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -960,9 +954,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1069,9 +1060,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1263,9 +1251,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/walk_of_echoes/mobs.yaml
+++ b/data/zones/walk_of_echoes/mobs.yaml
@@ -55,21 +55,6 @@ templates:
       combat:
         skill: club
       jobs: [sch, rdm]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -1332,21 +1317,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/waughroon_shrine/mobs.yaml
+++ b/data/zones/waughroon_shrine/mobs.yaml
@@ -743,9 +743,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/waughroon_shrine/mobs.yaml
+++ b/data/zones/waughroon_shrine/mobs.yaml
@@ -96,13 +96,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -128,13 +121,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -222,13 +208,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -277,13 +256,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -311,13 +283,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [drk, drk]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -576,13 +541,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -610,13 +568,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -670,13 +621,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -704,13 +648,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1445,13 +1382,6 @@ templates:
       combat:
         skill: great_sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1476,13 +1406,6 @@ templates:
       combat:
         skill: great_sword
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1506,13 +1429,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1540,13 +1456,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard

--- a/data/zones/west_ronfaure/mobs.yaml
+++ b/data/zones/west_ronfaure/mobs.yaml
@@ -1029,13 +1029,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta/mobs.yaml
+++ b/data/zones/west_sarutabaruta/mobs.yaml
@@ -1140,13 +1140,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta/mobs.yaml
+++ b/data/zones/west_sarutabaruta/mobs.yaml
@@ -11,9 +11,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -762,9 +759,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1311,9 +1305,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1344,9 +1335,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta_s/mobs.yaml
+++ b/data/zones/west_sarutabaruta_s/mobs.yaml
@@ -352,9 +352,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -701,9 +698,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -723,9 +717,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1732,9 +1723,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2438,9 +2426,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3371,9 +3356,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta_s/mobs.yaml
+++ b/data/zones/west_sarutabaruta_s/mobs.yaml
@@ -1095,13 +1095,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2250,9 +2243,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2526,13 +2516,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3363,13 +3346,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3428,13 +3404,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3543,16 +3512,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -4045,25 +4004,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -4086,16 +4026,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard

--- a/data/zones/windurst_waters_s/mobs.yaml
+++ b/data/zones/windurst_waters_s/mobs.yaml
@@ -959,13 +959,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1706,9 +1699,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -2310,13 +2300,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -2403,16 +2386,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -2561,25 +2534,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rng, rng]
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          wind:    4
-          earth:   4
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    1
-          bind:        1
-          silence:     4
-          slow:        4
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard

--- a/data/zones/windurst_waters_s/mobs.yaml
+++ b/data/zones/windurst_waters_s/mobs.yaml
@@ -389,9 +389,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/woh_gates/mobs.yaml
+++ b/data/zones/woh_gates/mobs.yaml
@@ -85,12 +85,6 @@ templates:
     attributes:
       combat:
         skill: staff
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard
@@ -344,10 +338,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          earth: -2
-        rank_status:
-          slow: -2
       render:
         look:
           type:  standard
@@ -372,12 +362,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -526,12 +510,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard
@@ -693,12 +671,6 @@ templates:
           slashing: -5000
           piercing: -5000
           h2h:      -7500
-        rank_element:
-          earth: 3
-          water: 5
-        rank_status:
-          slow:   3
-          poison: 5
       render:
         look:
           type:  standard

--- a/data/zones/xarcabard/mobs.yaml
+++ b/data/zones/xarcabard/mobs.yaml
@@ -157,13 +157,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_element:
-          fire: -2
-          ice:   4
-        rank_status:
-          paralyze: 4
-          bind:     4
       render:
         look:
           type:  standard

--- a/data/zones/xarcabard_s/mobs.yaml
+++ b/data/zones/xarcabard_s/mobs.yaml
@@ -399,9 +399,6 @@ templates:
         skill: hand_to_hand
         delay: 480
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/xarcabard_s/mobs.yaml
+++ b/data/zones/xarcabard_s/mobs.yaml
@@ -996,13 +996,6 @@ templates:
         skill: sword
         delay: 265
       jobs: [whm, whm]
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -1234,13 +1227,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -1786,21 +1772,6 @@ templates:
     roam:          [stealth]
     skill_list_id: 6
     attributes:
-      resists:
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard
@@ -2461,9 +2432,6 @@ templates:
     species:       black_wyrm
     skill_list_id: 260
     attributes:
-      resists:
-        rank_element:
-          light: -2
       render:
         look:
           type:  standard
@@ -3244,23 +3212,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        rank_element:
-          fire:    4
-          ice:     4
-          wind:    2
-          earth:   2
-          thunder: 2
-          light:   2
-          dark:    2
-        rank_status:
-          paralyze:    4
-          bind:        4
-          silence:     2
-          slow:        2
-          light_sleep: 2
-          dark_sleep:  2
-          blind:       2
       render:
         look:
           type:  standard
@@ -3479,13 +3430,6 @@ templates:
           piercing: -6250
           blunt:    -6250
           h2h:      -6250
-        rank_element:
-          light: 8
-          dark:  1
-        rank_status:
-          light_sleep: 8
-          dark_sleep:  1
-          blind:       1
       render:
         look:
           type:  standard
@@ -3613,16 +3557,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, rdm]
-      resists:
-        rank_element:
-          ice:   -3
-          wind:  11
-          earth: 11
-        rank_status:
-          paralyze: -3
-          bind:     -3
-          silence:  11
-          slow:     11
       render:
         look:
           type:  standard
@@ -3647,13 +3581,6 @@ templates:
       combat:
         skill: dagger
         delay: 265
-      resists:
-        rank_element:
-          fire:     2
-          thunder: -1
-          water:    2
-        rank_status:
-          poison: 2
       render:
         look:
           type:  standard
@@ -3827,20 +3754,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [stun, slow, poison, light_sleep, dark_sleep]
-        rank_element:
-          fire:    2
-          ice:     1
-          thunder: 2
-          water:   2
-          light:   2
-          dark:    4
-        rank_status:
-          paralyze:    1
-          bind:        1
-          poison:      2
-          light_sleep: 2
-          dark_sleep:  4
-          blind:       4
       render:
         look:
           type:  standard

--- a/data/zones/yahse_hunting_grounds/mobs.yaml
+++ b/data/zones/yahse_hunting_grounds/mobs.yaml
@@ -416,9 +416,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/yahse_hunting_grounds/mobs.yaml
+++ b/data/zones/yahse_hunting_grounds/mobs.yaml
@@ -331,14 +331,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -516,14 +508,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -651,12 +635,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/yhoator_jungle/mobs.yaml
+++ b/data/zones/yhoator_jungle/mobs.yaml
@@ -1765,9 +1765,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/yorcia_weald/mobs.yaml
+++ b/data/zones/yorcia_weald/mobs.yaml
@@ -11,14 +11,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, war]
-      resists:
-        rank_element:
-          light: 10
-          dark:  10
-        rank_status:
-          light_sleep: 10
-          dark_sleep:  10
-          blind:       10
       render:
         look:
           type:  standard
@@ -54,9 +46,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        rank_status:
-          dark_sleep: 6
       render:
         look:
           type:  standard
@@ -406,14 +395,6 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
-        rank_element:
-          ice:  4
-          dark: 4
-        rank_status:
-          paralyze:   4
-          bind:       4
-          dark_sleep: 4
-          blind:      4
       render:
         look:
           type:  standard
@@ -568,12 +549,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        rank_element:
-          dark: 10
-        rank_status:
-          dark_sleep: 10
-          blind:      10
       render:
         look:
           type:  standard

--- a/data/zones/yuhtunga_jungle/mobs.yaml
+++ b/data/zones/yuhtunga_jungle/mobs.yaml
@@ -924,9 +924,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1634,9 +1631,6 @@ templates:
         skill: hand_to_hand
         delay: 360
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/yuhtunga_jungle/mobs.yaml
+++ b/data/zones/yuhtunga_jungle/mobs.yaml
@@ -1380,18 +1380,6 @@ templates:
         skill: scythe
         delay: 200
       jobs: [brd, brd]
-      resists:
-        rank_element:
-          fire:    6
-          thunder: 6
-          water:   6
-          light:   6
-          dark:    6
-        rank_status:
-          poison:      6
-          light_sleep: 6
-          dark_sleep:  6
-          blind:       6
       render:
         look:
           type:  standard


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Second round to PR: https://github.com/LandSandBoat/server/pull/11335

There will most likely be several more PRs in order to make sure we don't break or overwrite anything we shouldn't be. Updated workbook: https://docs.google.com/spreadsheets/d/135MyNvjsihPktQrpPa_dOHe3Vswsbf-ZhyiF5vnRS9k/edit?gid=25969651#gid=25969651

- All non-NM mobs now default to their species res ranks instead of the old res-ranks
- NMs have kept their res ranks for now until checked
- Few corrections to actual species groups missed in the first PR
- Updated dmg_phys, dmg_magic and mdef with more accurate sheet info and removes duplicates for dmg_phys and dmg_mag
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Same steps as last PR just make sure its all working correctly:
!gotoid 17199326
!getmod PIERCE_SDT
It should be 2500
<!-- Clear and detailed steps to test your changes here -->
