### PR TITLE
[lua] Restrict Rank 2-3 BCNM entry requirements

### DIFF
--- a/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
+++ b/scripts/battlefields/Horlais_Peak/rank_2_mission.lua
@@ -20,7 +20,8 @@ local content = Battlefield:new({
 function content:entryRequirement(player, npc, isRegistrant, trade)
     local isCurrentMission    = player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.THE_THREE_KINGDOMS_SANDORIA2 or
         player:getCurrentMission(xi.mission.log_id.BASTOK) == xi.mission.id.bastok.THE_EMISSARY_SANDORIA2
-    local currentRequirements = isCurrentMission
+    local missionStatus       = player:getMissionStatus(player:getNation())
+    local currentRequirements = isCurrentMission and missionStatus >= 9
     local nonRegistrantReqs   = player:hasCompletedMission(player:getNation(), 5) or currentRequirements
 
     return (not isRegistrant and nonRegistrantReqs) or currentRequirements

--- a/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
+++ b/scripts/battlefields/Waughroon_Shrine/rank_2_mission.lua
@@ -21,7 +21,8 @@ local content = Battlefield:new({
 function content:entryRequirement(player, npc, isRegistrant, trade)
     local isCurrentMission    = player:getCurrentMission(xi.mission.log_id.SANDORIA) == xi.mission.id.sandoria.JOURNEY_TO_BASTOK2 or
         player:getCurrentMission(xi.mission.log_id.WINDURST) == xi.mission.id.windurst.THE_THREE_KINGDOMS_BASTOK2
-    local currentRequirements = isCurrentMission
+    local missionStatus       = player:getMissionStatus(player:getNation())
+    local currentRequirements = isCurrentMission and missionStatus >= 10
     local nonRegistrantReqs   = player:hasCompletedMission(player:getNation(), 5) or currentRequirements
 
     return (not isRegistrant and nonRegistrantReqs) or currentRequirements


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Restricts the Rank 2-3 BCNM fight for Sandoria and Bastok to require the player to be at that part of the mission to match the Windurst BCNM fight entry requirements.

Previously, someone who didn't do all of the steps prior to the BCNM could participate in the fight and not advance the mission.

I did ```local missionStatus``` to match similar battlefield styles.

## Steps to test these changes

Run the leg 2 for Windurst, Bastok, and Sandoria in the Sandoria and Bastok cities.
