### PR TITLE
[yaml] Corrects the final mismatches in species resistances and remove duplicates DT overrides

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -607,24 +607,24 @@ ecosystems:
                 dmg_magic:
                   all: -2500
                 rank_element:
-                  fire:    -3
-                  ice:     -2
+                  fire:    -1
+                  ice:     -1
                   wind:    -2
-                  earth:   -2
-                  thunder: -2
-                  water:   -2
-                  light:   -2
-                  dark:    -2
+                  earth:   -1
+                  thunder: -1
+                  water:   -1
+                  light:    1
+                  dark:     1
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
+                  paralyze:    -1
+                  bind:        -1
                   silence:     -2
-                  slow:        -2
-                  poison:      -2
-                  light_sleep: -2
-                  dark_sleep:  -2
-                  blind:       -2
-                  stun:        -2
+                  slow:        -1
+                  poison:      -1
+                  light_sleep:  1
+                  dark_sleep:   1
+                  blind:        1
+                  stun:        -1
                   gravity:     -2
               mods:
                 mdef: 20
@@ -1470,25 +1470,25 @@ ecosystems:
                 dmg_magic:
                   all: -1250
                 rank_element:
-                  fire:    -2
-                  ice:     -3
-                  wind:    -2
-                  earth:   -2
-                  thunder: -3
-                  water:    4
-                  light:   -2
-                  dark:    -2
+                  fire:    -1
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    6
+                  light:   -1
+                  dark:    -1
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -2
-                  slow:        -2
-                  poison:       4
-                  light_sleep: -2
-                  dark_sleep:  -2
-                  blind:       -2
-                  stun:        -3
-                  gravity:     -2
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:       6
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
           sea_monk:
             id: 42
             attributes:
@@ -1500,25 +1500,25 @@ ecosystems:
                 dmg_magic:
                   all: -1250
                 rank_element:
-                  fire:    -2
-                  ice:     -3
-                  wind:    -2
-                  earth:   -2
-                  thunder: -3
-                  water:    4
-                  light:   -2
-                  dark:    -2
+                  fire:    -1
+                  ice:     -2
+                  wind:    -1
+                  earth:   -1
+                  thunder: -2
+                  water:    6
+                  light:   -1
+                  dark:    -1
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
-                  silence:     -2
-                  slow:        -2
-                  poison:       4
-                  light_sleep: -2
-                  dark_sleep:  -2
-                  blind:       -2
-                  stun:        -3
-                  gravity:     -2
+                  paralyze:    -2
+                  bind:        -2
+                  silence:     -1
+                  slow:        -1
+                  poison:       6
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:        -2
+                  gravity:     -1
               mob_mods:
                 roam_cool: 30
       uragnite:
@@ -1744,8 +1744,6 @@ ecosystems:
           batons:
             id: 49
             attributes:
-              mods:
-                mdef: 25
               element: earth
               resists:
                 dmg_magic:
@@ -3062,8 +3060,6 @@ ecosystems:
                   blind:        1
                   stun:         1
                   gravity:      1
-              mods:
-                mdef: -20
       buffalo:
         id: 40
         species:
@@ -3292,25 +3288,25 @@ ecosystems:
             attributes:
               resists:
                 rank_element:
-                  fire:    -2
-                  ice:     -2
-                  wind:    -2
-                  earth:   -3
-                  thunder:  0
-                  water:   -2
-                  light:   -2
-                  dark:    -2
+                  fire:     0
+                  ice:     -1
+                  wind:    -1
+                  earth:   -2
+                  thunder:  3
+                  water:   -1
+                  light:   -1
+                  dark:    -1
                 rank_status:
-                  paralyze:    -2
-                  bind:        -2
-                  silence:     -2
-                  slow:        -3
-                  poison:      -2
-                  light_sleep: -2
-                  dark_sleep:  -2
-                  blind:       -2
-                  stun:         0
-                  gravity:     -2
+                  paralyze:    -1
+                  bind:        -1
+                  silence:     -1
+                  slow:        -2
+                  poison:      -1
+                  light_sleep: -1
+                  dark_sleep:  -1
+                  blind:       -1
+                  stun:         3
+                  gravity:     -1
       dhalmel:
         id: 44
         species:
@@ -5639,8 +5635,6 @@ ecosystems:
                   blind:        2
                   stun:        -2
                   gravity:      0
-              mods:
-                mdef: 14
       yagudo:
         id: 74
         attributes:
@@ -6858,8 +6852,6 @@ ecosystems:
           kindred:
             id: 201
             attributes:
-              mods:
-                mdef: 25
               detects:
                 - sight
                 - scent
@@ -7268,8 +7260,7 @@ ecosystems:
                   stun:        -1
                   gravity:      2
               mods:
-                mdef:  24
-                hpp:  -30
+                hpp: -30
               mob_mods:
                 sublink:      13
                 roam_cool:    50
@@ -7748,13 +7739,13 @@ ecosystems:
                   light:    0
                   dark:     0
                 rank_status:
-                  paralyze:     0
-                  bind:         0
+                  paralyze:    11
+                  bind:        11
                   silence:      0
                   slow:         0
                   poison:      -2
-                  light_sleep:  6
-                  dark_sleep:   6
+                  light_sleep:  0
+                  dark_sleep:   0
                   blind:        0
                   stun:         0
                   gravity:      0
@@ -8600,24 +8591,24 @@ ecosystems:
                   piercing: -5000
                   blunt:    -6250
                 rank_element:
-                  fire:    11 # absorbs on retail
-                  ice:     11
+                  fire:     4
+                  ice:      2
                   wind:    11
                   earth:   11
-                  thunder: 11
-                  water:   -3
+                  thunder:  4
+                  water:    4
                   light:   11
-                  dark:    11
+                  dark:     2
                 rank_status:
-                  paralyze:    11
-                  bind:        11
+                  paralyze:     2
+                  bind:         2
                   silence:     11
                   slow:        11
-                  poison:      -3
+                  poison:       4
                   light_sleep: 11
-                  dark_sleep:  11
-                  blind:       11
-                  stun:        11
+                  dark_sleep:   2
+                  blind:        2
+                  stun:         4
                   gravity:     11
               mods:
                 udmgbreath: -2500
@@ -10046,25 +10037,25 @@ ecosystems:
                 - sight
               resists:
                 rank_element:
-                  fire:    11 # absorbs on retail
-                  ice:     11 # absorbs on retail
-                  wind:    11 # absorbs on retail
-                  earth:   11 # absorbs on retail
-                  thunder: 11 # absorbs on retail
-                  water:   11 # absorbs on retail
-                  light:   11 # absorbs on retail
-                  dark:    11 # absorbs on retail
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
                 rank_status:
-                  paralyze:    11 # absorbs on retail
-                  bind:        11 # absorbs on retail
-                  silence:     11 # absorbs on retail
-                  slow:        11 # absorbs on retail
-                  poison:      11 # absorbs on retail
-                  light_sleep: 11 # absorbs on retail
-                  dark_sleep:  11 # absorbs on retail
-                  blind:       11 # absorbs on retail
-                  stun:        11 # absorbs on retail
-                  gravity:     11 # absorbs on retail
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
       tarutaru:
         id: 121
         species:
@@ -12967,7 +12958,7 @@ ecosystems:
             attributes:
               resists:
                 dmg_magic:
-                  all: -625
+                  all: -630
                 rank_element:
                   fire:     0
                   ice:      2
@@ -12989,13 +12980,13 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mods:
-                udmgbreath: -625
+                udmgbreath: -630
           crowned_corpselight:
             id: 392
             attributes:
               resists:
                 dmg_magic:
-                  all: -625
+                  all: -630
                 rank_element:
                   fire:     0
                   ice:      2
@@ -13017,13 +13008,13 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mods:
-                udmgbreath: -625
+                udmgbreath: -630
           psychopomp:
             id: 393
             attributes:
               resists:
                 dmg_magic:
-                  all: -625
+                  all: -630
                 rank_element:
                   fire:     0
                   ice:      2
@@ -13045,7 +13036,7 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mods:
-                udmgbreath: -625
+                udmgbreath: -630
       corse:
         id: 168
         attributes:
@@ -13093,7 +13084,6 @@ ecosystems:
                   stun:        -1
                   gravity:     -1
               mods:
-                mdef:          25
                 udmgbreath: -5000
               mob_mods:
                 roam_cool:  50
@@ -13374,7 +13364,7 @@ ecosystems:
                 rank_element:
                   fire:    -2
                   ice:      4
-                  wind:     1
+                  wind:     0
                   earth:    0
                   thunder:  0
                   water:    0
@@ -13383,14 +13373,14 @@ ecosystems:
                 rank_status:
                   paralyze:     4
                   bind:         4
-                  silence:      1
+                  silence:      0
                   slow:         0
                   poison:       0
                   light_sleep: -2
                   dark_sleep:   4
                   blind:        4
                   stun:         0
-                  gravity:      1
+                  gravity:      0
           fomor:
             id: 403
             attributes:
@@ -13408,7 +13398,7 @@ ecosystems:
                 rank_element:
                   fire:    -2
                   ice:      4
-                  wind:     1
+                  wind:     0
                   earth:    0
                   thunder:  0
                   water:    0
@@ -13417,14 +13407,14 @@ ecosystems:
                 rank_status:
                   paralyze:     4
                   bind:         4
-                  silence:      1
+                  silence:      0
                   slow:         0
                   poison:       0
                   light_sleep: -2
                   dark_sleep:   4
                   blind:        4
                   stun:         0
-                  gravity:      1
+                  gravity:      0
               mob_mods:
                 roam_cool:   50
                 roam_turns:   2
@@ -13477,7 +13467,7 @@ ecosystems:
                 rank_element:
                   fire:    -2
                   ice:      4
-                  wind:     1
+                  wind:     0
                   earth:    0
                   thunder:  0
                   water:    0
@@ -13486,14 +13476,14 @@ ecosystems:
                 rank_status:
                   paralyze:     4
                   bind:         4
-                  silence:      1
+                  silence:      0
                   slow:         0
                   poison:       0
                   light_sleep: -2
                   dark_sleep:   4
                   blind:        4
                   stun:         0
-                  gravity:      1
+                  gravity:      0
           valkyr:
             id: 406
             attributes:
@@ -13508,7 +13498,7 @@ ecosystems:
                 rank_element:
                   fire:    -2
                   ice:      4
-                  wind:     1
+                  wind:     0
                   earth:    0
                   thunder:  0
                   water:    0
@@ -13517,14 +13507,14 @@ ecosystems:
                 rank_status:
                   paralyze:     4
                   bind:         4
-                  silence:      1
+                  silence:      0
                   slow:         0
                   poison:       0
                   light_sleep: -2
                   dark_sleep:   4
                   blind:        4
                   stun:         0
-                  gravity:      1
+                  gravity:      0
       ghost:
         id: 173
         attributes:
@@ -13933,23 +13923,23 @@ ecosystems:
                   piercing: -5000
                   blunt:     2500
                 rank_element:
-                  fire:    -2
-                  ice:      2
+                  fire:    -1
+                  ice:      1
                   wind:    -1
-                  earth:   -1
+                  earth:    0
                   thunder: -1
-                  water:   -1
-                  light:   -2
-                  dark:     4
+                  water:    1
+                  light:    4
+                  dark:     5
                 rank_status:
-                  paralyze:     2
-                  bind:         2
+                  paralyze:     1
+                  bind:         1
                   silence:     -1
-                  slow:        -1
-                  poison:      -1
-                  light_sleep: -2
+                  slow:         0
+                  poison:       1
+                  light_sleep:  4
                   dark_sleep:  11
-                  blind:        4
+                  blind:        5
                   stun:        -1
                   gravity:     -1
           robed_skeletons:
@@ -15259,20 +15249,20 @@ ecosystems:
               resists:
                 rank_element:
                   fire:     0
-                  ice:     -3
+                  ice:     -2
                   wind:     0
                   earth:    0
                   thunder: -2
-                  water:   -2
-                  light:   -3
+                  water:    4
+                  light:    0
                   dark:     0
                 rank_status:
-                  paralyze:    -3
-                  bind:        -3
+                  paralyze:    -2
+                  bind:        -2
                   silence:      0
                   slow:         0
-                  poison:      -2
-                  light_sleep: -3
+                  poison:       4
+                  light_sleep:  0
                   dark_sleep:   0
                   blind:        0
                   stun:        -2

--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -8388,10 +8388,6 @@ ecosystems:
                 - sight
                 - magic
               resists:
-                dmg_physical:
-                  slashing: -7500
-                  piercing: -5000
-                  blunt:    -6250
                 rank_element:
                   fire:    11
                   ice:     -3
@@ -8412,8 +8408,6 @@ ecosystems:
                   blind:       11
                   stun:        11
                   gravity:     11 # absorbs on retail
-              mods:
-                udmgbreath: -2500
               mob_mods:
                 hp_standback: -1
           ifrit:

--- a/data/zones/abyssea_altepa/mobs.yaml
+++ b/data/zones/abyssea_altepa/mobs.yaml
@@ -550,9 +550,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1062,9 +1059,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1373,12 +1367,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_attohwa/mobs.yaml
+++ b/data/zones/abyssea_attohwa/mobs.yaml
@@ -332,11 +332,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -1531,12 +1526,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1556,12 +1545,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_grauberg/mobs.yaml
+++ b/data/zones/abyssea_grauberg/mobs.yaml
@@ -1132,9 +1132,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1247,12 +1244,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1312,9 +1303,6 @@ templates:
       combat:
         skill: club
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1393,12 +1381,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1536,12 +1518,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_konschtat/mobs.yaml
+++ b/data/zones/abyssea_konschtat/mobs.yaml
@@ -391,9 +391,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -426,9 +423,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1070,11 +1064,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -1638,11 +1627,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -1673,11 +1657,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -2349,12 +2328,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_la_theine/mobs.yaml
+++ b/data/zones/abyssea_la_theine/mobs.yaml
@@ -415,9 +415,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -763,12 +760,6 @@ templates:
       combat:
         skill: staff
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1815,12 +1806,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1840,12 +1825,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_misareaux/mobs.yaml
+++ b/data/zones/abyssea_misareaux/mobs.yaml
@@ -1775,12 +1775,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1800,12 +1794,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_tahrongi/mobs.yaml
+++ b/data/zones/abyssea_tahrongi/mobs.yaml
@@ -1504,12 +1504,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1677,9 +1671,6 @@ templates:
       combat:
         skill: hand_to_hand
       jobs: [blm, mnk]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_uleguerand/mobs.yaml
