### PR TITLE
Add Effect Tiers to Slow TP Moves / Audit Yovra Abilities

### DIFF
--- a/scripts/actions/mobskills/bai_wing.lua
+++ b/scripts/actions/mobskills/bai_wing.lua
@@ -30,7 +30,12 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 9000, 0, 120)
+        local effectTable =
+        {
+            [1] = { effectId = xi.effect.SLOW, power = 9000, duration = 120, tier = 8 },
+        }
+
+        xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, { messageBypass = true })
     end
 
     return info.damage

--- a/scripts/actions/mobskills/chemical_bomb.lua
+++ b/scripts/actions/mobskills/chemical_bomb.lua
@@ -10,11 +10,13 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.ELEGY, 5000, 0, 120))
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 120))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.ELEGY, power = 5000, duration = 120           },
+        [2] = { effectId = xi.effect.SLOW,  power = 5000, duration = 120, tier = 8 },
+    }
 
-    -- This likely doesn't behave like retail.
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/cimicine_discharge.lua
+++ b/scripts/actions/mobskills/cimicine_discharge.lua
@@ -11,16 +11,19 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    local power = 1950
+    local power    = 1950
     local duration = math.randomInt(60, 180)
 
     if not mob:hasStatusEffect(xi.effect.HASTE) then
         mob:addStatusEffect(xi.effect.HASTE, { power = 1500, duration = duration, origin = mob })
     end
 
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, power, 0, duration))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = power, duration = duration, tier = 8 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 
     --[[ Is there suppsoed to be a message about haste?
     skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.HASTE, 150, 0, duration))

--- a/scripts/actions/mobskills/demonic_howl.lua
+++ b/scripts/actions/mobskills/demonic_howl.lua
@@ -13,9 +13,13 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, duration))
 
-    return xi.effect.SLOW
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 5000, duration = duration, tier = 1 },
+    }
+
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/filamented_hold.lua
+++ b/scripts/actions/mobskills/filamented_hold.lua
@@ -10,9 +10,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 2500, 0, 120))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 2500, duration = 120, tier = 8 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/fluorescence.lua
+++ b/scripts/actions/mobskills/fluorescence.lua
@@ -13,7 +13,9 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BOOST, 400, 0, 5))
+    local subPower = 1
+
+    skill:setMsg(xi.mobskills.mobBuffMove(mob, xi.effect.BOOST, 400, 0, 180, nil, subPower))
 
     return xi.effect.BOOST
 end

--- a/scripts/actions/mobskills/gloeosuccus.lua
+++ b/scripts/actions/mobskills/gloeosuccus.lua
@@ -11,9 +11,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 1250, 0, 180))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 1250, duration = 180, tier = 1 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/gravity_field.lua
+++ b/scripts/actions/mobskills/gravity_field.lua
@@ -10,9 +10,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 4500, 0, math.randomInt(240, 420)))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 4500, duration = math.randomInt(240, 420), tier = 1 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/horror_cloud.lua
+++ b/scripts/actions/mobskills/horror_cloud.lua
@@ -15,9 +15,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, 120))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 5000, duration = 120, tier = 1 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/radiant_breath.lua
+++ b/scripts/actions/mobskills/radiant_breath.lua
@@ -31,8 +31,13 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
          -- TODO: Function name is duration. We might want to rename to something more universal.
         local power = xi.mobskills.calculateDuration(skill:getTP(), 1250, 1250) -- TODO: Capture power values
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, power, 0, 120)
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SILENCE, 1, 0, 120)
+        local effectTable =
+        {
+            [1] = { effectId = xi.effect.SLOW,    power = power, duration = 120, tier = 1 },
+            [2] = { effectId = xi.effect.SILENCE, power =     1, duration = 120           },
+        }
+
+        xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, { messageBypass = true })
     end
 
     return info.damage

--- a/scripts/actions/mobskills/sticky_thread.lua
+++ b/scripts/actions/mobskills/sticky_thread.lua
@@ -11,9 +11,13 @@ end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local duration = xi.mobskills.calculateDuration(skill:getTP(), 180, 540)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 5000, 0, duration))
 
-    return xi.effect.SLOW
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 5000, duration = duration, tier = 1 },
+    }
+
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/viscid_nectar.lua
+++ b/scripts/actions/mobskills/viscid_nectar.lua
@@ -5,7 +5,6 @@
 --  Type: Enfeebling
 --  Utsusemi/Blink absorb: Ignores shadows
 --  Range: Unknown cone
