### PR TITLE
Scale Conquest influence gain based on current influence

### DIFF
--- a/src/world/conquest_system.cpp
+++ b/src/world/conquest_system.cpp
@@ -145,6 +145,19 @@ bool ConquestSystem::updateInfluencePoints(int points, unsigned int nation, REGI
         rset->get<int>("windurst_influence"),
     };
 
+    // Nation gets a multiplier based on their current ranking in the region. 1st place gets 1x.
+    // For 2nd and 3rd place, if their influence is less than half the 1st place's influence, they get 3x.
+    // Else, 2nd and 3rd place get a 2x multiplier.
+    const int firstPlaceInfluence = std::max({ influences[0], influences[1], influences[2] });
+    if (influences[nation] < firstPlaceInfluence / 2)
+    {
+        points *= 3;
+    }
+    else if (influences[nation] < firstPlaceInfluence)
+    {
+        points *= 2;
+    }
+
     const int total = influences[0] + influences[1] + influences[2];
 
     // Read from main settings. Protect against 0 or too high of number.


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

There is a catch-up mechanic in Conquest for influence. If a nation is not in first, they get a 3x multiplier if below 1/2 the influence of the first place nation, else their multiplier is 2x.

Additionally, Conquest influence is only based off of the base exp rate, not the chain exp rate. This will be changed in an additional follow-up PR.

## Captures
Here is a capture right after reset of me exping off of mobs (all the exact same level) on different nations; same character.

The model is assuming influence = base xp where as on LSB we do influence = CP * 1.5 / 10. (I think retail may just do base xp)

<img width="1617" height="439" alt="image" src="https://github.com/user-attachments/assets/15cb1df4-8ef3-4e21-bb5f-af24b729de2b" />
https://youtu.be/PZFheaJ7Hn4
https://drive.google.com/file/d/1IG9HXl_I1KIttBTWjCh995iMnveCnvht/view?usp=drive_link
There is a little more data in this capture, but this is the most relevant.

I have a few more captures where this is observed when trading equipment for influence in the different regions. For equipment trading, there are 3 messages. 

Small Amount < 200/400/600 gil sell value depending on current influence.
Medium Amount < 2000/4000/6000 gil sell value depending on current influence.
This demonstrates there is a 1x/2x/3x multiplier that exists that appears at the same conditions as mentioned above.
All those captures are located at https://drive.google.com/drive/folders/16o3I08D33cu49SkMUixjQrEkTQT2YH1L?usp=drive_link
I can get more granular data or videos if you need.

## Steps to test these changes

!updateconquest 0 to reset
Go kill the mobs in the order to mimic the capture with Signet.