### PR TITLE
[lua] Adjust base mhitrate ratio based off retail data

### DIFF
--- a/scripts/combat/basic/magic_hit_rate.lua
+++ b/scripts/combat/basic/magic_hit_rate.lua
@@ -466,8 +466,11 @@ end
 -- Magic Hit Rate. The function gets fed the result of both functions above.
 -----------------------------------
 local function calculateMagicHitRate(params)
-    local magicHitRate = params.actorMagicAccuracy - params.targetMagicEvasion
+    -- macc == meva = 75% hit rate
+    -- below 50% hit rate it takes 2 macc to move hitrate by 1%
+    local magicHitRate = params.actorMagicAccuracy - params.targetMagicEvasion + 25
 
+    -- macc - meva < -25
     if magicHitRate < 0 then
         magicHitRate = math.floor(magicHitRate / 2)
     end


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Essentially, all data (and new data taken) points to monster rank C meva with 4/level correction on meva where level correction applies. We tested against mobs where we have no correction and everything holds true that
macc == meva = 75% base hit rate

<img width="783" height="149" alt="image" src="https://github.com/user-attachments/assets/a3871330-9f33-418b-be4e-2a198f157705" />

validation of the algorithm that does what we want
https://onecompiler.com/lua/452r9gcdu

We already have 4/level correction, and base C rank meva for monsters.

## Steps to test these changes

cast magic n stuff
