### PR TITLE
[lua] Even more blue magic stuff

### DIFF
--- a/scripts/actions/spells/blue/amorphic_spikes.lua
+++ b/scripts/actions/spells/blue/amorphic_spikes.lua
@@ -24,9 +24,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.AMORPH
     params.tpModifier = xi.spells.blue.tpMod.ATTACK
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 

--- a/scripts/actions/spells/blue/asuran_claws.lua
+++ b/scripts/actions/spells/blue/asuran_claws.lua
@@ -24,9 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.BEAST
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- TODO: made up
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -40,7 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 0.625
     params.ftp3000       = 0.625
     params.ftpAzure      = 0.625
-    params.baseDamageCap = 21
+    params.baseDamageCap = 999 -- uncapped in retail. was 21 here before?
+    params.attackMult    = 1.05
 
     -- D seems low for its level, but the spell never did good damage, so a low D is a good way of keeping overall damage down.
     -- More discussion on https://ffxiclopedia.fandom.com/wiki/Talk:Asuran_Claws

--- a/scripts/actions/spells/blue/battle_dance.lua
+++ b/scripts/actions/spells/blue/battle_dance.lua
@@ -36,16 +36,25 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.str_wsc       = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 90
+
+    -- TODO: 0tp duration needs verification
+    if params.hasAzureLore then
+        duration = 800
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 90, 480, 680)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.DEX_DOWN, 9, 6, 60 },
+        [1] = { xi.effect.DEX_DOWN, 9, 6, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/actions/spells/blue/bludgeon.lua
+++ b/scripts/actions/spells/blue/bludgeon.lua
@@ -24,9 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.ARCANA
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- This is entirely made up, apparently.
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -40,7 +41,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.0
     params.ftpAzure      = 1.0
     params.baseDamageCap = 21
-    params.chr_wsc       = 0.3
+    params.attackMult    = 1.55
+
+    params.chr_wsc = 0.3
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/body_slam.lua
+++ b/scripts/actions/spells/blue/body_slam.lua
@@ -32,8 +32,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 1.5
     params.ftp3000       = 1.5
     params.ftpAzure      = 1.5
-    params.baseDamageCap = 75
-    params.vit_wsc       = 0.4
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.3
+
+    if params.hasAzureLore then
+        params.attackMult = 2.15
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.3, 1.7, 2.10)
+    end
+
+    params.vit_wsc = 0.4
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/cannonball.lua
+++ b/scripts/actions/spells/blue/cannonball.lua
@@ -31,8 +31,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp0          = 1.75
     params.ftp1500       = 2.125
     params.ftp3000       = 2.75
-    params.ftpAzure      = 2.875
-    params.baseDamageCap = 75
+    params.ftpAzure      = 3
+    params.baseDamageCap = 999 -- uncapped
 
     params.str_wsc = 0.5
     params.vit_wsc = 0.5

--- a/scripts/actions/spells/blue/claw_cyclone.lua
+++ b/scripts/actions/spells/blue/claw_cyclone.lua
@@ -33,6 +33,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.4375
     params.ftpAzure      = 1.4375
     params.baseDamageCap = 23
+    params.attackMult    = 1.3
+
+    if params.hasAzureLore then
+        params.attackMult = 2.1
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.3, 1.8, 2.0)
+    end
 
     params.dex_wsc = 0.3
 

--- a/scripts/actions/spells/blue/death_scissors.lua
+++ b/scripts/actions/spells/blue/death_scissors.lua
@@ -33,7 +33,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 2.75
     params.ftp3000       = 3.25
     params.ftpAzure      = 3.3
-    params.baseDamageCap = 74
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.7
 
     params.str_wsc = 0.6
 

--- a/scripts/actions/spells/blue/delta_thrust.lua
+++ b/scripts/actions/spells/blue/delta_thrust.lua
@@ -45,9 +45,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.vit_wsc = 0.50
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/delta_thrust.lua
+++ b/scripts/actions/spells/blue/delta_thrust.lua
@@ -23,9 +23,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     local params     = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem = xi.ecosystem.LIZARD
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 

--- a/scripts/actions/spells/blue/dimensional_death.lua
+++ b/scripts/actions/spells/blue/dimensional_death.lua
@@ -33,7 +33,14 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 2.25
     params.ftp3000       = 2.25
     params.ftpAzure      = 2.25
