### PR TITLE
[sql] Additional Fishing Skill Cap Corrections and Reversions

### DIFF
--- a/sql/fishing_fish.sql
+++ b/sql/fishing_fish.sql
@@ -62,7 +62,7 @@ CREATE TABLE `fishing_fish` (
 
 LOCK TABLES `fishing_fish` WRITE;
 /*!40000 ALTER TABLE `fishing_fish` DISABLE KEYS */;
-INSERT INTO `fishing_fish` VALUES (5476,'Abaia',128,37,7,13,170,350,34,1,0,255,255,0,0,0,0,0,1,0,0,1,500,0,'',0,0,0,1);
+INSERT INTO `fishing_fish` VALUES (5476,'Abaia',150,37,7,13,170,350,34,1,0,255,255,0,0,0,0,0,1,0,0,1,500,0,'',0,0,0,1);
 INSERT INTO `fishing_fish` VALUES (5455,'Ahtapot',90,31,8,7,55,145,25,1,0,255,255,0,0,3,1,4,0,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5461,'Alabaligi',37,16,5,11,1,1,15,0,0,255,255,0,0,3,1,10,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4316,'Armored Pisces',108,22,9,12,50,125,19,1,0,255,255,0,0,3,1,0,0,0,0,1,350,0,'',0,0,1,0);
@@ -83,7 +83,7 @@ INSERT INTO `fishing_fish` VALUES (4399,'Bluetail',55,24,4,12,1,1,14,0,0,255,255
 INSERT INTO `fishing_fish` VALUES (5469,'Brass Loach',42,27,11,7,1,1,99,0,0,255,255,0,0,0,5,8,0,0,0,1,750,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5474,'Ca Cuong',78,17,12,6,1,1,99,0,0,255,255,0,0,0,0,0,0,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5465,'Caedarva Frog',30,17,6,13,1,1,5,0,0,255,255,0,0,4,2,0,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (4309,'Cave Cherax',121,36,7,4,120,235,32,1,0,255,255,0,0,3,1,0,1,0,0,1,500,0,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (4309,'Cave Cherax',130,36,7,4,120,235,32,1,0,255,255,0,0,3,1,0,1,0,0,1,500,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4379,'Cheval Salmon',21,21,7,7,1,1,17,0,0,255,255,0,0,3,1,0,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4443,'Cobalt Jellyfish',5,28,13,0,1,1,14,0,0,255,255,0,0,1,1,0,0,0,1,1,700,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5128,'Cone Calamary',48,40,10,5,1,1,10,0,0,255,255,0,1,3,1,3,0,0,0,3,850,0,'',0,0,0,0);
@@ -106,7 +106,7 @@ INSERT INTO `fishing_fish` VALUES (12316,'Fish Scale Shield',7,15,13,2,1,1,13,0,
 INSERT INTO `fishing_fish` VALUES (4289,'Forest Carp',20,11,9,11,1,1,14,0,0,255,255,0,0,3,2,1,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5472,'Garpike',83,24,3,10,1,1,99,0,0,255,255,0,0,0,4,4,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4477,'Gavial Fish',81,30,14,15,40,130,23,1,0,255,255,0,0,3,4,4,0,0,0,1,400,0,'',0,0,1,0);
-INSERT INTO `fishing_fish` VALUES (5471,'Gerrothorax',122,29,7,8,120,285,30,1,0,255,255,0,0,0,2,9,1,0,0,1,500,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (5471,'Gerrothorax',134,29,7,8,120,285,30,1,0,255,255,0,0,0,2,9,1,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4469,'Giant Catfish',31,13,6,12,40,130,19,1,0,255,255,0,0,4,1,6,0,0,0,1,900,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4308,'Giant Chirai',110,25,4,15,75,170,27,1,0,255,255,0,0,3,1,0,1,0,0,1,500,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4306,'Giant Donko',50,17,14,8,45,150,23,1,0,255,255,0,0,3,5,4,0,0,0,1,900,0,'',0,0,1,0);
@@ -117,7 +117,7 @@ INSERT INTO `fishing_fish` VALUES (4383,'Gold Lobster',46,35,4,3,1,1,14,0,0,255,
 INSERT INTO `fishing_fish` VALUES (4500,'Greedie',14,10,7,14,1,1,10,0,1,255,255,0,0,1,3,7,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4304,'Grimmonite',90,31,8,7,55,145,25,1,0,255,255,0,0,3,1,4,0,0,0,1,450,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4480,'Gugru Tuna',41,16,6,13,40,120,22,1,1,255,255,0,16,1,1,0,0,0,0,1,850,0,'',0,0,1,0);
-INSERT INTO `fishing_fish` VALUES (5127,'Gugrusaurus',125,39,6,5,155,420,33,1,1,255,255,0,0,3,1,4,1,7,0,1,350,1977,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (5127,'Gugrusaurus',140,39,6,5,155,420,33,1,1,255,255,0,0,3,1,4,1,7,0,1,350,1977,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (5132,'Gurnard',26,13,11,9,1,1,5,0,0,255,255,0,0,6,4,3,0,0,0,1,550,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5449,'Hamsi',9,21,11,6,1,1,10,0,0,255,255,0,1,7,1,6,0,0,0,3,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (2341,'Hydrogauge',7,25,13,2,1,1,1,0,0,6,25,0,0,0,0,0,0,0,1,1,1000,0,'',0,0,0,0);
@@ -133,14 +133,14 @@ INSERT INTO `fishing_fish` VALUES (5460,'Kayabaligi',75,30,7,8,1,1,10,0,0,255,25
 INSERT INTO `fishing_fish` VALUES (5451,'Kilicbaligi',61,18,10,11,1,1,23,1,0,255,255,0,0,7,1,8,0,0,0,1,800,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5450,'Lakerda',41,16,6,13,55,100,22,1,0,255,255,0,0,1,4,0,0,0,0,1,900,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (2216,'Lamp Marimo',3,26,13,2,1,1,1,0,0,255,255,0,0,6,2,5,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5129,'Lik',125,48,2,14,185,460,33,1,0,255,255,0,0,3,1,6,1,8,0,1,850,1977,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (5129,'Lik',140,48,2,14,185,460,33,1,0,255,255,0,0,3,1,6,1,8,0,1,850,1977,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4315,'Lungfish',32,16,4,8,1,1,10,0,0,255,255,0,0,1,1,8,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5468,'Matsya',130,31,5,12,425,950,99,1,0,255,255,0,0,0,1,0,1,0,0,1,500,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (5468,'Matsya',150,31,5,12,425,950,99,1,0,255,255,0,0,0,1,0,1,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5467,'Megalodon',93,33,10,11,446,625,99,1,0,255,255,0,0,0,0,0,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5454,'Mercanbaligi',86,31,7,9,1,1,22,0,0,255,255,0,0,3,1,0,0,0,0,1,400,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4401,'Moat Carp',11,16,10,9,1,1,7,0,0,255,255,0,0,3,1,0,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (1638,'Moblin Mask',54,44,13,2,1,1,5,0,0,255,255,0,0,0,0,0,0,0,1,1,800,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5134,'Mola Mola',122,16,12,12,110,200,30,1,1,255,255,0,16,1,5,8,1,0,0,1,500,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (5134,'Mola Mola',135,16,12,12,110,200,30,1,1,255,255,0,16,1,5,8,1,0,0,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4462,'Monke-Onke',51,17,11,9,45,115,18,1,0,255,255,0,0,3,1,4,0,0,0,1,550,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (5121,'Moorish Idol',26,18,6,11,1,1,9,0,1,255,255,0,0,3,2,4,0,0,0,1,700,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5462,'Morinabaligi',91,36,4,13,1,1,23,0,0,255,255,0,0,3,1,8,0,0,0,1,450,0,'',0,0,0,0);
@@ -166,7 +166,7 @@ INSERT INTO `fishing_fish` VALUES (16606,'Rusty Greatsword',60,57,13,2,1,1,5,0,0
 INSERT INTO `fishing_fish` VALUES (14117,'Rusty Leggings',7,26,13,2,1,1,18,0,0,255,255,0,9,2,0,0,0,0,1,1,500,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (16655,'Rusty Pick',40,47,13,2,1,1,5,0,0,255,255,0,8,2,1,0,0,0,1,1,400,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (14242,'Rusty Subligar',5,22,13,2,1,1,5,0,0,255,255,0,8,2,0,0,0,0,1,1,500,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (4305,'Ryugu Titan',118,48,1,15,200,490,34,1,1,255,255,0,0,0,1,8,1,0,0,1,700,0,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (4305,'Ryugu Titan',150,48,1,15,200,490,34,1,1,255,255,0,0,0,1,8,1,0,0,1,700,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4291,'Sandfish',50,36,3,10,1,1,13,0,0,255,255,0,1,3,3,7,0,0,0,3,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5459,'Sazanbaligi',56,18,10,14,1,1,14,0,0,255,255,0,0,3,1,1,0,0,0,1,650,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4475,'Sea Zombie',101,39,3,15,80,195,28,1,1,255,255,0,0,4,1,2,1,0,0,1,350,0,'',0,0,1,0);
@@ -179,13 +179,13 @@ INSERT INTO `fishing_fish` VALUES (5130,'Tavnazian Goby',75,30,7,8,1,1,10,0,0,25
 INSERT INTO `fishing_fish` VALUES (4478,'Three-Eyed Fish',81,22,10,10,50,120,25,1,0,255,255,0,0,3,4,8,0,0,0,1,500,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4483,'Tiger Cod',29,23,9,9,1,1,10,0,0,255,255,0,0,3,1,8,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (4310,'Tiny Goldfish',20,22,0,14,1,1,5,0,0,255,255,0,0,5,1,7,0,0,0,3,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5120,'Titanic Sawfish',118,39,6,13,75,145,29,1,1,255,255,0,0,0,1,9,1,0,0,1,400,0,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (5120,'Titanic Sawfish',125,39,6,13,75,145,29,1,1,255,255,0,0,0,1,9,1,0,0,1,400,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4476,'Titanictus',101,28,3,12,75,210,28,1,1,255,255,0,0,3,5,8,1,0,0,1,350,0,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4426,'Tricolored Carp',27,19,12,12,1,1,13,0,0,255,255,0,0,3,1,8,0,0,0,1,1000,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (4319,'Tricorn',120,38,11,9,105,210,31,1,0,255,255,0,0,0,4,10,1,0,0,1,500,1976,'',0,0,1,0);
+INSERT INTO `fishing_fish` VALUES (4319,'Tricorn',128,38,11,9,105,210,31,1,0,255,255,0,0,0,4,10,1,0,0,1,500,1976,'',0,0,1,0);
 INSERT INTO `fishing_fish` VALUES (4317,'Trilobite',59,27,5,6,1,1,14,0,1,255,255,0,0,3,2,10,0,0,0,1,1000,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5466,'Trumpet Shell',63,18,10,5,1,1,99,0,0,255,255,0,0,0,1,3,0,0,0,1,550,0,'',0,0,0,0);
-INSERT INTO `fishing_fish` VALUES (5137,'Turnabaligi',100,30,7,12,65,175,24,1,0,255,255,0,16,6,1,7,0,0,0,1,450,0,'',0,0,0,0);
+INSERT INTO `fishing_fish` VALUES (5137,'Turnabaligi',105,30,7,12,65,175,24,1,0,255,255,0,16,6,1,7,0,0,0,1,450,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5452,'Uskumru',55,24,4,12,1,1,14,0,0,255,255,0,0,3,2,3,0,0,0,1,550,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5141,'Veydal Wrasse',37,13,11,5,40,125,25,1,0,255,255,0,0,6,4,3,0,0,0,1,400,0,'',0,0,0,0);
 INSERT INTO `fishing_fish` VALUES (5131,'Vongola Clam',53,20,8,4,1,1,13,0,1,255,255,0,1,3,1,3,0,0,0,1,900,0,'',0,0,0,0);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

I am submitting this PR to correct an error I made in https://github.com/LandSandBoat/server/pull/11348. 

TL;DR - In my last PR I miscalculated the skill caps of some legendary fish. My numbers were derived after multiple testing sessions with legendary fish and packet captures of same but I misunderstood how fatigue interacts with legendary fish. When you are 17 skill levels above a fish, you incur extra fatigue. Captures make that clear. But I mistakenly thought this system applied globally to normal fish and legendary fish - but it has become clear that it only applies to normal fish and legendary fish play by their own rules and receive only their own unique penalty. Essentially, I mistakenly believe that legendary fish received the normal 17 skill levels above penalty and their unique legendary penalty - but they only have the legendary penalty. When that is corrected, the prior skill caps are actually correct. I am attaching my fish DB and a longer explanation below. I also corrected the skill cap of Turnabaligi after reviewing the packets I had for them.

[FishMon.zip](https://github.com/user-attachments/files/31820818/FishMon.zip)

-----------------

Much of what I am writing here is probably not of importance as you likely already know this is correct as LSB's fishing system comes from Eden. I am just memorializing my thought process and how I arrived at my updated conclusion.

This PR is a partial reversion for https://github.com/LandSandBoat/server/pull/11348 - but for legendary fish only. All of the others stay. Unfortunately I miscalculated the skill caps of legendary fish in my initial research conclusions. I did more digging on JP wiki and read some of the talk pages discussing the different skill levels at which HP regen eases when fighting these legendary fish. This made me think I may have miscalculated, and I went back to re-review my fishing packets once more.

Because fishing caps at skill 110 in retail, these fish are impossible to sus out from skill ups alone as they are all skill 120+ per JP wiki, but the packets provide more insight. The server tells your client how much stamina a hooked fish has. That number is the fish's own fixed stamina value with a random wobble of about 5 percent either way thrown on top. Catch the same fish a few dozen times and you can determine the fish's real stamina with the randomness stripped back out. Cave Cherax came out at 83 stamina in multiple testing sessions. I hooked it hundreds of times and this number was constant. Gugrusaurus and Lik both came out at 88 stamina. You can see this in the retail packet. GP_SERV_COMMAND_FISH, id 0x115 which sends the following for Cave Cherax:

| Offset | Bytes | Hex | Decimal | Field |
|---|---|---|---:|---|
| 0x00 | `15 0D` | | | packet id 0x115 + size |
| 0x02 | `BA 01` | | | sync |
| 0x04 | `6C 20` | 0x206C | 8300 | **stamina** |
| 0x06 | `08 00` | 0x0008 | 8 | arrow_delay |
| 0x08 | `82 00` | 0x0082 | 130 | regen |
| 0x0A | `04 00` | 0x0004 | 4 | move_frequency |
| 0x0C | `38 04` | 0x0438 | 1080 | arrow_damage |
| 0x0E | `90 01` | 0x0190 | 400 | arrow_regen |
| 0x10 | `28 00` | 0x0028 | 40 | time |
| 0x12 | `01` | 0x01 | 1 | angler_sense |
| 0x14 | `1C 00 00 00` | 0x0000001C | 28 | intuition |

All fields little endian. 8300 is 83 x 100, so the stamina is 83. This is the same packet LSB sends. 

The accepted formula for calculating this in fishingutils.cpp matches observed retail data across 29 different unrelated fish of all skill levels. In the below piece of code, if you have a fish that is skill cap 130, the calculation produces a stamina number of 83:

```
uint16 CalculateStamina(int skill, uint8 count)
{
    float multiplier = 1.0f + (0.1f * (count - 1));
    int   modSkill   = (int)std::floor(multiplier * skill);

    return (uint16)std::floor(xirand::GetRandomNumber(95, 105) * ((modSkill + 36) / 2));
}
```

To get the final skill cap number natively from retail packets, you double the stamina number then subtract 35 or 36. So in the case of Cave Cherax: 83 base stamina x2 = 166 minus 35 or 36 = 130 or 131 as the true skill cap. LSB previously had 130, and that number is correct. LSB only ever runs this forward, from the cap in its database to the stamina it sends. The packets let me run it backward, from the stamina retail sent to the cap retail must be holding, and that lands on the number LSB had before my last PR. Gugrusaurus and Liks follow the same conclusion. Stamina of 88 x2 = 176 - 36 = 140, aka what LSB had previously. Therefore, the skill caps were mistakenly adjusted and I see my error now - which became clear after I further clarified the fatigue rules for legendary fish. The others I do not have packet captures for yet but based on my error and the fact that they are on the higher end felt I should revert them until I (or someone else) can confirm the stamina packets.

## Steps to test these changes

Run DB tool. No errors.
