### PR TITLE
[lua] Add traded item text to Mamaulabion events

### DIFF
--- a/scripts/zones/Norg/npcs/Mamaulabion.lua
+++ b/scripts/zones/Norg/npcs/Mamaulabion.lua
@@ -19,9 +19,6 @@
 --I did alot of copy/pasting, so you may notice a reduncency on comments XD
 --But it can make it easier to follow aswell.
 
---"Mamaulabion will inform you of the items delivered thus far, as of the May 2011 update."
---i have no clue where this event is, so i have no idea how to add this (if this gets scripted, please remove this comment)
-
 --"Upon completion of this quest, the above items no longer appear in the rewards list for defeating the Prime Avatars."
 --will require changing other avatar quests and making a variable for it all. (if this gets scripted, please remove this comment)
 
@@ -49,15 +46,15 @@ entity.onTrade = function(player, npc, trade)
             local wasSet = utils.mask.getBit(mask, bitToSet)
 
             if wasSet then
-                player:startEvent(194) -- Traded an item you already gave
+                player:startEvent(194, tradedItem) -- Traded an item you already gave
             else
                 mask = utils.mask.setBit(mask, bitToSet, true)
                 player:setCharVar('tradesMamaMia', mask)
 
                 if utils.mask.isFull(mask, 7) then
-                    player:startEvent(195) -- Traded all seven items
+                    player:startEvent(195, tradedItem) -- Traded all seven items
                 else
-                    player:startEvent(193) -- Traded an item
+                    player:startEvent(193, tradedItem) -- Traded an item
                 end
             end
         end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds item string to events for Mamaulabion based on capture by Siknoz.
https://www.dropbox.com/scl/fi/oodp944bhuroafbmivutx/Quest-Outlands-Mama-Mia-Start-CS-Trades.zip?rlkey=kjqarhar49kcccn7h4voffw0h&dl=0

## Steps to test these changes

Go to norg and test events with !cs Num ItemNum
