### PR TITLE
[core] Fetch increased merit cost when increasing merits

### DIFF
--- a/src/map/merit.cpp
+++ b/src/map/merit.cpp
@@ -312,6 +312,7 @@ void CMeritPoints::RaiseMerit(const xi::Merit merit)
         }
 
         PMerit->count++;
+        PMerit->next = nextUpgradeCost(*PMerit);
 
         // Reset traits
         charutils::BuildingCharTraitsTable(m_PChar);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

We were fetching `nextUpgradeCost` only on decrease but not increase.
So this PR adds the fetch on increase.

## Steps to test these changes

Increase attribute merit from nothing and see cost go from 3->6->9 instead of 3->3->3
