### PR TITLE
Changed post 60 stats scaling for old rates

### DIFF
--- a/modules/era/data/stats.yaml
+++ b/modules/era/data/stats.yaml
@@ -1,4 +1,7 @@
 # Player growth as it was before the April 2014 update.
+#
+# Attributes past 60 follow the level 1 to 75 tables of the datasync FFXI stat predictor (v1.7, 2005):
+# https://web.archive.org/web/20060202001724/http://www.datasync.com/~dsmith/FFXIStats/
 
 stats:
   round_once: false # Each part was rounded on its own
@@ -20,3 +23,23 @@ stats:
       31: {hume:  3, elvaan: 3, tarutaru:  6, mithra:  3, galka: 0}
       61: {hume:  4, elvaan: 1, tarutaru:  4, mithra:  4, galka: 1}
       76: {hume:  0, elvaan: 0, tarutaru:  0, mithra:  0, galka: 0}
+
+  # Past 60 each grade gains whole points at fixed levels instead of the retail half point schedule.
+  attributes:
+    1:  {a: 100, b: 80, c: 80, d: 60, e: 60, f: 40, g: 40}
+    2:  {a:  10, b:  9, c:  8, d:  7, e:  6, f:  5, g:  4}
+    61: {a:   0, b:  0, c:  0, d:  0, e:  0, f:  0, g:  0}
+    62: {a:   0, b:  0, c:  0, d: 20, e: 20, f: 20, g: 20}
+    63: {a:   0, b:  0, c: 20, d:  0, e:  0, f:  0, g:  0}
+    64: {a:   0, b: 20, c:  0, d:  0, e:  0, f: 20, g: 20}
+    65: {a:   0, b:  0, c:  0, d: 20, e: 20, f:  0, g:  0}
+    66: {a:   0, b:  0, c:  0, d:  0, e:  0, f:  0, g:  0}
+    67: {a:   0, b:  0, c: 20, d:  0, e:  0, f: 20, g: 20}
+    68: {a:   0, b:  0, c:  0, d: 20, e: 20, f:  0, g:  0}
+    69: {a:  20, b: 20, c:  0, d:  0, e:  0, f: 20, g: 20}
+    70: {a:   0, b:  0, c:  0, d:  0, e:  0, f:  0, g:  0}
+    71: {a:   0, b:  0, c: 20, d: 20, e: 20, f:  0, g:  0}
+    72: {a:   0, b:  0, c:  0, d:  0, e:  0, f: 20, g: 20}
+    73: {a:   0, b:  0, c:  0, d:  0, e:  0, f:  0, g:  0}
+    74: {a:   0, b: 20, c:  0, d: 20, e: 20, f: 20, g: 20}
+    75: {a:   0, b:  0, c: 20, d:  0, e:  0, f:  0, g:  0}


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
Changes the old stat scaling back to whole points instead of half point schedule for post 60. Slight oversight by myself since we had no information on it but we verified that the old datasync for 60-74 is correct.
<!-- Describe what your PR does here. If it closes an existing issue, you can mention: "Closes #1234" and GitHub will link this PR to that issue. -->

## Steps to test these changes
Set `USE_OLD_STAT_FORMULAS = true`
See all the stats match the book + https://web.archive.org/web/20060202001724/http://www.datasync.com/~dsmith/FFXIStats/
<!-- Clear and detailed steps to test your changes here -->
