### PR TITLE
Only flag registered transports as always relevant

### DIFF
--- a/src/map/transports/ship_handler.cpp
+++ b/src/map/transports/ship_handler.cpp
@@ -97,6 +97,8 @@ void ShipHandler::registerShip(const xi::data::TransportData& entry, CZone* PDoc
         }
     }
 
+    PShip->setAlwaysRelevant(true);
+
     // A ship only moves if some phase tells it to.
     const auto relocates = std::ranges::any_of(entry.Phases,
                                                [](const auto& phase)

--- a/src/map/zone_entities.cpp
+++ b/src/map/zone_entities.cpp
@@ -282,8 +282,6 @@ void CZoneEntities::InsertNPC(CBaseEntity* PNpc)
 
         if (PNpc->look.size == MODEL_SHIP)
         {
-            static_cast<CNpcEntity*>(PNpc)->setAlwaysRelevant(true);
-
             if (m_TransportList.contains(PNpc->targid))
             {
                 ShowError("Error: Inserting Transport NPC with duplicate ID!");


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?
3rd time fixing this. Only set the actual ships as always relevant instead of every NPC whose model string starts with SubKind 4 (which includes decorations etc)

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