-    params.baseDamageCap = 70
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.2
+
+    if params.hasAzureLore then
+        params.attackMult = 2.3
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.2, 2.2, 2.25)
+    end
 
     params.str_wsc = 0.5
 

--- a/scripts/actions/spells/blue/disseverment.lua
+++ b/scripts/actions/spells/blue/disseverment.lua
@@ -24,9 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem   = xi.ecosystem.LUMINIAN
     params.tpModifier  = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- TODO: made up
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -39,15 +40,16 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 1.5
     params.ftp3000       = 1.5
     params.ftpAzure      = 1.5
-    params.baseDamageCap = 100
+    params.baseDamageCap = 89
+    params.attackMult    = 1.05
 
     params.str_wsc = 0.2
     params.dex_wsc = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/feather_storm.lua
+++ b/scripts/actions/spells/blue/feather_storm.lua
@@ -20,16 +20,9 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local params      = xi.spells.blue.getDefaultParams(caster)
-    params.ecosystem  = xi.ecosystem.BEASTMEN
-    params.tpModifier = xi.spells.blue.tpMod.CRITICAL
-
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critChance = 55
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critChance = math.floor(caster:getTP() / 75)
-    end
-
+    local params          = xi.spells.blue.getDefaultParams(caster)
+    params.ecosystem      = xi.ecosystem.BEASTMEN
+    params.tpModifier     = xi.spells.blue.tpMod.DURATION
     params.attackType     = xi.attackType.RANGED
     params.damageType     = xi.damageType.PIERCING
     params.skillchainType = xi.skillchainType.TRANSFIXION
@@ -44,16 +37,25 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.agi_wsc    = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 180
+
+    -- TODO: duration needs verification.
+    if params.hasAzureLore then
+        duration = 450
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 180, 360, 400)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.POISON, 1, 3, 180 },
+        [1] = { xi.effect.POISON, 1, 3, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/actions/spells/blue/foot_kick.lua
+++ b/scripts/actions/spells/blue/foot_kick.lua
@@ -24,10 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.BEAST
     params.tpModifier = xi.spells.blue.tpMod.CRITICAL
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critChance = 55
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critChance = math.floor(caster:getTP() / 75)
+    if params.hasAzureLore then
+        params.critChance = 35
+    elseif params.hasChainAffinity then
+        params.critChance = xi.spells.blue.calculatefTP(caster:getTP(), 0, 15, 30)
     end
 
     params.attackType     = xi.attackType.PHYSICAL
@@ -40,6 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.0
     params.ftpAzure      = 1.0
     params.baseDamageCap = 9
+    params.attackMult    = 2
 
     params.str_wsc = 0.1
     params.dex_wsc = 0.1

--- a/scripts/actions/spells/blue/frenetic_rip.lua
+++ b/scripts/actions/spells/blue/frenetic_rip.lua
@@ -28,11 +28,11 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillchainType = xi.skillchainType.INDURATION
 
     params.numHits       = 3
-    params.ftp0          = 1.36
-    params.ftp1500       = 2.08
-    params.ftp3000       = 2.36
-    params.ftpAzure      = 2.61
-    params.baseDamageCap = 75
+    params.ftp0          = 1.359375
+    params.ftp1500       = 2.0703125
+    params.ftp3000       = 2.359375
+    params.ftpAzure      = 2.609375
+    params.baseDamageCap = 73
 
     params.str_wsc = 0.2
     params.dex_wsc = 0.2

--- a/scripts/actions/spells/blue/frypan.lua
+++ b/scripts/actions/spells/blue/frypan.lua
@@ -24,9 +24,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.BEASTMEN
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -35,19 +35,19 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillchainType = xi.skillchainType.IMPACTION
 
     params.numHits       = 1
-    params.ftp0          = 1.78
-    params.ftp1500       = 1.78
-    params.ftp3000       = 1.78
-    params.ftpAzure      = 1.78
-    params.baseDamageCap = 75
+    params.ftp0          = 1.7734375
+    params.ftp1500       = 1.7734375
+    params.ftp3000       = 1.7734375
+    params.ftpAzure      = 1.7734375
+    params.baseDamageCap = 999 -- uncapped
 
     params.str_wsc    = 0.2
     params.mnd_wsc    = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/goblin_rush.lua
+++ b/scripts/actions/spells/blue/goblin_rush.lua
@@ -24,9 +24,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.BEASTMEN
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 

--- a/scripts/actions/spells/blue/grand_slam.lua
+++ b/scripts/actions/spells/blue/grand_slam.lua
@@ -32,6 +32,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.0
     params.ftpAzure      = 1.0
     params.baseDamageCap = 33
+    params.attackMult    = 1.6
+
+    if params.hasAzureLore then
+        params.attackMult = 2.4
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.6, 2, 2.3)
+    end
 
     params.vit_wsc = 0.3
 

