### PR TITLE
[core] Allow mob templates to name their own spells

### DIFF
--- a/data/zones/xarcabard/mobs.yaml
+++ b/data/zones/xarcabard/mobs.yaml
@@ -185,10 +185,13 @@ templates:
         square_of_wool_cloth: 0
 
   Boreal_Coeurl:
-    id:            509
-    species:       coeurl
-    type:          [notorious]
-    spell_list_id: 102
+    id:      509
+    species: coeurl
+    type:    [notorious]
+    spells:
+      - thundaga_ii
+      - burst
+      - shock_spikes
     skill_list_id: 71
     attributes:
       combat:

--- a/src/map/data/datasets/zones/mobs/dataset.cpp
+++ b/src/map/data/datasets/zones/mobs/dataset.cpp
@@ -180,6 +180,16 @@ auto convertTemplate(const std::string& key, const wire::Template& source) -> Mo
         throw std::runtime_error(fmt::format("template '{}' declares reserved pool id 0", key));
     }
 
+    if (source.spells && source.spell_list_id)
+    {
+        throw std::runtime_error(fmt::format("template '{}' names its own spells and a spell_list_id", key));
+    }
+
+    if (source.spells && source.spells->empty())
+    {
+        throw std::runtime_error(fmt::format("template '{}' has a spells list that names nothing", key));
+    }
+
     return {
         .Id          = source.id,
         .Name        = key,
@@ -189,6 +199,7 @@ auto convertTemplate(const std::string& key, const wire::Template& source) -> Mo
         .RoamFlags   = yaml::resolveFlags(source.roam),
         .SpellList   = source.spell_list_id.value_or(0),
         .SkillList   = source.skill_list_id.value_or(0),
+        .Spells      = source.spells.value_or(std::vector<std::string>{}),
         .Attributes  = convertAttributes(source.attributes, key),
         .Loot        = convertLoot(source.loot, key),
         .Allegiance  = yaml::resolveEnum(source.allegiance),

--- a/src/map/data/datasets/zones/mobs/dataset.h
+++ b/src/map/data/datasets/zones/mobs/dataset.h
@@ -72,6 +72,8 @@ struct MobTemplateData
     uint16       SpellList{};
     uint16       SkillList{};
 
+    std::vector<std::string> Spells; // TODO: Replace with Spell enums
+
     MobAttributesOverrides Attributes{}; // applied over the species chain
 
     LootData       Loot{};

--- a/src/map/data/datasets/zones/mobs/yaml.h
+++ b/src/map/data/datasets/zones/mobs/yaml.h
@@ -84,7 +84,8 @@ struct Template
     yaml::EnumToken<xi::Species>                              species;
     std::optional<std::vector<yaml::EnumToken<xi::MobType>>>  type;
     std::optional<std::vector<yaml::EnumToken<xi::RoamFlag>>> roam;
-    std::optional<uint16>                                     spell_list_id; // TODO: Bring in actual spells rather than a global list
+    std::optional<std::vector<std::string>>                   spells;
+    std::optional<uint16>                                     spell_list_id; // superseded by spells
     std::optional<uint16>                                     skill_list_id; // TODO: Bring in actual skills rather than a global list
     std::optional<shared::MobAttributes>                      attributes;
     std::optional<Loot>                                       loot;
@@ -175,7 +176,8 @@ struct glz::json_schema<xi::data::datasets::zones::mobs::wire::Template>
     glz::schema species{ .description = "Species in data/ecosystems.yaml. Its attributes, and its family's and ecosystem's, are the base this template overrides." };
     glz::schema type{ .description = "Mob classification flags, such as notorious. Defaults to an empty list.", .uniqueItems = true };
     glz::schema roam{ .description = "Roaming behaviour flags. Defaults to an empty list.", .uniqueItems = true };
-    glz::schema spell_list_id{ .description = "Spell list id. Defaults to 0, meaning none." };
+    glz::schema spells{ .description = "Spells this mob casts. Mutually exclusive with spell_list_id.", .uniqueItems = true };
+    glz::schema spell_list_id{ .description = "Spell list id. Defaults 0, meaning none. Mutually exclusive with spells." };
     glz::schema skill_list_id{ .description = "Mob skill list id. Defaults to 0, meaning none." };
     glz::schema attributes{ .description = "Attribute overrides applied over the species chain. Same block families and species use." };
     glz::schema loot{ .description = "What this mob yields when killed, stolen from or despoiled." };

--- a/src/map/lua/lua_base_entity.cpp
+++ b/src/map/lua/lua_base_entity.cpp
@@ -18504,7 +18504,14 @@ auto CLuaBaseEntity::getSpellListId() const -> uint16
     {
         if (PMob->m_SpellListContainer)
         {
-            return PMob->m_SpellListContainer->getId();
+            const auto listId = PMob->m_SpellListContainer->getId();
+            if (!listId)
+            {
+                ShowErrorFmt("CLuaBaseEntity::getSpellListId: {} names its own spells and has no list id", PMob->getName());
+                return 0;
+            }
+
+            return *listId;
         }
     }
 

--- a/src/map/mob_spell_list.cpp
+++ b/src/map/mob_spell_list.cpp
@@ -27,12 +27,12 @@
 
 #include "mob_spell_list.h"
 
-CMobSpellList::CMobSpellList(const uint16 listId)
+CMobSpellList::CMobSpellList(Maybe<uint16> listId)
 : m_listId(listId)
 {
 }
 
-auto CMobSpellList::getId() const -> uint16
+auto CMobSpellList::getId() const -> Maybe<uint16>
 {
     return m_listId;
 }

--- a/src/map/mob_spell_list.h
+++ b/src/map/mob_spell_list.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "common/cbasetypes.h"
+#include "common/types/maybe.h"
 
 #include "spell.h"
 
@@ -39,9 +40,9 @@ typedef struct
 class CMobSpellList
 {
 public:
-    CMobSpellList(uint16 listId);
+    CMobSpellList(Maybe<uint16> listId);
 
-    auto getId() const -> uint16;
+    auto getId() const -> Maybe<uint16>;
 
     void AddSpell(SpellID spellId, uint16 minLvl, uint16 maxLvl);
     auto GetSpellMinLevel(SpellID spellId) const -> uint16;
@@ -50,7 +51,7 @@ public:
     std::vector<MobSpell_t> m_spellList;
 
 private:
-    uint16 m_listId{};
+    Maybe<uint16> m_listId{};
 };
 
 namespace mobSpellList

--- a/src/map/spell.cpp
+++ b/src/map/spell.cpp
@@ -22,6 +22,8 @@
 #include <array>
 #include <cstring>
 
+#include "common/types/hash_map.h"
+
 #include "lua/luautils.h"
 
 #include "blue_spell.h"
@@ -641,6 +643,31 @@ CSpell* GetSpell(SpellID SpellID)
     // False positive: this is CSpell*, so it's OK
     // cppcheck-suppress CastIntegerToAddressAtReturn
     return PSpellList[id];
+}
+
+auto lookupIdByName(const std::string_view name) -> Maybe<SpellID>
+{
+    static const auto byName = []
+    {
+        HashMap<std::string, SpellID> names;
+        for (auto* PSpell : PSpellList)
+        {
+            if (PSpell)
+            {
+                names.try_emplace(PSpell->getName(), PSpell->getID());
+            }
+        }
+
+        return names;
+    }();
+
+    const auto entry = byName.find(std::string{ name });
+    if (entry == byName.end())
+    {
+        return std::nullopt;
+    }
+
+    return entry->second;
 }
 
 bool CanUseSpell(CBattleEntity* PCaster, SpellID SpellID)

