### PR TITLE
Update Wild Wild Whiskers

### DIFF
--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -297,11 +297,10 @@ xi.mobSkill =
 
     PETRIFACTIVE_BREATH           =  480,
 
+    POUNCE                        =  482,
     CHARGED_WHISKER               =  483,
-
     BLACK_CLOUD                   =  484,
     BLOOD_SABER                   =  485,
-
     WHIP_TONGUE                   =  486,
     TRANSMOGRIFICATION            =  487, -- Mammet-800
 

--- a/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
+++ b/scripts/zones/Balgas_Dais/mobs/Macan_Gadangan.lua
@@ -8,15 +8,24 @@ local balgasID = zones[xi.zone.BALGAS_DAIS]
 ---@type TMobEntity
 local entity = {}
 
--- Phase table : data = { [1] HP Percent, [2] Spell Multiplier, [3] Magic Cooldown, [4] Spell, [5] Message }
+-- Phase table : data = { [1] Times Interrupted, [2] Spell Multiplier, [3] Magic Cooldown { min, max }, [4] Spell List, [5] Message }
 local phaseTable =
 {
-    [1] = { 80,   0, 20, xi.magic.spell.THUNDER,     balgasID.text.WILD_WILD_WHISKERS_OFFSET     }, -- Slightly...
-    [2] = { 60,  10, 20, xi.magic.spell.THUNDER_II,  balgasID.text.WILD_WILD_WHISKERS_OFFSET + 1 }, -- Rapidly...
-    [3] = { 40,  30, 25, xi.magic.spell.THUNDAGA,    balgasID.text.WILD_WILD_WHISKERS_OFFSET + 2 }, -- Wildly...
-    [4] = { 20,  50, 30, xi.magic.spell.THUNDAGA_II, balgasID.text.WILD_WILD_WHISKERS_OFFSET + 3 }, -- Violently...
-    [5] = {  0,  70, 90, xi.magic.spell.BURST,       balgasID.text.WILD_WILD_WHISKERS_OFFSET + 4 }, -- Uncontrollably!
+    [1] = {  0,   0, { 40, 50 }, { xi.magic.spell.THUNDER, xi.magic.spell.THUNDAGA, xi.magic.spell.THUNDER_II, xi.magic.spell.THUNDAGA_II }, balgasID.text.WILD_WILD_WHISKERS_OFFSET     }, -- Slightly...
+    [2] = {  1,  10, { 35, 45 }, { xi.magic.spell.THUNDAGA, xi.magic.spell.THUNDER_II, xi.magic.spell.THUNDAGA_II },                         balgasID.text.WILD_WILD_WHISKERS_OFFSET + 1 }, -- Rapidly...
+    [3] = {  2,  30, { 30, 40 }, { xi.magic.spell.THUNDER_II, xi.magic.spell.THUNDAGA_II },                                                  balgasID.text.WILD_WILD_WHISKERS_OFFSET + 2 }, -- Wildly...
+    [4] = {  3,  50, { 25, 35 }, { xi.magic.spell.THUNDAGA_II },                                                                             balgasID.text.WILD_WILD_WHISKERS_OFFSET + 3 }, -- Violently...
+    [5] = {  0,  70, { 20, 30 }, { xi.magic.spell.BURST },                                                                                   balgasID.text.WILD_WILD_WHISKERS_OFFSET + 4 }, -- Uncontrollably!
 }
+
+local function scheduleSpell(mob, delay)
+    local currentPhase  = mob:getLocalVar('phase')
+    local spellCooldown = phaseTable[currentPhase][3]
+    local castTime      = GetSystemTime() + (delay or math.randomInt(spellCooldown[1], spellCooldown[2]))
+
+    mob:setLocalVar('messageTime', castTime - 3)
+    mob:setLocalVar('castTime', castTime)
+end
 
 entity.onMobInitialize = function(mob)
     mob:addImmunity(xi.immunity.LIGHT_SLEEP)
