### PR TITLE
[core] [lua] PD/ALL_MISS + Seigan preventActionEffect + SA/TA, Bully fixes

### DIFF
--- a/scripts/combat/basic/counter.lua
+++ b/scripts/combat/basic/counter.lua
@@ -30,6 +30,17 @@ xi.combat.counter.checkSeiganCounter = function(attacker, defender)
         return false
     end
 
+    if
+        attacker:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        attacker:hasStatusEffect(xi.effect.ALL_MISS)
+    then
+        return false
+    end
+
+    if defender:hasPreventActionEffect() then
+        return false
+    end
+
     -- Calculate counter chance.
     local baseCounterRate = 25 + defender:getMod(xi.mod.THIRD_EYE_COUNTER_RATE)
     local hitRateFactor   = xi.combat.physicalHitRate.getPhysicalHitRate(defender, attacker, 0, xi.attackAnimation.RIGHT_ATTACK, false)

--- a/scripts/combat/physical_utilities.lua
+++ b/scripts/combat/physical_utilities.lua
@@ -95,14 +95,15 @@ local shieldSizeToBlockRateTable =
 xi.combat.physical.calculateAttackDamage = function(actor, target, slot, physicalAttackType, isH2H, isFirstSwing, isSneakAttack, isTrickAttack, damageRatio)
     local bonusBasePhysicalDamage = 0
     local damage                  = 0
+    local isTHF                   = actor:getMainJob() == xi.job.THF
 
     -- Sneak Attack
-    if isSneakAttack then
+    if isSneakAttack and isTHF then
         bonusBasePhysicalDamage = math.floor(bonusBasePhysicalDamage + actor:getStat(xi.mod.DEX) * (1 + actor:getMod(xi.mod.SNEAK_ATK_DEX) / 100))
     end
 
     -- Trick Attack
-    if isTrickAttack then
+    if isTrickAttack and isTHF then
         bonusBasePhysicalDamage = math.floor(bonusBasePhysicalDamage + actor:getStat(xi.mod.AGI) * (1 + actor:getMod(xi.mod.TRICK_ATK_AGI) / 100))
     end
 

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -420,6 +420,14 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
         end
     end
 
+    if
+        target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        target:hasStatusEffect(xi.effect.ALL_MISS)
+    then
+        hitrate           = -1
+        sneakIsApplicable = false
+    end
+
     params.tpHitsLanded = 0
     params.hitsLanded   = 0
 

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -266,6 +266,14 @@ xi.job_utils.dancer.useStepAbility = function(player, target, ability, action, s
         player:delTP(100 + player:getMod(xi.mod.STEP_TP_CONSUMED))
     end
 
+    -- TODO: does PD modify the message?
+    if
+        target:hasStatusEffect(xi.effect.PERFECT_DODGE) or
+        target:hasStatusEffect(xi.effect.ALL_MISS)
+    then
+        hitRate = -1
+    end
+
     if math.randomFloat(0, 1) <= hitRate then
         local maxSteps         = player:getMainJob() == xi.job.DNC and 10 or 5
         local debuffEffect     = target:getStatusEffect(stepEffect)
@@ -379,9 +387,12 @@ xi.job_utils.dancer.useDesperateFlourishAbility = function(player, target, abili
 
     setFinishingMoves(player, numMoves - 1)
 
+    -- TODO: does PD modify the message?
     if
-        math.randomFloat(0, 1) <= xi.weaponskills.getHitRate(player, target, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT), xi.attackAnimation.LEFT_ATTACK) or
-        (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target))
+        (not target:hasStatusEffect(xi.effect.PERFECT_DODGE) and
+        not target:hasStatusEffect(xi.effect.ALL_MISS)) and
+        (math.randomFloat(0, 1) <= xi.weaponskills.getHitRate(player, target, player:getJobPointLevel(xi.jp.FLOURISH_I_EFFECT), xi.attackAnimation.LEFT_ATTACK) or
+        (player:hasStatusEffect(xi.effect.SNEAK_ATTACK) and player:isBehind(target)))
     then
         infoValue = actionInfo[ability:getID()][2]
 

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -2559,7 +2559,11 @@ uint8 GetCritHitRate(CBattleEntity* PAttacker, CBattleEntity* PDefender, bool ig
     }
     else if (PAttacker->objtype == TYPE_PC && (!ignoreSneakTrickAttack) && PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::SneakAttack))
     {
-        if (behind(PAttacker->loc.p, PDefender->loc.p, 64) || PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Hide))
+        if (PAttacker->GetMJob() == xi::Job::THF and PDefender->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Doubt))
+        {
+            critHitRate = 100;
+        }
+        else if (behind(PAttacker->loc.p, PDefender->loc.p, 64) || PAttacker->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Hide))
         {
             critHitRate = 100;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Add PD/ALL_MISS checks in a bunch of places
Check THF main job on SA/TA for bonus damage in lus
Actually crit when a THF main hits a mob with bully (it was previously only adding the bonus base damage)
Don't seigan counter when asleep/stunned/etc

## Steps to test these changes

Use the stuff that was changed, see it works