### PR TITLE
[Module] Era Lottery NM Cooldowns

### DIFF
--- a/modules/era/lua/globals/old_nm_respawn_timers.lua
+++ b/modules/era/lua/globals/old_nm_respawn_timers.lua
@@ -21,6 +21,21 @@
 --   Bloodsucker (Bostaunieux Oubliette)    : 72 hours exactly
 --   Dosetsu Tree (Qufim Island)            : 21 to 24 hours, still thunder weather only
 --   N/E/W/S Shadow (Fei'Yin)               : 16 hour lottery cooldown from Specter PHs
+--   Bloodpool Vorax (Pashhow Marshlands)   : 60 minute lottery cooldown
+--   Hovering Hotpot (Garlaige Citadel)     : 90 minute lottery cooldown, only with WotG content on
+--   Hyakume (Ranguemont Pass)              : 60 minute lottery cooldown, only with WotG content on
+--   Nocuous Weapon (Inner Horutoto Ruins)  : 60 minute lottery cooldown, only with WotG content on
+--   Slippery Sucker (Qufim Island)         : 60 minute lottery cooldown, only with WotG content on
+--   Stray Mary (Konschtat Highlands)       : 60 minute lottery cooldown
+--   Valkurm Emperor (Valkurm Dunes)        : 60 minute lottery cooldown
+--   Lumbering Lambert (La Theine Plateau)  : 60 minute lottery cooldown
+--   Leaping Lizzy (South Gustaberg)        : 60 minute lottery cooldown
+--   Rampaging Ram (Konschtat Highlands)    : 60 minute lottery cooldown
+--   Baron Vapula (Castle Zvahl Keep)       : 2 hour lottery cooldown
+--   Baronet Romwe (Castle Zvahl Keep)      : 2 hour lottery cooldown
+--   Count Bifrons (Castle Zvahl Keep)      : 2 hour lottery cooldown
+--
+-- Most of the lottery figures come from a dated before and after on the Japanese wiki.
 -----------------------------------
 require('modules/module_utils')
 -----------------------------------
@@ -144,3 +159,55 @@ m:addOverride('xi.zones.FeiYin.mobs.Specter.onMobDespawn', function(mob)
     xi.mob.phOnDespawn(mob, feiyinID.mob.WESTERN_SHADOW, 10, 57600) -- 16 hours
     xi.mob.phOnDespawn(mob, feiyinID.mob.SOUTHERN_SHADOW, 10, 57600) -- 16 hours
 end)
+
+-----------------------------------
+-- Lottery cooldowns
+-- These NMs re-enter the lottery almost as soon as a placeholder dies. Base
+-- uses the shortened post-update waits. Before the update the wait was an
+-- hour, ninety minutes on Hovering Hotpot.
+--
+-- phOnDespawn stores the wait on the NM as a 'pop' deadline from its own
+-- DESPAWN listener. onMobDespawn runs first, so doNotInvokeCooldown makes that
+-- listener skip and the value here stands. Overriding the NM instead of the
+-- placeholder leaves the roll chance and the placeholder list untouched, and
+-- keeps it to one override each where Slippery Sucker has four placeholders
+-- and Hovering Hotpot two.
+--
+-- The cooldown lives in a local var and resets with the server, the same as
+-- every other lottery NM.
+-----------------------------------
+local lotteryNMs =
+{
+    -- { zone folder name, mob file name, cooldown }
+    { 'Castle_Zvahl_Keep',   'Baron_Vapula',      7200 }, -- 2 hours
+    { 'Castle_Zvahl_Keep',   'Baronet_Romwe',     7200 }, -- 2 hours
+    { 'Castle_Zvahl_Keep',   'Count_Bifrons',     7200 }, -- 2 hours
+    { 'Konschtat_Highlands', 'Rampaging_Ram',     3600 }, -- 60 minutes
+    { 'Konschtat_Highlands', 'Stray_Mary',        3600 }, -- 60 minutes
+    { 'La_Theine_Plateau',   'Lumbering_Lambert', 3600 }, -- 60 minutes
+    { 'Pashhow_Marshlands',  'Bloodpool_Vorax',   3600 }, -- 60 minutes
+    { 'South_Gustaberg',     'Leaping_Lizzy',     3600 }, -- 60 minutes
+    { 'Valkurm_Dunes',       'Valkurm_Emperor',   3600 }, -- 60 minutes
+}
+
+-- These four are WotG content. Their scripts never load when that content is
+-- off. The overrides would error at every boot.
+if not xi.pre(xi.expansion.WOTG) then
+    table.insert(lotteryNMs, { 'Garlaige_Citadel',     'Hovering_Hotpot',   5400 }) -- 90 minutes
+    table.insert(lotteryNMs, { 'Inner_Horutoto_Ruins', 'Nocuous_Weapon',    3600 }) -- 60 minutes
+    table.insert(lotteryNMs, { 'Qufim_Island',         'Slippery_Sucker',   3600 }) -- 60 minutes
+    table.insert(lotteryNMs, { 'Ranguemont_Pass',      'Hyakume',           3600 }) -- 60 minutes
+end
+
+for _, entry in pairs(lotteryNMs) do
+    local zoneName = entry[1]
+    local mobName  = entry[2]
+    local cooldown = entry[3]
+
+    m:addOverride(string.format('xi.zones.%s.mobs.%s.onMobDespawn', zoneName, mobName), function(mob)
+        super(mob)
+
+        mob:setLocalVar('doNotInvokeCooldown', 1)
+        mob:setLocalVar('pop', GetSystemTime() + cooldown)
+    end)
+end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR edits the era NM respawn module to change the cooldown on multiple lottery NMs which were seemingly adjusted per JP wiki after the [November 2013 update](https://forum.square-enix.com/ffxi/threads/38100).

## Steps to test these changes

Load module. Test CDs. See they are longer than base with the proper server settings.