--- a/src/map/spell.h
+++ b/src/map/spell.h
@@ -22,9 +22,12 @@
 #pragma once
 
 #include "common/cbasetypes.h"
+#include "common/types/maybe.h"
 #include "data/enums/skill_type.h"
 #include "data/enums/zone_misc.h"
 #include "entities/battle_entity.h"
+
+#include <string_view>
 
 #define CANNOT_USE_SPELL 0
 
@@ -1302,5 +1305,7 @@ CSpell* GetSpell(SpellID SpellID);
 bool    CanUseSpell(CBattleEntity* PCaster, SpellID SpellID);
 bool    CanUseSpell(CBattleEntity* PCaster, CSpell* PSpell);
 bool    CanUseSpellWith(SpellID spellId, xi::Job job, uint8 level);
+
+auto lookupIdByName(std::string_view name) -> Maybe<SpellID>;
 
 }; // namespace spell

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1526,8 +1526,11 @@ void GetAvailableSpells(CMobEntity* PMob)
 
 void SetSpellList(CMobEntity* PMob, uint16 spellList)
 {
-    PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(spellList);
-    RecalculateSpellContainer(PMob);
+    if (auto* PSpellList = mobSpellList::GetMobSpellList(spellList))
+    {
+        PMob->m_SpellListContainer = PSpellList;
+        RecalculateSpellContainer(PMob);
+    }
 }
 
 void InitializeMob(CMobEntity* PMob)

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -46,6 +46,7 @@
 #include "roam_region.h"
 #include "spawn_handler.h"
 #include "spawn_slot.h"
+#include "spell.h"
 #include "transports/elevator_handler.h"
 #include "zone_instance.h"
 
@@ -68,6 +69,8 @@ using ZoneSettingsDataset = xi::data::datasets::zones::settings::Dataset;
 using NpcsDataset         = xi::data::datasets::zones::npcs::Dataset;
 using MobsDataset         = xi::data::datasets::zones::mobs::Dataset;
 using RegionsDataset      = xi::data::datasets::zones::regions::Dataset;
+
+Synchronized<std::deque<CMobSpellList>> ownedSpellLists;
 
 // Each zone's entity files, parsed once: the id lookups and the entity inserts both read these.
 struct ZoneEntityFiles