--- a/scripts/actions/spells/blue/head_butt.lua
+++ b/scripts/actions/spells/blue/head_butt.lua
@@ -33,14 +33,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 2.25
     params.ftpAzure      = 2.375
     params.baseDamageCap = 17
+    params.attackMult    = 1.05
 
     params.str_wsc = 0.2
     params.int_wsc = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/helldive.lua
+++ b/scripts/actions/spells/blue/helldive.lua
@@ -33,6 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 2.00
     params.ftpAzure      = 2.125
     params.baseDamageCap = 19
+    params.attackMult    = 1.85
 
     params.agi_wsc = 0.3
 

--- a/scripts/actions/spells/blue/hydro_shot.lua
+++ b/scripts/actions/spells/blue/hydro_shot.lua
@@ -32,7 +32,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 1.25
     params.ftp3000       = 1.25
     params.ftpAzure      = 1.25
-    params.baseDamageCap = 75
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.85
 
     params.agi_wsc = 0.3
 

--- a/scripts/actions/spells/blue/jet_stream.lua
+++ b/scripts/actions/spells/blue/jet_stream.lua
@@ -24,9 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.BIRD
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- TODO: this is made up
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -40,6 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.125
     params.ftpAzure      = 1.125
     params.baseDamageCap = 39
+    params.attackMult    = 1.3
 
     params.agi_wsc = 0.3
 

--- a/scripts/actions/spells/blue/mandibular_bite.lua
+++ b/scripts/actions/spells/blue/mandibular_bite.lua
@@ -33,6 +33,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 2.0
     params.ftpAzure      = 2.0
     params.baseDamageCap = 45
+    params.attackMult    = 1.75
+
+    if params.hasAzureLore then
+        params.attackMult = 2.65
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.75, 2.1, 2.5)
+    end
 
     params.str_wsc = 0.2
     params.int_wsc = 0.2

