### PR TITLE
Make Conquest influence be based on exp instead of CP

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -633,7 +633,6 @@ uint32 AddConquestPoints(CCharEntity* PChar, uint32 exp)
         const uint32 points = static_cast<uint32>(static_cast<double>(exp) * percentage);
 
         charutils::AddPoints(PChar, charutils::GetConquestPointsName(PChar).c_str(), points);
-        GainInfluencePoints(PChar, points / 2);
     }
     return 0; // added conquest points
 }

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -5026,8 +5026,12 @@ void AddExperiencePoints(bool expFromRaise, bool awardRegionPoints, bool fromScr
         // Should this user be awarded conquest points..
         if (PChar->StatusEffectContainer->HasStatusEffect(xi::StatusEffect::Signet) && (region >= REGION_TYPE::RONFAURE && region <= REGION_TYPE::JEUNO))
         {
-            // Add influence for the players region..
+            // Add CP to the player.
             conquest::AddConquestPoints(PChar, exp);
+
+            // Add influence for the player's region.
+            // TODO: Chain exp should not affect influence.
+            conquest::GainInfluencePoints(PChar, exp / 20);
         }
 
         // Should this user be awarded imperial standing..


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Conquest influence is not based on CP at all. It seems to be based on the exp gained before the exp chain is applied. I have not been able to confirm what exp specifically it is, but we need to detach it from CP since CP can get a 1.5x or 2x multiplier. I added a "// TODO" to figure this out. CP is still based on the actual exp.

PR #11408 demonstrates that the influence is based on the XP and not the Chain XP.

From the below capture, we can see that the Current LSB model is incorrect. If we do not use the CP scaling and we use the 1x/2x/3x multiplier, we match what is seen on retail.

<img width="2351" height="220" alt="image" src="https://github.com/user-attachments/assets/ccf07f3a-48f1-46f1-99e2-e1212c3dcf30" />

Capture Video: https://youtu.be/PZFheaJ7Hn4
Capture: https://drive.google.com/file/d/1IG9HXl_I1KIttBTWjCh995iMnveCnvht/view?usp=drive_link

Additionally, there is a separate Moghancement for Region and Conquest where one increases CP gained and one increases Influence Points gained. https://wiki.ffo.jp/html/5555.html

The "/ 20" is left in there to scale the influence to a similar scale that exists on current LSB; CP scales by "/ 10" and then points scales by "CP / 2". Current behavior also means exp < 20 gives 0 influence. I need to look into it more, but I don't think that scale should be there at all, but I want to do a more thorough check before I remove that scaling.

## Steps to test these changes

Have a zone be controlled by a nation. Kill a mob with each of the nations to view the exp gain matches the capture.
!updateconquest 0 - Resets conquest
!setplayernation 0/1/2 changes nation

## Conquest TODOs after this
This is for my reference or those who come after.
- Implement equipment trading for influence
- Moghancement for influence currently goes to 0 every time
- No exp loss on death = no beastmen influence gain
- Check scaling of influence points (The "/ 20")
- More testing as to what exp specifically affects influence.
- Alliance fixes: Capture an alliance beating first place and fix the packet.
- Fix Beastmen messages on the hourly update
- Figure out secondary between nation system. This is what the weekly ranking is actually based on, not regions owned.