@@ -131,6 +134,28 @@ auto buildDropList(const xi::ZoneId zoneId, const std::string& templateName, con
                                 {
                                     return &lists.emplace_back(std::move(dropList));
                                 });
+}
+
+auto buildSpellList(const xi::ZoneId zoneId, const std::string& templateName, const std::vector<std::string>& spells) -> CMobSpellList*
+{
+    CMobSpellList spellList(std::nullopt);
+
+    for (const auto& name : spells)
+    {
+        const auto spellId = spell::lookupIdByName(name);
+        if (!spellId)
+        {
+            ShowCriticalFmt("buildSpellList: template '{}' in zone {} names unknown spell '{}'", templateName, static_cast<uint32>(zoneId), name);
+            std::exit(-1);
+        }
+
+        spellList.AddSpell(*spellId, 0, 255);
+    }
+
+    return ownedSpellLists.write([&](auto& lists) -> CMobSpellList*
+                                 {
+                                     return &lists.emplace_back(std::move(spellList));
+                                 });
 }
 
 void InsertNPCs(CZone* PZone, const xi::ZoneId zoneId, const xi::data::Npcs& npcs)
@@ -209,11 +234,17 @@ void InsertMobs(CZone* PZone, const xi::ZoneId zoneId, const xi::data::Mobs& mob
     }
 
     HashMap<std::string, const DropList_t*> dropListByTemplate;
+    HashMap<std::string, CMobSpellList*>    spellListByTemplate;
     for (const auto& [name, mobTemplate] : mobs.Templates)
     {
         if (!mobTemplate.Loot.empty())
         {
             dropListByTemplate[name] = buildDropList(zoneId, name, mobTemplate.Loot);
+        }
+
+        if (!mobTemplate.Spells.empty())
+        {
+            spellListByTemplate[name] = buildSpellList(zoneId, name, mobTemplate.Spells);
         }
     }
 
@@ -327,7 +358,14 @@ void InsertMobs(CZone* PZone, const xi::ZoneId zoneId, const xi::data::Mobs& mob
                 PMob->setMobMod(xi::MobMod::SpawnAnimationsub, PMob->animationsub);
             }
 
-            PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(mobTemplate.SpellList);
+            if (const auto spellList = spellListByTemplate.find(spawn.TemplateName); spellList != spellListByTemplate.end())
+            {
+                PMob->m_SpellListContainer = spellList->second;
+            }
+            else
+            {
+                PMob->m_SpellListContainer = mobSpellList::GetMobSpellList(mobTemplate.SpellList);
+            }
 
             PMob->m_Pool = mobTemplate.Id;
 

--- a/src/test/tests/data/zones/mobs_tests.cpp
+++ b/src/test/tests/data/zones/mobs_tests.cpp
@@ -207,6 +207,56 @@ TEST_CASE("mobs: a template keeps its mods and mob mods", "[data][mob]")
     REQUIRE(digger.Attributes.Links.value_or(false));
 }
 
+TEST_CASE("mobs: a template names its own spells", "[data][mob]")
+{
+    constexpr auto named = R"(
+templates:
+  Forest_Hare:
+    id:      1
+    species: rabbit
+    spells:  [stone, stone_ii, dia]
+spawns:
+  17186822: { template: Forest_Hare }
+)";
+
+    const auto  records = MobsDataset::decode(named);
+    const auto& hare    = records.Templates.at("Forest_Hare");
+
+    REQUIRE(hare.Spells == std::vector<std::string>{ "stone", "stone_ii", "dia" });
+    REQUIRE(hare.SpellList == 0);
+}
+
+TEST_CASE("mobs: a template names spells or a spell list, never both", "[data][mob]")
+{
+    constexpr auto both = R"(
+templates:
+  Forest_Hare:
+    id:            1
+    species:       rabbit
+    spells:        [stone]
+    spell_list_id: 21
+spawns:
+  17186822: { template: Forest_Hare }
+)";
+
+    REQUIRE_THROWS_AS(MobsDataset::decode(both), std::runtime_error);
+}
+
+TEST_CASE("mobs: a spells list naming nothing is rejected", "[data][mob]")
+{
+    constexpr auto empty = R"(
+templates:
+  Forest_Hare:
+    id:      1
+    species: rabbit
+    spells:  []
+spawns:
+  17186822: { template: Forest_Hare }
+)";
+
+    REQUIRE_THROWS_AS(MobsDataset::decode(empty), std::runtime_error);
+}
+
 TEST_CASE("mobs: a spawn naming an unknown template is rejected", "[data][mob]")
 {
     constexpr auto unknownTemplate = R"(


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Allow defining spells directly on the mob template instead of referencing a spell list ID. 

Example included. No auto-complete until I migrate the spells themselves.

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Fight Boreal Coeurl, watch it cast the 3 defined spells.

<!-- Clear and detailed steps to test your changes here -->
