### PR TITLE
[core] Allow spawns to be part of several roam regions

### DIFF
--- a/src/map/data/datasets/zones/mobs/dataset.cpp
+++ b/src/map/data/datasets/zones/mobs/dataset.cpp
@@ -110,7 +110,7 @@ auto convertOneOf(const std::optional<wire::OneOf>& source, const std::string_vi
     return members;
 }
 
-auto convertSteal(const std::optional<wire::Steal>& source) -> std::vector<std::string>
+auto convertNames(const std::optional<wire::Names>& source) -> std::vector<std::string>
 {
     if (!source)
     {
@@ -168,7 +168,7 @@ auto convertLoot(const std::optional<wire::Loot>& source, const std::string_view
         }
     }
 
-    loot.Steal   = convertSteal(source->steal);
+    loot.Steal   = convertNames(source->steal);
     loot.Despoil = convertWeights(source->despoil);
     return loot;
 }
@@ -239,6 +239,12 @@ auto convertSpawn(const uint32 id, const wire::Spawn& source) -> MobSpawnData
         throw std::runtime_error(fmt::format("spawn {} sets more than one of at, region, path and circuit", id));
     }
 
+    auto regions = convertNames(source.region);
+    if (source.region && regions.empty())
+    {
+        throw std::runtime_error(fmt::format("spawn {} lists no regions", id));
+    }
+
     const auto level = source.level.value_or(std::array<uint8, 2>{});
 
     MobSpawnData spawn{
@@ -250,7 +256,7 @@ auto convertSpawn(const uint32 id, const wire::Spawn& source) -> MobSpawnData
         .Position     = shared::toPosition(source.at, fmt::format("spawn {}", id)),
         .MinLevel     = level[0],
         .MaxLevel     = level[1],
-        .Region       = source.region.value_or(std::string{}),
+        .Regions      = std::move(regions),
         .Attributes   = convertAttributes(source.attributes, fmt::format("spawn {}", id)),
     };
 

--- a/src/map/data/datasets/zones/mobs/dataset.h
+++ b/src/map/data/datasets/zones/mobs/dataset.h
@@ -92,8 +92,8 @@ struct MobSpawnData
     uint8       MinLevel{};
     uint8       MaxLevel{};
 
-    std::string             Region; // roams this region instead of a fixed point
-    std::vector<position_t> Route;  // a `path` arrives folded back on itself, so every route is a closed loop
+    std::vector<std::string> Regions; // roams one of these instead of a fixed point, picked on every spawn
+    std::vector<position_t>  Route;   // a `path` arrives folded back on itself, so every route is a closed loop
 
     MobAttributesOverrides Attributes{};
 };

--- a/src/map/data/datasets/zones/mobs/yaml.h
+++ b/src/map/data/datasets/zones/mobs/yaml.h
@@ -60,8 +60,8 @@ using Chance = std::variant<yaml::EnumToken<xi::DropRate>, double>;
 //   nothing:      10.0
 using OneOf = std::variant<std::vector<std::string>, std::map<std::string, double>>;
 
-// A mob has one stealable item. A few name several because the source was ambiguous.
-using Steal = std::variant<std::string, std::vector<std::string>>;
+// One name, or several where the source names more than one: a few stealable items, or the regions a spawn may pick from.
+using Names = std::variant<std::string, std::vector<std::string>>;
 
 struct Loot
 {
@@ -73,7 +73,7 @@ struct Loot
     };
 
     std::optional<std::vector<Roll>>             drops;
-    std::optional<Steal>                         steal;
+    std::optional<Names>                         steal;
     std::optional<std::map<std::string, uint16>> despoil; // TODO: This may need to move to species level
 };
 
@@ -99,7 +99,7 @@ struct Spawn
     std::optional<std::string>                     templateRef;
     std::optional<std::string>                     script;
     std::optional<std::vector<float>>              at;
-    std::optional<std::string>                     region;
+    std::optional<Names>                           region;
     std::optional<std::vector<std::vector<float>>> path;
     std::optional<std::vector<std::vector<float>>> circuit;
     std::optional<std::array<uint8, 2>>            level;
