### PR TITLE
[lua] Fix sequence for The Pickpocket

### DIFF
--- a/scripts/globals/interaction/actions/sequence.lua
+++ b/scripts/globals/interaction/actions/sequence.lua
@@ -91,9 +91,8 @@ function Sequence.performSequenceAction(action, player, targetEntity)
 
     elseif action.perform then
         -- Not a sequence-only action, so delegate responsibility to the corresponding action class
-        if action:perform(player, targetEntity) then
-            Sequence.performSequenceAction(action.__nextAction, player, targetEntity)
-        end
+        action:perform(player, targetEntity)
+        Sequence.performSequenceAction(action.__nextAction, player, targetEntity)
     end
 end
 

--- a/scripts/quests/sandoria/The_Pickpocket.lua
+++ b/scripts/quests/sandoria/The_Pickpocket.lua
@@ -135,7 +135,7 @@ quest.sections =
                 onTrigger = quest:event(547),
 
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHas(trade, xi.item.GILT_GLASSES) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.GILT_GLASSES, 1 } }) then
                         return quest:progressEvent(550)
                     else
                         return quest:event(551)
@@ -181,7 +181,7 @@ quest.sections =
 
                 [550] = function(player, csid, option, npc)
                     if quest:complete(player) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },
@@ -200,9 +200,11 @@ quest.sections =
                 end,
 
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHas(trade, xi.item.EAGLE_BUTTON) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.EAGLE_BUTTON, 1 } }) then
                         return quest:progressEvent(121)
                     end
+
+                    return quest:event(122)
                 end,
             },
 
@@ -210,7 +212,7 @@ quest.sections =
             {
                 [121] = function(player, csid, option, npc)
                     if npcUtil.giveItem(player, xi.item.GILT_GLASSES, { fromTrade = true }) then
-                        player:confirmTrade()
+                        player:tradeComplete()
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

During the quest The Pickpocket, talking to Maurinne locks your client until you log off and on again. This is because she uses a ```quest:sequence`` and a message returns ```nil```, so it never advances to the next part of the sequence. She is the only consumer of quest:sequence I can find, so I fixed this by removing the ```if``` check instead of making it so every message returned something.

Maurinne's code
```
['Maurinne'] =      quest:sequence(
                        { text = northernSandOriaID.text.PICKPOCKET_MAURINNE, wait = 1000 },
                        { text = northernSandOriaID.text.PICKPOCKET_MAURINNE + 1, face = 82, wait = 2000 },
                        { face = 115 }
                    ),
```

Added a incorrect trade message event based on capture by Siknoz. https://www.dropbox.com/scl/fi/ucd8hporczzrx5cgizjge/Quest-Sandoria-The-Pickpocket.zip?rlkey=9e5rqbrtng7cvlfk385n7509s&dl=0

Updated to tradeMatches.

## Steps to test these changes

!quest 0 The_Pickpocket
Accept the quest then go to Maurinne.
!additem eagle_button
Practice wrong trade then right trade on Esca then Altiret