+++ b/data/zones/abyssea_uleguerand/mobs.yaml
@@ -499,9 +499,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1214,12 +1211,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/abyssea_vunkerl/mobs.yaml
+++ b/data/zones/abyssea_vunkerl/mobs.yaml
@@ -9,10 +9,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -253,9 +249,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -285,9 +278,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1219,9 +1209,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1808,12 +1795,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1833,12 +1814,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/al_zahbi/mobs.yaml
+++ b/data/zones/al_zahbi/mobs.yaml
@@ -147,9 +147,6 @@ templates:
         skill: polearm
         delay: 360
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -174,9 +171,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -200,9 +194,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -598,9 +589,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -688,11 +676,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -717,11 +700,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -763,11 +741,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -792,11 +765,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -1384,9 +1352,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          blunt: -1250
       render:
         look:
           type:  standard
@@ -2563,9 +2528,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2927,9 +2889,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2951,9 +2910,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/arrapago_reef/mobs.yaml
+++ b/data/zones/arrapago_reef/mobs.yaml
@@ -339,9 +339,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -372,9 +369,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -406,9 +400,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -439,9 +430,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -778,9 +766,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -844,11 +829,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -1754,11 +1734,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -2807,9 +2782,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -2842,9 +2814,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -2878,9 +2847,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -2913,9 +2879,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -2949,9 +2912,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/arrapago_remnants/mobs.yaml
+++ b/data/zones/arrapago_remnants/mobs.yaml
@@ -1013,9 +1013,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -1051,9 +1048,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -1090,9 +1084,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -1128,9 +1119,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard

--- a/data/zones/attohwa_chasm/mobs.yaml
+++ b/data/zones/attohwa_chasm/mobs.yaml
@@ -108,9 +108,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -394,9 +391,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard

--- a/data/zones/balgas_dais/mobs.yaml
+++ b/data/zones/balgas_dais/mobs.yaml
@@ -1447,10 +1447,6 @@ templates:
       combat:
         skill:    scythe
         dmg_mult: 125
-      resists:
-        rank_status:
-          paralyze: 11
-          bind:     11
       render:
         look:
           type:  standard

--- a/data/zones/bastok_markets_s/mobs.yaml
+++ b/data/zones/bastok_markets_s/mobs.yaml
@@ -1191,12 +1191,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1298,9 +1292,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1988,9 +1979,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2238,10 +2226,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2357,12 +2341,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/batallia_downs/mobs.yaml
+++ b/data/zones/batallia_downs/mobs.yaml
@@ -1500,12 +1500,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/batallia_downs_s/mobs.yaml
+++ b/data/zones/batallia_downs_s/mobs.yaml
@@ -1157,12 +1157,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1241,9 +1235,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2587,12 +2578,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -2717,9 +2702,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3246,10 +3228,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3499,12 +3477,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/beadeaux_s/mobs.yaml
+++ b/data/zones/beadeaux_s/mobs.yaml
@@ -1522,12 +1522,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1634,9 +1628,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2677,11 +2668,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -2867,9 +2853,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2960,9 +2943,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3150,10 +3130,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3314,12 +3290,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3468,9 +3438,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/beaucedine_glacier_s/mobs.yaml
+++ b/data/zones/beaucedine_glacier_s/mobs.yaml
@@ -202,10 +202,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -976,10 +972,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1135,12 +1127,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1217,9 +1203,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1600,9 +1583,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2523,9 +2503,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3042,10 +3019,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3295,12 +3268,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/bhaflau_remnants/mobs.yaml
+++ b/data/zones/bhaflau_remnants/mobs.yaml
@@ -329,11 +329,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -358,11 +353,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard

--- a/data/zones/bhaflau_thickets/mobs.yaml
+++ b/data/zones/bhaflau_thickets/mobs.yaml
@@ -196,9 +196,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -223,9 +220,6 @@ templates:
         skill: polearm
         delay: 360
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -250,9 +244,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -276,9 +267,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -487,9 +475,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -678,11 +663,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -707,11 +687,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -2466,9 +2441,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/buburimu_peninsula/mobs.yaml
+++ b/data/zones/buburimu_peninsula/mobs.yaml
@@ -1036,12 +1036,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/caedarva_mire/mobs.yaml
+++ b/data/zones/caedarva_mire/mobs.yaml
@@ -196,11 +196,6 @@ templates:
     attributes:
       combat:
         skill: dagger
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/caedarva_mire/mobs.yaml
+++ b/data/zones/caedarva_mire/mobs.yaml
@@ -332,9 +332,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -477,9 +474,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -510,9 +504,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -544,9 +535,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -577,9 +565,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -910,9 +895,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -968,11 +950,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -1285,11 +1262,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -1321,9 +1293,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1654,9 +1623,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1850,9 +1816,6 @@ templates:
       combat:
         skill: polearm
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -1886,9 +1849,6 @@ templates:
       combat:
         skill: polearm
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard

--- a/data/zones/castle_oztroja_s/mobs.yaml
+++ b/data/zones/castle_oztroja_s/mobs.yaml
@@ -1168,12 +1168,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1219,9 +1213,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2260,9 +2251,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2396,9 +2384,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2586,10 +2571,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2709,12 +2690,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_baileys_s/mobs.yaml
+++ b/data/zones/castle_zvahl_baileys_s/mobs.yaml
@@ -262,10 +262,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1548,9 +1544,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1627,12 +1620,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1711,9 +1698,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3055,9 +3039,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3472,10 +3453,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3647,12 +3624,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/castle_zvahl_keep_s/mobs.yaml
+++ b/data/zones/castle_zvahl_keep_s/mobs.yaml
@@ -263,10 +263,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1682,9 +1678,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1759,12 +1752,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1866,9 +1853,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2378,9 +2362,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3286,9 +3267,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3749,10 +3727,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3886,12 +3860,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3905,10 +3873,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard

--- a/data/zones/ceizak_battlegrounds/mobs.yaml
+++ b/data/zones/ceizak_battlegrounds/mobs.yaml
@@ -181,6 +181,7 @@ templates:
   Colkhab:
     id:            4927
     species:       bztavian
