### PR TITLE
[cpp] Adjust desynth skill up rates

### DIFF
--- a/scripts/tests/systems/crafting/skillup_rates.lua
+++ b/scripts/tests/systems/crafting/skillup_rates.lua
@@ -100,10 +100,70 @@ describe('SkillUpRates', function()
             { [2] = 40, [3] = 30, [4] = 20, [5] = 10 })
     end)
 
-    it('skill 60.0 and above only ever gives +0.1', function()
-        -- Lu Shangs Fishing Rod cap 70, skill 60.0: distance 10 would give 40/40/20 below level 60
-        -- That means anything above +0.1 here means the gate broke.
-        runSkillUps(player, 600, xi.item.LIGHT_CRYSTAL, xi.item.BROKEN_LU_SHANGS_FISHING_ROD,
-            { [1] = 100 })
+    describe('desynth', function()
+        local desynthTries = 2000
+
+        -- Desynth skill up chance is the flat retail 5% in synthutils.cpp, same on break and success, in both craft systems.
+        -- Leather Highboots desynth is leathercraft 6. successRateMod +100 never breaks, -100 always breaks.
+        local function runDesynthSkillUps(p, skillTenths, successRateMod, modernSystem)
+            xi.test.world:setSeed(1)
+            xi.test.world:setSetting('map.CRAFT_MODERN_SYSTEM', modernSystem)
+            xi.test.world:setSetting('map.CRAFT_CHANCE_MULTIPLIER', 1.0)
+
+            p:setSkillRank(xi.skill.LEATHERCRAFT, 9)
+            p:setMod(xi.mod.SYNTH_SUCCESS_RATE_DESYNTHESIS, successRateMod)
+            p:setMod(xi.mod.SYNTH_SPEED_LEATHERCRAFT, 17000)
+
+            local total = 0
+
+            for i = 1, desynthTries do
+                if i % 400 == 0 then
+                    print(string.format('iter %d: %d skill ups', i, total))
+                end
+
+                p:setSkillLevel(xi.skill.LEATHERCRAFT, skillTenths)
+                p:addItem(xi.item.LIGHTNING_CRYSTAL)
+                p:addItem(xi.item.LEATHER_HIGHBOOTS)
+
+                p.actions:craft(xi.item.LIGHTNING_CRYSTAL, { xi.item.LEATHER_HIGHBOOTS })
+                xi.test.world:skipTime(15)
+
+                local gain = p:getCharSkillLevel(xi.skill.LEATHERCRAFT) - skillTenths
+                assert(gain >= 0 and gain <= 2, string.format('desynth skill up of %d tenths, retail only ever gave +0.1 or +0.2', gain))
+
+                if gain > 0 then
+                    total = total + 1
+                end
+
+                p:delContainerItems(xi.inv.INVENTORY)
+            end
+
+            local prob  = 0.05
+            local mean  = desynthTries * prob
+            local sigma = math.sqrt(desynthTries * prob * (1.0 - prob))
+            local lo    = mean - 4 * sigma
+            local hi    = mean + 4 * sigma
+            print(string.format('%d skill ups in %d desynths (%.2f%%, expected 5%%)',
+                total, desynthTries, total * 100.0 / desynthTries))
+
+            assert(total >= lo and total <= hi, string.format(
+                'skill up count %d outside 4 sigma range [%.0f, %.0f] (expected %.1f)', total, lo, hi, mean))
+        end
+
+        it('gap 5 on success gives a flat 5%', function()
+            runDesynthSkillUps(player, 10, 100, true)
+        end)
+
+        it('gap 5 on break gives the same 5% with no break penalty', function()
+            runDesynthSkillUps(player, 10, -100, true)
+        end)
+
+        it('gap 1 gives the same flat 5%', function()
+            runDesynthSkillUps(player, 50, 100, true)
+        end)
+
+        it('gap 5 on break gives the same 5% under the era system', function()
+            runDesynthSkillUps(player, 10, -100, false)
+        end)
     end)
 end)

