### PR TITLE
[core] Reset TP when joining a level synced party

### DIFF
--- a/scripts/tests/systems/level_sync.lua
+++ b/scripts/tests/systems/level_sync.lua
@@ -1,7 +1,8 @@
 describe('Level Sync', function()
-    it('resets TP when applied', function()
+    it('resets TP when applied, and for a player joining afterwards', function()
         local leader = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
         local target = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 20, zone = xi.zone.SOUTHERN_SAN_DORIA })
+        local joiner = xi.test.world:spawnPlayer({ job = xi.job.WAR, level = 75, zone = xi.zone.SOUTHERN_SAN_DORIA })
 
         leader.actions:inviteToParty(target)
         target.actions:acceptPartyInvite()
@@ -15,5 +16,13 @@ describe('Level Sync', function()
         assert(leader:getMainLvl() == 20, string.format('expected sync to 20, level=%d', leader:getMainLvl()))
         assert(leader:getTP() == 0, string.format('expected leader TP reset, TP=%d', leader:getTP()))
         assert(target:getTP() == 0, string.format('expected target TP reset, TP=%d', target:getTP()))
+
+        joiner:setTP(1000)
+        leader.actions:inviteToParty(joiner)
+        joiner.actions:acceptPartyInvite()
+
+        joiner.assert:hasEffect(xi.effect.LEVEL_SYNC)
+        assert(joiner:getMainLvl() == 20, string.format('expected joiner sync to 20, level=%d', joiner:getMainLvl()))
+        assert(joiner:getTP() == 0, string.format('expected joiner TP reset, TP=%d', joiner:getTP()))
     end)
 end)

--- a/src/map/party.cpp
+++ b/src/map/party.cpp
@@ -683,6 +683,8 @@ void CParty::AddMember(CBattleEntity* PEntity)
             {
                 PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, m_PSyncTarget->GetMLevel(), MsgStd::LevelSyncActivated);
                 PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable | xi::StatusEffectFlag::OnZone);
+                PChar->health.tp = 0;
+                PChar->updatemask |= UPDATE_HP;
                 PChar->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), m_PSyncTarget->GetMLevel(), 0s, 0s);
                 PChar->loc.zone->PushPacket(PChar, CHAR_INRANGE, std::make_unique<CCharSyncPacket>(PChar));
             }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -6464,6 +6464,8 @@ void ReloadParty(CCharEntity* PChar)
         {
             PChar->pushPacket<GP_SERV_COMMAND_BATTLE_MESSAGE>(PChar, PChar, 0, PSyncTarget->GetMLevel(), MsgBasic::LevelSyncActivated);
             PChar->StatusEffectContainer->DelStatusEffectsByFlag(xi::StatusEffectFlag::Dispelable);
+            PChar->health.tp = 0;
+            PChar->updatemask |= UPDATE_HP;
             PChar->StatusEffectContainer->AddStatusEffectSilent(xi::StatusEffect::LevelSync, static_cast<uint16>(xi::StatusEffect::LevelSync), PSyncTarget->GetMLevel(), 0s, 0s);
         }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Reset TP of anyone joining an already synced party. Forgot to check this case earlier.

<img width="1907" height="950" alt="image" src="https://github.com/user-attachments/assets/e35eb627-6801-40cb-921b-2f1e74f1aea2" />


## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
