### PR TITLE
[yaml] [sql] Northlands Dynamis TP Fix and Mnk delay sweep

### DIFF
--- a/data/zones/dynamis_beaucedine/mobs.yaml
+++ b/data/zones/dynamis_beaucedine/mobs.yaml
@@ -80,7 +80,7 @@ templates:
     species:       ahriman
     type:          [notorious]
     spell_list_id: 2
-    skill_list_id: 4
+    skill_list_id: 2110
     attributes:
       combat:
         skill: dagger
@@ -117,7 +117,7 @@ templates:
     id:            6093
     species:       ahriman
     type:          [notorious]
-    skill_list_id: 4
+    skill_list_id: 2110
     attributes:
       combat:
         skill: dagger
@@ -620,7 +620,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -955,7 +955,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       resists:
         rank_element:
@@ -2179,7 +2179,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2214,7 +2214,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -4520,7 +4520,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 360
+        delay: 240
       jobs: [mnk, mnk]
       resists:
         dmg_physical:
@@ -5679,7 +5679,7 @@ templates:
     species:       ahriman
     type:          [notorious]
     spell_list_id: 11
-    skill_list_id: 4
+    skill_list_id: 2110
     attributes:
       combat:
         skill: staff
@@ -5757,7 +5757,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -6980,7 +6980,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -7871,7 +7871,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 360
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:

--- a/data/zones/dynamis_jeuno/mobs.yaml
+++ b/data/zones/dynamis_jeuno/mobs.yaml
@@ -250,7 +250,7 @@ templates:
     attributes:
       combat:
         skill: dagger
-        delay: 360
+        delay: 240
       jobs: [mnk, mnk]
       resists:
         rank_element:

--- a/data/zones/dynamis_san_doria/mobs.yaml
+++ b/data/zones/dynamis_san_doria/mobs.yaml
@@ -916,7 +916,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -958,7 +958,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:

--- a/data/zones/dynamis_windurst/mobs.yaml
+++ b/data/zones/dynamis_windurst/mobs.yaml
@@ -2039,7 +2039,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2081,7 +2081,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2125,7 +2125,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2506,7 +2506,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:

--- a/data/zones/dynamis_xarcabard/mobs.yaml
+++ b/data/zones/dynamis_xarcabard/mobs.yaml
@@ -320,7 +320,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       resists:
         rank_element:
@@ -835,6 +835,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 5
+    skill_list_id: 2111
     attributes:
       combat:
         skill: katana
@@ -896,6 +897,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 30
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -935,7 +937,7 @@ templates:
     id:            817
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: katana
@@ -973,7 +975,7 @@ templates:
     id:            818
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1011,7 +1013,7 @@ templates:
     id:            819
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1049,7 +1051,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 3
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: katana
@@ -1087,11 +1089,11 @@ templates:
     id:            1133
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -1127,6 +1129,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 3
+    skill_list_id: 2111
     attributes:
       combat:
         skill: katana
