### PR TITLE
[core] Fix null PAI deref in the charm controller dtor

### DIFF
--- a/src/map/ai/controllers/player_charm_controller.cpp
+++ b/src/map/ai/controllers/player_charm_controller.cpp
@@ -34,6 +34,11 @@ CPlayerCharmController::CPlayerCharmController(CCharEntity* PChar)
 
 CPlayerCharmController::~CPlayerCharmController()
 {
+    if (!POwner->PAI)
+    {
+        return;
+    }
+
     if (POwner->PAI->IsEngaged())
     {
         POwner->PAI->Internal_Disengage();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
This is what's causing the macOS CI jobs to fail with my charmed death test.

The charm controller cleanup code reaches back for the player's AI object but on macOS the standard library has already set that pointer to null before running the cleanup. (libc++ unique_ptr implementation)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
