### PR TITLE
[search] Improve request logging with requester and counts

### DIFF
--- a/src/search/data_loader.cpp
+++ b/src/search/data_loader.cpp
@@ -21,6 +21,7 @@
 
 #include "common/database.h"
 #include "common/earth_time.h"
+#include "common/ipp.h"
 #include "common/logging.h"
 #include "common/mmo.h"
 #include "common/settings.h"
@@ -85,8 +86,6 @@ auto CDataLoader::GetAHItemHistory(uint16 ItemID, bool stack) const -> std::vect
 
 auto CDataLoader::GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem>
 {
-    ShowDebugFmt("Try find category: {}", ahCategoryID);
-
     std::vector<AuctionHouseItem> ItemList;
 
     const auto rset = [&]()
@@ -725,6 +724,34 @@ auto CDataLoader::GetSearchComment(uint32 playerId) const -> std::string
         return rset->get<std::string>("seacom_message");
     }
     return std::string();
+}
+
+auto CDataLoader::GetCharName(uint32 playerId) const -> std::string
+{
+    auto rset = db::preparedStmt("SELECT charname FROM chars WHERE charid = ?", playerId);
+    FOR_DB_SINGLE_RESULT(rset)
+    {
+        return rset->get<std::string>("charname");
+    }
+    return std::string();
+}
+
+auto CDataLoader::GetPlayerNamesByIP(const std::string& ipAddress) const -> std::vector<std::string>
+{
+    std::vector<std::string> names;
+    const uint32             clientAddr = str2ip(ipAddress);
+
+    auto rset = db::preparedStmt(
+        "SELECT charname, charid FROM accounts_sessions JOIN chars USING (charid) WHERE client_addr = ?",
+        clientAddr);
+
+    FOR_DB_MULTIPLE_RESULTS(rset)
+    {
+        names.push_back(fmt::format("{}({})",
+                                    rset->get<std::string>("charname"),
+                                    rset->get<uint32>("charid")));
+    }
+    return names;
 }
 
 struct ListingToExpire

--- a/src/search/data_loader.h
+++ b/src/search/data_loader.h
@@ -88,6 +88,8 @@ public:
     auto GetPartyList(uint32 PartyID, uint32 AllianceID) const -> std::vector<SearchEntity>;
     auto GetLinkshellList(uint32 LinkshellID) const -> std::vector<SearchEntity>;
     auto GetPlayersList(SearchRequest sr, int* count) const -> std::vector<SearchEntity>;
+    auto GetPlayerNamesByIP(const std::string& ipAddress) const -> std::vector<std::string>;
+    auto GetCharName(uint32 playerId) const -> std::string;
     auto GetSearchComment(uint32 playerId) const -> std::string;
     auto GetAHItemsToCategory(uint8 ahCategoryID, const std::string& orderByString) const -> std::vector<AuctionHouseItem>;
     auto GetAHItemFromItemID(uint16 ItemID) const -> AuctionHouseItem;

--- a/src/search/search_handler.cpp
+++ b/src/search/search_handler.cpp
@@ -70,6 +70,13 @@ SearchHandler::SearchHandler(Scheduler& scheduler, asio::ip::tcp::socket socket,
             socket_.lowest_layer().close();
             return;
         }
+
+        if (settings::get<bool>("logging.LOG_INFO"))
+        {
+            const CDataLoader PDataLoader;
+            const auto        names = PDataLoader.GetPlayerNamesByIP(ipAddress_);
+            requestingPlayers_      = names.empty() ? "unknown" : fmt::format("{}", fmt::join(names, ", "));
+        }
     }
 }
 
@@ -235,6 +242,31 @@ inline auto searchTypeToString(const uint8 type) -> std::string
     }
 }
 
