### PR TITLE
Implement gear trading for Conquest influence

### DIFF
--- a/scripts/globals/conquest.lua
+++ b/scripts/globals/conquest.lua
@@ -1751,6 +1751,60 @@ xi.conquest.vendorOnEventFinish = function(player, option, vendorRegion)
     end
 end
 
+-- TODO: Handle Evoliths
+-- Patch notes on February 26, 2004 mentions a cap per region per nation. 813,126 gil of equipment was traded and no cap was found.
+xi.conquest.vendorOnTrade = function(player, npc, trade)
+    local text          = zones[player:getZoneID()].text
+    local gilTotal      = 0
+    local rejectedCount = 0
+    local slotCount     = trade:getSlotCount()
+
+    -- Check Trade. Only weapons, armor, and ammunition that have sell value.
+    for slot = 0, slotCount - 1 do
+        local item      = trade:getItem(slot)
+        local itemWorth = item:getBasePrice()
+
+        if
+            item:isType(xi.itemType.ARMOR) and -- Covers weapons, armor, and ammunition
+            itemWorth > 0 and
+            bit.band(item:getFlag(), xi.itemFlag.NO_SALE) == 0
+        then
+            gilTotal = gilTotal + itemWorth * trade:getSlotQty(slot)
+        else
+            rejectedCount = rejectedCount + 1
+        end
+    end
+
+    -- Deal with items that can not be traded.
+    if rejectedCount == slotCount then
+        player:messageText(npc, text.CONQUEST + 88, 2) -- "Sorry. I can only take certain types of weapons, shields, or armor."
+        return
+    elseif rejectedCount > 0 then
+        player:messageText(npc, text.CONQUEST + 87, 2) -- "I could not accept one or more items you tried to trade me. Please remove those items and try again."
+        return
+    end
+
+    -- Exchange rate is 1 gil = 1 exp worth of influence at standard rates. LSB divides exp by 20. Cannot receive 0 influence from trade.
+    local influenceGain = math.max(1, math.floor(gilTotal / 20))
+
+    if not player:tradeComplete() then
+        return
+    end
+
+    player:gainConquestInfluence(influenceGain)
+
+    -- Send success message to user
+    -- TODO: Retail updates the current influence values with a packet push, applies the multiplier (1x/2x/3x), then checks against the threshold.
+    --       We would need to force update the influence values on map, then calculate the expected multiplier before displaying the message.
+    if gilTotal < 600 then
+        player:messageText(npc, text.CONQUEST + 84, 2) -- "Thank you. This will increase your nation's region points by a small amount. If you have anything else, by all means, trade them to me."
+    elseif gilTotal < 6000 then
+        player:messageText(npc, text.CONQUEST + 85, 2) -- "Thank you. This will increase your nation's region points moderately. If you have anything else, by all means, trade them to me."
+    else
+        player:messageText(npc, text.CONQUEST + 86, 2) -- "Thank you. This will increase your nation's region points greatly. If you have anything else, by all means, trade them to me."
+    end
+end
+
 -----------------------------------
 -- (PUBLIC) outpost teleport NPC
 -----------------------------------

--- a/scripts/zones/Beaucedine_Glacier/npcs/Gueriette.lua
+++ b/scripts/zones/Beaucedine_Glacier/npcs/Gueriette.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.FAUREGANDI
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Buburimu_Peninsula/npcs/Lobho_Ukipturi.lua
+++ b/scripts/zones/Buburimu_Peninsula/npcs/Lobho_Ukipturi.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.KOLSHUSHU
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Cape_Teriggan/npcs/Bright_Moon.lua
+++ b/scripts/zones/Cape_Teriggan/npcs/Bright_Moon.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.VOLLBOW
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Eastern_Altepa_Desert/npcs/Sowande.lua
+++ b/scripts/zones/Eastern_Altepa_Desert/npcs/Sowande.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.KUZOTZ
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Jugner_Forest/npcs/Mionie.lua
+++ b/scripts/zones/Jugner_Forest/npcs/Mionie.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.NORVALLEN
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Lufaise_Meadows/npcs/Jersey.lua
+++ b/scripts/zones/Lufaise_Meadows/npcs/Jersey.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.TAVNAZIANARCH
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Meriphataud_Mountains/npcs/Mushosho.lua
+++ b/scripts/zones/Meriphataud_Mountains/npcs/Mushosho.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.ARAGONEU
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/North_Gustaberg/npcs/Kuleo.lua
+++ b/scripts/zones/North_Gustaberg/npcs/Kuleo.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.GUSTABERG
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Oldton_Movalpolos/IDs.lua
+++ b/scripts/zones/Oldton_Movalpolos/IDs.lua
@@ -18,6 +18,7 @@ zones[xi.zone.OLDTON_MOVALPOLOS] =
         LOGIN_NUMBER                  = 7008, -- In celebration of your most recent login (login no. <number>), we have provided you with <number> points! You currently have a total of <number> points.
         MEMBERS_LEVELS_ARE_RESTRICTED = 7028, -- Your party is unable to participate because certain members' levels are restricted.
         CONQUEST_BASE                 = 7073, -- Tallying conquest results...
