### PR TITLE
[lua] Various Edits to Era NM Respawn Module

### DIFF
--- a/modules/era/lua/globals/old_nm_respawn_timers.lua
+++ b/modules/era/lua/globals/old_nm_respawn_timers.lua
@@ -1,20 +1,25 @@
 -----------------------------------
 -- Old NM Respawn Timers
 -- Date : 2013-11-04 (One day prior to the November 5, 2013 version update)
--- Reverts the respawn timers of multiple notorious monsters to their
--- values prior to the November 5, 2013 version update, which reduced
--- them across the original areas:
--- https://forum.square-enix.com/ffxi/threads/38100
--- Windows are persisted across server restarts via server variables.
+-- The November 5, 2013 version update shortened NM respawn timers across the
+-- original areas. This module puts the old timers back.
+--
+-- Source: https://forum.square-enix.com/ffxi/threads/38100
+--
+-- Each window is set when the zone loads. A restart starts it over.
+-- Base spawns Juggler Hecatomb, Manipulator and Atkorkamuy at load. This
+-- module holds them until their window ends.
 --
 --   Argus / Leech King (Maze of Shakhrami) : 18 to 30 hours, shared spawn pair
 --   Roc (Sauromugue Champaign)             : 21 to 24 hours
 --   Morbolger (Ordelle's Caves)            : 21 to 24 hours
 --   Juggler Hecatomb (Gusgen Mines)        : 21 to 24 hours
 --   Capricious Cassie (Fei'Yin)            : 21 to 24 hours
---   Manipulator (Temple of Uggalepih)      : 15 minutes to 2
---   Dosetsu Tree (Qufim Island)            : 21 to 24 hours, still thunder weather only
+--   Simurgh (Rolanberry Fields)            : 21 to 24 hours
+--   Manipulator (Temple of Uggalepih)      : 2 hours
+--   Atkorkamuy (Qufim Island)              : 2 hours, only with WotG content on
 --   Bloodsucker (Bostaunieux Oubliette)    : 72 hours exactly
+--   Dosetsu Tree (Qufim Island)            : 21 to 24 hours, still thunder weather only
 --   N/E/W/S Shadow (Fei'Yin)               : 16 hour lottery cooldown from Specter PHs
 -----------------------------------
 require('modules/module_utils')
@@ -23,81 +28,58 @@ local m = Module:new('era_old_nm_respawn_timers', xi.pre(xi.expansion.SOA))
 
 local shakhramiID = zones[xi.zone.MAZE_OF_SHAKHRAMI]
 local feiyinID    = zones[xi.zone.FEIYIN]
-local bostauID    = zones[xi.zone.BOSTAUNIEUX_OUBLIETTE]
 
 -----------------------------------
 -- Simple timed NMs
--- On despawn: roll a new window, persist it. On zone init: restore the
--- remaining window, or spawn the NM if it came due during downtime.
+-- Each override registers the window during initialize. The boot spawn pass
+-- skips a mob with a pending respawn, so the NM stays down.
+-- This table handles normal and scripted spawn types only. The engine blocks
+-- lottery and windowed mobs after initialize.
 -----------------------------------
 local timedNMs =
 {
     -- { zone folder name, mob file name, min respawn, max respawn }
-    { 'Sauromugue_Champaign', 'Roc',               75600, 86400 }, -- 21 to 24 hours
-    { 'Ordelles_Caves',       'Morbolger',         75600, 86400 }, -- 21 to 24 hours
-    { 'Gusgen_Mines',         'Juggler_Hecatomb',  75600, 86400 }, -- 21 to 24 hours
-    { 'FeiYin',               'Capricious_Cassie', 75600, 86400 }, -- 21 to 24 hours
-    { 'Temple_of_Uggalepih',  'Manipulator',        7200,  7200 }, -- 2 hours
+    { 'Sauromugue_Champaign',  'Roc',                75600,  86400 }, -- 21 to 24 hours
+    { 'Ordelles_Caves',        'Morbolger',          75600,  86400 }, -- 21 to 24 hours
+    { 'Gusgen_Mines',          'Juggler_Hecatomb',   75600,  86400 }, -- 21 to 24 hours
+    { 'FeiYin',                'Capricious_Cassie',  75600,  86400 }, -- 21 to 24 hours
+    { 'Rolanberry_Fields',     'Simurgh',            75600,  86400 }, -- 21 to 24 hours
+    { 'Temple_of_Uggalepih',   'Manipulator',         7200,   7200 }, -- 2 hours
+    { 'Bostaunieux_Oubliette', 'Bloodsucker_NM',    259200, 259200 }, -- 72 hours
 }
+
+-- Atkorkamuy is WotG content. His script never loads when that content is
+-- off. The override would error at every boot.
+if not xi.pre(xi.expansion.WOTG) then
+    table.insert(timedNMs, { 'Qufim_Island', 'Atkorkamuy', 7200, 7200 }) -- 2 hours
+end
 
 for _, entry in pairs(timedNMs) do
     local zoneName   = entry[1]
     local mobName    = entry[2]
     local respawnMin = entry[3]
     local respawnMax = entry[4]
-    local varName    = '[Respawn]' .. mobName
 
-    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobDespawn', zoneName, mobName), function(mob)
-        if mob:getLocalVar('[Respawn]bootSync') == 1 then
-            -- Forced back down by zone init below to restore the saved window; keep it
-            mob:setLocalVar('[Respawn]bootSync', 0)
-            return
-        end
-
+    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobInitialize', zoneName, mobName), function(mob)
         super(mob)
 
-        local respawn = math.randomInt(respawnMin, respawnMax)
-        mob:setRespawnTime(respawn)
-        SetServerVariable(varName, GetSystemTime() + respawn)
+        -- Base only rolls a spawn point for Juggler Hecatomb and Atkorkamuy
+        -- on despawn. Roll one here so their first pop is not a fixed spot.
+        xi.mob.updateNMSpawnPoint(mob)
+        mob:setRespawnTime(math.randomInt(respawnMin, respawnMax))
     end)
 
-    m:addOverride(string.format('xi.zones.%s.Zone.onInitialize', zoneName), function(zone)
-        super(zone)
+    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobDespawn', zoneName, mobName), function(mob)
+        super(mob)
 
-        local mob = zone:queryEntitiesByName(mobName)[1]
-        if not mob then
-            return
-        end
-
-        local respawn = GetServerVariable(varName)
-        if respawn == 0 and not mob:isSpawned() then
-            -- First boot with the module: seed a fresh window instead of popping immediately
-            respawn = GetSystemTime() + math.randomInt(respawnMin, respawnMax)
-            SetServerVariable(varName, respawn)
-        end
-
-        if GetSystemTime() < respawn then
-            xi.mob.updateNMSpawnPoint(mob)
-            mob:setRespawnTime(respawn - GetSystemTime())
-
-            if mob:isSpawned() then
-                -- Engine popped this spawntype 0 mob at boot mid-window
-                mob:setLocalVar('[Respawn]bootSync', 1)
-                DespawnMob(mob:getID())
-            end
-        elseif not mob:isSpawned() then
-            -- Clear any respawn the mob script registered at load, or the
-            -- engine will pop the NM again on top of this spawn when it comes due
-            mob:setRespawnTime(0)
-            SpawnMob(mob:getID())
-        end
+        mob:setRespawnTime(math.randomInt(respawnMin, respawnMax))
     end)
 end
 
 -----------------------------------
 -- Argus / Leech King
--- Either NM despawning rolls 50/50 for which of the two comes back,
--- 18 to 30 hours later (base scripts use the same roll at 1 to 2 hours).
+-- Either NM despawning rolls 50/50 for which one comes back, 18 to 30 hours
+-- later. Base uses the same roll at 1 to 2 hours.
 -----------------------------------
 local function scheduleLeechPair(nextId, seconds)
     local otherId = nextId == shakhramiID.mob.ARGUS and shakhramiID.mob.LEECH_KING or shakhramiID.mob.ARGUS
@@ -106,8 +88,6 @@ local function scheduleLeechPair(nextId, seconds)
     DisallowRespawn(nextId, false)
     xi.mob.updateNMSpawnPoint(nextId)
     GetMobByID(nextId):setRespawnTime(seconds)
-    SetServerVariable('[Respawn]LeechKingArgus_Mob', nextId)
-    SetServerVariable('[Respawn]LeechKingArgus_Time', GetSystemTime() + seconds)
 end
 
 m:addOverride('xi.zones.Maze_of_Shakhrami.mobs.Argus.onMobDespawn', function(mob)
@@ -125,98 +105,42 @@ end)
 m:addOverride('xi.zones.Maze_of_Shakhrami.Zone.onInitialize', function(zone)
     super(zone)
 
-    -- The base zone script in super just picked one of the pair and
-    -- scheduled it to pop 15 minutes to 2 hours from now. Wipe that from
-    -- both mobs before applying the saved schedule, or the engine will
-    -- still pop the base pick later on its own timer.
+    -- Super picked one of the pair and scheduled it 15 minutes to 2 hours
+    -- out. Clear both timers first. The engine pops the base pick otherwise.
     GetMobByID(shakhramiID.mob.ARGUS):setRespawnTime(0)
     GetMobByID(shakhramiID.mob.LEECH_KING):setRespawnTime(0)
 
-    local nextId   = GetServerVariable('[Respawn]LeechKingArgus_Mob')
-    local nextTime = GetServerVariable('[Respawn]LeechKingArgus_Time')
-
-    if nextId == 0 then
-        -- First boot with the module: seed a fresh roll and window
-        scheduleLeechPair(
-            math.randomInt(1, 100) <= 50 and shakhramiID.mob.ARGUS or shakhramiID.mob.LEECH_KING,
-            math.randomInt(64800, 108000)) -- 18 to 30 hours
-    elseif GetSystemTime() < nextTime then
-        scheduleLeechPair(nextId, nextTime - GetSystemTime())
-    else
-        -- Came due during downtime
-        DisallowRespawn(nextId == shakhramiID.mob.ARGUS and shakhramiID.mob.LEECH_KING or shakhramiID.mob.ARGUS, true)
-        xi.mob.updateNMSpawnPoint(nextId)
-        SpawnMob(nextId)
-    end
+    scheduleLeechPair(
+        math.randomInt(1, 100) <= 50 and shakhramiID.mob.ARGUS or shakhramiID.mob.LEECH_KING,
+        math.randomInt(64800, 108000)) -- 18 to 30 hours
 end)
 
 -----------------------------------
 -- Dosetsu Tree
--- Window widened from 1-2 hours to 21-24 hours. Qufim's Zone.lua still
--- gates the actual spawn behind thunder weather via the 'respawn' local var.
--- Depopping without being killed counts the same as a kill: the window
--- rolls on every despawn, weather included.
+-- Window widened from 1 to 2 hours to 21 to 24 hours. Qufim's Zone.lua
+-- still gates the spawn on thunder weather through the 'respawn' local var.
+-- The window rolls on every despawn. A weather depop counts as a kill.
 -----------------------------------
-m:addOverride('xi.zones.Qufim_Island.mobs.Dosetsu_Tree.onMobDespawn', function(mob)
-    local respawn = GetSystemTime() + math.randomInt(75600, 86400) -- 21 to 24 hours
-    mob:setLocalVar('respawn', respawn)
-    SetServerVariable('[Respawn]Dosetsu_Tree', respawn)
+m:addOverride('xi.zones.Qufim_Island.mobs.Dosetsu_Tree.onMobInitialize', function(mob)
+    super(mob)
+
+    mob:setLocalVar('respawn', GetSystemTime() + math.randomInt(75600, 86400)) -- 21 to 24 hours
 end)
 
-m:addOverride('xi.zones.Qufim_Island.Zone.onInitialize', function(zone)
-    super(zone)
-
-    local tree = zone:queryEntitiesByName('Dosetsu_Tree')[1]
-    if not tree then
-        return
-    end
-
-    -- Local vars are lost on restart; restore the pop window.
-    tree:setLocalVar('respawn', GetServerVariable('[Respawn]Dosetsu_Tree'))
+m:addOverride('xi.zones.Qufim_Island.mobs.Dosetsu_Tree.onMobDespawn', function(mob)
+    mob:setLocalVar('respawn', GetSystemTime() + math.randomInt(75600, 86400)) -- 21 to 24 hours
 end)
 
 -----------------------------------
 -- N/E/W/S Shadows
--- Lottery cooldowns set to a flat 16 hours for all four (base rolls
--- 1 to 2 hours). Chance stays at the base 10 percent and the Specter
--- PH mechanics are unchanged.
--- NOTE: lottery cooldowns live in a local var and do not survive restarts;
--- this matches base behavior for all lottery NMs.
+-- All four take a flat 16 hour cooldown. Base rolls 1 to 2 hours. The 10
+-- percent chance and the Specter placeholder mechanics are unchanged.
+-- The cooldown lives in a local var and resets with the server, the same as
+-- every other lottery NM.
 -----------------------------------
 m:addOverride('xi.zones.FeiYin.mobs.Specter.onMobDespawn', function(mob)
     xi.mob.phOnDespawn(mob, feiyinID.mob.NORTHERN_SHADOW, 10, 57600) -- 16 hours
     xi.mob.phOnDespawn(mob, feiyinID.mob.EASTERN_SHADOW, 10, 57600) -- 16 hours
     xi.mob.phOnDespawn(mob, feiyinID.mob.WESTERN_SHADOW, 10, 57600) -- 16 hours
     xi.mob.phOnDespawn(mob, feiyinID.mob.SOUTHERN_SHADOW, 10, 57600) -- 16 hours
-end)
-
------------------------------------
--- Bloodsucker
--- Window widened from 1 hour to 72 hours, persisted.
------------------------------------
-m:addOverride('xi.zones.Bostaunieux_Oubliette.mobs.Bloodsucker_NM.onMobDespawn', function(mob)
-    super(mob)
-
-    mob:setRespawnTime(259200) -- 72 hours
-    SetServerVariable('[Respawn]Bloodsucker_NM', GetSystemTime() + 259200)
-end)
-
-m:addOverride('xi.zones.Bostaunieux_Oubliette.Zone.onInitialize', function(zone)
-    super(zone)
-
-    local bloodsucker = GetMobByID(bostauID.mob.BLOODSUCKER)
-    if not bloodsucker then
-        return
-    end
-
-    local respawn = GetServerVariable('[Respawn]Bloodsucker_NM')
-    if GetSystemTime() < respawn then
-        -- Replaces the 1 hour respawn his script registered at load
-        bloodsucker:setRespawnTime(respawn - GetSystemTime())
-    elseif not bloodsucker:isSpawned() then
-        -- Clear the 1 hour respawn his script registered at load, or the
-        -- engine pops him again an hour after boot
-        bloodsucker:setRespawnTime(0)
-        SpawnMob(bostauID.mob.BLOODSUCKER)
-    end
 end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds Simurgh (21-24 hours) and Atkorkamuy (2 hours), both recorded on the JP wiki as shortened by the November 5, 2013 update. Removes the server variable persistence, since that is not retail behavior and should not have been here to begin with (my mistake), and registers each window in onMobInitialize instead so the NM stays out of the boot spawn pass.

## Steps to test these changes

Load the module. Kill things. See they go on appropriate era CDs just like before, but now with more NMs added to it.