+inline auto ahSortToString(const uint8 sortType) -> std::string
+{
+    switch (sortType)
+    {
+        case 2:
+            return "level";
+        case 3:
+            return "race";
+        case 4:
+            return "job";
+        case 5:
+            return "damage";
+        case 6:
+            return "delay";
+        case 7:
+            return "defense";
+        case 8:
+            return "resistance";
+        case 9:
+            return "name";
+        default:
+            return "unknown";
+    }
+}
+
 void SearchHandler::read_func(const uint16_t length)
 {
     if (length != ref<uint16>(buffer_.data(), 0x00) || length < 28)
@@ -249,7 +281,10 @@ void SearchHandler::read_func(const uint16_t length)
     {
         uint8 packetType = buffer_[0x0B];
 
-        ShowInfoFmt("Search Request: {} ({}), size: {}, ip: {}", searchTypeToString(packetType), packetType, length, ipAddress_);
+        if (packetType != TCP_AH_REQUEST_MORE)
+        {
+            ShowInfoFmt("Search Request: {} ({}) from [{}], size: {}, ip: {}", searchTypeToString(packetType), packetType, requestingPlayers_, length, ipAddress_);
+        }
 
         switch (packetType)
         {
@@ -329,15 +364,13 @@ void SearchHandler::HandleGroupListRequest()
     uint32       linkshellid1 = ref<uint32>(buffer_.data(), 0x18);
     uint32       linkshellid2 = ref<uint32>(buffer_.data(), 0x1C);
 
-    ShowInfoFmt("SEARCH::PartyID = {}", partyid);
-    ShowInfoFmt("SEARCH::LinkshellIDs = {}, {}", linkshellid1, linkshellid2);
-
     const CDataLoader PDataLoader;
 
     if (partyid != 0 || allianceid != 0)
     {
         const auto PartyList = PDataLoader.GetPartyList(partyid, allianceid);
 
+        ShowInfoFmt("Group list request: party={}, alliance={}, results={}", partyid, allianceid, PartyList.size());
         CPartyListPacket PPartyPacket(partyid, static_cast<uint32>(PartyList.size()));
 
         std::size_t membersSent = 0;
@@ -364,6 +397,8 @@ void SearchHandler::HandleGroupListRequest()
 
         const uint32 totalResults  = static_cast<uint32>(LinkshellList.size());
         uint32       currentResult = 0;
+
+        ShowInfoFmt("Group list request: linkshell={}, results={}", linkshellid, totalResults);
 
         // Iterate through the linkshell list, splitting up the results into
         // smaller chunks.
@@ -401,10 +436,12 @@ void SearchHandler::HandleGroupListRequest()
 
 void SearchHandler::HandleSearchComment()
 {
-    const uint32 playerId = ref<uint32>(buffer_.data(), 0x10);
-
+    const uint32      playerId = ref<uint32>(buffer_.data(), 0x10);
     const CDataLoader PDataLoader;
-    const std::string comment = PDataLoader.GetSearchComment(playerId);
+    const std::string comment    = PDataLoader.GetSearchComment(playerId);
+    const std::string playerName = PDataLoader.GetCharName(playerId);
+
+    ShowInfoFmt("Search comment request: target={}({}), length={}", playerName, playerId, comment.length());
     if (comment.empty())
     {
         return;
@@ -475,12 +512,16 @@ void SearchHandler::HandleAuctionHouseRequest()
     // 7 - defense
     // 8 - resistance
     // 9 - name
-    std::string OrderByString = "ORDER BY";
-    const uint8 paramCount    = ref<uint8>(buffer_.data(), 0x12);
+    std::string OrderByString    = "ORDER BY";
+    const uint8 paramCount       = ref<uint8>(buffer_.data(), 0x12);
+    const bool  isInitialRequest = (buffer_[0x0B] == TCP_AH_REQUEST);
     for (uint8 i = 0; i < paramCount; ++i) // Item sort options
     {
         uint8 param = ref<uint32>(buffer_.data(), 0x18 + 8 * i);
-        ShowInfoFmt(" Param{}: {}", i, param);
+        if (isInitialRequest)
+        {
+            ShowInfoFmt("AH sort option: code={} ({})", param, ahSortToString(param));
+        }
         switch (param)
         {
             case 2:
@@ -505,6 +546,10 @@ void SearchHandler::HandleAuctionHouseRequest()
     const auto        ItemList = PDataLoader.GetAHItemsToCategory(AHCatID, OrderByArray);
 
     const std::size_t itemListSize = ItemList.size();
+    if (isInitialRequest)
+    {
+        ShowInfoFmt("AH request: category={}, results={}", AHCatID, itemListSize);
+    }
     const std::size_t PacketsCount = (itemListSize / 20) + (itemListSize % 20 != 0) + (itemListSize == 0);
 
     for (std::size_t i = 0; i < PacketsCount; ++i)
@@ -538,6 +583,8 @@ void SearchHandler::HandleAuctionHouseHistory()
 
     CAHHistoryPacket PAHPacket = CAHHistoryPacket(item, stack);
 
+    ShowInfoFmt("AH history request: itemid={}, stack={}", ItemID, stack);
+
     for (const auto& i : HistoryList)
     {
         PAHPacket.AddItem(i);
@@ -547,6 +594,7 @@ void SearchHandler::HandleAuctionHouseHistory()
 
     DebugPrintPacket(PAHPacket.GetData(), length);
     searchPackets_.emplace_back(PAHPacket.GetData(), length);
+    ShowInfoFmt("AH history: results={}", HistoryList.size());
 }
 
 auto SearchHandler::_HandleSearchRequest() -> SearchRequest

--- a/src/search/search_handler.h
+++ b/src/search/search_handler.h
@@ -76,6 +76,7 @@ private:
     std::deque<SearchPacket> searchPackets_;
 
     std::string             ipAddress_;
+    std::string             requestingPlayers_;
     asio::ip::tcp::socket   socket_;
     std::array<uint8, 4096> buffer_;
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Closes #2072.  Search-server request logging was sparse and inconsistent. Some handlers were lacking in logging while others were cryptic and noisy.
  - The shared request line now includes the player requester as a bracketed list by source IP.
  - The search-comment, group-list, auction-house, and AH-history handlers now log their parameters and result counts.
  - AH_REQUEST_MORE pagination is gated out of the per-request logs to stop it flooding on AH browsing.
  - Removed the Try find category debug log in GetAHItemsToCategory as it only printed the category id but fired on every query adding to log noise.
  - The requester lookup is skipped when LOG_INFO is off.
  - The player-search handler already logged adequately and was left as-is.

## Steps to test these changes

1. Build and run the server with logging.LOG_INFO = true.
2. tail/follow log/search-server.log
3. /sea for a player.
    - Search logs show: request type, requester, query details, results found, number displayed
4. View a player's seek comment (the target must have one set).
    - Search logs show: request type, requester, target, search comment length
5. Have a linkshell equipped, navigate the in game menu to linkshell -> select linkshell -> select link list.
    - Search logs show: request type, requester, linkshell ID, results ( number of players in linkshell)
6. Be in a party and navigate the in game menu to party -> member list
    - Search logs show: request type, requester, party ID, alliance ID, total members
7. Open the AH and browse a category
    - Search logs show: request type, requester, AH category ID, number of results
    - Search logs no longer show the AH_REQUEST_MORE flooding the search logs due to pagination/loading
8. View an item's price history
    - Search logs show: request type, requester, itemid, stack value, sale history results
