### PR TITLE
Fetch website branch for changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,8 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    - run: git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-    - run: git config --global user.name "github-actions[bot]"
+    - run: |
+        git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --global user.name "github-actions[bot]"
+
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -32,8 +34,8 @@ jobs:
           git stash --include-untracked
     - name: Git checkout website branch
       run: |
-          git checkout website
-          git pull
+        git fetch origin website
+        git checkout -b website origin/website
     - name: Git stash pop changes
       run: |
           git stash pop


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Default behavior of `actions/checkout` changed between versions 1 and 6 so the website branch wasn't being fetched.

## Steps to test these changes

https://github.com/cocosolos/server/actions/runs/34005098739
