### PR TITLE
Add nil check to sky god death

### DIFF
--- a/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Byakko.lua
@@ -61,7 +61,9 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.SKY_GOD_OFFSET + 12)
+    if player then
+        player:showText(mob, ID.text.SKY_GOD_OFFSET + 12)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Genbu.lua
@@ -67,7 +67,9 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.SKY_GOD_OFFSET + 6)
+    if player then
+        player:showText(mob, ID.text.SKY_GOD_OFFSET + 6)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Seiryu.lua
@@ -87,7 +87,9 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.SKY_GOD_OFFSET + 10)
+    if player then
+        player:showText(mob, ID.text.SKY_GOD_OFFSET + 10)
+    end
 end
 
 entity.onMobDespawn = function(mob)

--- a/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
+++ b/scripts/zones/RuAun_Gardens/mobs/Suzaku.lua
@@ -75,7 +75,9 @@ entity.onAdditionalEffect = function(mob, target, damage)
 end
 
 entity.onMobDeath = function(mob, player, optParams)
-    player:showText(mob, ID.text.SKY_GOD_OFFSET + 8)
+    if player then
+        player:showText(mob, ID.text.SKY_GOD_OFFSET + 8)
+    end
 end
 
 entity.onMobDespawn = function(mob)


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Adds a nil guard to the sky god death messages incase player is nil, similar to the guard we added to titles.

## Steps to test these changes

!hp 0 some idle sky gods, see no error in log
