### PR TITLE
Corrects Dynamis delays and Goblin drg skill list

### DIFF
--- a/data/zones/dynamis_bastok/mobs.yaml
+++ b/data/zones/dynamis_bastok/mobs.yaml
@@ -130,7 +130,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, rng]
       resists:
         dmg_physical:
@@ -456,7 +456,7 @@ templates:
     attributes:
       combat:
         skill: dagger
-        delay: 265
+        delay: 240
       jobs: [drk, smn]
       resists:
         dmg_physical:
@@ -547,7 +547,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -591,7 +591,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -637,7 +637,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -681,7 +681,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -724,7 +724,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -769,7 +769,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -813,7 +813,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -858,7 +858,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -905,7 +905,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -1078,7 +1078,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -1122,7 +1122,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -1168,7 +1168,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -1212,7 +1212,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -1257,7 +1257,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -1304,7 +1304,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -1347,7 +1347,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -1389,7 +1389,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -1433,7 +1433,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -1603,7 +1603,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -1648,7 +1648,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -1695,7 +1695,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -1739,7 +1739,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -1784,7 +1784,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -1831,7 +1831,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -2263,7 +2263,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -2308,7 +2308,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -2355,7 +2355,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -2398,7 +2398,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -2441,7 +2441,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -2486,7 +2486,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -2579,7 +2579,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -2605,7 +2605,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [brd, mnk]
       resists:
         dmg_physical:
@@ -2674,7 +2674,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       resists:
         dmg_physical:
@@ -2743,7 +2743,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [blm, sam]
       resists:
         dmg_physical:

--- a/data/zones/dynamis_beaucedine/mobs.yaml
+++ b/data/zones/dynamis_beaucedine/mobs.yaml
@@ -289,7 +289,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [smn, smn]
       resists:
         dmg_physical:
@@ -729,7 +729,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [blm, blm]
       resists:
         dmg_physical:
@@ -1121,7 +1121,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       resists:
         dmg_physical:
@@ -1293,7 +1293,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 265
+        delay: 240
       jobs: [drg, drg]
       resists:
         dmg_physical:
@@ -1462,7 +1462,7 @@ templates:
     attributes:
       combat:
         skill: great_katana
-        delay: 265
+        delay: 240
       jobs: [rng, rng]
       resists:
         dmg_physical:
@@ -1528,7 +1528,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       resists:
         dmg_physical:
           piercing: 2500
@@ -2931,7 +2931,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3002,7 +3002,7 @@ templates:
     attributes:
       combat:
         skill: great_katana
-        delay: 265
+        delay: 240
       jobs: [thf, thf]
       resists:
         dmg_physical:
@@ -3068,7 +3068,7 @@ templates:
     attributes:
       combat:
         skill: great_katana
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       resists:
         dmg_physical:
@@ -3355,7 +3355,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       resists:
         dmg_physical:
@@ -3618,7 +3618,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       resists:
         dmg_physical:
@@ -3685,7 +3685,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       resists:
         dmg_physical:
@@ -3796,7 +3796,7 @@ templates:
     attributes:
       combat:
         skill: katana
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       resists:
         dmg_physical:
@@ -4434,7 +4434,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       resists:
         dmg_physical:
@@ -4718,7 +4718,7 @@ templates:
     attributes:
       combat:
         skill: dagger
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       resists:
         dmg_physical:
@@ -4828,7 +4828,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -5243,7 +5243,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -5369,7 +5369,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -5409,7 +5409,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -5487,7 +5487,7 @@ templates:
   Vanguard_Dragontamer:
     id:            4649
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -5808,7 +5808,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -5930,7 +5930,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -6015,7 +6015,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -6135,7 +6135,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -6254,7 +6254,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -6770,7 +6770,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -7283,7 +7283,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -7324,7 +7324,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -7586,7 +7586,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_buburimu/mobs.yaml
+++ b/data/zones/dynamis_buburimu/mobs.yaml
@@ -346,7 +346,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -478,7 +478,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       resists:
         dmg_physical:
@@ -658,7 +658,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -875,7 +875,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 360
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -1650,7 +1650,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       resists:
         dmg_physical:
           piercing: 2500
@@ -1868,7 +1868,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       resists:
         dmg_physical:
@@ -1924,7 +1924,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [thf, thf]
       resists:
         dmg_physical:
@@ -2594,7 +2594,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -2630,7 +2630,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -2666,7 +2666,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -2910,7 +2910,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2945,7 +2945,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2980,7 +2980,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -3014,7 +3014,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -3051,7 +3051,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -3088,7 +3088,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -3735,7 +3735,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -3769,7 +3769,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -3803,7 +3803,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -3938,7 +3938,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3974,7 +3974,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -4010,7 +4010,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -4250,7 +4250,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -4286,7 +4286,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -4322,7 +4322,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -4461,7 +4461,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -4498,7 +4498,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -4535,7 +4535,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -4775,7 +4775,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -4809,7 +4809,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -4843,7 +4843,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -5076,7 +5076,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -5113,7 +5113,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -5150,7 +5150,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -6367,7 +6367,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -6404,7 +6404,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -6441,7 +6441,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -6776,7 +6776,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -6810,7 +6810,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -6844,7 +6844,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -7694,7 +7694,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -7731,7 +7731,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -7768,7 +7768,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -7801,7 +7801,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -7836,7 +7836,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -7871,7 +7871,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -8281,7 +8281,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_jeuno/mobs.yaml
+++ b/data/zones/dynamis_jeuno/mobs.yaml
@@ -1797,7 +1797,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -2758,7 +2758,7 @@ templates:
   Vanguard_Dragontamer:
     id:            4649
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -2797,7 +2797,7 @@ templates:
     id:            4649
     display_name:  Vanguard_Dragontamer
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -4301,7 +4301,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_qufim/mobs.yaml
+++ b/data/zones/dynamis_qufim/mobs.yaml
@@ -1709,7 +1709,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -1745,7 +1745,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -1781,7 +1781,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -2025,7 +2025,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2060,7 +2060,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2095,7 +2095,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2129,7 +2129,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2166,7 +2166,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2203,7 +2203,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2333,7 +2333,7 @@ templates:
   Vanguard_Dragontamer:
     id:            4649
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -2368,7 +2368,7 @@ templates:
     id:            4649
     display_name:  Vanguard_Dragontamer
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -2782,7 +2782,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2816,7 +2816,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2850,7 +2850,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2985,7 +2985,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3021,7 +3021,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3057,7 +3057,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3297,7 +3297,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3333,7 +3333,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3369,7 +3369,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3474,7 +3474,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3511,7 +3511,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3548,7 +3548,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3788,7 +3788,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -3822,7 +3822,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -3856,7 +3856,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -4089,7 +4089,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -4126,7 +4126,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -4163,7 +4163,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -5415,7 +5415,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5452,7 +5452,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5489,7 +5489,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5824,7 +5824,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -5858,7 +5858,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -6642,7 +6642,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6679,7 +6679,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6716,7 +6716,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6749,7 +6749,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -6784,7 +6784,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -6819,7 +6819,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -7168,7 +7168,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_san_doria/mobs.yaml
+++ b/data/zones/dynamis_san_doria/mobs.yaml
@@ -184,7 +184,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -1170,7 +1170,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -1214,7 +1214,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -1804,7 +1804,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_tavnazia/mobs.yaml
+++ b/data/zones/dynamis_tavnazia/mobs.yaml
@@ -636,7 +636,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -1039,7 +1039,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -1169,7 +1169,7 @@ templates:
     attributes:
       combat:
         skill: staff
-        delay: 290
+        delay: 240
       jobs: [blm, blm]
       render:
         look:
@@ -1308,7 +1308,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -1482,7 +1482,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [smn, smn]
       render:
         look:
@@ -1665,7 +1665,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_valkurm/mobs.yaml
+++ b/data/zones/dynamis_valkurm/mobs.yaml
@@ -1811,7 +1811,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -1847,7 +1847,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -1883,7 +1883,7 @@ templates:
     attributes:
       combat:
         skill: axe
-        delay: 265
+        delay: 240
       jobs: [bst, bst]
       render:
         look:
@@ -2093,7 +2093,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2128,7 +2128,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2163,7 +2163,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [whm, whm]
       render:
         look:
@@ -2197,7 +2197,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2234,7 +2234,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2271,7 +2271,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [pld, pld]
       render:
         look:
@@ -2401,7 +2401,7 @@ templates:
   Vanguard_Dragontamer:
     id:            4649
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -2436,7 +2436,7 @@ templates:
     id:            4649
     display_name:  Vanguard_Dragontamer
     species:       goblin
-    skill_list_id: 360
+    skill_list_id: 2108
     attributes:
       combat:
         skill: sword
@@ -2918,7 +2918,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2952,7 +2952,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -2986,7 +2986,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -3088,7 +3088,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3124,7 +3124,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3160,7 +3160,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 265
+        delay: 240
       jobs: [sam, sam]
       render:
         look:
@@ -3400,7 +3400,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3436,7 +3436,7 @@ templates:
     attributes:
       combat:
         skill: polearm
-        delay: 290
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3577,7 +3577,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3614,7 +3614,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3651,7 +3651,7 @@ templates:
     attributes:
       combat:
         skill: great_axe
-        delay: 265
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -3891,7 +3891,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -3925,7 +3925,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -3959,7 +3959,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 220
+        delay: 240
       jobs: [rng, rng]
       render:
         look:
@@ -4192,7 +4192,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -4229,7 +4229,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -4266,7 +4266,7 @@ templates:
     attributes:
       combat:
         skill: club
-        delay: 265
+        delay: 240
       jobs: [brd, brd]
       render:
         look:
@@ -5483,7 +5483,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5520,7 +5520,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5557,7 +5557,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -5892,7 +5892,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -5926,7 +5926,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -5960,7 +5960,7 @@ templates:
     attributes:
       combat:
         skill: hand_to_hand
-        delay: 480
+        delay: 240
       jobs: [mnk, mnk]
       render:
         look:
@@ -6778,7 +6778,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6815,7 +6815,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6852,7 +6852,7 @@ templates:
     attributes:
       combat:
         skill: great_sword
-        delay: 265
+        delay: 240
       jobs: [drk, drk]
       render:
         look:
@@ -6885,7 +6885,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -6920,7 +6920,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -6955,7 +6955,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 260
+        delay: 240
       render:
         look:
           type:  standard
@@ -7308,7 +7308,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_windurst/mobs.yaml
+++ b/data/zones/dynamis_windurst/mobs.yaml
@@ -2476,7 +2476,7 @@ templates:
     attributes:
       combat:
         skill: sword
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:

--- a/data/zones/dynamis_xarcabard/mobs.yaml
+++ b/data/zones/dynamis_xarcabard/mobs.yaml
@@ -1526,7 +1526,7 @@ templates:
     attributes:
       combat:
         skill: staff
-        delay: 290
+        delay: 240
       jobs: [blm, blm]
       render:
         look:
@@ -1560,7 +1560,7 @@ templates:
     attributes:
       combat:
         skill: staff
-        delay: 290
+        delay: 240
       jobs: [blm, blm]
       render:
         look:
@@ -1796,7 +1796,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -1830,7 +1830,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [nin, nin]
       render:
         look:
@@ -2134,7 +2134,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [smn, smn]
       render:
         look:
@@ -2168,7 +2168,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 290
+        delay: 240
       jobs: [smn, smn]
       render:
         look:
@@ -2447,7 +2447,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 200
+        delay: 240
       jobs: [drg, drg]
       render:
         look:
@@ -3760,7 +3760,7 @@ templates:
     attributes:
       combat:
         skill: scythe
-        delay: 200
+        delay: 240
       render:
         look:
           type:  standard


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR implements the correct delay of 240 across the board for most dynamis beastmen.

There were wild delays in the repo for random beastmen that didn't make any sense, like 290 delay for demon smn and 200 delay for drg summone'd wyverns.  It's all bullshit, everything is 240.

<img width="459" height="166" alt="image" src="https://github.com/user-attachments/assets/972b30a0-d003-418f-8cbf-a25b1567a9c8" />
<img width="477" height="160" alt="image" src="https://github.com/user-attachments/assets/89330763-71a0-4e7f-8a5a-d42b961a99dd" />
<img width="460" height="165" alt="image" src="https://github.com/user-attachments/assets/23ba35b6-d8c6-4cba-ba69-b7662a18ed9b" />

This also correct the skill list for goblin drgs.  For some reason they were using the yagudo list.  Not sure if I messed that up in the update.

## Steps to test these changes

Get smacked at a very steady pace.