--- a/scripts/actions/spells/blue/pinecone_bomb.lua
+++ b/scripts/actions/spells/blue/pinecone_bomb.lua
@@ -38,16 +38,25 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.agi_wsc    = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 90
+
+    -- TODO: 3k/azure lore duration needs verification
+    if params.hasAzureLore then
+        duration = 240
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 90, 150, 210)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.SLEEP_I, 1, 0, 60 },
+        [1] = { xi.effect.SLEEP_I, 1, 0, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/actions/spells/blue/power_attack.lua
+++ b/scripts/actions/spells/blue/power_attack.lua
@@ -24,10 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.VERMIN
     params.tpModifier = xi.spells.blue.tpMod.CRITICAL
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critChance = 55
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critChance = math.floor(caster:getTP() / 75)
+    if params.hasAzureLore then
+        params.critChance = 35
+    elseif params.hasChainAffinity then
+        params.critChance = xi.spells.blue.calculatefTP(caster:getTP(), 0, 15, 30)
     end
 
     params.attackType     = xi.attackType.PHYSICAL
@@ -40,8 +40,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.125
     params.ftpAzure      = 1.125
     params.baseDamageCap = 11
+    params.attackMult    = 1.8
 
-    params.vit_wsc = 0.3
+    params.str_wsc = 0.1
+    params.vit_wsc = 0.1
 
     return xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 end

--- a/scripts/actions/spells/blue/quadrastrike.lua
+++ b/scripts/actions/spells/blue/quadrastrike.lua
@@ -25,9 +25,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.DEMON
     params.tpModifier = xi.spells.blue.tpMod.CRITICAL
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 

--- a/scripts/actions/spells/blue/queasyshroom.lua
+++ b/scripts/actions/spells/blue/queasyshroom.lua
@@ -37,16 +37,25 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.int_wsc = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 90
+
+    -- TODO: duration needs verification
+    if params.hasAzureLore then
+        duration = 210
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 90, 150, 180)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.POISON, 3, 3, 180 },
+        [1] = { xi.effect.POISON, 3, 3, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/actions/spells/blue/ram_charge.lua
+++ b/scripts/actions/spells/blue/ram_charge.lua
@@ -32,7 +32,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 1.375
     params.ftp3000       = 1.75
     params.ftpAzure      = 1.875
-    params.baseDamageCap = 75
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 2.5
 
     params.str_wsc = 0.3
     params.mnd_wsc = 0.5

--- a/scripts/actions/spells/blue/rending_deluge.lua
+++ b/scripts/actions/spells/blue/rending_deluge.lua
@@ -19,16 +19,17 @@ spellObject.onMagicCastingCheck = function(caster, target, spell)
 end
 
 spellObject.onSpellCast = function(caster, target, spell)
-    local multi = 1.0
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        multi = multi + 1.50
-    end
-
     local params       = xi.spells.blue.getDefaultParams(caster)
     params.ecosystem   = xi.ecosystem.AQUAN
     params.attackType  = xi.attackType.MAGICAL
     params.damageType  = xi.damageType.WATER
     params.dStat       = xi.mod.INT
+
+    local multi = 1.0
+
+    if params.hasAzureLore then
+        multi = multi + 1.50
+    end
 
     params.ftp0            = multi
     params.dStatMultiplier = 3.5

--- a/scripts/actions/spells/blue/screwdriver.lua
+++ b/scripts/actions/spells/blue/screwdriver.lua
@@ -24,10 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem    = xi.ecosystem.AQUAN
     params.tpModifier   = xi.spells.blue.tpMod.CRITICAL
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critChance = 55
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critChance = math.floor(caster:getTP() / 75)
+    if params.hasAzureLore then
+        params.critChance = 35
+    elseif params.hasChainAffinity then
+        params.critChance = xi.spells.blue.calculatefTP(caster:getTP(), 0, 15, 30)
     end
 
     params.attackType      = xi.attackType.PHYSICAL
@@ -41,6 +41,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.375
     params.ftpAzure      = 1.375
     params.baseDamageCap = 27
+    params.attackMult    = 1.6
 
     params.str_wsc = 0.2
     params.mnd_wsc = 0.2

--- a/scripts/actions/spells/blue/seedspray.lua
+++ b/scripts/actions/spells/blue/seedspray.lua
@@ -33,14 +33,14 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 0.875
     params.ftp3000       = 0.875
     params.ftpAzure      = 0.875
-    params.baseDamageCap = 69
+    params.baseDamageCap = 999 -- uncapped
 
     params.dex_wsc    = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sickle_slash.lua
+++ b/scripts/actions/spells/blue/sickle_slash.lua
@@ -24,10 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.VERMIN
     params.tpModifier = xi.spells.blue.tpMod.CRITICAL
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
-        params.critChance = 55
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
-        params.critChance = math.floor(caster:getTP() / 75)
+    if params.hasAzureLore then
+        params.critChance = 35
+    elseif params.hasChainAffinity then
+        params.critChance = xi.spells.blue.calculatefTP(caster:getTP(), 0, 15, 30)
     end
 
     params.attackType     = xi.attackType.PHYSICAL
@@ -40,6 +40,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.5
     params.ftpAzure      = 1.5
     params.baseDamageCap = 49
+    params.attackMult    = 2.1
 
     params.dex_wsc = 0.5
 

--- a/scripts/actions/spells/blue/smite_of_rage.lua
+++ b/scripts/actions/spells/blue/smite_of_rage.lua
@@ -33,6 +33,7 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 2.5
     params.ftpAzure      = 2.53125
     params.baseDamageCap = 35
+    params.attackMult    = 1.3
 
     params.str_wsc = 0.2
     params.dex_wsc = 0.2

--- a/scripts/actions/spells/blue/spinal_cleave.lua
+++ b/scripts/actions/spells/blue/spinal_cleave.lua
@@ -24,9 +24,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.UNDEAD
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- TODO: made up
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -40,7 +41,8 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 3.0
     params.ftp3000       = 3.0
     params.ftpAzure      = 3.0
-    params.baseDamageCap = 75
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.05
 
     params.str_wsc = 0.3
 

--- a/scripts/actions/spells/blue/spiral_spin.lua
+++ b/scripts/actions/spells/blue/spiral_spin.lua
@@ -27,19 +27,19 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.damageType     = xi.damageType.SLASHING
     params.skillchainType = xi.skillchainType.TRANSFIXION
 
-    params.numHits      = 1
-    params.ftp0         = 2.0
-    params.ftp1500      = 2.0
-    params.ftp3000      = 2.0
-    params.ftpAzure     = 2.0
-    params.baseDamageCap = 69
+    params.numHits       = 1
+    params.ftp0          = 2.0
+    params.ftp1500       = 2.0
+    params.ftp3000       = 2.0
+    params.ftpAzure      = 2.0
+    params.baseDamageCap = 999 -- uncapped
 
     params.agi_wsc = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sprout_smack.lua
+++ b/scripts/actions/spells/blue/sprout_smack.lua
@@ -37,16 +37,25 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.vit_wsc = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 180
+
+    -- TODO: duration needs verification
+    if params.hasAzureLore then
+        duration = 450
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 180, 360, 400)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.SLOW, 1500, 0, 180 },
+        [1] = { xi.effect.SLOW, 1500, 0, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/actions/spells/blue/sub-zero_smash.lua
+++ b/scripts/actions/spells/blue/sub-zero_smash.lua
@@ -33,14 +33,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 2.0
     params.ftp3000       = 2.0
     params.ftpAzure      = 2.0
-    params.baseDamageCap = 72
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.05
 
-    params.vit_wsc    = 0.6
+    params.vit_wsc = 0.6
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/sudden_lunge.lua
+++ b/scripts/actions/spells/blue/sudden_lunge.lua
@@ -38,9 +38,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.agi_wsc    = 0.4
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/tail_slap.lua
+++ b/scripts/actions/spells/blue/tail_slap.lua
@@ -33,15 +33,22 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 1.625
     params.ftp3000       = 1.625
     params.ftpAzure      = 1.625
-    params.baseDamageCap = 75
+    params.baseDamageCap = 999 -- uncapped
+    params.attackMult    = 1.05
+
+    if params.hasAzureLore then
+        params.attackMult = 2.65
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.05, 2.5, 2.60)
+    end
 
     params.str_wsc = 0.2
     params.vit_wsc = 0.5
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/terror_touch.lua
+++ b/scripts/actions/spells/blue/terror_touch.lua
@@ -25,9 +25,10 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ecosystem  = xi.ecosystem.UNDEAD
     params.tpModifier = xi.spells.blue.tpMod.ACC
 
