### PR TITLE
[C++, yaml] Refactor add/del EquipModifiers

### DIFF
--- a/data/enums/mod.yaml
+++ b/data/enums/mod.yaml
@@ -818,7 +818,6 @@ values:
   sub_dmg_rating:      367 # adds damage rating to off hand weapon
   ranged_dmg_rating:   376 # adds damage rating to ranged weapon
   main_dmg_rank:       377 # adds weapon rank to main weapon http://wiki.bluegartr.com/bg/Weapon_Rank
-  sub_dmg_rank:        378 # adds weapon rank to sub weapon
   ranged_dmg_rank:     379 # adds weapon rank to ranged weapon
   regain:              368 # auto regain TP (from items) | this is multiplied by 10 e.g. 20 is 2% TP
   regain_down:         406 # plague, reduce tp
@@ -1276,4 +1275,4 @@ values:
 
   # The spares take care of finding the next ID to use so long as we don't forget to list IDs that have been freed up by refactoring.
   # 570 through 825 used by WS DMG mods these are not spares.
-  # SPARE IDs: 1215 and onward
+  # SPARE IDs: 1215 and onward, 378

--- a/docs/mods_by_id.txt
+++ b/docs/mods_by_id.txt
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -340,7 +340,6 @@
     CURE_POTENCY_RCVD            = 375, // % potency of received cure | healer's roll, some items have this
     RANGED_DMG_RATING            = 376, // adds damage rating to ranged weapon
     MAIN_DMG_RANK                = 377, // adds weapon rank to main weapon http://wiki.bluegartr.com/bg/Weapon_Rank
-    SUB_DMG_RANK                 = 378, // adds weapon rank to sub weapon
     RANGED_DMG_RANK              = 379, // adds weapon rank to ranged weapon
     DELAYP                       = 380, // delay addition percent (does not affect tp gain)
     RANGED_DELAYP                = 381, // ranged delay addition percent (does not affect tp gain)

--- a/src/map/entities/battle_entity.cpp
+++ b/src/map/entities/battle_entity.cpp
@@ -1831,85 +1831,13 @@ void CBattleEntity::addModifiers(std::vector<CModifier>* modList)
     }
 }
 
-void CBattleEntity::addEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)
+void CBattleEntity::addEquipModifiers(CItemEquipment* PItem)
 {
     TracyZoneScoped;
 
-    if (GetMLevel() >= itemLevel)
+    for (auto& i : PItem->modList)
     {
-        for (auto& i : *modList)
-        {
-            if (slotid == SLOT_SUB)
-            {
-                if (i.getModID() == xi::Mod::MAIN_DMG_RANK)
-                {
-                    m_modStat[xi::Mod::SUB_DMG_RANK] += i.getModAmount();
-                }
-                else
-                {
-                    m_modStat[i.getModID()] += i.getModAmount();
-                }
-            }
-            else
-            {
-                m_modStat[i.getModID()] += i.getModAmount();
-            }
-        }
-    }
-    else
-    {
-        for (auto& i : *modList)
-        {
-            int16 modAmount = GetMLevel() * i.getModAmount();
-            switch (i.getModID())
-            {
-                case xi::Mod::DEF:
-                case xi::Mod::MAIN_DMG_RATING:
-                case xi::Mod::SUB_DMG_RATING:
-                case xi::Mod::RANGED_DMG_RATING:
-                    modAmount *= 3;
-                    modAmount /= 4;
-                    break;
-                case xi::Mod::HP:
-                case xi::Mod::MP:
-                    modAmount /= 2;
-                    break;
-                case xi::Mod::STR:
-                case xi::Mod::DEX:
-                case xi::Mod::VIT:
-                case xi::Mod::AGI:
-                case xi::Mod::INT:
-                case xi::Mod::MND:
-                case xi::Mod::CHR:
-                case xi::Mod::ATT:
-                case xi::Mod::RATT:
-                case xi::Mod::ACC:
-                case xi::Mod::RACC:
-                case xi::Mod::MATT:
-                case xi::Mod::MACC:
-                    modAmount /= 3;
-                    break;
-                default:
-                    modAmount = 0;
-                    break;
-            }
-            modAmount /= itemLevel;
-            if (slotid == SLOT_SUB)
-            {
-                if (i.getModID() == xi::Mod::MAIN_DMG_RANK)
-                {
-                    m_modStat[xi::Mod::SUB_DMG_RANK] += modAmount;
-                }
-                else
-                {
-                    m_modStat[i.getModID()] += modAmount;
-                }
-            }
-            else
-            {
-                m_modStat[i.getModID()] += modAmount;
-            }
-        }
+        m_modStat[i.getModID()] += battleutils::GetScaledItemModifier(this, PItem, i.getModID());
     }
 }
 