@@ -1167,7 +1170,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 5
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: scythe
@@ -1400,7 +1403,7 @@ templates:
     id:            2232
     species:       kindred
     spell_list_id: 6
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -1433,7 +1436,7 @@ templates:
     id:            6615
     species:       kindred
     spell_list_id: 6
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -1467,7 +1470,7 @@ templates:
   Kindred_Beastmaster:
     id:            2233
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1499,7 +1502,7 @@ templates:
   Kindred_Beastmaster_HI:
     id:            6616
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1534,7 +1537,7 @@ templates:
     id:            2234
     species:       kindred
     spell_list_id: 21
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: staff
@@ -1568,7 +1571,7 @@ templates:
     id:            6618
     species:       kindred
     spell_list_id: 21
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: staff
@@ -1604,7 +1607,7 @@ templates:
     id:            2235
     species:       kindred
     spell_list_id: 5
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1637,7 +1640,7 @@ templates:
     id:            6620
     species:       kindred
     spell_list_id: 5
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1671,7 +1674,7 @@ templates:
   Kindred_Dragoon:
     id:            2236
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1703,7 +1706,7 @@ templates:
   Kindred_Dragoon_HI:
     id:            6621
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1737,7 +1740,7 @@ templates:
   Kindred_Monk:
     id:            2237
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1769,7 +1772,7 @@ templates:
   Kindred_Monk_HI:
     id:            6622
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1804,7 +1807,7 @@ templates:
     id:            2238
     species:       kindred
     spell_list_id: 7
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: scythe
@@ -1838,7 +1841,7 @@ templates:
     id:            6623
     species:       kindred
     spell_list_id: 7
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: scythe
@@ -1874,7 +1877,7 @@ templates:
     id:            2239
     species:       kindred
     spell_list_id: 4
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1907,7 +1910,7 @@ templates:
     id:            6624
     species:       kindred
     spell_list_id: 4
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -1941,7 +1944,7 @@ templates:
   Kindred_Ranger:
     id:            2240
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -1973,7 +1976,7 @@ templates:
   Kindred_Ranger_HI:
     id:            6625
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -2008,7 +2011,7 @@ templates:
     id:            2241
     species:       kindred
     spell_list_id: 3
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -2041,7 +2044,7 @@ templates:
     id:            6626
     species:       kindred
     spell_list_id: 3
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -2075,7 +2078,7 @@ templates:
   Kindred_Samurai:
     id:            2242
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2107,7 +2110,7 @@ templates:
   Kindred_Samurai_HI:
     id:            6627
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2142,7 +2145,7 @@ templates:
     id:            2243
     species:       kindred
     spell_list_id: 31
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: scythe
@@ -2176,7 +2179,7 @@ templates:
     id:            6629
     species:       kindred
     spell_list_id: 31
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: scythe
@@ -2211,7 +2214,7 @@ templates:
   Kindred_Thief:
     id:            2248
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2243,7 +2246,7 @@ templates:
   Kindred_Thief_HI:
     id:            6630
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2277,7 +2280,7 @@ templates:
   Kindred_Warrior:
     id:            2249
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -2308,7 +2311,7 @@ templates:
   Kindred_Warrior_HI:
     id:            6632
     species:       kindred
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -2342,7 +2345,7 @@ templates:
     id:            2250
     species:       kindred
     spell_list_id: 20
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -2375,7 +2378,7 @@ templates:
     id:            6633
     species:       kindred
     spell_list_id: 20
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: club
@@ -2481,7 +2484,7 @@ templates:
     id:            2263
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: polearm
@@ -2518,7 +2521,7 @@ templates:
     id:            2570
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: great_axe
@@ -2558,6 +2561,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 7
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2595,7 +2599,7 @@ templates:
     id:            2572
     species:       kindred
     type:          [notorious]
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: great_axe
@@ -2635,7 +2639,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 6
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: katana
@@ -2675,7 +2679,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 7
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2715,7 +2719,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 141
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: great_sword
@@ -2755,7 +2759,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 21
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: axe
@@ -2795,7 +2799,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 4
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: great_sword
@@ -2858,7 +2862,7 @@ templates:
     species:       kindred
     type:          [notorious]
     spell_list_id: 20
-    skill_list_id: 358
+    skill_list_id: 2111
     attributes:
       combat:
         skill: sword
@@ -2897,7 +2901,7 @@ templates:
     species:       ahriman
     type:          [notorious]
     spell_list_id: 11
-    skill_list_id: 4
+    skill_list_id: 2110
     attributes:
       combat:
         skill: staff
@@ -3159,7 +3163,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       resists:
         rank_element:
@@ -3686,7 +3690,7 @@ templates:
     species:       ahriman
     type:          [notorious]
     spell_list_id: 11
-    skill_list_id: 4
+    skill_list_id: 2110
     attributes:
       combat:
         skill: staff

--- a/scripts/actions/mobskills/condemnation.lua
+++ b/scripts/actions/mobskills/condemnation.lua
@@ -38,7 +38,7 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
         -- TODO: Capture stun duration
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, 12)
+        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.STUN, 1, 0, math.randomInt(10, 15))
     end
 
     return info.damage