--- a/src/map/utils/synthutils.cpp
+++ b/src/map/utils/synthutils.cpp
@@ -933,11 +933,14 @@ void doSynthSkillUp(CCharEntity* PChar)
             continue; // Break current loop iteration.
         }
 
+        const bool modernSystem = settings::get<bool>("map.CRAFT_MODERN_SYSTEM");
+        const bool isDesynth    = PChar->craftState().craftMode() == CRAFT_DESYNTHESIS;
+
         // We don't Skill Up if the recipe isn't difficult enough.
         // Era -> Char lvl must be bellow recipe level. Retail -> Char level myst be bellow recipe level + 10.
         // Char level does NOT count the effects of image support/gear.
         const int16 baseDiff = static_cast<int16>(PChar->craftState().skillRequired(skillID - static_cast<uint8>(xi::SkillType::Woodworking)) - charSkill / 10);
-        const int8  minDiff  = settings::get<bool>("map.CRAFT_MODERN_SYSTEM") ? -11 : 0;
+        const int8  minDiff  = modernSystem ? -11 : 0;
         if (baseDiff <= minDiff)
         {
             continue; // Break current loop iteration.
@@ -954,7 +957,12 @@ void doSynthSkillUp(CCharEntity* PChar)
         //------------------------------
         double skillUpChance = 0.0;
 
-        if (settings::get<bool>("map.CRAFT_MODERN_SYSTEM"))
+        if (isDesynth)
+        {
+            // Retail desynth logs (2833 synths, recipe 1-5 levels over skill 0-10): flat ~5%, identical on break and success.
+            skillUpChance = 0.05;
+        }
+        else if (modernSystem)
         {
             if (baseDiff > 1)
             {
@@ -989,15 +997,10 @@ void doSynthSkillUp(CCharEntity* PChar)
         const double craftChanceMultiplier = settings::get<double>("map.CRAFT_CHANCE_MULTIPLIER");
         skillUpChance                      = skillUpChance * craftChanceMultiplier;
 
-        // Chance penalties.
+        // Chance penalties. The retail desynth rate was measured with breaks included, so it takes none.
         uint8 penalty = 1;
 
-        if (PChar->craftState().craftMode() == CRAFT_DESYNTHESIS) // If it's a desynth, lower skill up rate
-        {
-            penalty += 1;
-        }
-
-        if (PChar->craftState().result() == SYNTHESIS_FAIL) // If synth breaks, lower skill up rate
+        if (!isDesynth && PChar->craftState().result() == SYNTHESIS_FAIL) // If synth breaks, lower skill up rate
         {
             penalty += 1;
         }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Adjust the skill up rates for desynth to be a flat 5% as per retail research.

LSB current rates: they basically follow the regular skill up rates for modern retail which vary depending on the level. This ranges from 8% to 100%...yes 100%. Quite different from the 5% flat we are observing.

2,833 craft desynths were done for this. (see logs below). Skill gaps were between 1-5. Anything above that the success rate and skill up rate are so low we would need thousands and thousands of data points to get. This lowers the made up rate we currently have to the highest skill up rate you are going to observe during a desynth. 

Summed up in a chart
| Measurement | Retail |
|---|---|
| Skill-up chance, all desynths | 5.2% (146 of 2,833, 95% CI 4.3% to 6.0%) |
| Skill-up chance on break | 5.3% (104 of 1,957) |
| Skill-up chance on success | 4.8% (42 of 876) |

The rate does not change between a break and a success.

[Namonaki_2026.08.12.log](https://github.com/user-attachments/files/31857521/Namonaki_2026.08.12.log)
[Subjob_2026.08.12.log](https://github.com/user-attachments/files/31857529/Subjob_2026.08.12.log)
[Subjob_2026.08.11.log](https://github.com/user-attachments/files/31857527/Subjob_2026.08.11.log)

<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Added a test for this because there isnt a real way to test this in-game.

Test format follows previous formats displayed in older tests.
<!-- Clear and detailed steps to test your changes here -->
