### PR TITLE
[sql] [lua] Adjust several evasion skills to EVAP and various other mobskill changes

### DIFF
--- a/scripts/actions/mobskills/evasion.lua
+++ b/scripts/actions/mobskills/evasion.lua
@@ -14,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local power    =  50
+    local power    = 120
     local duration = 180
 
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, power, 0, duration))

--- a/scripts/actions/mobskills/hi-freq_field.lua
+++ b/scripts/actions/mobskills/hi-freq_field.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 40, 0, 180))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 25, 0, 180, 1))
 
     return xi.effect.EVASION_DOWN
 end

--- a/scripts/actions/mobskills/power_attack.lua
+++ b/scripts/actions/mobskills/power_attack.lua
@@ -1,7 +1,7 @@
 -----------------------------------
 -- Power Attack
 -- Family: Beetle
--- Description : Deals physical damage to a single target - 100% Attack Boost
+-- Description : Deals physical damage to a single target - 100% Critical hit
 -- TODO: Currently used by jug pet beetle. Needs to be renamed
 -----------------------------------
 ---@type TMobSkill
@@ -20,7 +20,8 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.attackType       = xi.attackType.PHYSICAL
     params.damageType       = xi.damageType.HAND_TO_HAND
     params.shadowBehavior   = xi.mobskills.shadowBehavior.NUMSHADOWS_1
-    params.attackMultiplier = { 2.0, 2.0, 2.0 }
+    params.canCrit          = true
+    params.criticalChance   = { 1.0, 1.0, 1.0 }
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/rhino_attack.lua
+++ b/scripts/actions/mobskills/rhino_attack.lua
@@ -20,8 +20,6 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     params.damageType     = xi.damageType.BLUNT
     params.shadowBehavior = xi.mobskills.shadowBehavior.NUMSHADOWS_1
     params.attackMultiplier = { 2.0, 2.0, 2.0 }
-    params.canCrit        = true
-    params.criticalChance = { 0.10, 0.20, 0.25 } -- TODO: Capture crit rate
 
     local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 

--- a/scripts/actions/mobskills/rhino_guard.lua
+++ b/scripts/actions/mobskills/rhino_guard.lua
@@ -2,7 +2,7 @@
 -- Rhino Guard
 -- Description: Enhances evasion, duration scales with TP.
 -- Range: Self
--- Notes: Very sharp evasion increase.
+-- Notes: 25% evasion increase
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -12,8 +12,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 780)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, duration, 1))
 
     return xi.effect.EVASION_BOOST
 end

--- a/scripts/actions/mobskills/rumble.lua
+++ b/scripts/actions/mobskills/rumble.lua
@@ -13,8 +13,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 45, 375)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 10, 0, duration))
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.EVASION_DOWN, 10, 0, (math.random(60, 240)), 1))
 
     return xi.effect.EVASION_DOWN
 end

--- a/scripts/actions/mobskills/spoil.lua
+++ b/scripts/actions/mobskills/spoil.lua
@@ -11,7 +11,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 3, 300))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
+
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STR_DOWN, 10, 9, duration))
 
     return xi.effect.STR_DOWN
 end

--- a/scripts/actions/mobskills/sticky_thread.lua
+++ b/scripts/actions/mobskills/sticky_thread.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 360)
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
     skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, duration))
 
     return xi.effect.SLOW

--- a/scripts/actions/mobskills/water_shield.lua
+++ b/scripts/actions/mobskills/water_shield.lua
@@ -1,6 +1,5 @@
 -----------------------------------
 --  Water Shield
---
 --  Description: Enhances evasion.
 --  Type: Enhancing
 --  Utsusemi/Blink absorb: N/A
@@ -15,7 +14,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 20, 0, 30))
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.EVASION_BOOST, 25, 0, 90))  -- The duration of this ability may vary all the way to 9 minutes with a HEAVY weight towards 90 seconds.
 
     return xi.effect.EVASION_BOOST
 end

--- a/scripts/actions/mobskills/water_wall.lua
+++ b/scripts/actions/mobskills/water_wall.lua
@@ -10,7 +10,7 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.DEFENSE_BOOST, 100, 0, 60))
+    skill:setMsg(xi.mobskills.mobBuffMove(target, xi.effect.DEFENSE_BOOST, 100, 0, 90)) -- The duration of this ability may vary all the way to 9 minutes with a HEAVY weight towards 90 seconds.
 
     return xi.effect.DEFENSE_BOOST
 end