---  Notes: Slow is equivalent to Slow II.
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -15,9 +14,12 @@ mobskillObject.onMobSkillCheck = function(target, mob, skill)
 end
 
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
-    skill:setMsg(xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 10000, 0, 120))
+    local effectTable =
+    {
+        [1] = { effectId = xi.effect.SLOW, power = 10000, duration = 120, tier = 8 },
+    }
 
-    return xi.effect.SLOW
+    return xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, {})
 end
 
 return mobskillObject

--- a/scripts/actions/mobskills/vitriolic_barrage.lua
+++ b/scripts/actions/mobskills/vitriolic_barrage.lua
@@ -1,8 +1,7 @@
 -----------------------------------
 -- Vitriolic Barrage
 -- Family: Yovra
--- Description: Deals unaspected? magic damage to targets in range. Additional Effect: Poison
--- Notes: Affected by MDEF stat.
+-- Description: Deals 1000 physical damage divided between all targets in range. Additional Effect: Poison
 -----------------------------------
 ---@type TMobSkill
 local mobskillObject = {}
@@ -14,17 +13,20 @@ end
 mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     local params = {}
 
-    params.baseDamage           = 1000 / skill:getTotalTargets()
-    params.fTP                  = { 1.00, 1.00, 1.00 }
-    params.element              = xi.element.NONE -- TODO: Verify whether unaspected or elemental
-    params.attackType           = xi.attackType.MAGICAL
-    params.damageType           = xi.damageType.NONE
-    params.shadowBehavior       = xi.mobskills.shadowBehavior.WIPE_SHADOWS
-    -- https://youtu.be/DgQrZQJEqDY?t=409
-    -- Looks like it bypasses MDT(Shell) but is reduced by MDEF
-    params.skipDamageAdjustment = true
+    params.baseDamage         = 1000 / skill:getTotalTargets()
+    params.numHits            = 1
+    params.fTP                = { 1.0, 1.0, 1.0 }
+    params.attackType         = xi.attackType.PHYSICAL
+    params.damageType         = xi.damageType.PIERCING
+    params.shadowBehavior     = xi.mobskills.shadowBehavior.WIPE_SHADOWS
+    params.guaranteedFirstHit = true
+    params.skipPDIF           = true
+    params.skipFSTR           = true
+    params.skipParry          = true
+    params.skipGuard          = true
+    params.skipBlock          = true
 
-    local info = xi.mobskills.mobMagicalMove(mob, target, skill, action, params)
+    local info = xi.mobskills.mobPhysicalMove(mob, target, skill, action, params)
 
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)

--- a/scripts/actions/mobskills/wing_thrust.lua
+++ b/scripts/actions/mobskills/wing_thrust.lua
@@ -26,7 +26,12 @@ mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
     if xi.mobskills.processDamage(mob, target, skill, action, info) then
         target:takeDamage(info.damage, mob, info.attackType, info.damageType)
 
-        xi.mobskills.mobStatusEffectMove(mob, target, xi.effect.SLOW, 3437, 0, math.randomInt(30, 60)) -- TODO: Duration random, resisted or scale with TP?
+        local effectTable =
+        {
+            [1] = { effectId = xi.effect.SLOW, power = 3437, duration = math.randomInt(30, 60), tier = 1 }, -- TODO: Duration random, resisted or scale with TP?
+        }
+
+        xi.combat.action.executeMobskillStatusEffect(mob, target, skill, effectTable, { messageBypass = true })
     end
 
     return info.damage


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Adds Slow effect tiers to several TP moves based off of this chart from the JP Wiki
https://wiki.ffo.jp/html/4125.html

* Changes Vitriolic Barrage to be 1000 physical damage divided by targets in range. (1000 Needles)
<img width="482" height="80" alt="image" src="https://github.com/user-attachments/assets/5add37af-0c17-48b1-8474-fb9802a3271e" />
(Confirmed by putting on Genbus Shield)

* Changes Fluorescence to be 4x raw damage boost (Like Fantod)
https://wiki.ffo.jp/html/24776.html

## Steps to test these changes

Check out how Haste overwrites/blocks Sticky Thread
See huge damage from Yovra after Fluorescence
