### PR TITLE
[lua] Return early if QD is absorbed

### DIFF
--- a/scripts/globals/job_utils/corsair.lua
+++ b/scripts/globals/job_utils/corsair.lua
@@ -1031,6 +1031,14 @@ xi.job_utils.corsair.useElementalShot = function(actor, target, ability, action)
         actor:trySkillUp(xi.skill.MARKSMANSHIP, target:getMainLvl())
     end
 
+    -- Return early to not boost effects on absorb (probably doesn't happen)
+    -- if message is not set explicitly, a 100% HPP absorb reports the wrong message
+    if damage < 0 then
+        ability:setMsg(xi.msg.basic.JA_RECOVERS_HP)
+
+        return damage
+    end
+
     -- Handle effect boost.
     xi.job_utils.corsair.handleQuickDrawEffectBoost(actor, target, abilityId, data.multiplier)
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Return early to not boost effects of QD elemenmt
Also, there was a minor bug where if you used QD on a mob that absorbs at 100% HP that it would report they took 0 damage instead of absorbed zero.

Retail evidence for the latter:
<img width="196" height="43" alt="image" src="https://github.com/user-attachments/assets/56f0a45f-1935-4a1a-a5a6-f1e1e913d1f7" />


## Steps to test these changes

use wind shot on a puk at 100%, see above.
