### PR TITLE
[lua] Stop conquest hourly messages in Dynamis

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -11,10 +11,10 @@ xi = xi or {}
 xi.conquest = xi.conquest or {}
 
 -----------------------------------
--- (LOCAL) constants
+-- (GLOBAL) constants
 -----------------------------------
 
-local conquestConstants =
+xi.conquest.constants =
 {
     TALLY_START = 0,
     TALLY_END   = 1,
@@ -1939,14 +1939,6 @@ xi.conquest.sendConquestTallyUpdateMessage = function(player, messageBase, owner
 end
 
 xi.conquest.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    -- onConquestUpdate is called for zones in city regions as well
-    -- in such cases, owner and influence is undetermined, so we call a city specific method.
-    local regionId = zone:getRegionID()
-    if regionId > xi.region.TAVNAZIANARCH and regionId < xi.region.DYNAMIS then
-        xi.conquest.onCityConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
-        return
-    end
-
     local messageBase        = zones[zone:getID()].text.CONQUEST_BASE
     local players            = zone:getPlayers()
 
@@ -1954,41 +1946,42 @@ xi.conquest.onConquestUpdate = function(zone, updatetype, influence, owner, rank
     -- WARNING: This is iterating every player in a zone, be careful not
     --        : to put expensive operations like db reads in here!
     -----------------------------------
-    for _, player in pairs(players) do
-        if updatetype == conquestConstants.TALLY_START then
+    if updatetype == xi.conquest.constants.TALLY_START then
+        for _, player in pairs(players) do
             xi.conquest.sendConquestTallyStartMessage(player, messageBase)
-
-        elseif updatetype == conquestConstants.TALLY_END then
+        end
+    elseif updatetype == xi.conquest.constants.TALLY_END then
+        for _, player in pairs(players) do
             xi.conquest.sendConquestTallyEndMessage(player, messageBase, owner, ranking, isConquestAlliance)
-
-        elseif updatetype == conquestConstants.UPDATE then
+        end
+    elseif updatetype == xi.conquest.constants.UPDATE then
+        for _, player in pairs(players) do
             xi.conquest.sendConquestTallyUpdateMessage(player, messageBase, owner, ranking, influence, isConquestAlliance)
         end
     end
 end
 
-xi.conquest.onCityConquestUpdate = function(zone, updatetype, ranking, isconquestAlliance)
-    local messageBase        = zones[zone:getID()].text.CONQUEST_BASE
-    local players            = zone:getPlayers()
-
-    -----------------------------------
-    -- Once per zone logic
-    -----------------------------------
-
-    -- Triggers regional npc updates for city zones only
-    if updatetype == conquestConstants.TALLY_END then
-        xi.conquest.toggleRegionalNPCs(zone)
+xi.conquest.onNonRegionConquestUpdate = function(zone, updatetype, ranking, isconquestAlliance)
+    if
+        updatetype ~= xi.conquest.constants.TALLY_START and
+        updatetype ~= xi.conquest.constants.TALLY_END
+    then
+        return
     end
+
+    local messageBase = zones[zone:getID()].text.CONQUEST_BASE
+    local players     = zone:getPlayers()
 
     -----------------------------------
     -- WARNING: This is iterating every player in a zone, be careful not
     --        : to put expensive operations like db reads in here!
     -----------------------------------
-    for _, player in pairs(players) do
-        if updatetype == conquestConstants.TALLY_START then
+    if updatetype == xi.conquest.constants.TALLY_START then
+        for _, player in pairs(players) do
             xi.conquest.sendConquestTallyStartMessage(player, messageBase)
-
-        elseif updatetype == conquestConstants.TALLY_END then
+        end
+    elseif updatetype == xi.conquest.constants.TALLY_END then
+        for _, player in pairs(players) do
             xi.conquest.sendCityConquestTallyEndMessage(player, messageBase, ranking, isconquestAlliance)
         end
     end

--- a/scripts/zones/Bastok_Markets/Zone.lua
+++ b/scripts/zones/Bastok_Markets/Zone.lua
@@ -13,7 +13,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Bastok_Mines/Zone.lua
+++ b/scripts/zones/Bastok_Mines/Zone.lua
@@ -19,7 +19,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Chateau_dOraguille/Zone.lua
+++ b/scripts/zones/Chateau_dOraguille/Zone.lua
@@ -24,7 +24,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Dynamis-Bastok/Zone.lua
+++ b/scripts/zones/Dynamis-Bastok/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Beaucedine/Zone.lua
+++ b/scripts/zones/Dynamis-Beaucedine/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Buburimu/Zone.lua
+++ b/scripts/zones/Dynamis-Buburimu/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Jeuno/Zone.lua
+++ b/scripts/zones/Dynamis-Jeuno/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Qufim/Zone.lua
+++ b/scripts/zones/Dynamis-Qufim/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-San_dOria/Zone.lua
+++ b/scripts/zones/Dynamis-San_dOria/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Tavnazia/Zone.lua
+++ b/scripts/zones/Dynamis-Tavnazia/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Valkurm/Zone.lua
+++ b/scripts/zones/Dynamis-Valkurm/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Windurst/Zone.lua
+++ b/scripts/zones/Dynamis-Windurst/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Dynamis-Xarcabard/Zone.lua
+++ b/scripts/zones/Dynamis-Xarcabard/Zone.lua
@@ -9,7 +9,7 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Heavens_Tower/Zone.lua
+++ b/scripts/zones/Heavens_Tower/Zone.lua
@@ -24,7 +24,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Lower_Jeuno/Zone.lua
+++ b/scripts/zones/Lower_Jeuno/Zone.lua
@@ -33,7 +33,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Metalworks/Zone.lua
+++ b/scripts/zones/Metalworks/Zone.lua
@@ -29,7 +29,7 @@ zoneObject.afterZoneIn = function(player)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Northern_San_dOria/Zone.lua
+++ b/scripts/zones/Northern_San_dOria/Zone.lua
@@ -28,7 +28,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Port_Bastok/Zone.lua
+++ b/scripts/zones/Port_Bastok/Zone.lua
@@ -31,7 +31,10 @@ zoneObject.onInitialize = function(zone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
+    if updatetype == xi.conquest.constants.TALLY_END then
+        xi.conquest.toggleRegionalNPCs(zone)
+    end
 end
 
 zoneObject.onZoneIn = function(player, prevZone)

--- a/scripts/zones/Port_Jeuno/Zone.lua
+++ b/scripts/zones/Port_Jeuno/Zone.lua
@@ -59,7 +59,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportName)

--- a/scripts/zones/Port_San_dOria/Zone.lua
+++ b/scripts/zones/Port_San_dOria/Zone.lua
@@ -27,7 +27,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Port_Windurst/Zone.lua
+++ b/scripts/zones/Port_Windurst/Zone.lua
@@ -27,7 +27,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTransportEvent = function(player, prevZoneId, transportName)

--- a/scripts/zones/RuLude_Gardens/Zone.lua
+++ b/scripts/zones/RuLude_Gardens/Zone.lua
@@ -13,7 +13,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Southern_San_dOria/Zone.lua
+++ b/scripts/zones/Southern_San_dOria/Zone.lua
@@ -20,7 +20,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
+    if updatetype == xi.conquest.constants.TALLY_END then
+        xi.conquest.toggleRegionalNPCs(zone)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Upper_Jeuno/Zone.lua
+++ b/scripts/zones/Upper_Jeuno/Zone.lua
@@ -13,7 +13,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Windurst_Walls/Zone.lua
+++ b/scripts/zones/Windurst_Walls/Zone.lua
@@ -13,7 +13,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Windurst_Waters/Zone.lua
+++ b/scripts/zones/Windurst_Waters/Zone.lua
@@ -16,7 +16,7 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)

--- a/scripts/zones/Windurst_Woods/Zone.lua
+++ b/scripts/zones/Windurst_Woods/Zone.lua
@@ -16,7 +16,10 @@ zoneObject.onZoneIn = function(player, prevZone)
 end
 
 zoneObject.onConquestUpdate = function(zone, updatetype, influence, owner, ranking, isConquestAlliance)
-    xi.conquest.onConquestUpdate(zone, updatetype, influence, owner, ranking, isConquestAlliance)
+    xi.conquest.onNonRegionConquestUpdate(zone, updatetype, ranking, isConquestAlliance)
+    if updatetype == xi.conquest.constants.TALLY_END then
+        xi.conquest.toggleRegionalNPCs(zone)
+    end
 end
 
 zoneObject.onTriggerAreaEnter = function(player, triggerArea)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The hourly conquest message shouldn't display in Dynamis, only the weekly message. It behaves just like cities.

Weekly update
<img width="1847" height="515" alt="image" src="https://github.com/user-attachments/assets/a7a91c3f-64e2-44fe-bd1c-de1b703071d1" />

## Steps to test these changes

Zone into one of the Dynamis zones. Do !updateconquest 0 to see weekly. Watch the hourly tick over.