+    type:          [notorious]
     skill_list_id: 456
     attributes:
       combat:
@@ -692,9 +693,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/cirdas_caverns/mobs.yaml
+++ b/data/zones/cirdas_caverns/mobs.yaml
@@ -9,11 +9,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -154,11 +149,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -213,12 +203,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -238,11 +222,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -551,12 +530,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        dmg_physical:
-          slashing: -7500
-          piercing: -7500
-          blunt:    -8750
-          h2h:      -8750
       render:
         look:
           type:  standard
@@ -656,11 +629,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard

--- a/data/zones/crawlers_nest_s/mobs.yaml
+++ b/data/zones/crawlers_nest_s/mobs.yaml
@@ -1643,12 +1643,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1722,9 +1716,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2975,9 +2966,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3290,10 +3278,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3368,12 +3352,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/den_of_rancor/mobs.yaml
+++ b/data/zones/den_of_rancor/mobs.yaml
@@ -416,11 +416,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/dho_gates/mobs.yaml
+++ b/data/zones/dho_gates/mobs.yaml
@@ -48,12 +48,6 @@ templates:
       combat:
         skill: staff
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          slashing: -1000
-          piercing: -1000
-          blunt:    -1000
-          h2h:      -1000
       render:
         look:
           type:  standard
@@ -152,12 +146,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -358,11 +346,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -440,11 +423,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_bastok/mobs.yaml
+++ b/data/zones/dynamis_bastok/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -554,9 +549,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -601,9 +593,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -650,9 +639,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -697,9 +683,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -743,9 +726,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -791,9 +771,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -838,9 +815,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -886,9 +860,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -936,9 +907,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -981,9 +949,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1027,9 +992,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1075,9 +1037,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1121,9 +1080,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1168,9 +1124,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1217,9 +1170,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1264,9 +1214,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1312,9 +1259,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1362,9 +1306,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1408,9 +1349,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1453,9 +1391,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1500,9 +1435,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1545,9 +1477,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1589,9 +1518,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1635,9 +1561,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1682,9 +1605,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1730,9 +1650,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1780,9 +1697,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1827,9 +1741,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1875,9 +1786,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1925,9 +1833,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1970,9 +1875,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2016,9 +1918,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2064,9 +1963,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2110,9 +2006,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2155,9 +2048,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2202,9 +2092,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2248,9 +2135,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2293,9 +2177,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2340,9 +2221,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2387,9 +2265,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2435,9 +2310,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2485,9 +2357,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2530,9 +2399,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2576,9 +2442,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2624,9 +2487,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_beaucedine/mobs.yaml
+++ b/data/zones/dynamis_beaucedine/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -224,11 +219,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1372,11 +1362,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -4245,11 +4230,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -5265,9 +5245,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5394,9 +5371,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5437,9 +5411,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5559,9 +5530,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5842,9 +5810,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6052,9 +6017,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6175,9 +6137,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6257,9 +6216,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6300,9 +6256,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6819,9 +6772,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6862,9 +6812,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7134,9 +7081,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7258,9 +7202,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7344,9 +7285,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7387,9 +7325,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_buburimu/mobs.yaml
+++ b/data/zones/dynamis_buburimu/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -542,11 +537,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -923,11 +913,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1758,11 +1743,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -2616,9 +2596,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2655,9 +2632,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2694,9 +2668,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2941,9 +2912,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2979,9 +2947,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3017,9 +2982,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3054,9 +3016,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3094,9 +3053,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3134,9 +3090,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3372,9 +3325,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3410,9 +3360,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3448,9 +3395,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3996,9 +3940,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4035,9 +3976,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4074,9 +4012,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4528,9 +4463,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4568,9 +4500,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4608,9 +4537,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4851,9 +4777,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4888,9 +4811,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4925,9 +4845,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5061,9 +4978,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5097,9 +5011,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5133,9 +5044,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5170,9 +5078,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5210,9 +5115,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5250,9 +5152,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6470,9 +6369,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6510,9 +6406,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6550,9 +6443,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6585,9 +6475,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6623,9 +6510,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6661,9 +6545,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7297,9 +7178,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7334,9 +7212,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7371,9 +7246,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7617,9 +7489,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7654,9 +7523,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7691,9 +7557,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7833,9 +7696,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7873,9 +7733,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7913,9 +7770,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7948,9 +7802,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7986,9 +7837,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -8024,9 +7872,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_jeuno/mobs.yaml
+++ b/data/zones/dynamis_jeuno/mobs.yaml
@@ -840,11 +840,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_qufim/mobs.yaml
+++ b/data/zones/dynamis_qufim/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -184,11 +179,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -376,11 +366,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1099,11 +1084,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1729,9 +1709,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1768,9 +1745,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1807,9 +1781,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2054,9 +2025,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2092,9 +2060,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2130,9 +2095,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2167,9 +2129,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2207,9 +2166,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2247,9 +2203,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2485,9 +2438,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2523,9 +2473,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2561,9 +2508,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3041,9 +2985,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3080,9 +3021,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3119,9 +3057,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3539,9 +3474,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3579,9 +3511,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3619,9 +3548,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3862,9 +3788,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3899,9 +3822,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3936,9 +3856,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4072,9 +3989,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4108,9 +4022,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4144,9 +4055,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4181,9 +4089,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4221,9 +4126,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4261,9 +4163,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5516,9 +5415,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5556,9 +5452,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5596,9 +5489,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5631,9 +5521,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5669,9 +5556,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5707,9 +5591,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6277,9 +6158,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6314,9 +6192,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6351,9 +6226,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6563,9 +6435,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6600,9 +6469,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6637,9 +6503,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6779,9 +6642,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6819,9 +6679,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6859,9 +6716,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6894,9 +6748,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6932,9 +6783,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6970,9 +6818,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_san_doria/mobs.yaml
+++ b/data/zones/dynamis_san_doria/mobs.yaml
@@ -335,11 +335,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_tavnazia/mobs.yaml
+++ b/data/zones/dynamis_tavnazia/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -435,11 +430,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1704,11 +1694,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1915,10 +1900,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2024,11 +2005,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_valkurm/mobs.yaml
+++ b/data/zones/dynamis_valkurm/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -224,11 +219,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -415,11 +405,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -781,9 +766,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -819,9 +801,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1147,11 +1126,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1839,9 +1813,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1878,9 +1849,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1917,9 +1885,6 @@ templates:
         skill: axe
         delay: 265
       jobs: [bst, bst]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2130,9 +2095,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2168,9 +2130,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2206,9 +2165,6 @@ templates:
         skill: club
         delay: 265
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2243,9 +2199,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2283,9 +2236,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2323,9 +2273,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2561,9 +2508,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2599,9 +2543,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2637,9 +2578,6 @@ templates:
       combat:
         skill: sword
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3152,9 +3090,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3191,9 +3126,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3230,9 +3162,6 @@ templates:
         skill: scythe
         delay: 265
       jobs: [sam, sam]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3650,9 +3579,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3690,9 +3616,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3730,9 +3653,6 @@ templates:
         skill: great_axe
         delay: 265
       jobs: [nin, nin]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3973,9 +3893,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4010,9 +3927,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4047,9 +3961,6 @@ templates:
         skill: club
         delay: 220
       jobs: [rng, rng]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4183,9 +4094,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4219,9 +4127,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4255,9 +4160,6 @@ templates:
       combat:
         skill: club
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4292,9 +4194,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4332,9 +4231,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4372,9 +4268,6 @@ templates:
         skill: club
         delay: 265
       jobs: [brd, brd]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5592,9 +5485,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5632,9 +5522,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5672,9 +5559,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5707,9 +5591,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5745,9 +5626,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5783,9 +5661,6 @@ templates:
       combat:
         skill: club
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6387,9 +6262,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6424,9 +6296,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6461,9 +6330,6 @@ templates:
       combat:
         skill: club
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6707,9 +6573,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6744,9 +6607,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6781,9 +6641,6 @@ templates:
       combat:
         skill: club
       jobs: [smn, smn]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6923,9 +6780,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -6963,9 +6817,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7003,9 +6854,6 @@ templates:
         skill: great_sword
         delay: 265
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7038,9 +6886,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7076,9 +6921,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -7114,9 +6956,6 @@ templates:
       combat:
         skill: scythe
         delay: 260
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_windurst/mobs.yaml
+++ b/data/zones/dynamis_windurst/mobs.yaml
@@ -63,11 +63,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/dynamis_xarcabard/mobs.yaml
+++ b/data/zones/dynamis_xarcabard/mobs.yaml
@@ -11,11 +11,6 @@ templates:
         skill: staff
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -796,11 +791,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1304,11 +1294,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -3548,11 +3533,6 @@ templates:
       jobs: [blm, blm]
       resists:
         immune_status: [silence, slow, elegy, light_sleep, dark_sleep]
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/east_ronfaure/mobs.yaml
+++ b/data/zones/east_ronfaure/mobs.yaml
@@ -972,12 +972,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/east_ronfaure_s/mobs.yaml
+++ b/data/zones/east_ronfaure_s/mobs.yaml
@@ -1100,12 +1100,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1227,9 +1221,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1624,9 +1615,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2037,9 +2025,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2650,12 +2635,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -2824,9 +2803,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2847,9 +2823,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3387,10 +3360,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3565,12 +3534,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/east_sarutabaruta/mobs.yaml
+++ b/data/zones/east_sarutabaruta/mobs.yaml
@@ -727,12 +727,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/escha_zitah/mobs.yaml
+++ b/data/zones/escha_zitah/mobs.yaml
@@ -311,9 +311,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -466,9 +463,6 @@ templates:
     attributes:
       combat:
         skill: sword
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/feiyin/mobs.yaml
+++ b/data/zones/feiyin/mobs.yaml
@@ -288,9 +288,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -414,9 +411,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -898,9 +892,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/foret_de_hennetiel/mobs.yaml
+++ b/data/zones/foret_de_hennetiel/mobs.yaml
@@ -308,12 +308,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        dmg_physical:
-          slashing: -7500
-          piercing: -7500
-          blunt:    -8750
-          h2h:      -8750
       render:
         look:
           type:  standard
