### PR TITLE
[module][sql] Adds fame checker module

### DIFF
--- a/modules/era/lua/data/fame_rank_points.lua
+++ b/modules/era/lua/data/fame_rank_points.lua
@@ -22,4 +22,19 @@ m:addOverride('xi.server.onServerStart', function()
         [8] = 2200,
         [9] = 2450,
     }
+
+    -- Namonutice event 31 and Mendi event 82 are special cases
+    -- For whatever reason the fame values are baked into the client, don't ask
+    xi.data.fame.fameConversionPoints =
+    {
+        [1] = 0,
+        [2] = 50,
+        [3] = 125,
+        [4] = 225,
+        [5] = 325,
+        [6] = 425,
+        [7] = 488,
+        [8] = 550,
+        [9] = 613,
+    }
 end)

--- a/modules/era/lua/zones/lower_jeuno/npcs/fame_check.lua
+++ b/modules/era/lua/zones/lower_jeuno/npcs/fame_check.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Mendi: Fame checker
+-- Event 82 has hard coded fame values so pass the value based on rank
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('lower_jeuno_fame_check')
+
+m:addOverrideByEra('xi.zones.Lower_Jeuno.npcs.Mendi.onTrigger', {
+    [xi.expansion.ROV] = function(player, npc)
+        player:startEvent(82, xi.data.fame.fameConversionPoints[player:getFameLevel(xi.fameArea.JEUNO)])
+    end,
+})

--- a/modules/era/lua/zones/southern_san_doria/npcs/fame_check.lua
+++ b/modules/era/lua/zones/southern_san_doria/npcs/fame_check.lua
@@ -1,0 +1,13 @@
+-----------------------------------
+-- Namonutice: Fame checker
+-- Event 31 has hard coded fame values so pass the value based on rank
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('southern_san_doria_fame_check')
+
+m:addOverrideByEra('xi.zones.Southern_San_dOria.npcs.Namonutice.onTrigger', {
+    [xi.expansion.ROV] = function(player, npc)
+        player:startEvent(31, xi.data.fame.fameConversionPoints[player:getFameLevel(xi.fameArea.SANDORIA)])
+    end,
+})


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adds modules for fame checker for old fame ranks.

For whatever reason, unknown to all, they decided to hard-code the new fame values into not one...but two npcs? Every other check fame NPC checks the actual player fame level in the client except these two special people.

<img width="288" height="517" alt="image" src="https://github.com/user-attachments/assets/d79c2527-d9fc-4d97-82ea-503484e1335c" />

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Turn fame data module on, go talk to one of them see correct fame returned.
<!-- Clear and detailed steps to test your changes here -->