@@ -2029,85 +1957,13 @@ void CBattleEntity::delModifiers(std::vector<CModifier>* modList)
     }
 }
 
-void CBattleEntity::delEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid)
+void CBattleEntity::delEquipModifiers(CItemEquipment* PItem, bool isDelevel /* = false */)
 {
     TracyZoneScoped;
 
-    if (GetMLevel() >= itemLevel)
+    for (auto& i : PItem->modList)
     {
-        for (auto& i : *modList)
-        {
-            if (slotid == SLOT_SUB)
-            {
-                if (i.getModID() == xi::Mod::MAIN_DMG_RANK)
-                {
-                    m_modStat[xi::Mod::SUB_DMG_RANK] -= i.getModAmount();
-                }
-                else
-                {
-                    m_modStat[i.getModID()] -= i.getModAmount();
-                }
-            }
-            else
-            {
-                m_modStat[i.getModID()] -= i.getModAmount();
-            }
-        }
-    }
-    else
-    {
-        for (auto& i : *modList)
-        {
-            int16 modAmount = GetMLevel() * i.getModAmount();
-            switch (i.getModID())
-            {
-                case xi::Mod::DEF:
-                case xi::Mod::MAIN_DMG_RATING:
-                case xi::Mod::SUB_DMG_RATING:
-                case xi::Mod::RANGED_DMG_RATING:
-                    modAmount *= 3;
-                    modAmount /= 4;
-                    break;
-                case xi::Mod::HP:
-                case xi::Mod::MP:
-                    modAmount /= 2;
-                    break;
-                case xi::Mod::STR:
-                case xi::Mod::DEX:
-                case xi::Mod::VIT:
-                case xi::Mod::AGI:
-                case xi::Mod::INT:
-                case xi::Mod::MND:
-                case xi::Mod::CHR:
-                case xi::Mod::ATT:
-                case xi::Mod::RATT:
-                case xi::Mod::ACC:
-                case xi::Mod::RACC:
-                case xi::Mod::MATT:
-                case xi::Mod::MACC:
-                    modAmount /= 3;
-                    break;
-                default:
-                    modAmount = 0;
-                    break;
-            }
-            modAmount /= itemLevel;
-            if (slotid == SLOT_SUB)
-            {
-                if (i.getModID() == xi::Mod::MAIN_DMG_RANK)
-                {
-                    m_modStat[xi::Mod::SUB_DMG_RANK] -= modAmount;
-                }
-                else
-                {
-                    m_modStat[i.getModID()] -= modAmount;
-                }
-            }
-            else
-            {
-                m_modStat[i.getModID()] -= modAmount;
-            }
-        }
+        m_modStat[i.getModID()] -= battleutils::GetScaledItemModifier(this, PItem, i.getModID(), isDelevel);
     }
 }
 

--- a/src/map/entities/battle_entity.h
+++ b/src/map/entities/battle_entity.h
@@ -252,10 +252,10 @@ public:
     void setModifier(xi::Mod type, int16 amount);
     void delModifier(xi::Mod type, int16 amount);
     void addModifiers(std::vector<CModifier>* modList);
-    void addEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid);
+    void addEquipModifiers(CItemEquipment* PItem);
     void setModifiers(std::vector<CModifier>* modList);
     void delModifiers(std::vector<CModifier>* modList);
-    void delEquipModifiers(std::vector<CModifier>* modList, uint8 itemLevel, uint8 slotid);
+    void delEquipModifiers(CItemEquipment* PItem, bool isDelevel = false);
     void saveModifiers();    // save current state of modifiers
     void restoreModifiers(); // restore to saved state
     void savePetModifiers(); // saves dynamic pet modifiers

--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 ===========================================================================
 
   Copyright (c) 2010-2015 Darkstar Dev Teams
@@ -6030,7 +6030,7 @@ int32 GetMeritValue(CBattleEntity* PEntity, xi::Merit merit)
     return 0;
 }
 