@@ -354,12 +348,6 @@ templates:
       combat:
         skill: staff
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          slashing: -1000
-          piercing: -1000
-          blunt:    -1000
-          h2h:      -1000
       render:
         look:
           type:  standard

--- a/data/zones/fort_karugo_narugo_s/mobs.yaml
+++ b/data/zones/fort_karugo_narugo_s/mobs.yaml
@@ -1059,12 +1059,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1134,9 +1128,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2084,12 +2075,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -2275,9 +2260,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2578,10 +2560,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2667,12 +2645,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/garlaige_citadel/mobs.yaml
+++ b/data/zones/garlaige_citadel/mobs.yaml
@@ -202,9 +202,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -284,9 +281,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -650,11 +644,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -953,9 +942,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1322,11 +1308,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/garlaige_citadel_s/mobs.yaml
+++ b/data/zones/garlaige_citadel_s/mobs.yaml
@@ -1021,12 +1021,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1096,9 +1090,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2024,9 +2015,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2328,10 +2316,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2428,12 +2412,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/grauberg_s/mobs.yaml
+++ b/data/zones/grauberg_s/mobs.yaml
@@ -1585,12 +1585,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1693,9 +1687,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2078,9 +2069,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2918,12 +2906,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3107,9 +3089,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3292,9 +3271,6 @@ templates:
     species:       quadav
     skill_list_id: 337
     attributes:
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3605,10 +3581,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3655,12 +3627,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3807,12 +3773,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/gusgen_mines/mobs.yaml
+++ b/data/zones/gusgen_mines/mobs.yaml
@@ -493,11 +493,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/halvung/mobs.yaml
+++ b/data/zones/halvung/mobs.yaml
@@ -193,11 +193,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -412,11 +407,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard

--- a/data/zones/ilrusi_atoll/mobs.yaml
+++ b/data/zones/ilrusi_atoll/mobs.yaml
@@ -69,11 +69,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -130,12 +125,6 @@ templates:
       combat:
         skill: scythe
         delay: 250
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -246,9 +235,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -272,9 +258,6 @@ templates:
       combat:
         skill: staff
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -376,9 +359,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/jade_sepulcher/mobs.yaml
+++ b/data/zones/jade_sepulcher/mobs.yaml
@@ -386,9 +386,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/jugner_forest/mobs.yaml
+++ b/data/zones/jugner_forest/mobs.yaml
@@ -2069,12 +2069,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/jugner_forest_s/mobs.yaml
+++ b/data/zones/jugner_forest_s/mobs.yaml
@@ -331,9 +331,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1011,12 +1008,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1120,9 +1111,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2934,9 +2922,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3470,10 +3455,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3676,12 +3657,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3707,12 +3682,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3971,12 +3940,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/konschtat_highlands/mobs.yaml
+++ b/data/zones/konschtat_highlands/mobs.yaml
@@ -986,12 +986,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/la_theine_plateau/mobs.yaml
+++ b/data/zones/la_theine_plateau/mobs.yaml
@@ -1201,12 +1201,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/la_vaule_s/mobs.yaml
+++ b/data/zones/la_vaule_s/mobs.yaml
@@ -1165,12 +1165,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1345,9 +1339,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2024,9 +2015,6 @@ templates:
       combat:
         skill: scythe
         delay: 220
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2876,9 +2864,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3194,9 +3179,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3387,10 +3369,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3657,12 +3635,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/labyrinth_of_onzozo/mobs.yaml
+++ b/data/zones/labyrinth_of_onzozo/mobs.yaml
@@ -1030,11 +1030,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/leujaoam_sanctum/mobs.yaml
+++ b/data/zones/leujaoam_sanctum/mobs.yaml
@@ -346,9 +346,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/lower_delkfutts_tower/mobs.yaml
+++ b/data/zones/lower_delkfutts_tower/mobs.yaml
@@ -641,9 +641,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -696,9 +693,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -728,9 +722,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/mamook/mobs.yaml
+++ b/data/zones/mamook/mobs.yaml
@@ -120,9 +120,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1561,9 +1558,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1722,9 +1716,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/mamool_ja_training_grounds/mobs.yaml
+++ b/data/zones/mamool_ja_training_grounds/mobs.yaml
@@ -565,9 +565,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -606,9 +603,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          blunt: -1250
       render:
         look:
           type:  standard
