### PR TITLE
[Core] Fix several mob casting behaviors

### DIFF
--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -176,7 +176,8 @@ auto CMobController::Engage(const EntityId& target) -> bool
     // Optional opening delays so we don't immediately cast / use a special ability on engage.
     if (PMob->getMobMod(xi::MobMod::MagicDelay) != 0)
     {
-        m_nextMagicTime = m_Tick + std::chrono::seconds(PMob->getMobMod(xi::MobMod::MagicCool) + xirand::GetRandomNumber(PMob->getMobMod(xi::MobMod::MagicDelay)));
+        // Fetch remaining magic cooldown and apply magic delay on top of it.
+        m_nextMagicTime = std::max(m_nextMagicTime, m_Tick) + std::chrono::seconds(xirand::GetRandomNumber(PMob->getMobMod(xi::MobMod::MagicDelay)));
     }
 
     if (PMob->getMobMod(xi::MobMod::SpecialDelay) != 0)
@@ -212,9 +213,10 @@ void CMobController::Reset()
     // Wait a little while before roaming again.
     m_LastActionTime = m_Tick - std::chrono::seconds(xirand::GetRandomNumber(PMob->getMobMod(xi::MobMod::RoamCool)));
 
-    // Don't attack player right off of spawn
+    // Don't attack player right off of spawn // Don't cast magic immediately either
     PMob->m_neutral = true;
     m_NeutralTime   = m_Tick;
+    m_nextMagicTime = m_Tick + 1500ms;
 
     setTarget(nullptr);
     ClearFollowTarget();

--- a/src/map/ai/states/magic_state.cpp
+++ b/src/map/ai/states/magic_state.cpp
@@ -264,6 +264,13 @@ auto CMagicState::Update(timer::time_point tick) -> bool
         if (battleutils::IsParalyzed(m_PEntity))
         {
             ActionInterrupts::MagicParalyzed(m_PEntity, m_PSpell.get(), PTarget);
+
+            // If Paralyzed entity is a mob, reset their magic cooldown.
+            if (auto* mobController = dynamic_cast<CMobController*>(m_PEntity->PAI->GetController()))
+            {
+                mobController->OnCastStopped(*this, action);
+            }
+
             Complete();
             return false;
         }
@@ -271,6 +278,13 @@ auto CMagicState::Update(timer::time_point tick) -> bool
         if (battleutils::IsIntimidated(m_PEntity, PTarget))
         {
             ActionInterrupts::MagicIntimidated(m_PEntity, m_PSpell.get(), PTarget);
+
+            // If Intimidated entity is a mob, reset their magic cooldown.
+            if (auto* mobController = dynamic_cast<CMobController*>(m_PEntity->PAI->GetController()))
+            {
+                mobController->OnCastStopped(*this, action);
+            }
+
             Complete();
             return false;
         }

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1171,27 +1171,22 @@ void SetupJob(CMobEntity* PMob)
             break;
         case xi::Job::PLD:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 7);
             break;
         case xi::Job::DRK:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 7);
             break;
         case xi::Job::WHM:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 10);
             break;
         case xi::Job::BRD:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
             PMob->defaultMobMod(xi::MobMod::GaChance, 25);
             PMob->defaultMobMod(xi::MobMod::BuffChance, 60);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 10);
             break;
         case xi::Job::RDM:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
             PMob->defaultMobMod(xi::MobMod::GaChance, 15);
             PMob->defaultMobMod(xi::MobMod::BuffChance, 40);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 10);
             break;
         case xi::Job::SMN:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 70);
@@ -1201,7 +1196,6 @@ void SetupJob(CMobEntity* PMob)
             PMob->defaultMobMod(xi::MobMod::SpecialCool, 9);
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);
             PMob->defaultMobMod(xi::MobMod::BuffChance, 20);
-            PMob->defaultMobMod(xi::MobMod::MagicDelay, 7);
             break;
         case xi::Job::BLU:
             PMob->defaultMobMod(xi::MobMod::MagicCool, 35);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Mobs now wait 1.5s to cast their first spell after spawning - this resolves an issue where mobs would begin casting before even fully rendering, and the "mob begins casting spell" wouldn't show in the log.

* Reworked how the magic delay mod works in Engage, now fetches remaining spell cooldown time and places the magic delay time on top of it.

* Removed magic delay from several jobs after observing no such delays present on retail.

* Paralyzed / Intimidated mobs now have their spell cooldown consumed, this resolves a bug where mobs would begin casting immediately after being interrupted. 

## Captures
Casting Delay Captures
https://youtu.be/NTjxgDX77EI
https://youtu.be/axecqo3eRYA
https://youtu.be/SVWVu1b3mvc

Paralysis consumes magic cooldown
https://youtu.be/4n0lY0aQnHk

Intimidate consumes magic cooldown
https://youtu.be/221Y0RMjpiI

## Steps to test these changes

!zone Ro Meave
!changejob RDM 99
Paralyze an Infernal Weapon, observe magic cooldown reset on paralysis proc.
!changejob DRK 99 
Observe magic cooldown reset on intimidation proc.
!zone West Sarutabaruta
Find a Yagudo Scribe, observe them cast immediately on aggroing them.