-    if caster:hasStatusEffect(xi.effect.AZURE_LORE) then
+    -- TODO: this is made up
+    if params.hasAzureLore then
         params.bonusAcc = 70
-    elseif caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    elseif params.hasChainAffinity then
         params.bonusAcc = math.floor(caster:getTP() / 50)
     end
 
@@ -42,14 +43,15 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.5
     params.ftpAzure      = 1.5
     params.baseDamageCap = 41
+    params.attackMult    = 1.05
 
     params.dex_wsc = 0.2
     params.int_wsc = 0.2
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/uppercut.lua
+++ b/scripts/actions/spells/blue/uppercut.lua
@@ -34,6 +34,13 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp3000       = 1.5
     params.ftpAzure      = 1.5
     params.baseDamageCap = 39
+    params.attackMult    = 1.6
+
+    if params.hasAzureLore then
+        params.attackMult = 2.4
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.6, 2, 2.3)
+    end
 
     params.str_wsc = 0.35
 

--- a/scripts/actions/spells/blue/vertical_cleave.lua
+++ b/scripts/actions/spells/blue/vertical_cleave.lua
@@ -32,7 +32,14 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.ftp1500       = 3.0
     params.ftp3000       = 3.0
     params.ftpAzure      = 3.0
-    params.baseDamageCap = 75
+    params.baseDamageCap = 89
+    params.attackMult    = 1.05
+
+    if params.hasAzureLore then
+        params.attackMult = 2.25
+    elseif params.hasChainAffinity then
+        params.attackMult = xi.spells.blue.calculatefTP(caster:getTP(), 1.05, 2.1, 2.2)
+    end
 
     params.str_wsc = 0.5
 

--- a/scripts/actions/spells/blue/whirl_of_rage.lua
+++ b/scripts/actions/spells/blue/whirl_of_rage.lua
@@ -39,9 +39,9 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.mnd_wsc = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
     end
 