--- a/scripts/actions/mobskills/demonic_howl.lua
+++ b/scripts/actions/mobskills/demonic_howl.lua
@@ -12,7 +12,8 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 240))
+    local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
+    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, duration))
 
     return xi.effect.SLOW
 end

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -4406,7 +4406,22 @@ INSERT INTO `mob_skill_lists` VALUES ('DynamisGoblin',2108,1097);
 INSERT INTO `mob_skill_lists` VALUES ('Jack_Cardian',2109,683); -- bludgeon
 INSERT INTO `mob_skill_lists` VALUES ('Jack_Cardian',2109,684); -- deal_out
 
--- Next ID : 2110
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1136); -- Blindeye
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1137); -- Eyes on Me
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1138); -- Hypnosis
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1139); -- Mind Break
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1140); -- Binding Wave
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1141); -- Airy Shield
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1143); -- Magic Shield
+INSERT INTO `mob_skill_lists` VALUES ('DynamisEye',2110,1144); -- Level 5 Petrify
+
+INSERT INTO `mob_skill_lists` VALUES ('DynamisDemon',2111,1145); -- Soul Drain
+INSERT INTO `mob_skill_lists` VALUES ('DynamisDemon',2111,1146); -- Hecatomb Wave
+INSERT INTO `mob_skill_lists` VALUES ('DynamisDemon',2111,1147); -- Demonic Howl
+INSERT INTO `mob_skill_lists` VALUES ('DynamisDemon',2111,1148); -- Condemation
+INSERT INTO `mob_skill_lists` VALUES ('DynamisDemon',2111,1150); -- Quadrastrike
+
+-- Next ID : 2112
 -- ------------------------------------------------------------
 -- Start of Ambuscade section
 -- NOTE: The mobs are changed every update in the DATs, so using out-of-date

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -269,19 +269,19 @@ INSERT INTO `mob_skills` VALUES (235,145,'oshala',0,0.0,7.0,2000,0,4,0,0,0,11,7,
 INSERT INTO `mob_skills` VALUES (238,243,'uriel_blade',1,0.0,10.0,2000,0,4,0,0,0,13,12,4);
 INSERT INTO `mob_skills` VALUES (239,242,'glory_slash',1,0.0,10.0,2000,0,4,0,0,0,13,11,0);
 INSERT INTO `mob_skills` VALUES (240,149,'tartarus_torpor',2,10.0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (241,249,'netherspikes',4,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (242,242,'carnal_nightmare',1,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (243,251,'aegis_schism',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (244,252,'dancing_chains',1,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (245,253,'barbed_crescent',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (246,246,'shackled_fists',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (247,247,'foxfire',4,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (248,248,'grim_halo',1,0.0,10.0,2000,0,4,0,0,2,0,0,0);
-INSERT INTO `mob_skills` VALUES (249,249,'netherspikes',4,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (250,250,'carnal_nightmare',1,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (251,251,'aegis_schism',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (252,252,'dancing_chains',1,0.0,10.0,2000,0,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (253,253,'barbed_crescent',0,0.0,7.0,2000,0,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (241,249,'netherspikes',4,0.0,10.0,2000,500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (242,242,'carnal_nightmare',1,0.0,10.0,3400,500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (243,251,'aegis_schism',0,0.0,7.0,2500,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (244,252,'dancing_chains',1,0.0,10.0,3300,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (245,253,'barbed_crescent',0,0.0,7.0,1600,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (246,246,'shackled_fists',0,0.0,7.0,3400,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (247,247,'foxfire',4,0.0,10.0,2000,1000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (248,248,'grim_halo',1,0.0,10.0,2000,1500,4,0,0,2,0,0,0);
+INSERT INTO `mob_skills` VALUES (249,249,'netherspikes',4,0.0,10.0,2000,500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (250,250,'carnal_nightmare',1,0.0,10.0,3400,500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (251,251,'aegis_schism',0,0.0,7.0,2500,2000,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (252,252,'dancing_chains',1,0.0,10.0,3300,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (253,253,'barbed_crescent',0,0.0,7.0,1600,2000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (254,254,'vulcan_shot',4,0.0,21.0,2000,1500,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (255,190,'dimensional_death',0,0.0,7.0,2000,2000,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (256,253,'#0',2,0.0,50.0,2000,500,6,0,0,0,0,0,0); -- Formerly Heat Wave. Displays #0 in log
@@ -1164,23 +1164,23 @@ INSERT INTO `mob_skills` VALUES (1132,321,'oblivion_smash',1,30.0,18.0,2000,1000
 INSERT INTO `mob_skills` VALUES (1133,322,'oblivion_smash_2',1,30.0,18.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1134,323,'tera_slash',4,0.0,30.0,2000,1000,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1135,324,'tera_slash_2',4,0.0,30.0,2000,1000,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1136,292,'blindeye',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1137,293,'eyes_on_me',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1138,294,'hypnosis',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1139,295,'mind_break',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1140,296,'binding_wave',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1141,885,'airy_shield',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1136,292,'blindeye',0,0.0,7.0,1400,1000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1137,293,'eyes_on_me',0,0.0,7.0,1300,3000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1138,294,'hypnosis',0,0.0,10.0,3600,3000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1139,295,'mind_break',4,0.0,7.0,2000,3000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1140,296,'binding_wave',1,0.0,7.0,2300,1000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1141,297,'airy_shield',0,0.0,7.0,3000,1000,1,0,0,0,0,0,0); -- Dynamis Vanguard
 INSERT INTO `mob_skills` VALUES (1142,774,'pet_charm',0,0.0,7.0,100,0,1,0,0,0,0,0,0); -- Angra Mainyu's teleport
--- INSERT INTO `mob_skills` VALUES (1143,299,'magic_barrier',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1144,888,'level_5_petrify',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1145,889,'soul_drain',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1146,304,'hecatomb_wave',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1147,307,'demonic_howl',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1148,311,'condemnation',4,0.0,10.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1149,313,'quadrastrike',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (1150,894,'quadrastrike',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1151,314,'eagle_eye_shot',0,0.0,25.0,2000,0,4,2,0,0,0,0,0); -- kindred
-INSERT INTO `mob_skills` VALUES (1152,304,'hecatomb_wave_ra',4,0.0,15.0,2000,1500,4,0,0,0,0,0,0); -- kindred
+INSERT INTO `mob_skills` VALUES (1143,299,'magic_barrier',0,0.0,7.0,1700,1000,1,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1144,301,'level_5_petrify',1,0.0,20.0,1550,3000,4,0,0,0,0,0,0); -- Dynamis Vanguard
+INSERT INTO `mob_skills` VALUES (1145,303,'soul_drain',0,0.0,7.0,3000,1000,4,0,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1146,304,'hecatomb_wave',4,0.0,7.0,1500,2000,4,0,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1147,307,'demonic_howl',1,0.0,10.0,3000,1000,4,0,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1148,311,'condemnation',4,0.0,10.0,3000,2000,4,0,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1149,313,'quadrastrike',0,0.0,7.0,3900,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1150,313,'quadrastrike',0,0.0,7.0,3900,2000,4,0,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1151,314,'eagle_eye_shot',0,0.0,25.0,2800,2000,4,2,0,0,0,0,0); -- Dynamis Kindred
+INSERT INTO `mob_skills` VALUES (1152,304,'hecatomb_wave_ra',4,0.0,15.0,1500,2000,4,0,0,0,0,0,0); -- Dynamis Kindred Ranged Attack
 -- INSERT INTO `mob_skills` VALUES (1153,897,'eagle_eye_shot',0,0.0,7.0,2000,1500,4,2,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (1154,898,'ranged_attack',0,0.0,7.0,2000,1500,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1155,337,'subsonics',1,0.0,16.0,2000,1500,4,0,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR adjusts Vanguard Eyes and Demons to use the correct ability IDs for Dynamis.

https://www.dropbox.com/scl/fo/cq5xhxfyvlfhk2qll15be/AEtgcJQr05gpU-iF3ka614w?rlkey=sm2rfgk27qt2vst9t6fls6sqa&st=eo6sab6u&dl=0

Also adds ready time to Fomor skills, which captain is unable to properly record due to masking itself as a player ability or something...  The dyna fomors used the same id's as the ones in Sacrarium and seems to have the same ready times.
I manually used a timer to determine ready times.

I also adjusted Dyna monks to have 240 delay, because they do.

<img width="490" height="177" alt="image" src="https://github.com/user-attachments/assets/4b4b72c4-8468-4b06-aca2-4df68f685385" />

## Steps to test these changes

!tp 3000 some eyes, demons and fomors.