-int32 GetScaledItemModifier(CBattleEntity* PEntity, CItemEquipment* PItem, xi::Mod mod)
+int32 GetScaledItemModifier(CBattleEntity* PEntity, CItemEquipment* PItem, xi::Mod mod, bool isDelevel /* = false */)
 {
     if (!PEntity || !PItem)
     {
@@ -6038,7 +6038,11 @@ int32 GetScaledItemModifier(CBattleEntity* PEntity, CItemEquipment* PItem, xi::M
         return 0;
     }
 
-    if (PEntity->GetMLevel() < PItem->getReqLvl())
+    // When a player delevels - their level has already been decremented by the time we perform this check
+    // To avoid not removing all of the stats given upon equip, we run this check with the previous level.
+    int playerLevel = isDelevel ? PEntity->GetMLevel() + 1 : PEntity->GetMLevel();
+
+    if (playerLevel < PItem->getReqLvl())
     {
         auto modAmount = PItem->getModifier(mod);
         switch (mod)

--- a/src/map/utils/battleutils.h
+++ b/src/map/utils/battleutils.h
@@ -260,7 +260,7 @@ int16           CalculateWeaponSkillTP(CBattleEntity*, CWeaponSkill*, int16);
 bool            RemoveAmmo(CCharEntity*, int quantity = 1);
 int32           GetMeritValue(CBattleEntity*, xi::Merit);
 
-int32 GetScaledItemModifier(CBattleEntity*, CItemEquipment*, xi::Mod);
+int32 GetScaledItemModifier(CBattleEntity*, CItemEquipment*, xi::Mod, bool isDelevel = false);
 auto  GetSpikesDamageType(ActionReactKind spikesType) -> xi::DamageType;
 auto  GetEnspellDamageType(ENSPELL enspellType) -> xi::DamageType;
 auto  GetRuneEnhancementDamageType(xi::StatusEffect runeEffect) -> xi::DamageType;

--- a/src/map/utils/charutils.cpp
+++ b/src/map/utils/charutils.cpp
@@ -1747,7 +1747,7 @@ void DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity,
  *                                                                       *
  ************************************************************************/
 
-void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
+void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate, bool isDelevel /* = false */)
 {
     if (PChar == nullptr)
     {
@@ -1837,7 +1837,7 @@ void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, Recalculate recalculate)
             }
             PChar->m_dualWield = false;
         }
-        PChar->delEquipModifiers(&((CItemEquipment*)PItem)->modList, ((CItemEquipment*)PItem)->getReqLvl(), equipSlotID);
+        PChar->delEquipModifiers((CItemEquipment*)PItem, isDelevel);
         PChar->PLatentEffectContainer->DelLatentEffects(((CItemEquipment*)PItem)->getReqLvl(), equipSlotID);
         PChar->delPetModifiers(&((CItemEquipment*)PItem)->petModList);
 
@@ -3029,7 +3029,7 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
                     }
                 }
 
-                PChar->addEquipModifiers(&PItem->modList, PItem->getReqLvl(), equipSlotID);
+                PChar->addEquipModifiers(PItem);
                 PChar->PLatentEffectContainer->AddLatentEffects(PItem->latentList, PItem->getReqLvl(), equipSlotID);
                 PChar->PLatentEffectContainer->CheckLatentsEquip(equipSlotID);
                 PChar->addPetModifiers(&PItem->petModList);
@@ -3086,7 +3086,7 @@ void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 contai
  *                                                                       *
  ************************************************************************/
 
-void CheckValidEquipment(CCharEntity* PChar)
+void CheckValidEquipment(CCharEntity* PChar, bool isDelevel /* = false */)
 {
     CItemEquipment* PItem = nullptr;
 
@@ -3100,7 +3100,7 @@ void CheckValidEquipment(CCharEntity* PChar)
 
         if (PItem->getReqLvl() > (settings::get<bool>("map.DISABLE_GEAR_SCALING") ? PChar->GetMLevel() : PChar->jobs.job[static_cast<uint8>(PChar->GetMJob())]))
         {
-            UnequipItem(PChar, slotID);
+            UnequipItem(PChar, slotID, Recalculate::Yes, isDelevel);
             continue;
         }
 
@@ -3109,7 +3109,7 @@ void CheckValidEquipment(CCharEntity* PChar)
             // Unequip if no main weapon or a non-grip subslot without DW
             if (!PChar->getEquip(SLOT_MAIN) || (!charutils::hasTrait(PChar, TRAIT_DUAL_WIELD) && !(((CItemWeapon*)PItem)->getSkillType() == xi::SkillType::None)))
             {
-                UnequipItem(PChar, SLOT_SUB);
+                UnequipItem(PChar, SLOT_SUB, Recalculate::Yes, isDelevel);
                 continue;
             }
         }
@@ -3119,7 +3119,7 @@ void CheckValidEquipment(CCharEntity* PChar)
             continue;
         }
 
