### PR TITLE
Olduum Quest Bug Fixes and Era Module

### DIFF
--- a/data/zones/wajaom_woodlands/npcs.yaml
+++ b/data/zones/wajaom_woodlands/npcs.yaml
@@ -813,18 +813,9 @@ npcs:
     script: blank
     render:
       look:
-        type:  equipped
-        race:  2
-        face:  2
-        head:  4096
-        body:  8363
-        hands: 12463
-        legs:  16555
-        feet:  20655
-        main:  24576
-        sub:   28672
-      entity_flags: 27
-      name_prefix:  32
+        type:  standard
+        model: 50
+      entity_flags: 2051
     speed:           40
     animation_speed: 40
 

--- a/modules/era/lua/quests/ahturhgan/olduum.lua
+++ b/modules/era/lua/quests/ahturhgan/olduum.lua
@@ -1,0 +1,31 @@
+-----------------------------------
+-- Olduum
+-- Restores the 24-hour wait for another Olduum Ring.
+-- The June 7, 2016 update reduced this to one minute.
+-----------------------------------
+-- Source: https://forum.square-enix.com/ffxi/threads/50760-Jun.-7-2016-(JST)-Version-Update
+-- Source: https://wiki.ffo.jp/html/7472.html
+-----------------------------------
+require('modules/module_utils')
+-----------------------------------
+local m = Module:new('era_quest_olduum', xi.pre(xi.expansion.ROV))
+
+m:addOverride('xi.server.onServerStart', function()
+    super()
+
+    xi.module.modifyInteractionEntry('scripts/quests/ahtUrhgan/Olduum', function(quest)
+        local wajaom          = quest.sections[3][xi.zone.WAJAOM_WOODLANDS]
+        local baseEventFinish = wajaom.onEventFinish[2]
+
+        wajaom.onEventFinish[2] = function(player, csid, option, npc)
+            local previousWait = quest:getVar(player, 'Wait')
+            local result       = baseEventFinish(player, csid, option, npc)
+
+            if quest:getVar(player, 'Wait') ~= previousWait then
+                quest:setVar(player, 'Wait', GetSystemTime() + 86400) -- Module change
+            end
+
+            return result
+        end
+    end)
+end)

--- a/scripts/quests/ahtUrhgan/Olduum.lua
+++ b/scripts/quests/ahtUrhgan/Olduum.lua
@@ -19,14 +19,14 @@ local keyItems =
     xi.ki.ELECTROLOCOMOTIVE,
 }
 
-local hasQuestKeyItem = function(player)
-    for _, v in pairs(keyItems) do
-        if player:hasKeyItem(v) then
-            return true
+local function getQuestKeyItem(player)
+    for _, keyItem in ipairs(keyItems) do
+        if player:hasKeyItem(keyItem) then
+            return keyItem
         end
     end
 
-    return false
+    return xi.ki.NONE
 end
 
 quest.sections =
@@ -67,20 +67,32 @@ quest.sections =
             ['Dkhaaya'] =
             {
                 onTrigger = function(player, npc)
-                    if hasQuestKeyItem(player) then
-                        return quest:progressEvent(6)
+                    local questKeyItem = getQuestKeyItem(player)
+
+                    if questKeyItem > 0 then
+                        return quest:progressEvent(6, { [0] = questKeyItem })
                     else
                         return quest:event(5)
                     end
                 end
             },
 
+            onEventUpdate =
+            {
+                [6] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:updateEvent(keyItems[quest:getVar(player, 'Prog')])
+                    end
+                end,
+            },
+
             onEventFinish =
             {
                 [6] = function(player, csid, option, npc)
+                    local cellKeyItem = keyItems[quest:getVar(player, 'Prog')]
+
                     if quest:complete(player) then
-                        player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
-                        player:delKeyItem(xi.ki.DKHAAYAS_RESEARCH_JOURNAL)
+                        player:delKeyItem(cellKeyItem)
                     end
                 end,
             },
@@ -93,7 +105,7 @@ quest.sections =
                 onTrade = function(player, npc, trade)
                     if
                         not player:hasItem(xi.item.OLDUUM_RING) and
-                        not hasQuestKeyItem(player) and
+                        getQuestKeyItem(player) == xi.ki.NONE and
                         npcUtil.tradeMatches(trade, { { xi.item.PICKAXE, 1 } })
                     then
                         if math.randomInt(1, 100) <= 50 then