--- a/scripts/actions/spells/blue/wild_oats.lua
+++ b/scripts/actions/spells/blue/wild_oats.lua
@@ -28,25 +28,34 @@ spellObject.onSpellCast = function(caster, target, spell)
     params.skillchainType = xi.skillchainType.TRANSFIXION
 
     params.numHits       = 1
-    params.ftp0          = 1.84
-    params.ftp1500       = 1.84
-    params.ftp3000       = 1.84
-    params.ftpAzure      = 1.84
+    params.ftp0          = 1.8359375
+    params.ftp1500       = 1.8359375
+    params.ftp3000       = 1.8359375
+    params.ftpAzure      = 1.8359375
     params.baseDamageCap = 11
 
     params.agi_wsc = 0.3
 
     -- Handle damage.
-    local damage, hitsLanded = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
+    local damage = xi.spells.blue.usePhysicalSpell(caster, target, spell, params)
 
-    if hitsLanded <= 0 then
+    if params.hitsLanded <= 0 then
         return damage
+    end
+
+    local duration = 180
+
+    -- TODO: duration needs verification
+    if params.hasAzureLore then
+        duration = 450
+    elseif params.hasChainAffinity then
+        duration = xi.spells.blue.calculatefTP(caster:getTP(), 180, 360, 400)
     end
 
     -- Handle status effects.
     local effectTable =
     {
-        [1] = { xi.effect.VIT_DOWN, 9, 6, 60 },
+        [1] = { xi.effect.VIT_DOWN, 9, 6, duration },
     }
 
     xi.spells.blue.applyBlueAdditionalEffect(caster, target, params, effectTable)

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -339,6 +339,8 @@ end
 xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     spell:setCritical(false)
 
+    local isCannonball = spell:getID() == xi.magic.spell.CANNONBALL
+
     -- Initial D value
     local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell, params)
     initialD       = utils.clamp(initialD, 0, params.baseDamageCap)
@@ -351,6 +353,11 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         fStr = calculatefSTR2(dSTR, caster:getMainLvl())
     else
         fStr = calculatefSTR(dSTR, caster:getMainLvl())
+    end
+
+    -- Cannonball specifically is capped to 22 fSTR
+    if isCannonball then
+        fStr = math.min(fStr, 22)
     end
 
     -- ftp, bonus WSC
@@ -384,7 +391,6 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     params.bonusAcc     = params.bonusAcc or 0
     params.critChance   = calculateCritChance(caster, target, params)
 
-    local isCannonball         = spell:getID() == xi.magic.spell.CANNONBALL
     local potencyAttackMod     = 1 + (caster:getMerit(xi.merit.PHYSICAL_POTENCY) * 2) / 256 -- Each merit value is 2, but SE uses 4/256 for attack merit values.
     local spellAttackMod       = params.attackMult
     local attackMultiplier     = spellAttackMod * potencyAttackMod

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -56,7 +56,7 @@ local function calculateWSC(attacker, params)
 end
 
 -- Get the fTP multiplier (by applying 2 straight lines between ftp0-ftp1500 and ftp1500-ftp3000)
-local function calculatefTP(tp, ftp0, ftp1500, ftp3000)
+xi.spells.blue.calculatefTP = function(tp, ftp0, ftp1500, ftp3000)
     tp = utils.clamp(tp, 0, 3000)
 
     if tp >= 1500 then
@@ -356,7 +356,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     local tp         = getTPBonus(caster)
 
     if tp > 0 then
-        ftp = calculatefTP(tp, params.ftp0, params.ftp1500, params.ftp3000)
+        ftp = xi.spells.blue.calculatefTP(tp, params.ftp0, params.ftp1500, params.ftp3000)
     end
 
     -- WSC

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -166,17 +166,18 @@ end
 ---@param caster CBaseEntity
 ---@param target CBaseEntity
 ---@param spell CSpell
+---@param params blueSkillParams
 ---@return number
-local function getPhysicalBlueMagicBaseDamage(caster, target, spell)
+local function getPhysicalBlueMagicBaseDamage(caster, target, spell, params)
     local skill      = caster:getSkillLevel(xi.skill.BLUE_MAGIC)
     local multiplier = 1
     local extraDmg   = 0
 
-    if caster:hasStatusEffect(xi.effect.EFFLUX) then
+    if params.hasEfflux then
         multiplier = 1.5
     end
 