@@ -191,7 +191,7 @@ struct glz::json_schema<xi::data::datasets::zones::mobs::wire::Spawn>
     glz::schema templateRef{ .description = "Template this spawn instantiates. Omitting disables this spawn entirely." };
     glz::schema script{ .description = "Script identity, resolving to scripts/zones/<zone>/mobs/<script>.lua. Defaults to the template name." };
     glz::schema at{ .description = "A fixed spawn point, as x, y, z and optionally a facing of 0-255. Mutually exclusive with region, path and circuit." };
-    glz::schema region{ .description = "Name of a region in regions.yaml to spawn and roam in. Mutually exclusive with at, path and circuit." };
+    glz::schema region{ .description = "Region in regions.yaml to spawn and roam in. A list means one is picked at random on every spawn. Mutually exclusive with at, path and circuit." };
     glz::schema path{ .description = "Patrol route as x, y, z waypoints. Walked out and back, retracing the same legs, then looped for as long as the mob is left alone. Mutually exclusive with at, region and circuit." };
     glz::schema circuit{ .description = "Patrol route as x, y, z waypoints. Walked as a closed loop, the last waypoint leading back to the first. Mutually exclusive with at, region and path." };
     glz::schema level{ .description = "Minimum and maximum level. Defaults to 0, 0." };

--- a/src/map/data/datasets/zones/regions/yaml.h
+++ b/src/map/data/datasets/zones/regions/yaml.h
@@ -62,5 +62,5 @@ struct glz::json_schema<xi::data::datasets::zones::regions::wire::Region>
 template <>
 struct glz::json_schema<xi::data::datasets::zones::regions::wire::Document>
 {
-    glz::schema regions{ .description = "Areas a mob may roam in, keyed by name. A spawn joins one by naming it." };
+    glz::schema regions{ .description = "Areas a mob may roam in, keyed by name. A spawn joins one by naming it, or lists several and picks one on each spawn." };
 };

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -401,9 +401,9 @@ void CMobEntity::setPatrolRoute(std::vector<position_t> route)
     }
 }
 
