### PR TITLE
[lua] Fix Tenshodo Membership Quest Requirements

### DIFF
--- a/scripts/quests/jeuno/Tenshodo_Membership.lua
+++ b/scripts/quests/jeuno/Tenshodo_Membership.lua
@@ -19,8 +19,7 @@ quest.sections =
 {
     {
         check = function(player, status, vars)
-            return status == xi.questStatus.QUEST_AVAILABLE and
-                player:getFameLevel(xi.fameArea.JEUNO) >= 3
+            return status == xi.questStatus.QUEST_AVAILABLE
         end,
 
         [xi.zone.LOWER_JEUNO] =
@@ -28,16 +27,18 @@ quest.sections =
             ['Ghebi_Damomohe'] =
             {
                 onTrade = function(player, npc, trade)
-                    if npcUtil.tradeHasExactly(trade, { xi.item.TENSHODO_INVITE }) then
+                    if npcUtil.tradeMatches(trade, { { xi.item.TENSHODO_INVITE, 1 } }) then
                         return quest:progressEvent(108)
                     end
                 end,
 
                 onTrigger = function(player, npc)
-                    if player:hasKeyItem(xi.keyItem.TENSHODO_APPLICATION_FORM) then
-                        return quest:progressEvent(107)
-                    else
-                        return quest:event(106)
+                    if player:getFameLevel(xi.fameArea.JEUNO) >= 3 then
+                        if player:hasKeyItem(xi.keyItem.TENSHODO_APPLICATION_FORM) then
+                            return quest:progressEvent(107)
+                        else
+                            return quest:event(106)
+                        end
                     end
                 end,
             },


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Allows the Tenshodo Membership quest to be completed without any fame and instead gates the hidden menu option behind rank 3 fame. 

## Capture
https://www.youtube.com/watch?v=lydwW-rB-I8

## Source
https://wiki.ffo.jp/html/12913.html

## Steps to test these changes

Make a brand new character, check the event menu, see no hidden option - turn in a tenshodo invite, get accepted to the Tenshodo
Make a 2nd character, get rank 3 fame, see hidden option