--- a/scripts/effects/evasion_boost.lua
+++ b/scripts/effects/evasion_boost.lua
@@ -5,14 +5,22 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
-    target:addMod(xi.mod.EVA, effect:getPower())
+    if effect:getSubType() == 1 then
+        target:addMod(xi.mod.EVA_PERCENT, effect:getPower())
+    else
+        target:addMod(xi.mod.EVA, effect:getPower())
+    end
 end
 
 effectObject.onEffectTick = function(target, effect)
 end
 
 effectObject.onEffectLose = function(target, effect)
-    target:delMod(xi.mod.EVA, effect:getPower())
+    if effect:getSubType() == 1 then
+        target:delMod(xi.mod.EVA_PERCENT, effect:getPower())
+    else
+        target:delMod(xi.mod.EVA, effect:getPower())
+    end
 end
 
 return effectObject

--- a/scripts/effects/evasion_down.lua
+++ b/scripts/effects/evasion_down.lua
@@ -5,6 +5,11 @@
 local effectObject = {}
 
 effectObject.onEffectGain = function(target, effect)
+    if effect:getSubType() == 1 then
+        target:delMod(xi.mod.EVA_PERCENT, effect:getPower())
+        return
+    end
+
     local power = math.min(effect:getPower(), target:getStat(xi.mod.EVA))
     effect:setPower(power)
     target:delMod(xi.mod.EVA, power)
@@ -15,12 +20,21 @@ effectObject.onEffectTick = function(target, effect)
     local power = effect:getPower()
     local adj = math.min(power, 10)
     effect:setPower(power - adj)
-    target:addMod(xi.mod.EVA, adj)
+
+    if effect:getSubType() == 1 then
+        target:addMod(xi.mod.EVA_PERCENT, adj)
+    else
+        target:addMod(xi.mod.EVA, adj)
+    end
 end
 
 effectObject.onEffectLose = function(target, effect)
     local power = effect:getPower()
-    target:addMod(xi.mod.EVA, power)
+    if effect:getSubType() == 1 then
+        target:addMod(xi.mod.EVA_PERCENT, power)
+    else
+        target:addMod(xi.mod.EVA, power)
+    end
 end
 
 return effectObject

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -366,12 +366,12 @@ INSERT INTO `mob_skills` VALUES (334,78,'sharp_sting',0,0.0,10.0,2000,1500,4,0,0
 INSERT INTO `mob_skills` VALUES (335,79,'pollen',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (336,80,'final_sting',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (337,81,'noisy_buzz',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (338,82,'power_attack_beetle',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (339,83,'hi-freq_field',4,0.0,16.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (340,84,'rhino_attack',0,0.0,7.0,2000,1500,4,0,0,1,0,0,0);
-INSERT INTO `mob_skills` VALUES (341,85,'rhino_guard',0,0.0,7.0,2000,1500,1,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (338,82,'power_attack_beetle',0,0.0,7.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (339,83,'hi-freq_field',4,0.0,16.0,1700,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (340,84,'rhino_attack',0,0.0,7.0,1800,1000,4,0,0,1,0,0,0);
+INSERT INTO `mob_skills` VALUES (341,85,'rhino_guard',0,0.0,7.0,2700,1000,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (342,256,'vulcanian_impact',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (343,87,'spoil',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (343,87,'spoil',0,0.0,7.0,1900,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (344,88,'sticky_thread',4,0.0,12.0,3500,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (345,89,'poison_breath_crawler',4,0.0,12.0,2616,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (346,90,'cocoon',0,0.0,7.0,3700,1000,1,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts several evasion skills that needed to be a percentage.

<img width="595" height="415" alt="image" src="https://github.com/user-attachments/assets/da4528a2-2949-4c85-828a-a55688410999" />
<img width="845" height="208" alt="image" src="https://github.com/user-attachments/assets/ae604049-c6f1-458a-aa05-4ad1b8beb34f" />

Scorp Evasion is 120 flat:
<img width="915" height="654" alt="image" src="https://github.com/user-attachments/assets/56afa100-13ac-42e8-965d-d9e0e5a21921" />

Pugil Eva 25 flat:
<img width="674" height="306" alt="image" src="https://github.com/user-attachments/assets/ba3c2efc-1e6a-451d-8a8f-c485576f5a0e" />

This PR also adjusts the duration of several abilities, as well as correct sticky thread after the tp calculation change.
This includes ready and lockout durations of beetles:
https://www.dropbox.com/scl/fo/lee1exbo83gxlqmzdanwc/AH-Y0sxH091b9hCdMUFt-FU?rlkey=4kyejytw0wzw8sq21ggp64z1k&st=uvz5mjcu&dl=0

## Steps to test these changes

!tp 3000 some mobs.  Watch evasion become %.
