### PR TITLE
[lua] Check equipped item is at required level before granting effects

### DIFF
--- a/scripts/actions/abilities/pets/concentric_pulse.lua
+++ b/scripts/actions/abilities/pets/concentric_pulse.lua
@@ -9,7 +9,7 @@ abilityObject.onAbilityCheck = function(player, target, ability)
 end
 
 abilityObject.onPetAbility = function(target, pet, petskill, master, action)
-    local masterEquippedHead = master:getEquipID(xi.slot.HEAD)
+    local masterEquippedHead = xi.equipment.getUsableEquipID(master, xi.slot.HEAD)
     local dmgBoost           = master:getJobPointLevel(xi.jp.CONCENTRIC_PULSE_EFFECT)
     local dmg                = pet:getHP()
 

--- a/scripts/actions/spells/white/cure.lua
+++ b/scripts/actions/spells/white/cure.lua
@@ -72,10 +72,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/actions/spells/white/cure_ii.lua
+++ b/scripts/actions/spells/white/cure_ii.lua
@@ -72,10 +72,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/actions/spells/white/cure_iii.lua
+++ b/scripts/actions/spells/white/cure_iii.lua
@@ -68,10 +68,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/actions/spells/white/cure_iv.lua
+++ b/scripts/actions/spells/white/cure_iv.lua
@@ -67,10 +67,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/actions/spells/white/cure_v.lua
+++ b/scripts/actions/spells/white/cure_v.lua
@@ -76,10 +76,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/actions/spells/white/cure_vi.lua
+++ b/scripts/actions/spells/white/cure_vi.lua
@@ -54,10 +54,10 @@ spellObject.onSpellCast = function(caster, target, spell)
             not target:hasStatusEffect(xi.effect.STONESKIN)
         then
             local solaceStoneskin = 0
-            local equippedBody = caster:getEquipID(xi.slot.BODY)
-            if equippedBody == 11186 then
+            local equippedBody = xi.equipment.getUsableEquipID(caster, xi.slot.BODY)
+            if equippedBody == xi.item.ORISON_BLIAUT_P1 then
                 solaceStoneskin = math.floor(final * 0.30)
-            elseif equippedBody == 11086 then
+            elseif equippedBody == xi.item.ORISON_BLIAUT_P2 then
                 solaceStoneskin = math.floor(final * 0.35)
             else
                 solaceStoneskin = math.floor(final * 0.25)

--- a/scripts/globals/equipment.lua
+++ b/scripts/globals/equipment.lua
@@ -321,4 +321,18 @@ xi.equipment.hasRelic = function(player, relic, tier)
     return false
 end
 
+---Equipped item id for the slot, or 0 when its required level is above the player's current level (level sync/cap)
+---@nodiscard
+---@param player CBaseEntity
+---@param slot xi.slot
+---@return xi.item
+xi.equipment.getUsableEquipID = function(player, slot)
+    local item = player:getEquippedItem(slot)
+    if item and item:getReqLvl() <= player:getMainLvl() then
+        return item:getID()
+    end
+
+    return xi.item.NONE
+end
+
 xi.equip = xi.equipment

--- a/scripts/globals/job_utils/beastmaster.lua
+++ b/scripts/globals/job_utils/beastmaster.lua
@@ -275,7 +275,7 @@ xi.job_utils.beastmaster.checkReward = function(player, target, ability)
     then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
-        local id = player:getEquipID(xi.slot.AMMO)
+        local id = xi.equipment.getUsableEquipID(player, xi.slot.AMMO)
         if
             id >= xi.item.PET_FOOD_ALPHA_BISCUIT and
             id <= xi.item.PET_FOOD_THETA_BISCUIT
@@ -513,7 +513,7 @@ end
 
 xi.job_utils.beastmaster.useReward = function(player, target, ability)
     -- 1st need to get the pet food is equipped in the range slot.
-    local rangeObj         = player:getEquipID(xi.slot.AMMO)
+    local rangeObj         = xi.equipment.getUsableEquipID(player, xi.slot.AMMO)
     local minimumHealing   = 0
     local totalHealing     = 0
     local playerMnd        = player:getStat(xi.mod.MND)
@@ -536,7 +536,7 @@ xi.job_utils.beastmaster.useReward = function(player, target, ability)
     end
 
     -- Now calculating the bonus based on gear.