+        CONQUEST                      = 7241, -- You've earned conquest points!
         FISHING_MESSAGE_OFFSET        = 7592, -- You can't fish here.
         MINING_IS_POSSIBLE_HERE       = 7724, -- Mining is possible here if you have <item>.
         NO_FIRES_NO_BOMBS             = 7731, -- This place being for garbage. No fires. No bombs.

--- a/scripts/zones/Oldton_Movalpolos/npcs/Bartabaq.lua
+++ b/scripts/zones/Oldton_Movalpolos/npcs/Bartabaq.lua
@@ -7,12 +7,15 @@
 ---@type TNpcEntity
 local entity = {}
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, xi.region.MOVALPOLOS, 32756)
 end
 
 -- TODO: Implement evoliths trading.
--- TODO: Check if you can trade equipment.
 
 entity.onEventFinish = function(player, csid, option, npc)
     if option == 1 then

--- a/scripts/zones/Pashhow_Marshlands/npcs/Tahmasp.lua
+++ b/scripts/zones/Pashhow_Marshlands/npcs/Tahmasp.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.DERFLAND
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Qufim_Island/npcs/Jiwon.lua
+++ b/scripts/zones/Qufim_Island/npcs/Jiwon.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.QUFIMISLAND
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Kasim.lua
+++ b/scripts/zones/The_Sanctuary_of_ZiTah/npcs/Kasim.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.LITELOR
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Valkurm_Dunes/npcs/Medicine_Axe.lua
+++ b/scripts/zones/Valkurm_Dunes/npcs/Medicine_Axe.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.ZULKHEIM
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/West_Ronfaure/npcs/Harvetour.lua
+++ b/scripts/zones/West_Ronfaure/npcs/Harvetour.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.RONFAURE
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/West_Sarutabaruta/npcs/Mahien-Uhien.lua
+++ b/scripts/zones/West_Sarutabaruta/npcs/Mahien-Uhien.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.SARUTABARUTA
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Xarcabard/npcs/Pelogrant.lua
+++ b/scripts/zones/Xarcabard/npcs/Pelogrant.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.VALDEAUNIA
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Yhoator_Jungle/npcs/Mugha_Dovajaiho.lua
+++ b/scripts/zones/Yhoator_Jungle/npcs/Mugha_Dovajaiho.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.ELSHIMO_UPLANDS
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/scripts/zones/Yuhtunga_Jungle/npcs/Robino-Mobino.lua
+++ b/scripts/zones/Yuhtunga_Jungle/npcs/Robino-Mobino.lua
@@ -10,6 +10,10 @@ local entity = {}
 local vendorRegion  = xi.region.ELSHIMO_LOWLANDS
 local vendorEvent   = 32756
 
+entity.onTrade = function(player, npc, trade)
+    xi.conquest.vendorOnTrade(player, npc, trade)
+end
+
 entity.onTrigger = function(player, npc)
     xi.conquest.vendorOnTrigger(player, vendorRegion, vendorEvent)
 end

--- a/settings/default/main.lua
+++ b/settings/default/main.lua
@@ -208,7 +208,7 @@ xi.settings.main =
     NM_LOTTERY_COOLDOWN = 1.0,
 
     -- CONQUEST SETTINGS
-    CONQUEST_INFLUENCE_CAP = 250000, -- Combined influence pool per region shared across the 4 nations. Ceiling is 20 million.
+    CONQUEST_INFLUENCE_CAP = 10000000, -- Combined influence pool per region shared across the 4 nations. Ceiling is 20 million.
 
     -- GARRISON SETTINGS
     ENABLE_GARRISON        = true,  -- If true, enables garrison functionality


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- Implements trading weapons, armor, and ammunition for Conquest influence.
- Adds a gil cap to trading: we traded over 800,000 gil worth of equipment and never hit the cap. It's mentioned in patch notes (https://www.playonline.com/comnewsus/200402264502.html) so I put a gil cap in the settings and set it to 10 million gil. It silently rejects trades if above that cap. I found threads of players talking about donating several million gil worth of items, so I suspect the threshold is above 1 million gil.
- Updates the CONQUEST_INFLUENCE_CAP default setting to 10 million based on further testing. This is to help support this and all other recent influence changes.