@@ -669,9 +663,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -732,9 +723,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -756,9 +744,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/maquette_abdhaljs_legion_a/mobs.yaml
+++ b/data/zones/maquette_abdhaljs_legion_a/mobs.yaml
@@ -729,9 +729,6 @@ templates:
         skill: staff
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard

--- a/data/zones/maquette_abdhaljs_legion_b/mobs.yaml
+++ b/data/zones/maquette_abdhaljs_legion_b/mobs.yaml
@@ -533,9 +533,6 @@ templates:
         skill: staff
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard

--- a/data/zones/marjami_ravine/mobs.yaml
+++ b/data/zones/marjami_ravine/mobs.yaml
@@ -628,9 +628,6 @@ templates:
     attributes:
       combat:
         skill: dagger
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -654,9 +651,6 @@ templates:
     attributes:
       combat:
         skill: dagger
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/meriphataud_mountains/mobs.yaml
+++ b/data/zones/meriphataud_mountains/mobs.yaml
@@ -1273,12 +1273,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/meriphataud_mountains_s/mobs.yaml
+++ b/data/zones/meriphataud_mountains_s/mobs.yaml
@@ -1067,12 +1067,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1167,9 +1161,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2675,9 +2666,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3091,10 +3079,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3156,12 +3140,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3232,12 +3210,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/middle_delkfutts_tower/mobs.yaml
+++ b/data/zones/middle_delkfutts_tower/mobs.yaml
@@ -646,9 +646,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -678,9 +675,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/moh_gates/mobs.yaml
+++ b/data/zones/moh_gates/mobs.yaml
@@ -231,12 +231,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -311,12 +305,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        dmg_physical:
-          slashing: -7500
-          piercing: -7500
-          blunt:    -8750
-          h2h:      -8750
       render:
         look:
           type:  standard
@@ -699,11 +687,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard

--- a/data/zones/monarch_linn/mobs.yaml
+++ b/data/zones/monarch_linn/mobs.yaml
@@ -377,12 +377,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        dmg_physical:
-          slashing: -1250
-          piercing: -1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/mount_zhayolm/mobs.yaml
+++ b/data/zones/mount_zhayolm/mobs.yaml
@@ -326,9 +326,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -434,11 +431,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -468,9 +460,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/mount_zhayolm/mobs.yaml
+++ b/data/zones/mount_zhayolm/mobs.yaml
@@ -1536,6 +1536,8 @@ templates:
       resists:
         dmg_physical:
           piercing: 2500
+      mods:
+        mdef: 50
       render:
         look:
           type:  standard

--- a/data/zones/navukgo_execution_chamber/mobs.yaml
+++ b/data/zones/navukgo_execution_chamber/mobs.yaml
@@ -141,11 +141,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard

--- a/data/zones/north_gustaberg/mobs.yaml
+++ b/data/zones/north_gustaberg/mobs.yaml
@@ -1228,12 +1228,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/north_gustaberg_s/mobs.yaml
+++ b/data/zones/north_gustaberg_s/mobs.yaml
@@ -1527,12 +1527,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1551,12 +1545,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1578,11 +1566,6 @@ templates:
       jobs: [whm, whm]
       resists:
         immune_status: [silence, paralyze, blind, slow]
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1657,9 +1640,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3052,12 +3032,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3258,9 +3232,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3738,10 +3709,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3919,12 +3886,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/nyzul_isle/mobs.yaml
+++ b/data/zones/nyzul_isle/mobs.yaml
@@ -697,11 +697,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -1702,9 +1697,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -1882,11 +1874,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -2616,9 +2603,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2779,9 +2763,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3489,9 +3470,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -3750,9 +3728,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3775,9 +3750,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3800,9 +3772,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -4650,9 +4619,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -5942,11 +5908,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -6815,9 +6776,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          blunt: -1250
       render:
         look:
           type:  standard

--- a/data/zones/outer_rakaznar/mobs.yaml
+++ b/data/zones/outer_rakaznar/mobs.yaml
@@ -87,11 +87,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -130,12 +125,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -193,12 +182,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -339,9 +322,6 @@ templates:
       combat:
         skill: sword
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -364,9 +344,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -390,9 +367,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard

--- a/data/zones/pashhow_marshlands/mobs.yaml
+++ b/data/zones/pashhow_marshlands/mobs.yaml
@@ -1979,12 +1979,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/pashhow_marshlands_s/mobs.yaml
+++ b/data/zones/pashhow_marshlands_s/mobs.yaml
@@ -1335,12 +1335,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1441,9 +1435,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1739,9 +1730,6 @@ templates:
     species:       quadav
     skill_list_id: 200
     attributes:
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2932,9 +2920,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3296,10 +3281,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3488,12 +3469,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3733,12 +3708,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/periqia/mobs.yaml
+++ b/data/zones/periqia/mobs.yaml
@@ -78,9 +78,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -217,9 +214,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -244,11 +238,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -299,9 +288,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -792,11 +778,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/phomiuna_aqueducts/mobs.yaml
+++ b/data/zones/phomiuna_aqueducts/mobs.yaml
@@ -10,11 +10,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -803,11 +798,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard
@@ -1077,10 +1067,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1116,10 +1102,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard

--- a/data/zones/psoxja/mobs.yaml
+++ b/data/zones/psoxja/mobs.yaml
@@ -10,12 +10,6 @@ templates:
       combat:
         skill: scythe
         delay: 170
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -318,9 +312,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1556,9 +1547,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1589,9 +1577,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1908,12 +1893,6 @@ templates:
       combat:
         skill: scythe
         delay: 170
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard

--- a/data/zones/qubia_arena/mobs.yaml
+++ b/data/zones/qubia_arena/mobs.yaml
@@ -34,9 +34,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -535,9 +532,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -589,9 +583,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -850,9 +841,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1483,9 +1471,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [rdm, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1586,9 +1571,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -1786,9 +1768,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, blm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/rakaznar_inner_court/mobs.yaml
+++ b/data/zones/rakaznar_inner_court/mobs.yaml
@@ -75,9 +75,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -99,9 +96,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -125,9 +119,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -212,11 +203,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -261,12 +247,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -292,9 +272,6 @@ templates:
       combat:
         skill: sword
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -319,9 +296,6 @@ templates:
       combat:
         skill: polearm
       jobs: [drg, drg]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -345,9 +319,6 @@ templates:
       combat:
         skill: sword
       jobs: [drk, drk]
-      resists:
-        dmg_physical:
-          h2h: 1250
       render:
         look:
           type:  standard
@@ -390,12 +361,6 @@ templates:
       combat:
         skill: great_katana
       jobs: [blm, war]
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -507,12 +472,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -762,9 +721,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard

--- a/data/zones/rala_waterways_u/mobs.yaml
+++ b/data/zones/rala_waterways_u/mobs.yaml
@@ -90,6 +90,7 @@ templates:
   Colkhab:
     id:            4927
     species:       bztavian
+    type:          [notorious]
     skill_list_id: 456
     attributes:
       combat:

--- a/data/zones/reisenjima/mobs.yaml
+++ b/data/zones/reisenjima/mobs.yaml
@@ -839,9 +839,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -974,12 +971,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1068,9 +1059,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1211,12 +1199,6 @@ templates:
       combat:
         skill: club
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1338,12 +1320,6 @@ templates:
     attributes:
       combat:
         skill: axe
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -1366,12 +1342,6 @@ templates:
     attributes:
       combat:
         skill: club
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1394,9 +1364,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1951,12 +1918,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/riverne_site_a01/mobs.yaml
+++ b/data/zones/riverne_site_a01/mobs.yaml
@@ -170,9 +170,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -416,9 +413,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/riverne_site_b01/mobs.yaml
+++ b/data/zones/riverne_site_b01/mobs.yaml
@@ -493,9 +493,6 @@ templates:
         skill: dagger
         delay: 210
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -664,9 +661,6 @@ templates:
         skill: dagger
         delay: 210
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/rolanberry_fields/mobs.yaml
+++ b/data/zones/rolanberry_fields/mobs.yaml
@@ -1428,12 +1428,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/rolanberry_fields_s/mobs.yaml
+++ b/data/zones/rolanberry_fields_s/mobs.yaml
@@ -789,9 +789,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1493,9 +1490,6 @@ templates:
     species:       quadav
     skill_list_id: 337
     attributes:
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1592,9 +1586,6 @@ templates:
     species:       quadav
     skill_list_id: 200
     attributes:
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1772,12 +1763,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1851,9 +1836,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1951,9 +1933,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2418,9 +2397,6 @@ templates:
     attributes:
       combat:
         delay: 0
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3293,9 +3269,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3652,10 +3625,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3800,12 +3769,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3873,12 +3836,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -4122,9 +4079,6 @@ templates:
         skill: dagger
         delay: 265
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/romaeve/mobs.yaml
+++ b/data/zones/romaeve/mobs.yaml
@@ -222,9 +222,6 @@ templates:
     skill_list_id: 175
     attributes:
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -314,9 +311,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/ruaun_gardens/mobs.yaml
+++ b/data/zones/ruaun_gardens/mobs.yaml
@@ -709,9 +709,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/sacrarium/mobs.yaml
+++ b/data/zones/sacrarium/mobs.yaml
@@ -1152,10 +1152,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1187,10 +1183,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard

--- a/data/zones/sauromugue_champaign/mobs.yaml
+++ b/data/zones/sauromugue_champaign/mobs.yaml
@@ -1313,12 +1313,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/sauromugue_champaign_s/mobs.yaml
+++ b/data/zones/sauromugue_champaign_s/mobs.yaml
@@ -1037,12 +1037,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1112,9 +1106,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2489,9 +2480,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2838,10 +2826,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2920,12 +2904,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3037,12 +3015,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/sih_gates/mobs.yaml
+++ b/data/zones/sih_gates/mobs.yaml
@@ -85,11 +85,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -215,12 +210,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -566,12 +555,6 @@ templates:
       combat:
         skill: staff
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          slashing: -1000
-          piercing: -1000
-          blunt:    -1000
-          h2h:      -1000
       render:
         look:
           type:  standard
@@ -635,12 +618,6 @@ templates:
       combat:
         skill: staff
       jobs: [pld, pld]
-      resists:
-        dmg_physical:
-          slashing: -1000
-          piercing: -1000
-          blunt:    -1000
-          h2h:      -1000
       render:
         look:
           type:  standard
@@ -729,11 +706,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_remnants/mobs.yaml
+++ b/data/zones/silver_sea_remnants/mobs.yaml
@@ -371,9 +371,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -419,9 +416,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -455,9 +449,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -535,9 +526,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -732,9 +720,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -758,9 +743,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_route_to_al_zahbi/mobs.yaml
+++ b/data/zones/silver_sea_route_to_al_zahbi/mobs.yaml
@@ -230,9 +230,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/silver_sea_route_to_nashmau/mobs.yaml
+++ b/data/zones/silver_sea_route_to_nashmau/mobs.yaml
@@ -210,9 +210,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/south_gustaberg/mobs.yaml
+++ b/data/zones/south_gustaberg/mobs.yaml
@@ -896,12 +896,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/southern_san_doria_s/mobs.yaml
+++ b/data/zones/southern_san_doria_s/mobs.yaml
@@ -789,12 +789,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -899,9 +893,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1640,9 +1631,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2100,10 +2088,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2243,12 +2227,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/tahrongi_canyon/mobs.yaml
+++ b/data/zones/tahrongi_canyon/mobs.yaml
@@ -838,12 +838,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/talacca_cove/mobs.yaml
+++ b/data/zones/talacca_cove/mobs.yaml
@@ -137,9 +137,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -166,9 +163,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -259,11 +253,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/temple_of_uggalepih/mobs.yaml
+++ b/data/zones/temple_of_uggalepih/mobs.yaml
@@ -539,9 +539,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/the_ashu_talif/mobs.yaml
+++ b/data/zones/the_ashu_talif/mobs.yaml
@@ -202,11 +202,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -290,9 +285,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -313,9 +305,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -336,9 +325,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/the_boyahda_tree/mobs.yaml
+++ b/data/zones/the_boyahda_tree/mobs.yaml
@@ -1005,9 +1005,6 @@ templates:
     attributes:
       combat:
         skill: great_axe
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/the_eldieme_necropolis_s/mobs.yaml
+++ b/data/zones/the_eldieme_necropolis_s/mobs.yaml
@@ -924,12 +924,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1034,9 +1028,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2283,9 +2274,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2809,10 +2797,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3029,12 +3013,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/the_shrine_of_ruavitau/mobs.yaml
+++ b/data/zones/the_shrine_of_ruavitau/mobs.yaml
@@ -95,9 +95,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/toraimarai_canal/mobs.yaml
+++ b/data/zones/toraimarai_canal/mobs.yaml
@@ -1141,11 +1141,6 @@ templates:
       combat:
         skill: sword
         delay: 270
-      resists:
-        dmg_physical:
-          slashing:  1250
-          blunt:    -1250
-          h2h:      -1250
       render:
         look:
           type:  standard

--- a/data/zones/uleguerand_range/mobs.yaml
+++ b/data/zones/uleguerand_range/mobs.yaml
@@ -123,10 +123,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1016,10 +1012,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1509,10 +1501,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard

--- a/data/zones/upper_delkfutts_tower/mobs.yaml
+++ b/data/zones/upper_delkfutts_tower/mobs.yaml
@@ -586,9 +586,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard
@@ -627,9 +624,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/valkurm_dunes/mobs.yaml
+++ b/data/zones/valkurm_dunes/mobs.yaml
@@ -1733,12 +1733,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/velugannon_palace/mobs.yaml
+++ b/data/zones/velugannon_palace/mobs.yaml
@@ -153,9 +153,6 @@ templates:
       combat:
         skill: scythe
       jobs: [rdm, war]
-      resists:
-        dmg_physical:
-          h2h: 2500
       render:
         look:
           type:  standard

--- a/data/zones/vunkerl_inlet_s/mobs.yaml
+++ b/data/zones/vunkerl_inlet_s/mobs.yaml
@@ -1123,12 +1123,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1207,9 +1201,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2706,9 +2697,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3248,10 +3236,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3319,12 +3303,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3534,12 +3512,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/wajaom_woodlands/mobs.yaml
+++ b/data/zones/wajaom_woodlands/mobs.yaml
@@ -517,9 +517,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -753,11 +750,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -782,11 +774,6 @@ templates:
       combat:
         skill: staff
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          slashing: -1250
-          blunt:    -2500
-          h2h:      -2500
       render:
         look:
           type:  standard
@@ -2298,9 +2285,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2575,9 +2559,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -2599,9 +2580,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/west_ronfaure/mobs.yaml
+++ b/data/zones/west_ronfaure/mobs.yaml
@@ -1023,12 +1023,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta/mobs.yaml
+++ b/data/zones/west_sarutabaruta/mobs.yaml
@@ -1128,12 +1128,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/west_sarutabaruta_s/mobs.yaml
+++ b/data/zones/west_sarutabaruta_s/mobs.yaml
@@ -1080,12 +1080,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1180,9 +1174,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1295,10 +1286,6 @@ templates:
       combat:
         skill: scythe
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2495,12 +2482,6 @@ templates:
       combat:
         skill: scythe
       jobs: [whm, whm]
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -2749,9 +2730,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -3254,10 +3232,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3380,12 +3354,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/windurst_waters_s/mobs.yaml
+++ b/data/zones/windurst_waters_s/mobs.yaml
@@ -950,12 +950,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1002,9 +996,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1948,9 +1939,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2224,10 +2212,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2291,12 +2275,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard

--- a/data/zones/woh_gates/mobs.yaml
+++ b/data/zones/woh_gates/mobs.yaml
@@ -229,12 +229,6 @@ templates:
     attributes:
       combat:
         skill: great_katana
-      resists:
-        dmg_physical:
-          slashing: -2500
-          piercing: -2500
-          blunt:    -5000
-          h2h:      -5000
       render:
         look:
           type:  standard
@@ -335,9 +329,6 @@ templates:
       combat:
         skill: dagger
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -357,11 +348,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -505,11 +491,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard
@@ -666,11 +647,6 @@ templates:
     attributes:
       combat:
         skill: scythe
-      resists:
-        dmg_physical:
-          slashing: -5000
-          piercing: -5000
-          h2h:      -7500
       render:
         look:
           type:  standard

--- a/data/zones/xarcabard_s/mobs.yaml
+++ b/data/zones/xarcabard_s/mobs.yaml
@@ -237,10 +237,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -1218,12 +1214,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -1300,9 +1290,6 @@ templates:
       combat:
         skill: great_sword
       jobs: [sch, rdm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -1711,10 +1698,6 @@ templates:
         skill: hand_to_hand
         delay: 380
       jobs: [mnk, mnk]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2354,10 +2337,6 @@ templates:
     attributes:
       combat:
         delay: 200
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -2619,9 +2598,6 @@ templates:
         skill: club
         delay: 290
       jobs: [blm, rdm]
-      resists:
-        dmg_physical:
-          blunt: 2500
       render:
         look:
           type:  standard
@@ -2740,9 +2716,6 @@ templates:
       combat:
         skill: axe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3127,10 +3100,6 @@ templates:
         skill: scythe
         delay: 360
       jobs: [mnk, blm]
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3317,10 +3286,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard
@@ -3421,12 +3386,6 @@ templates:
     species:       pixie
     skill_list_id: 195
     attributes:
-      resists:
-        dmg_physical:
-          slashing: -6250
-          piercing: -6250
-          blunt:    -6250
-          h2h:      -6250
       render:
         look:
           type:  standard
@@ -3440,10 +3399,6 @@ templates:
     species:       taurus
     skill_list_id: 240
     attributes:
-      resists:
-        dmg_physical:
-          blunt: 5000
-          h2h:   2500
       render:
         look:
           type:  standard

--- a/data/zones/yahse_hunting_grounds/mobs.yaml
+++ b/data/zones/yahse_hunting_grounds/mobs.yaml
@@ -328,9 +328,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/yorcia_weald/mobs.yaml
+++ b/data/zones/yorcia_weald/mobs.yaml
@@ -392,9 +392,6 @@ templates:
         skill: scythe
         delay: 220
       jobs: [thf, thf]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard

--- a/data/zones/zhayolm_remnants/mobs.yaml
+++ b/data/zones/zhayolm_remnants/mobs.yaml
@@ -983,9 +983,6 @@ templates:
       combat:
         skill: scythe
       jobs: [blm, blm]
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3226,9 +3223,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3258,9 +3252,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3290,9 +3281,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard
@@ -3316,9 +3304,6 @@ templates:
       combat:
         skill: scythe
         delay: 200
-      resists:
-        dmg_physical:
-          piercing: 2500
       render:
         look:
           type:  standard


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Continuation of: https://github.com/LandSandBoat/server/pull/11351 and #11335

This finishes (hopefully) the move to species owned resistance data. Regular should have nothing carrying on their own.

NM carry unique resistance ranks for now. A future audit for each NM is most likely needed. I will be going through each NM and checking if it has been captured. If it has not been captured will be defaulting them to their species res ranks.

Some fixes in this PR:
- garuda DT fixes, initially copied from siren by accident
- siren, black_wyrm, lynx, gasha, boil, both sea monks, clawed_scolopendrid, and the fomor family move to their wiki/sheet tables, replacing older hand values pre-sql
- mithra ranks reset to 0 (100%)
- batons, corse, imp, kindred, red_velkk, and skormoth drop mdef values that no source supports (sheet or wiki)

Source sheet: https://docs.google.com/spreadsheets/d/135MyNvjsihPktQrpPa_dOHe3Vswsbf-ZhyiF5vnRS9k/edit?gid=978292679#gid=978292679
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Same steps as last PR just make sure its all working correctly:
!gotoid 17199326
!getmod PIERCE_SDT
It should be 2500

Pick any mob on the list !getmod whatever mod you want to check. FIRE_RES_RANK and see it match
<!-- Clear and detailed steps to test your changes here -->