-    switch(player:getEquipID(xi.slot.BODY)):caseof
+    switch(xi.equipment.getUsableEquipID(player, xi.slot.BODY)):caseof
     {
         [xi.item.BEAST_JACKCOAT] = function() -- beast jackcoat
             -- This will remove Paralyze, Poison and Blind from the pet.

--- a/scripts/globals/job_utils/dancer.lua
+++ b/scripts/globals/job_utils/dancer.lua
@@ -90,7 +90,7 @@ local function getStepFinishingMovesBase(player)
     end
 
     -- Terpsichore FM bonus. (Confirmed main-hand only)
-    local mainHandWeapon = player:getEquipID(xi.slot.MAIN)
+    local mainHandWeapon = xi.equipment.getUsableEquipID(player, xi.slot.MAIN)
 
     if terpsichoreTable[mainHandWeapon] then
         numAwardedMoves = numAwardedMoves + player:getMod(xi.mod.STEP_FINISH)

--- a/scripts/globals/job_utils/dragoon.lua
+++ b/scripts/globals/job_utils/dragoon.lua
@@ -397,7 +397,7 @@ xi.job_utils.dragoon.useSpiritLink = function(player, target, ability, action)
 
     local healPet = drainamount * 2
 
-    if player:getEquipID(xi.slot.HEAD) == xi.item.DRACHEN_ARMET_P1 then
+    if xi.equipment.getUsableEquipID(player, xi.slot.HEAD) == xi.item.DRACHEN_ARMET_P1 then
         healPet = healPet + 15
     end
 

--- a/scripts/globals/job_utils/puppetmaster.lua
+++ b/scripts/globals/job_utils/puppetmaster.lua
@@ -211,7 +211,7 @@ xi.job_utils.puppetmaster.onAbilityCheckRepair = function(player, target, abilit
     elseif pet:checkDistance(player) > 20.0 + player:getHitboxSize() + pet:getHitboxSize() then
         return xi.msg.basic.TOO_FAR_AWAY_2, 0
     else
-        local id = player:getEquipID(xi.slot.AMMO)
+        local id = xi.equipment.getUsableEquipID(player, xi.slot.AMMO)
 
         if xi.job_utils.puppetmaster.oilData[id] then
             return 0, 0
@@ -270,7 +270,7 @@ xi.job_utils.puppetmaster.onAbilityCheckMaintenance = function(player, target, a
     elseif not pet:isAutomaton() then
         return xi.msg.basic.NO_EFFECT_ON_PET, 0
     else
-        local id = player:getEquipID(xi.slot.AMMO)
+        local id = xi.equipment.getUsableEquipID(player, xi.slot.AMMO)
         if xi.job_utils.puppetmaster.oilData[id] then
             return 0, 0
         else

--- a/scripts/tests/jobs/pup/abilities/repair.lua
+++ b/scripts/tests/jobs/pup/abilities/repair.lua
@@ -1,0 +1,61 @@
+describe('Repair', function()
+    ---@type CClientEntityPair
+    local player
+    ---@type CClientEntityPair
+    local syncTarget
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.PUP,
+                level = 75,
+                zone  = xi.zone.SOUTHERN_SAN_DORIA,
+            })
+
+        syncTarget = xi.test.world:spawnPlayer(
+            {
+                job   = xi.job.WAR,
+                level = 20,
+                zone  = xi.zone.SOUTHERN_SAN_DORIA,
+            })
+
+        player:unlockAttachment(xi.item.HARLEQUIN_FRAME)
+        player:unlockAttachment(xi.item.HARLEQUIN_HEAD)
+    end)
+
+    local function useRepairWith(oilId)
+        player:addItem(oilId, 12)
+        player:equipItem(oilId)
+
+        player.actions:inviteToParty(syncTarget)
+        syncTarget.actions:acceptPartyInvite()
+        player.actions:setLevelSync(syncTarget)
+        assert(player:getMainLvl() == 20, string.format('expected sync to 20, level=%d', player:getMainLvl()))
+
+        player:spawnPet(xi.petId.AUTOMATON)
+        local pet = player:getPet()
+        assert(pet)
+
+        pet:setHP(1)
+        player.actions:useAbility(player, xi.jobAbility.REPAIR)
+        xi.test.world:tick()
+
+        return pet
+    end
+
+    it('heals the automaton with an oil at or below the synced level', function()
+        local pet      = useRepairWith(xi.item.CAN_OF_AUTOMATON_OIL)
+        local oilsLeft = player:getItemCount(xi.item.CAN_OF_AUTOMATON_OIL)
+
+        assert(pet:getHP() > 1, string.format('expected repair to heal, pet HP=%d', pet:getHP()))
+        assert(oilsLeft == 11, string.format('expected one oil consumed, count=%d', oilsLeft))
+    end)
+
+    it('refuses an oil above the synced level', function()
+        local pet      = useRepairWith(xi.item.CAN_OF_AUTOMATON_OIL_P2)
+        local oilsLeft = player:getItemCount(xi.item.CAN_OF_AUTOMATON_OIL_P2)
+
+        assert(pet:getHP() == 1, string.format('expected repair to be refused, pet HP=%d', pet:getHP()))
+        assert(oilsLeft == 12, string.format('expected no oil consumed, count=%d', oilsLeft))
+    end)
+end)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Union mandated weekly BST nerf.

Several abilities are blindly using consumables or referencing specific pieces of gear without checking that the player is meeting the level for the gear.

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