-        UnequipItem(PChar, slotID);
+        UnequipItem(PChar, slotID, Recalculate::Yes, isDelevel);
     }
     // Unarmed H2H weapon check
     if (!PChar->getEquip(SLOT_MAIN) || !PChar->getEquip(SLOT_MAIN)->isType(ITEM_EQUIPMENT) || PChar->m_Weapons[SLOT_MAIN] == xi::items::unarmedH2H())
@@ -4878,7 +4878,7 @@ void DelExperiencePoints(CCharEntity* PChar, float retainPercent, uint16 forcedX
             jobpointutils::RefreshGiftMods(PChar);
             BuildingCharSkillsTable(PChar);
             CalculateStats(PChar);
-            CheckValidEquipment(PChar);
+            CheckValidEquipment(PChar, true);
 
             BuildingCharAbilityTable(PChar);
             BuildingCharTraitsTable(PChar);
@@ -6387,7 +6387,7 @@ void RemoveAllEquipMods(CCharEntity* PChar)
         CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)slotID);
         if (PItem)
         {
-            PChar->delEquipModifiers(&PItem->modList, PItem->getReqLvl(), slotID);
+            PChar->delEquipModifiers(PItem);
             if (PItem->getReqLvl() <= PChar->GetMLevel())
             {
                 PChar->PLatentEffectContainer->DelLatentEffects(PItem->getReqLvl(), slotID);
@@ -6404,7 +6404,7 @@ void ApplyAllEquipMods(CCharEntity* PChar)
         CItemEquipment* PItem = PChar->getEquip((SLOTTYPE)slotID);
         if (PItem)
         {
-            PChar->addEquipModifiers(&PItem->modList, PItem->getReqLvl(), slotID);
+            PChar->addEquipModifiers(PItem);
             if (PItem->getReqLvl() <= PChar->GetMLevel())
             {
                 PChar->PLatentEffectContainer->AddLatentEffects(PItem->latentList, PItem->getReqLvl(), slotID);

--- a/src/map/utils/charutils.h
+++ b/src/map/utils/charutils.h
@@ -130,11 +130,11 @@ uint32 getItemCount(CCharEntity* PChar, uint16 ItemID);
 uint8  MoveItem(CCharEntity* PChar, uint8 LocationID, uint8 SlotID, uint8 NewSlotID);
 
 void DropItem(CCharEntity* PChar, uint8 container, uint8 slotID, int32 quantity, uint16 ItemID);
-void CheckValidEquipment(CCharEntity* PChar);
+void CheckValidEquipment(CCharEntity* PChar, bool isDelevel = false);
 void SaveJobChangeGear(CCharEntity* PChar);
 void LoadJobChangeGear(CCharEntity* PChar);
 void EquipItem(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);
-void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, xi::Flag<struct RecalculateTag> recalculate = Recalculate::Yes);
+void UnequipItem(CCharEntity* PChar, uint8 equipSlotID, xi::Flag<struct RecalculateTag> recalculate = Recalculate::Yes, bool isDelevel = false);
 bool hasSlotEquipped(CCharEntity* PChar, uint8 equipSlotID);
 void RemoveSub(CCharEntity* PChar);
 bool EquipArmor(CCharEntity* PChar, uint8 slotID, uint8 equipSlotID, uint8 containerID);


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

1. Refactors addEquipModifiers and delEquipModifiers to use `battleutils::GetScaledItemModifier` instead of replicating the code.
1. Cleans up orphaned `SUB_DMG_RANK` references and functionality
1. Plumbs a flag through Equipment Validation and Modifier Adjustment

## Steps to test these changes

1. Ensure Server Setting `DISABLE_GEAR_SCALING` is false
2. Level Sync or enter a level capped area with high level gear on.
3. Ensure the scaling as defined in `GetScaledItemModifier` is applied
4. Perform different scenarios to change level and gear - ensuring at each step that the expected and intended gear values are added/removed.

## Alternate consideration
I debated, instead of plumbing a boolean through core, the more correct solution would be to create a 16 slot cache map - likely an array containing a vector of Mods.  Indexing the array via `SLOTTYPE`.
Prob on CBattleEntitiy - although to be fair it only really applies to Chars.
```c++
std::array<std::vector<CModifier>, SLOT_BACK + 1> m_appliedEquipMods;
```
When equipping a piece of gear and applying the mods - we would use `GetScaledItemModifier` to determine the addition.
When clearing a piece of gear, we would use the cache instead of re-calculating via `GetScaledItemModifier`.
This would remove the need for any flags and ensure correctness.
For now, I went with this approach - but I'm open to the larger caching re-work
