### PR TITLE
[lua] Add setting to fetch old style blue magic attack

### DIFF
--- a/scripts/combat/physical_utilities.lua
+++ b/scripts/combat/physical_utilities.lua
@@ -81,6 +81,24 @@ local shieldSizeToBlockRateTable =
     [6] = 100, -- Ochain  https://www.bg-wiki.com/ffxi/Category:Shields
 }
 
+---@param actor CBaseEntity
+---@param weaponType xi.skill
+---@param weaponSlot xi.slot
+local function getMeleeAttack(actor, weaponType, weaponSlot)
+    local actorAttack = 0
+
+    if
+        weaponType == xi.skill.BLUE_MAGIC and
+        xi.settings.main.BLUE_SKILL_IS_BLUE_ATTACK
+    then
+        actorAttack = xi.spells.blue.getBlueMagicBaseAttack(actor)
+    else
+        actorAttack = actor:getStat(xi.mod.ATT, weaponSlot)
+    end
+
+    return math.max(1, actorAttack)
+end
+
 -- WARNING: This function is used in src/map/attack.cpp "ProcessDamage" function.
 -- If you update these parameters, update them there as well.
 ---@param actor CBaseEntity
@@ -628,7 +646,6 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
     -- Step 1: Attack / Defense Ratio
     ----------------------------------------
     local baseRatio     = 0
-    local actorAttack   = 0
     local targetDefense = math.max(1, target:getStat(xi.mod.DEF))
     local flourishBonus = 1
 
@@ -645,7 +662,7 @@ xi.combat.physical.calculateMeleePDIF = function(actor, target, weaponType, wsAt
 
     -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
     -- TODO: do flourish and attack mods come before or after food?
-    actorAttack = math.max(1, math.floor(actor:getStat(xi.mod.ATT, weaponSlot) * wsAttackMod * flourishBonus))
+    local actorAttack = math.floor(getMeleeAttack(actor, weaponType, weaponSlot) * wsAttackMod * flourishBonus)
 
     -- handle attuner
     -- note: isAutomaton is checked inside xi.automaton.handleAttuner and could be removed
@@ -812,7 +829,17 @@ xi.combat.physical.calculateRangedPDIF = function(actor, target, weaponType, wsA
     end
 
     -- TODO: it is unknown if ws attack mod and flourish bonus are additive or multiplicative
-    actorAttack = math.max(1, math.floor((actor:getStat(xi.mod.RATT) + bonusRangedAttack - distancePenalty) * wsAttackMod * flourishBonus))
+    -- TODO: do flourish and attack mods come before or after food?
+    if
+        weaponType == xi.skill.BLUE_MAGIC and
+        xi.settings.main.BLUE_SKILL_IS_BLUE_ATTACK
+    then
+        local baseBlueMagicAttack = xi.spells.blue.getBlueMagicBaseAttack(actor)
+
+        actorAttack = math.max(1, math.floor(baseBlueMagicAttack + bonusRangedAttack - distancePenalty) * wsAttackMod * flourishBonus)
+    else
+        actorAttack = math.max(1, math.floor((actor:getStat(xi.mod.RATT) + bonusRangedAttack - distancePenalty) * wsAttackMod * flourishBonus))
+    end
 
     -- Target Defense Modifiers.
     local ignoreDefenseFactor = 1

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -249,6 +249,15 @@ end
 -- Global functions
 -----------------------------------
 
+-- get old style blue magic attack. Not used normally. see combat utils
+---@param caster CBaseEntity
+---@return number
+xi.spells.blue.getBlueMagicBaseAttack = function(caster)
+    local baseAttack = 8 + caster:getSkillLevel(xi.skill.BLUE_MAGIC) + math.floor(caster:getStat(xi.mod.STR) * xi.settings.main.ONE_HAND_MAIN_HAND_STR_ATTACK_MULTIPLIER)
+
+    return baseAttack
+end
+
 ---@class blueSkillParams
 ---@field numHits          number
 ---@field ftp0             number

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -139,6 +139,10 @@ xi.settings.main =
     WEAPON_SKILL_POWER  = 1.000, -- Multiplies damage dealt by Weapon Skills.
     DELAY_REDUCTION_CAP = 0.80,  -- Set the cap for melee swing haste effect. (0.80 = 80% retail delay reduction max, 0.93 = 93% ToAU delay reduction max)
 
+    -- When true, use 8 + Blue magic skill + STR*ONE_HAND_MAIN_HAND_STR_ATTACK_MULTIPLIER for base attack (before blue magic merits) instead of current retail's "fetch main hand weapon attack" style
+    -- see xi.spells.blue.getBlueMagicBaseAttack
+    BLUE_SKILL_IS_BLUE_ATTACK = false,
+
     -- STR:ATT/RATT ratios. For players only. Mobs are hardcoded to 0.5
     TWO_HANDED_STR_ATTACK_MULTIPLIER         = 1.0,  -- 1.0: 1 STR = 1 Attack. This has been 0.5 and 0.75 in previous eras
     HAND_TO_HAND_STR_ATTACK_MULTIPLIER       = 1.0,  -- 1.0: 1 STR = 1 Attack. This has been 0.5 and 0.625 in previous eras.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

tl;dr: If we ship ways to use old weaponskills/alpha and str/attack ratios via settings, we should probably do the same for blue magic attack

This isn't the only way to do this, I could not have a setting and let a module alter `xi.spells.blue.getBlueMagicBaseAttack` which normally would be identical

for example, we could always fetch this function when using weaponType == xi.skill.BLUE_MAGIC

```
---@param caster CBaseEntity
---@return number
xi.spells.blue.getBlueMagicBaseAttack = function(caster)
    return math.floor(caster:getStat(xi.mod.ATT, weaponSlot)
end
```

## Steps to test these changes

Flip setting on/off, see stuff work with old style/new style
