### PR TITLE
[core, lua] Centurio XII-I Fixes + Mob Controller Bug Fix

### DIFF
--- a/scripts/mixins/rotz_bodyguarded_nm.lua
+++ b/scripts/mixins/rotz_bodyguarded_nm.lua
@@ -40,13 +40,14 @@ g_mixins.bodyguard = function(bodyguardedNM)
                 local guard = GetMobByID(guardID)
 
                 if guard then
-                    -- despawn bodyguard if they are still spawned for some reason
+                    -- A guard still up from the last pop is moved beside the NM. DespawnMob takes three seconds and spawn does nothing until it finishes.
                     if guard:isSpawned() then
-                        DespawnMob(guard:getID())
+                        guard:setPos(nmSpawnPos.x - spawnPosOffset[index], nmSpawnPos.y, nmSpawnPos.z)
+                    else
+                        guard:setSpawn(nmSpawnPos.x - spawnPosOffset[index], nmSpawnPos.y, nmSpawnPos.z)
+                        guard:spawn()
                     end
 
-                    guard:setSpawn(nmSpawnPos.x - spawnPosOffset[index], nmSpawnPos.y, nmSpawnPos.z)
-                    guard:spawn()
                     guard:follow(mob, xi.followType.ROAM)
                     guard:addListener('ROAM_TICK', 'ROTZ_BODYGUARD_ROAM', bodyGuardRoam)
                     guard:addListener('DESPAWN', 'ROTZ_BODYGUARD_DESPAWN', bodyGuardDespawn)

--- a/scripts/zones/Eastern_Altepa_Desert/mobs/Centurio_XII-I.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/mobs/Centurio_XII-I.lua
@@ -61,6 +61,11 @@ entity.spawnPoints =
     { x =   28.891, y =   0.369, z =  -246.506 },
 }
 
+entity.onMobInitialize = function(mob)
+    xi.mob.updateNMSpawnPoint(mob)
+    mob:setRespawnTime(72000 + math.randomInt(0, 1800)) -- 20 to 20.5 hours after a restart
+end
+
 -- all body guard functionality in the rotz_bodyguarded_nm mixin
 
 entity.onMobSpawn = function(mob)
@@ -72,9 +77,8 @@ entity.onMobSpawn = function(mob)
 end
 
 entity.onMobDespawn = function(mob)
-    -- Set Centurio XII-I's spawnpoint and respawn time (21-24 hours)
     xi.mob.updateNMSpawnPoint(mob)
-    mob:setRespawnTime(math.randomInt(75600, 86400))
+    mob:setRespawnTime(75600 + math.randomInt(600, 900)) -- 21 hours, plus 10 to 15 min
 end
 
 return entity

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1641,6 +1641,16 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
 
         if (!PMob->PAI->PathFind->IsFollowingPath())
         {
+            // Idle followers still shed neutral and still get the roam tick.
+            PMob->m_neutral = m_Tick <= m_NeutralTime + kNeutralDuration;
+
+            if (m_Tick >= m_LastRoamScript + 3s)
+            {
+                PMob->PAI->EventHandler.triggerListener("ROAM_TICK", PMob);
+                luautils::OnMobRoam(PMob);
+                m_LastRoamScript = m_Tick;
+            }
+
             co_return;
         }
     }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes Centurio XII-I in Eastern Altepa Desert and a bug in the mob controller that its bodyguards revaled.

- Centurio XII-I never spawns after a map restart. It is a scripted spawn with no respawn time and the script has no onMobInitialize, so nothing ever registers a timer. This PR adds one with a 20 to 20.5 hour boot timer, which matches retail timers after maintenance.
- Corrects the respawn from 21-24 hours to 21 hours plus 10-15 minutes. [Retail is 21h10m](https://wiki.ffo.jp/html/17169.html). Bo'Who Warmonger on the same mixin already uses this.
- Fixes rotz_bodyguarded_nm despawning and respawning a guard that is still up at the next pop. DespawnMob takes three seconds, so the spawn right after it did nothing and the NM popped with one guard. The guard is moved beside the NM instead.
- Fixes the mob controller so an idle FollowType::Roam follower still clears its neutral flag and still gets its roam tick. Before this, a follower standing beside its leader stayed neutral forever and never ran ROAM_TICK or onMobRoam, so the bodyguards never linked into the fight and never noticed the NM dying. This should also fix other bugs I have personally witnessed with mobs like Xolotl that have bodyguards never despawning even when the master is killed. 

## Steps to test these changes

Rebuild successfully and run the server. See mob behavior works as described. 