@@ -26,63 +35,134 @@ entity.onMobInitialize = function(mob)
     mob:setMod(xi.mod.REGAIN, 50)
     mob:setMod(xi.mod.REFRESH, 50) -- Seems to be able to cast spells infinitely, either has strong refresh or ludicrous MP pool
     mob:setMod(xi.mod.DOUBLE_ATTACK, 30)
+    mob:setMagicCastingEnabled(false) -- Casting is done manually since flavor text always plays 3 seconds before the spell is actually cast.
+
+    -- If silenced during any point in the fight, becomes immune silence and resistant to interrupts. Only uses Burst.
+    mob:addListener('EFFECT_GAIN', 'WHISKERS_SILENCED', function(mobArg, effect)
+        if
+            effect:getEffectType() == xi.effect.SILENCE and
+            mobArg:getLocalVar('phase') < 5
+        then
+            mobArg:setLocalVar('phase', 5)
+            mobArg:setLocalVar('messageTime', 0)
+            mobArg:setLocalVar('castTime', 0)
+            mobArg:setMod(xi.mod.SPELLINTERRUPT, 50)
+            mobArg:setMod(xi.mod.SILENCE_RES_RANK, 11)
+            mobArg:setMod(xi.mod.POWER_MULTIPLIER_SPELL, phaseTable[5][2])
+        end
+    end)
+
+    -- Once the silence effect wears off, schedule the next spell cast
+    mob:addListener('EFFECT_LOSE', 'WHISKERS_SILENCE_WORE', function(mobArg, effect)
+        if effect:getEffectType() == xi.effect.SILENCE then
+            scheduleSpell(mobArg)
+        end
+    end)
 end
 
 entity.onMobSpawn = function(mob)
-    mob:setLocalVar('hasBeenSilenced', 0)
+    mob:setMod(xi.mod.SPELLINTERRUPT, -50)
+    mob:setMod(xi.mod.SILENCE_RES_RANK, 0)
+    mob:setMod(xi.mod.POWER_MULTIPLIER_SPELL, 0)
+
+    mob:setLocalVar('phase', 1)
+    mob:setLocalVar('wasInterrupted', 0)
+    mob:setLocalVar('messageTime', 0)
+    mob:setLocalVar('castTime', 0)
 end
 
--- Check to see if I have been Silenced at any point during the fight
+entity.onMobEngage = function(mob, target)
+    scheduleSpell(mob, 10)
+end
+
+entity.onMobDisengage = function(mob)
+    mob:setLocalVar('messageTime', 0)
+    mob:setLocalVar('castTime', 0)
+end
+
 entity.onMobFight = function(mob, target)