-void CMobEntity::setRoamRegion(const RoamRegion* region)
+void CMobEntity::setRoamRegions(std::vector<const RoamRegion*> regions)
 {
-    roamRegion_ = region;
+    roamRegions_ = std::move(regions);
 
     // a region has no leeway: its edge is the limit, so nothing outside counts as home
     m_maxRoamDistance = 0.0f;
@@ -765,9 +765,11 @@ void CMobEntity::Spawn()
     mobutils::CalculateMobStats(this);
     mobutils::GetAvailableSpells(this);
 
-    // region mobs pick a fresh spawn point every life, and m_SpawnPoint keeps it for the point-based checks
-    if (roamRegion_ && loc.zone)
+    // region mobs pick one of their regions and a fresh point in it every life, and m_SpawnPoint keeps it for the point-based checks
+    if (!roamRegions_.empty() && loc.zone)
     {
+        roamRegion_ = xirand::GetRandomElement(roamRegions_);
+
         if (const auto point = roamRegion_->randomPoint(loc.zone->navMesh()))
         {
             m_SpawnPoint.x = point->x;

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -73,10 +73,10 @@ public:
 
     bool IsFarFromHome(); // check if mob is too far from spawn
 
-    auto DistanceFromHome() const -> float;       // how far it strayed: outside its roam region, or from its spawn point when it has none
-    auto GetRoamAnchor() const -> position_t;     // the point roaming is measured from
-    void setRoamRegion(const RoamRegion* region); // assigning a region drops m_maxRoamDistance to 0: its edge is the limit
-    auto roamRegion() const -> const RoamRegion*;
+    auto DistanceFromHome() const -> float;                      // how far it strayed: outside its roam region, or from its spawn point when it has none
+    auto GetRoamAnchor() const -> position_t;                    // the point roaming is measured from
+    void setRoamRegions(std::vector<const RoamRegion*> regions); // one is picked on every spawn and its edge is the roam limit, so m_maxRoamDistance drops to 0
+    auto roamRegion() const -> const RoamRegion*;                // the region picked for this life, null for a point spawner
     auto dropList() const -> const DropList_t*;
     void setPatrolRoute(std::vector<position_t> route); // walked as a loop from every spawn
 
@@ -250,7 +250,8 @@ private:
     static constexpr float                roam_home_distance{ 60.f };
     SpawnSlot*                            spawnSlot = nullptr;
     Maybe<SpawnWindow>                    spawnWindow_;
-    const RoamRegion*                     roamRegion_{ nullptr }; // area it spawns and roams in, owned by the zone
+    std::vector<const RoamRegion*>        roamRegions_;           // areas it may spawn in, owned by the zone
+    const RoamRegion*                     roamRegion_{ nullptr }; // the one picked for this life
     std::vector<position_t>               patrolRoute_;           // waypoints it loops while roaming, empty for a free roamer
 };
 

--- a/src/map/utils/zoneutils.cpp
+++ b/src/map/utils/zoneutils.cpp
@@ -378,17 +378,23 @@ void InsertMobs(CZone* PZone, const xi::ZoneId zoneId, const xi::data::Mobs& mob
             PMob->m_roamFlags    = mobTemplate.RoamFlags;
             PMob->m_MobSkillList = mobTemplate.SkillList;
 
-            if (!spawn.Region.empty())
+            if (!spawn.Regions.empty())
             {
-                if (const auto* region = PZone->roamRegion(spawn.Region))
+                std::vector<const RoamRegion*> regions;
+                regions.reserve(spawn.Regions.size());
+                for (const auto& name : spawn.Regions)
                 {
-                    PMob->setRoamRegion(region);
+                    const auto* region = PZone->roamRegion(name);
+                    if (!region)
+                    {
+                        ShowCriticalFmt("InsertMobs: spawn {} names region '{}', which the zone does not declare", spawn.Id, name);
+                        std::exit(-1);
+                    }
+
+                    regions.push_back(region);
                 }
-                else
-                {
-                    ShowCriticalFmt("InsertMobs: spawn {} names region '{}', which the zone does not declare", spawn.Id, spawn.Region);
-                    std::exit(-1);
-                }
+
+                PMob->setRoamRegions(std::move(regions));
             }
 
             if (!spawn.Route.empty())

--- a/src/test/tests/data/zones/mobs_tests.cpp
+++ b/src/test/tests/data/zones/mobs_tests.cpp
@@ -443,3 +443,49 @@ spawns:
     REQUIRE(overridden->Attributes.SpawnWindow.has_value());
     REQUIRE(overridden->Attributes.SpawnWindow->first == 20);
 }
+
+TEST_CASE("mobs: a spawn names one region or several", "[data][mob]")
+{
+    constexpr auto regions = R"(
+templates:
+  Wild_Rabbit:
+    id: 1
+    species: rabbit
+    attributes:
+      render:
+        look: { type: standard, model: 1 }
+spawns:
+  17186862:
+    template: Wild_Rabbit
+    region: e_46
+  17186863:
+    template: Wild_Rabbit
+    region: [e_46, e_47]
+)";
+
+    const auto records = MobsDataset::decode(regions);
+    REQUIRE(records.Spawns.size() == 2);
+
+    const auto one  = std::ranges::find(records.Spawns, 17186862u, &xi::data::MobSpawnData::Id);
+    const auto many = std::ranges::find(records.Spawns, 17186863u, &xi::data::MobSpawnData::Id);
+    REQUIRE(one != records.Spawns.end());
+    REQUIRE(many != records.Spawns.end());
+
+    REQUIRE(one->Placed);
+    REQUIRE(one->Regions == std::vector<std::string>{ "e_46" });
+    REQUIRE(many->Regions == std::vector<std::string>{ "e_46", "e_47" });
+}
+
+TEST_CASE("mobs: a spawn listing no regions is rejected", "[data][mob]")
+{
+    constexpr auto empty = R"(
+templates:
+  Wild_Rabbit:
+    id:      1
+    species: rabbit
+spawns:
+  17186862: { template: Wild_Rabbit, region: [] }
+)";
+
+    REQUIRE_THROWS_AS(MobsDataset::decode(empty), std::runtime_error);
+}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
@montijin rightfully brought up that certain mobs can spawn in different regions. There's not a lot of them but they exist (Golden Bat)

This PR changes the data structure to allow either a string or a list of strings and flows it all the way to the mob. On spawn a random one is selected.

Nothing uses it today, we'll do a separate pass assigning them.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
