### PR TITLE
Update Dagger/Sword Modules

### DIFF
--- a/modules/era/lua/actions/weaponskills/dagger.lua
+++ b/modules/era/lua/actions/weaponskills/dagger.lua
@@ -143,25 +143,23 @@ end)
 -- Energy Steal
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.energy_steal.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local fTPAnchors     = { 1.00, 1.50, 2.00 }
-    local startingAnchor = math.floor(tp / 1000)
-    local multiplier     = 0
+    local skill      = player:getSkillLevel(xi.skill.DAGGER)
+    local ftp        = xi.weaponskills.fTP(math.min(tp, 3000), { 1.00, 1.50, 2.00 })
+    local mpRestored = math.floor(math.floor(skill * 0.11) * ftp)
 
-    if tp >= 3000 then
-        multiplier = fTPAnchors[3]
-    else
-        local basefTP   = fTPAnchors[startingAnchor]
-        local nextfTP   = fTPAnchors[startingAnchor + 1]
-        local multPerTP = (nextfTP - basefTP) / 1000 * (tp - 1000 * startingAnchor)
-        multiplier = basefTP + multPerTP
-    end
-
-    local skill = player:getSkillLevel(xi.skill.DAGGER)
-    local wsc   = player:getStat(xi.mod.MND) * 1.0
-    local mpRestored = math.floor((math.floor(skill * 0.11) + wsc) * multiplier)
     if target:isUndead() then
         mpRestored = 0
     else
+        local maccParams =
+        {
+            magicalElement = xi.element.DARK,
+            skillType      = xi.skill.DAGGER,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+        mpRestored = math.floor(mpRestored * resistanceRate)
+
         mpRestored = target:delMP(mpRestored)
         mpRestored = player:addMP(mpRestored)
     end
@@ -175,24 +173,24 @@ end)
 -- Energy Drain
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.energy_drain.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local fTPAnchors = { 1.25, 1.75, 2.25 }
-    local startingAnchor = math.floor(tp / 1000)
-    local multiplier = 0
-    if tp >= 3000 then
-        multiplier = fTPAnchors[3]
-    else
-        local basefTP   = fTPAnchors[startingAnchor]
-        local nextfTP   = fTPAnchors[startingAnchor + 1]
-        local multPerTP = (nextfTP - basefTP) / 1000 * (tp - 1000 * startingAnchor)
-        multiplier = basefTP + multPerTP
-    end
+    local skill      = player:getSkillLevel(xi.skill.DAGGER)
+    local wsc        = math.floor(player:getStat(xi.mod.MND) * 0.25)
+    local ftp        = xi.weaponskills.fTP(math.min(tp, 3000), { 1.25, 1.75, 2.25 })
+    local mpRestored = math.floor((math.floor(skill * 0.11) + wsc) * ftp)
 
-    local skill = player:getSkillLevel(xi.skill.DAGGER)
-    local wsc   = player:getStat(xi.mod.MND) * 1.0
-    local mpRestored = math.floor((math.floor(skill * 0.11) + wsc) * multiplier)
     if target:isUndead() then
         mpRestored = 0
     else
+        local maccParams =
+        {
+            magicalElement = xi.element.DARK,
+            skillType      = xi.skill.DAGGER,
+        }
+
+        local resistanceRate = xi.combat.magicHitRate.calculateResistRate(player, target, maccParams)
+
+        mpRestored = math.floor(mpRestored * resistanceRate)
+
         mpRestored = target:delMP(mpRestored)
         mpRestored = player:addMP(mpRestored)
     end

--- a/modules/era/lua/actions/weaponskills/sword.lua
+++ b/modules/era/lua/actions/weaponskills/sword.lua
@@ -257,10 +257,10 @@ end)
 -- Atonement
 -----------------------------------
 m:addOverride('xi.actions.weaponskills.atonement.onUseWeaponSkill', function(player, target, wsID, tp, primary, action, taChar)
-    local params      = {}
-    params.numHits    = 2
-    params.ftpMod     = { 1.00, 1.50, 2.00 } -- 1x Enmity @ 1000 TP, 1.5x Enmity @ 2000 TP, 2x Enmity @ 3000 TP
-    params.enmityMult = utils.clamp(xi.weaponskills.fTP(tp, params.ftpMod), 1, 2) -- Enmity multiplier based on fTP, clamped between 1 and 2.
+    local params   = {}
+    params.numHits = 2
+    params.ftpMod  = { 1.00, 1.50, 2.00 }
+
     -- 1000 TP: 9% CE + 11% VE, 2000 TP: 11% CE + 14% VE, 3000 TP: 20% CE + 25% VE
     local cePercent = xi.weaponskills.fTP(tp, { 0.09, 0.11, 0.20 })
     local vePercent = xi.weaponskills.fTP(tp, { 0.11, 0.14, 0.25 })


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

* Removes 1.0 wSC MND Modifier from Energy Steal
* Adjusts MND wSC modifier on Energy Drain from 1.0 to .25
* Removes Enmity bonus fTP modifier from Atonement

## Steps to test these changes

Enable the modules, see Energy Drain much weaker (around 120~ with lots of dagger skill, 3000 TP and a good amount of MND)