@@ -134,32 +146,73 @@ quest.sections =
             ['Dkhaaya'] =
             {
                 onTrigger = function(player, npc)
-                    if hasQuestKeyItem(player) then
-                        return quest:progressEvent(8)
-                    elseif
+                    if
                         player:hasItem(xi.item.OLDUUM_RING) or
-                        player:hasItem(xi.item.LIGHTNING_BAND)
+                        player:hasItem(xi.item.LIGHTNING_BAND) or
+                        quest:getVar(player, 'Wait') > GetSystemTime()
                     then
-                        return quest:event(7)
-                    else
-                        local newRingCS = player:getLocalVar('RingCS')
-                        player:setLocalVar('RingCS', newRingCS + 1)
-                        if newRingCS > 1 then
-                            newRingCS = 1
+                        return quest:progressEvent(7)
+                    end
+
+                    if quest:getVar(player, 'Reissue') == 1 then
+                        local questKeyItem = getQuestKeyItem(player)
+
+                        if questKeyItem > 0 then
+                            return quest:progressEvent(8, { [0] = questKeyItem })
                         end
 
-                        return quest:event(7, { [7] = newRingCS + 1 })
+                        return quest:progressEvent(7, { [7] = 2 })
+                    end
+
+                    return quest:progressEvent(7, { [7] = 1 })
+                end,
+            },
+
+            onEventUpdate =
+            {
+                [8] = function(player, csid, option, npc)
+                    if option == 1 then
+                        player:updateEvent(keyItems[quest:getVar(player, 'Prog')])
                     end
                 end,
             },
 
             onEventFinish =
             {
-                [8] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.LIGHTNING_BAND) then
-                        player:delKeyItem(keyItems[quest:getVar(player, 'Prog')])
-                        quest:setVar(player, 'Prog', 0)
+                [7] = function(player, csid, option, npc)
+                    if
+                        option ~= 99 or
+                        player:hasItem(xi.item.OLDUUM_RING) or
+                        player:hasItem(xi.item.LIGHTNING_BAND) or
+                        getQuestKeyItem(player) > 0 or
+                        quest:getVar(player, 'Wait') > GetSystemTime()
+                    then
+                        return
                     end
+
+                    quest:setVar(player, 'Reissue', 1)
+                end,
+
+                [8] = function(player, csid, option, npc)
+                    local questKeyItem = getQuestKeyItem(player)
+
+                    if
+                        questKeyItem == xi.ki.NONE or
+                        player:hasItem(xi.item.OLDUUM_RING) or
+                        player:hasItem(xi.item.LIGHTNING_BAND) or
+                        quest:getVar(player, 'Reissue') ~= 1 or
+                        quest:getVar(player, 'Wait') > GetSystemTime()
+                    then
+                        return
+                    end
+
+                    if not npcUtil.giveItem(player, xi.item.LIGHTNING_BAND) then
+                        return
+                    end
+
+                    player:delKeyItem(questKeyItem)
+                    quest:setVar(player, 'Prog', 0)
+                    quest:setVar(player, 'Reissue', 0)
                 end,
             },
         },
@@ -170,8 +223,11 @@ quest.sections =
             {
                 onTrade = function(player, npc, trade)
                     if
+                        quest:getVar(player, 'Reissue') == 1 and
+                        quest:getVar(player, 'Wait') <= GetSystemTime() and
                         not player:hasItem(xi.item.OLDUUM_RING) and
-                        not hasQuestKeyItem(player) and
+                        not player:hasItem(xi.item.LIGHTNING_BAND) and
+                        getQuestKeyItem(player) == xi.ki.NONE and
                         npcUtil.tradeMatches(trade, { { xi.item.PICKAXE, 1 } })
                     then
                         if math.randomInt(1, 100) <= 50 then
@@ -205,9 +261,14 @@ quest.sections =
             ['Leypoint'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeMatches(trade, { { xi.item.LIGHTNING_BAND, 1 } }) then
+                    if
+                        not player:hasItem(xi.item.OLDUUM_RING) and
+                        npcUtil.tradeMatches(trade, { { xi.item.LIGHTNING_BAND, 1 } })
+                    then
                         if player:getFreeSlotsCount() == 0 then
-                            return quest:messageSpecial(zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED)
+                            return quest:messageSpecial(
+                                zones[player:getZoneID()].text.ITEM_CANNOT_BE_OBTAINED,
+                                xi.item.OLDUUM_RING)
                         else
                             return quest:progressEvent(2)
                         end
@@ -224,8 +285,12 @@ quest.sections =
             onEventFinish =
             {
                 [2] = function(player, csid, option, npc)
-                    if npcUtil.giveItem(player, xi.item.OLDUUM_RING) then
+                    if
+                        not player:hasItem(xi.item.OLDUUM_RING) and
+                        npcUtil.giveItem(player, xi.item.OLDUUM_RING)
+                    then
                         player:tradeComplete()
+                        quest:setVar(player, 'Wait', GetSystemTime() + 60) -- 1 minute
                     end
                 end,
             },


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR fixes an issue with the Olduum quest where the key item you excavate was not getting deleted properly on turn in. Also fixes some dialogue errors and blocks inappropriate replacement quest progression while holding key items and the olduum ring. It also adds an era module for the era wait time.

## Steps to test these changes

Run the quest and see you now properly lose the key item and can't repeat the quest freely without meeting the requirements. Load the module and see the repeat time is gated to once per JST midnight.

## Capture

Siknoz

[Quests - Toau - Olduum + Trade For Ring.zip](https://github.com/user-attachments/files/31905361/Quests.-.Toau.-.Olduum.%2B.Trade.For.Ring.zip)
