### PR TITLE
[C++] [lua] [sql] Migrate automaton magic cooldowns to lookup table, add 75 era automaton spell modules

### DIFF
--- a/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
+++ b/modules/era/lua/actions/abilities/pets/automaton/attachments.lua
@@ -11,15 +11,16 @@ local m = Module:new('attachments', xi.pre(xi.expansion.ABYSSEA))
 m:addOverride('xi.server.onServerStart', function()
     super()
 
-    -- Reduces Enmity boost from Strobe                                 : https://wiki.ffo.jp/html/8610.html
-    -- Reduces Store TP from Inhibitor                                  : https://wiki.ffo.jp/html/8625.html
-    -- Changes Armor Plate and Armor Plate II to Defense instead of PDT : https://wiki.ffo.jp/html/9070.html
-    -- Adds a Ranged Attack Penalty to Drum Magazine.                   : https://wiki.ffo.jp/html/8882.html
-    -- Changes Turbo Charger Haste to Gear Haste instead of Magic       : https://wiki.ffo.jp/html/8627.html
-    -- Adds Burden to Tactical Processor                                : https://wiki.ffo.jp/html/13527.html
-    -- Reduces scaling from Volt Gun                                    : https://wiki.ffo.jp/html/8752.html
-    -- Reduces Burden Decay From Heatsink                               : https://wiki.ffo.jp/html/8629.html
-    -- Reduces the potency of Steam Jackets Damage Reduction            : https://wiki.ffo.jp/html/15352.html
+    -- Reduces Enmity boost from Strobe                                  : https://wiki.ffo.jp/html/8610.html
+    -- Reduces Store TP from Inhibitor                                   : https://wiki.ffo.jp/html/8625.html
+    -- Changes Armor Plate and Armor Plate II to Defense instead of PDT  : https://wiki.ffo.jp/html/9070.html
+    -- Adds a Ranged Attack Penalty to Drum Magazine.                    : https://wiki.ffo.jp/html/8882.html
+    -- Changes Turbo Charger Haste to Gear Haste instead of Magic        : https://wiki.ffo.jp/html/8627.html
+    -- Adds Burden to Tactical Processor                                 : https://wiki.ffo.jp/html/13527.html
+    -- Reduces scaling from Volt Gun                                     : https://wiki.ffo.jp/html/8752.html
+    -- Reduces Burden Decay From Heatsink                                : https://wiki.ffo.jp/html/8629.html
+    -- Reduces the potency of Steam Jackets Damage Reduction             : https://wiki.ffo.jp/html/15352.html
+    -- Changes Mana Booster from Fast Cast, to global cooldown reduction : https://wiki.ffo.jp/html/8622.html
     xi.automaton.attachmentModifiers['strobe'            ] = { { modifier = xi.mod.ENMITY,                      values = {   5,   15,   25,   40 }, opticFiber = true  }, }
     xi.automaton.attachmentModifiers['inhibitor'         ] = { { modifier = xi.mod.STORETP,                     values = {   5,   10,   15,   20 }, opticFiber = true  }, }
     xi.automaton.attachmentModifiers['armor_plate'       ] = { { modifier = xi.mod.DEFP,                        values = {  10,   15,   20,   25 }, opticFiber = true  }, }
@@ -34,6 +35,7 @@ m:addOverride('xi.server.onServerStart', function()
     xi.automaton.attachmentModifiers['volt_gun'          ] = { { modifier = xi.mod.VOLT_GUN_POTENCY,            values = {   0,    0,    0,    0 }, opticFiber = false }, }
     xi.automaton.attachmentModifiers['heatsink'          ] = { { modifier = xi.mod.BURDEN_DECAY,                values = {   1,    1,    1,    1 }, opticFiber = false }, }
     xi.automaton.attachmentModifiers['steam_jacket'      ] = { { modifier = xi.mod.AUTO_STEAM_JACKET_REDUCTION, values = {  25,   35,   40,   60 }, opticFiber = true  }, }
+    xi.automaton.attachmentModifiers['mana_booster'      ] = { { modifier = xi.mod.AUTO_MAGIC_COOLDOWN,         values = {  -2,   -4,   -6,   -8 }, opticFiber = false }, }
 
     -- Reduces potency of Auto Repair Kit II and removed level based scaling from Mana Tank : https://wiki.ffo.jp/html/19739.html
     xi.automaton.repairKit.data['auto-repair_kit_ii' ] = { id = 196, hpBoost = 2, regenBase   = { 0, 2, 3, 4 }, regenMultiplier   = { 0, 0.4, 0.6, 0.8 } }

--- a/modules/era/lua/globals/pets/automaton.lua
+++ b/modules/era/lua/globals/pets/automaton.lua
@@ -36,6 +36,58 @@ local function applyEraFrameHPReductions()
     end
 end
 
+local eraMagicCooldowns =
+{
+    [xi.automaton.head.HARLEQUIN] =
+    {
+        global        = 30,
+        healing       = 20,
+        enfeebling    = 20,
+    },
+
+    [xi.automaton.head.VALOREDGE] =
+    {
+        global        = 45,
+        healing       = 30,
+    },
+
+    [xi.automaton.head.SHARPSHOT] =
+    {
+        global        = 45,
+        healing       = 30,
+        enfeebling    = 30,
+    },
+
+    [xi.automaton.head.STORMWAKER] =
+    {
+        global        = 25,
+        healing       = 15,
+        enfeebling    = 30,
+        elemental     = 30,
+    },
+
+    [xi.automaton.head.SOULSOOTHER] =
+    {
+        global        = 25,
+        healing       = 15,
+        enfeebling    = 30,
+        statusRemoval = 15,
+    },
+
+    [xi.automaton.head.SPIRITREAVER] =
+    {
+        global        = 25,
+        enfeebling    = 45,
+        elemental     = 15,
+    },
+}
+
+local function applyEraMagicCooldowns()
+    for head, cooldowns in pairs(eraMagicCooldowns) do
+        xi.pets.automaton.magicCooldowns[head] = cooldowns
+    end
+end
+
 m:addOverrideByEra('xi.server.onServerStart', {
     [xi.expansion.SOA] = function()
         super()
@@ -45,6 +97,8 @@ m:addOverrideByEra('xi.server.onServerStart', {
 
     [xi.expansion.ABYSSEA] = function()
         super()
+
+        applyEraMagicCooldowns()
 
         -- Adds Frame Specific DT Taken Modifiers. / Removes Valoredge Block : https://wiki.ffo.jp/html/19739.html / https://wiki.ffo.jp/html/31705.html
         xi.pets.automaton.frameMods[xi.automaton.frame.HARLEQUIN] =

--- a/modules/era/sql/wotg/automaton.sql
+++ b/modules/era/sql/wotg/automaton.sql
@@ -3,6 +3,10 @@
 -- https://wiki.ffo.jp/html/3764.html
 -- Removes Access to Bone Crusher, Armor Piercer, and Magic Mortar. (WoTG Era)
 
+-- Automaton Spell Adjustments
+-- https://wiki.ffo.jp/html/8523.html
+-- https://forum.square-enix.com/ffxi/threads/18132
+
 UPDATE `abilities` SET `animation` = 83, `animationTime` = 2000 WHERE `name` = 'fire_maneuver';
 UPDATE `abilities` SET `animation` = 83, `animationTime` = 2000 WHERE `name` = 'ice_maneuver';
 UPDATE `abilities` SET `animation` = 83, `animationTime` = 2000 WHERE `name` = 'wind_maneuver';
@@ -15,3 +19,42 @@ UPDATE `abilities` SET `animation` = 83, `animationTime` = 2000 WHERE `name` = '
 UPDATE `mob_skills` SET `mob_skill_param` = 999 WHERE `mob_skill_name` = 'bone_crusher';
 UPDATE `mob_skills` SET `mob_skill_param` = 999 WHERE `mob_skill_name` = 'armor_piercer';
 UPDATE `mob_skills` SET `mob_skill_param` = 999 WHERE `mob_skill_name` = 'magic_mortar';
+
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =   6; -- Cure VI
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  43; -- Protect
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  44; -- Protect II
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  45; -- Protect III
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  46; -- Protect IV
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  47; -- Protect V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  48; -- Shell
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  49; -- Shell II
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  50; -- Shell III
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  51; -- Shell IV
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  52; -- Shell V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  54; -- Stoneskin
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` =  57; -- Haste
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 106; -- Phalanx
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 129; -- Protectra V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 134; -- Shellra V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 143; -- Erase
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 148; -- Fire V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 153; -- Blizzard V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 158; -- Aero V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 163; -- Stone V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 168; -- Thunder V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 173; -- Water V
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 221; -- Poison II
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 248; -- Aspir II
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 260; -- Dispel
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 277; -- Dread Spikes
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 286; -- Addle
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 477; -- Regen IV
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 511; -- Haste II
+UPDATE `automaton_spells` SET `skilllevel` = 999 WHERE `spellid` = 847; -- Absorb-Attri
+
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 147; -- Fire IV
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 152; -- Blizzard IV
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 157; -- Aero IV
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 162; -- Stone IV
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 167; -- Thunder IV
+UPDATE `automaton_spells` SET `heads` = 32 WHERE `spellid` = 172; -- Water IV

--- a/scripts/globals/pets/automaton.lua
+++ b/scripts/globals/pets/automaton.lua
@@ -484,6 +484,56 @@ xi.pets.automaton.skillCaps =
     },
 }
 
+-- Automaton Magic Cooldowns, "Global" is the overall cooldown for magic, while others are specific to that category.
+xi.pets.automaton.magicCooldowns =
+{
+    [xi.automaton.head.HARLEQUIN] =
+    {
+        global        = 10,
+        healing       = 12,
+        enfeebling    = 12,
+    },
+
+    [xi.automaton.head.VALOREDGE] =
+    {
+        global        = 10,
+        healing       = 20,
+    },
+
+    [xi.automaton.head.SHARPSHOT] =
+    {
+        global        = 10,
+        healing       = 20,
+        enfeebling    = 12,
+    },
+
+    [xi.automaton.head.STORMWAKER] =
+    {
+        global        =  8,
+        healing       = 20,
+        enfeebling    = 10,
+        elemental     = 25,
+        enhancing     = 25,
+    },
+
+    [xi.automaton.head.SOULSOOTHER] =
+    {
+        global        =  8,
+        healing       = 10,
+        enfeebling    = 10,
+        enhancing     = 25,
+        statusRemoval = 10,
+    },
+
+    [xi.automaton.head.SPIRITREAVER] =
+    {
+        global        =  8,
+        enfeebling    = 10,
+        elemental     = 30,
+        enhancing     = 35,
+    },
+}
+
 xi.pets.automaton.frameMods =
 {
     -----------------------------------

--- a/src/map/ai/controllers/automaton_controller.cpp
+++ b/src/map/ai/controllers/automaton_controller.cpp
@@ -87,57 +87,38 @@ void CAutomatonController::setCooldowns()
     }
 }
 
-// New retail Automaton magic AI (Needs more information to accurately recreate)
+// Automaton magic cooldowns, looked up once on automaton creation and stored as variables.
 void CAutomatonController::setMagicCooldowns()
 {
-    switch (PAutomaton->head())
+    const auto maybeCooldowns = lua["xi"]["pets"]["automaton"]["magicCooldowns"].get<sol::optional<sol::table>>();
+    if (!maybeCooldowns)
     {
-        case AutomatonHead::Harlequin:
-        {
-            m_magicCooldown    = 10s;
-            m_enfeebleCooldown = 12s;
-            m_healCooldown     = 12s;
-        }
-        break;
-        case AutomatonHead::Valoredge:
-        {
-            m_magicCooldown = 10s;
-            m_healCooldown  = 20s;
-        }
-        break;
-        case AutomatonHead::Sharpshot:
-        {
-            m_magicCooldown    = 10s;
-            m_enfeebleCooldown = 12s;
-            m_healCooldown     = 20s;
-        }
-        break;
-        case AutomatonHead::Stormwaker:
-        {
-            m_magicCooldown     = 8s;
-            m_enfeebleCooldown  = 10s;
-            m_healCooldown      = 20s;
-            m_elementalCooldown = 25s;
-            m_enhanceCooldown   = 25s;
-        }
-        break;
-        case AutomatonHead::Soulsoother:
-        {
-            m_magicCooldown    = 8s;
-            m_enfeebleCooldown = 10s;
-            m_healCooldown     = 10s;
-            m_statusCooldown   = 10s;
-            m_enhanceCooldown  = 25s;
-        }
-        break;
-        case AutomatonHead::Spiritreaver:
-        {
-            m_magicCooldown     = 8s;
-            m_enfeebleCooldown  = 10s;
-            m_elementalCooldown = 30s;
-            m_enhanceCooldown   = 35s;
-        }
+        ShowError("CAutomatonController::setMagicCooldowns() - Missing xi.pets.automaton.magicCooldowns");
+        return;
     }
+
+    const auto head = static_cast<uint8>(PAutomaton->head());
+
+    const auto maybeHeadCooldowns = (*maybeCooldowns)[head].get<sol::optional<sol::table>>();
+    if (!maybeHeadCooldowns)
+    {
+        ShowErrorFmt("CAutomatonController::setMagicCooldowns() - Missing magic cooldowns for head {}", static_cast<uint16>(head));
+        return;
+    }
+
+    const auto& headCooldowns = *maybeHeadCooldowns;
+
+    const auto categoryCooldown = [&headCooldowns](const char* key) -> timer::duration
+    {
+        return std::chrono::seconds(headCooldowns[key].get<sol::optional<int32>>().value_or(0));
+    };
+
+    m_magicCooldown     = categoryCooldown("global");
+    m_healCooldown      = categoryCooldown("healing");
+    m_enfeebleCooldown  = categoryCooldown("enfeebling");
+    m_elementalCooldown = categoryCooldown("elemental");
+    m_enhanceCooldown   = categoryCooldown("enhancing");
+    m_statusCooldown    = categoryCooldown("statusRemoval");
 }
 
 // Determines standback behavior for the Automaton.


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Migrates automaton magic cooldown categories to a lookup table - this adds a hook for era servers to turn the cooldowns back to pre-abyssea values by mutating the table on startup

* Adds Mana Booster to the attachment module, converting its fast cast to a global spell cooldown reduction (This mod is already supported, so no changes need to be made for it to work)

* Adds spell changes to the WoTG SQL module, removing access to all out of era spells and removing tier 4 spells from Stormwaker

## Steps to test these changes

Rebuild, test automaton magic and see it works the same as before. 
Enable the modules, see automatons cast spells much slower and no longer have enhancing magic. Try out mana booster.