-    if mob:hasStatusEffect(xi.effect.SILENCE) then
-        mob:setLocalVar('hasBeenSilenced', 1)
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
+    local currentTime  = GetSystemTime()
+    local currentPhase = mob:getLocalVar('phase')
+    local messageTime  = mob:getLocalVar('messageTime')
+    local castTime     = mob:getLocalVar('castTime')
+
+    -- If Macan Gadangan was interrupted, retaliate with Charged Whisker or Frenzied rage depending on the phase.
+    if mob:getLocalVar('wasInterrupted') == 1 then
+        mob:setLocalVar('wasInterrupted', 0)
+
+        if
+            currentPhase == 5 and
+            mob:checkDistance(target) <= 10
+        then
+            mob:useMobAbility(xi.mobSkill.CHARGED_WHISKER)
+        elseif currentPhase < 5 then
+            mob:useMobAbility(xi.mobSkill.FRENZIED_RAGE_1)
+        end
+
+        return
+    end
+
+    -- If no cast time is scheduled or the mob is silenced, do nothing.
+    if
+        castTime == 0 or
+        mob:hasStatusEffect(xi.effect.SILENCE)
+    then
+        return
+    end
+
+    local phase = phaseTable[currentPhase]
+
+    -- Play the flavor text message 3 seconds before cast begins.
+    if
+        messageTime > 0 and
+        currentTime >= messageTime
+    then
+        mob:messageText(mob, phase[5], false)
+        mob:setLocalVar('messageTime', 0)
+        mob:setLocalVar('castTime', currentTime + 3)
+    end
+
+    -- If the message has been displayed and it's time to cast the spell, cast it - then schedule the next spell.
+    if
+        messageTime == 0 and
+        currentTime >= castTime
+    then
+        mob:castSpell(phase[4][math.randomInt(1, #phase[4])])
+        scheduleSpell(mob)
     end
 end
 
--- We only use Frenzied Rage if our spells are interrupted
 entity.onMobMobskillChoose = function(mob, target, skillId)
     local mobskillList =
     {
         xi.mobSkill.CHARGED_WHISKER,
         xi.mobSkill.CHAOTIC_EYE_1,
-        xi.mobSkill.PETRIFACTIVE_BREATH,
+        xi.mobSkill.POUNCE,
     }
+
+    if mob:getLocalVar('phase') >= 4 then
+        table.insert(mobskillList, xi.mobSkill.PETRIFACTIVE_BREATH)
+    end
 
     return mobskillList[math.randomInt(1, #mobskillList)]
 end
 
--- Choose spell based on current phase or default to phase 5 (Burst) if I have been Silenced
-entity.onMobSpellChoose = function(mob, target, spellId)
-    local phase = 5
-
-    if mob:getLocalVar('hasBeenSilenced') == 0 then
-        for i = 1, #phaseTable do
-            if mob:getHPP() >= phaseTable[i][1] then
-                phase = i
-                break
-            end
-        end
-    end
-
-    mob:setMod(xi.mod.POWER_MULTIPLIER_SPELL, phaseTable[phase][2]) -- Set spell damage multiplier for this phase
-    mob:setMobMod(xi.mobMod.MAGIC_COOL, phaseTable[phase][3])       -- Set magic cooldown for this phase
-
-    local battlefield = mob:getBattlefield()
-    if battlefield then
-        local players = battlefield:getPlayers()
-        for _, player in pairs(players) do
-            if player:isAlive() and mob:checkDistance(player) <= 30 then
-                player:messageSpecial(phaseTable[phase][5]) -- Display message for this phase
-            end
-        end
-    end
-
-    return phaseTable[phase][4] -- Return spell for this phase
-end
-
--- If any of my spells are interrupted, use Frenzied Rage
 entity.onSpellInterrupted = function(mob, spell)
-    mob:useMobAbility(xi.mobSkill.FRENZIED_RAGE_1)
+    local currentPhase = mob:getLocalVar('phase')
+
+    if currentPhase < 4 then
+        currentPhase = currentPhase + 1
+        mob:setLocalVar('phase', currentPhase)
+        mob:setMod(xi.mod.POWER_MULTIPLIER_SPELL, phaseTable[currentPhase][2])
+    end
+
+    mob:setLocalVar('wasInterrupted', 1)
+
+    scheduleSpell(mob)
 end
 
 return entity


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Updates Wild Wild Whiskers with some additional retail captures. Originally I thought the spell cast was based off of HP, but somehow missed that it actually changes phases with how many times it has been interrupted. After running it 5 times this morning im making the following changes...

* Spell cast is now manually scripted so that flavor text plays 3~ seconds before spell is cast, matching retail.
* Phases now advance when a spell is interrupted instead of being based off of HPP. (Silence still forces Burst phase)
* Spell selection is now limited based off of phase, with the weakest spell being removed from the list every time it advances.
* After being silenced Macan Gadangan becomes Immune to silence for the rest of the fight.
* Will retaliate with Charged Whisker in Burst Phase instead of Frenzied Rage (if you run out of range of Burst)
* Adds Pounce to the TP move list

## Capture
https://youtu.be/vH3TFmEl3M0
[wws_2026-9-6_10_50.zip](https://github.com/user-attachments/files/31883999/wws_2026-9-6_10_50.zip)

## Steps to test these changes

Do Wild Wild Whiskers in Balgas Dais