-    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    if params.hasChainAffinity then
         extraDmg = caster:getMod(xi.mod.ENHANCES_CHAIN_AFFINITY)
     end
 
@@ -192,9 +193,9 @@ end
 local calculateCritChance = function(caster, target, params)
     if
         params.critChance ~= nil and
-        (caster:hasStatusEffect(xi.effect.AZURE_LORE) or
-        caster:hasStatusEffect(xi.effect.EFFLUX) or
-        caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY))
+        (params.hasAzureLore or
+        params.hasEfflux or
+        params.hasChainAffinity)
     then
         -- native blue magic crit rate is 0%. Remove 5% on input.
         -- https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=S8:Y8
@@ -207,17 +208,18 @@ local calculateCritChance = function(caster, target, params)
 end
 
 ---@param caster CBaseEntity
+---@param params blueSkillParams
 ---@return number
-local getTPBonus = function(caster)
+local getTPBonus = function(caster, params)
     local tp = 0
 
     -- Efflux acts like a 1k tp Chain Affinity
     -- With Chain Affinity, this is effectively TP bonus +1000.
-    if caster:hasStatusEffect(xi.effect.EFFLUX) then
+    if params.hasEfflux then
         tp = 1000 -- TOOD: add Efflux bonus gear as mod
     end
 
-    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    if params.hasChainAffinity then
         tp = tp + caster:getTP() + caster:getMerit(xi.merit.ENCHAINMENT)
         tp = utils.clamp(tp, 0, 3000)
     end
@@ -226,8 +228,9 @@ local getTPBonus = function(caster)
 end
 
 ---@param caster CBaseEntity
+---@param params blueSkillParams
 ---@return number
-local getWSCBonuses = function(caster)
+local getWSCBonuses = function(caster, params)
     local bonusWSC = 0
 
     -- BLU AF3 bonus (triples the base WSC when it procs)
@@ -235,7 +238,7 @@ local getWSCBonuses = function(caster)
         bonusWSC = 2
     end
 
-    if caster:hasStatusEffect(xi.effect.CHAIN_AFFINITY) then
+    if params.hasChainAffinity then
         bonusWSC = bonusWSC + 1 -- Chain Affinity doubles base WSC
     end
 
@@ -337,7 +340,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     spell:setCritical(false)
 
     -- Initial D value
-    local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell)
+    local initialD = getPhysicalBlueMagicBaseDamage(caster, target, spell, params)
     initialD       = utils.clamp(initialD, 0, params.baseDamageCap)
 
     -- fSTR
@@ -352,8 +355,8 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     -- ftp, bonus WSC
     local ftp        = params.ftp0 or 1
-    local bonusWSC   = getWSCBonuses(caster)
-    local tp         = getTPBonus(caster)
+    local bonusWSC   = getWSCBonuses(caster, params)
+    local tp         = getTPBonus(caster, params)
 
     if tp > 0 then
         ftp = xi.spells.blue.calculatefTP(tp, params.ftp0, params.ftp1500, params.ftp3000)
@@ -383,7 +386,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     local isCannonball         = spell:getID() == xi.magic.spell.CANNONBALL
     local potencyAttackMod     = 1 + (caster:getMerit(xi.merit.PHYSICAL_POTENCY) * 2) / 256 -- Each merit value is 2, but SE uses 4/256 for attack merit values.
-    local spellAttackMod       = params.attackMult -- TODO: implement
+    local spellAttackMod       = params.attackMult
     local attackMultiplier     = spellAttackMod * potencyAttackMod
     local applyLevelCorrection = xi.data.levelCorrection.isLevelCorrectedZone(caster)
     local hitrate              = calculateHitrate(caster, target, params.bonusAcc)
@@ -493,7 +496,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
         wscMultiplier = wscMultiplier + 1
     end
 
-    if caster:hasStatusEffect(xi.effect.BURST_AFFINITY) then
+    if params.hasBurstAffinity then
         wscMultiplier = wscMultiplier + 1 + caster:getMod(xi.mod.ENHANCES_BURST_AFFINITY) / 100
     end
 
@@ -505,7 +508,7 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
 
     -- Azure Lore
     local azureBonus = 0
-    if caster:getStatusEffect(xi.effect.AZURE_LORE) then
+    if params.hasAzureLore then
         azureBonus = params.azureBonus or 0
     end
 
