### PR TITLE
[lua] Enable Zilart EF zones with city guard

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -826,6 +826,7 @@ local function getArg1(player, guardNation, guardType)
     local signet  = 0
     local cipher  = xi.extravaganza.campaignActive() * 20 * 65536
     local voucher = player:hasKeyItem(xi.ki.CONQUEST_PROMOTION_VOUCHER) and 0x20000 or 0
+    local zilart  = xi.settings.main.ENABLE_ROTZ == 1 and 0x10000 or 0
 
     if guardNation == xi.nation.WINDURST then
         output = 33
@@ -845,13 +846,13 @@ local function getArg1(player, guardNation, guardType)
     end
 
     if guardNation == xi.nation.OTHER then
-        output = (pNation * 16) + (3 * 256) + 65537
+        output = (pNation * 16) + (3 * 256) + 1
     else
         output = output + 256 * signet
     end
 
     if guardType == xi.conquest.guard.CITY then
-        output = output + voucher
+        output = output + voucher + zilart
     end
 
     if guardType >= xi.conquest.guard.OUTPOST then


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This enables the Zilart regions in the Expeditionary Force menu for the 9 conquest gate guards.
I checked the event decompile and it seems the only purpose of this bit is to enable the Zilart regions in the EF menu.

Right now, this bit is only passed into xi.nation.OTHER when it should be passed to all City guards.

Windurst city guard
<img width="1577" height="28" alt="image" src="https://github.com/user-attachments/assets/2c9728b6-25b7-4f32-9914-e78e68bc6df4" />
This shows arg1 = 196641 = 0x30021
0x20000 is my voucher and then 0x10000 is Zilart (what this PR adds).

Jeuno city guard as well
<img width="1437" height="22" alt="image" src="https://github.com/user-attachments/assets/0666e1c0-b78e-4ecf-bf24-793ecec07a0b" />
0x30021
The 0x10000 bit technically does nothing in the Jeuno guard event.

The fix:
Jeuno guards get 65537 = 0x10001. So instead give them just 1 and move the 0x10000 to city guards.

## Steps to test these changes

Be rank 3+, level 60+, go to gate guard and try and register for EF in one of the Zilart regions. Test city guards have no incorrect behavior.