The trading system is fairly straight forward.
- Influence gain is based solely on equipment sell value
- Any weapon, armor, ammunition can be traded if it is sellable and has sell value. You can trade multiple at once. If you try trading something invalid, you get one of two messages depending on if all are invalid or some are invalid.
- Influence gain feeds into the 1x/2x/3x multiplier outlined in PR #11408. That PR already handles the multiplier. (Mentioned this for capture information below)
- Sends a message based on how much the sell value is worth.
- Has an unknown cap based on https://www.playonline.com/comnewsus/200402264502.html

## Captures

Because you can trade multiple items, arrows (worth 1 gil each) allowed you to get exact values. There are 3 messages based on amount of influence. The two thresholds were found to be 200/400/600 and 2000/4000/6000 (Differs because of the 3x/2x/1x influence multiplier).  This is how it was determined influence was based on sell value.
Capture 1: https://drive.google.com/file/d/1-QV8F84G2WlnSs2hJQ1-RVUrobZ7mVkA/view?usp=drive_link
Capture 2: https://drive.google.com/file/d/1zZ0pelEMiGbhvVAF15ZeWt3l013RC7DT/view?usp=drive_link
Capture 3: https://drive.google.com/file/d/1DCB9Z_syM7gIOB3pVXmhQIZUZGHRfk4m/view?usp=drive_link

It was tracked to be about 1 exp = 1 gil sell value.
Capture 1: https://drive.google.com/file/d/1KTgbAx364060LJTbXIOOzThtY9SXZ_bR/view?usp=drive_link
Capture 2: https://drive.google.com/file/d/18nwin04r469xfqPTIX06y3SpP9aIPRWl/view?usp=drive_link

Here's a subset of that data from the three captures above that shows the 1 gil to 1 exp worth of influence ratio. Note, Sandoria had some influence before the test started but no one else gained influence during the test. I killed something as Windurst, then swapped to Bastok and traded equipment.
<img width="1002" height="283" alt="image" src="https://github.com/user-attachments/assets/5dda498a-1027-4626-b40a-b461cab4cb83" />

Skold did a test to try trading multiple items. That's how the allowable items were determined.
Capture: https://drive.google.com/file/d/1Km8SRP07IIxCAx1PKHLRKP2O4UndHwO9/view?usp=drive_link
| Accepted | Rejected |
|---|---|
| acheron_shield | genbus_kabuto |
| amity_cape | aurore_gloves |
| archers_knife | aurore_doublet |
| brave_belt | tactician_magicians_wand |
| brigandine_armor | kirins_pole |
| combat_casters_slacks | byakkos_axe |
| corsairs_knife | subduer |
| custom_f_gloves | eminent_scimitar |
| empress_hairpin | |
| exactitude_mantle | |
| fuma_kyahan | |
| halberd_+1 | |
| harpe | |
| headlong_belt | |
| hoplites_harpe | |
| horomusha_kote | |
| jujitsu_gi | |
| mercenary_captains_belt | |
| mercenary_captains_doublet | |
| republic_subligar | |
| royal_squires_breeches | |
| royal_squires_chainmail | |
| scorpion_harness | |
| thundercloud | |
| thunderers_mantle | |
| traders_saio | |
| wise_wizards_anelace | |

Repeated trades for diminishing returns were tested and found to most likely not exist. People on forums probably got enough to go above a threshold so the multiplier (1x/2x/3x) changed making it appear to have diminishing returns.
Capture: https://drive.google.com/file/d/1P6eNRAGaSAL_xuh2qJr7qS2vjX0ajt7x/view?usp=drive_link

## Steps to test these changes

Can add pebbles into your inventory as well as items that can not be traded like Eminent scimitar.
Go to outpost.
Trade Pebble for small increase.
Trade Eminent Scimitar.
Trade both Pebble and Eminent Scimitar.
Trade Acheron Shield for major increase.
Trade 3x Bone Axe for medium increase.
Check the server variable (I added a temporary print() in lua)

I did this for every outpost vendor. There is a vendor in every region except Sky.