@@ -539,8 +542,8 @@ xi.spells.blue.useMagicalSpell = function(caster, target, spell, params)
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement, 0))
 
     if
-        caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
-        caster:hasStatusEffect(xi.effect.AZURE_LORE)
+        params.hasBurstAffinity or
+        params.hasAzureLore
     then
         if skillchainCount > 0 then
             finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(caster, target, spellElement, skillchainCount))
@@ -605,8 +608,8 @@ xi.spells.blue.useDrainSpell = function(caster, target, spell, params, damageCap
     finalDamage = math.floor(finalDamage * xi.spells.damage.calculateMagicBonusDiff(caster, target, spellId, skillType, spellElement, 0))
 
     if
-        caster:hasStatusEffect(xi.effect.BURST_AFFINITY) or
-        caster:hasStatusEffect(xi.effect.AZURE_LORE)
+        params.hasBurstAffinity or
+        params.hasAzureLore
     then
         if skillchainCount > 0 then
             finalDamage = math.floor(finalDamage * xi.spells.damage.calculateIfMagicBurst(caster, target, spellElement, skillchainCount))

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -332,7 +332,7 @@ end
 ---@param target CBaseEntity
 ---@param spell CSpell
 ---@param params blueSkillParams
----@return number, number
+---@return number
 xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     spell:setCritical(false)
 
@@ -466,7 +466,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     caster:delStatusEffectSilent(xi.effect.EFFLUX)
 
-    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget), params.hitsLanded
+    return xi.spells.blue.applySpellDamage(caster, target, spell, finaldmg, params, trickAttackTarget)
 end
 
 -- Get the damage for a magical Blue Magic spell. Called from spell scripts.

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -257,7 +257,7 @@ end
 ---@field critChance       number
 ---@field bonusAcc         number
 ---@field bonusMacc        number
----@field attackMod        number
+---@field attackMult       number
 ---@field ecosystem        xi.ecosystem
 ---@field attackType       xi.attackType
 ---@field damageType       xi.damageType
@@ -296,7 +296,7 @@ xi.spells.blue.getDefaultParams = function(caster)
     params.critChance    = 0
     params.bonusAcc      = 0
     params.bonusMacc     = 0
-    params.attackMod     = 1.0
+    params.attackMult    = 1.0
 
     params.ecosystem       = xi.ecosystem.UNCLASSIFIED
     params.attackType      = xi.attackType.NONE
@@ -383,7 +383,7 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
 
     local isCannonball         = spell:getID() == xi.magic.spell.CANNONBALL
     local potencyAttackMod     = 1 + (caster:getMerit(xi.merit.PHYSICAL_POTENCY) * 2) / 256 -- Each merit value is 2, but SE uses 4/256 for attack merit values.
-    local spellAttackMod       = params.attackMod -- TODO: implement
+    local spellAttackMod       = params.attackMult -- TODO: implement
     local attackMultiplier     = spellAttackMod * potencyAttackMod
     local applyLevelCorrection = xi.data.levelCorrection.isLevelCorrectedZone(caster)
     local hitrate              = calculateHitrate(caster, target, params.bonusAcc)

--- a/scripts/specs/types/Spell.lua
+++ b/scripts/specs/types/Spell.lua
@@ -2,4 +2,4 @@
 
 ---@class TSpell
 ---@field onMagicCastingCheck? fun(PChar: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): integer?
----@field onSpellCast? fun(PCaster: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): (integer?, integer?)
+---@field onSpellCast? fun(PCaster: CBaseEntity, PTarget: CBaseEntity, PSpell: CSpell): integer?


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* rename attackMod to attackMult since "mult" is more clear on how it's used when inside a blue magic lua
* move blue magic ftp calculation to a global (it scales differently than player WS)
* audit blue magic TP modifiers, etc, base damage caps, based on [this sheet](https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=A2)
* Fix the secondary optional return value spec jank
* use cached values for Azure Lore, Chain Affinity, Burst Affinity, Efflux
* cap fSTR to +22 on cannonball only (see cell text [here](https://docs.google.com/spreadsheets/d/1UdAmVJwx8zCcDQ0KM4uJd-IxbUBEHBvys3jWpmDfrF0/edit?gid=1069646548#gid=1069646548&range=A34) 

## Steps to test these changes

Cast blue magic spells and stuff