### PR TITLE
[lua] Delete KI from The Promise on complete

### DIFF
--- a/scripts/quests/windurst/SOB7_The_Promise.lua
+++ b/scripts/quests/windurst/SOB7_The_Promise.lua
@@ -171,18 +171,21 @@ quest.sections =
             {
                 [522] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:delKeyItem(xi.ki.INVISIBLE_MAN_STICKER)
                         player:setCharVar('SOBfinalEvent', 1)
                     end
                 end,
 
                 [534] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:delKeyItem(xi.ki.INVISIBLE_MAN_STICKER)
                         player:setCharVar('SOBfinalEvent', 1)
                     end
                 end,
 
                 [542] = function(player, csid, option, npc)
                     if quest:complete(player) then
+                        player:delKeyItem(xi.ki.INVISIBLE_MAN_STICKER)
                         player:setCharVar('SOBfinalEvent', 1)
                     end
                 end,


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Deletes the KI when you complete the quest per the capture by Siknoz.
https://1drv.ms/u/c/87e665e10555c452/EdBQJOCUQgRHu0W1Kb7Di4MBYMZUqZ3P43_jKynzyNouiQ?e=BCKzHO

## Steps to test these changes

Run the quest. It's 3 events.
