### PR TITLE
[core] [lua] Normalize spell aoe getters to match mobskills

### DIFF
--- a/scripts/combat/basic/magic_aoe.lua
+++ b/scripts/combat/basic/magic_aoe.lua
@@ -13,7 +13,7 @@ xi.combat.magicAoE = xi.combat.magicAoE or {}
 xi.combat.magicAoE.calculateSongRadius = function(caster, spell)
     local baseRadius = spell:getRadius()
     local rangeType  = caster:getWeaponSkillType(xi.slot.RANGED)
-    local aoeType    = spell:isAoE()
+    local aoeType    = spell:getAoE()
 
     -- Spell is not AoE or caster is under Pianissimo
     if
@@ -68,7 +68,7 @@ end
 ---@param spell CSpell
 ---@return [xi.magic.aoe, number]
 xi.combat.magicAoE.calculateTypeAndRadius = function(caster, spell)
-    local baseType    = spell:isAoE()
+    local baseType    = spell:getAoE()
     local baseRadius  = spell:getRadius()
     local spellFamily = spell:getSpellFamily()
     local spellGroup  = spell:getSpellGroup()

--- a/scripts/globals/bluemagic.lua
+++ b/scripts/globals/bluemagic.lua
@@ -416,7 +416,10 @@ xi.spells.blue.usePhysicalSpell = function(caster, target, spell, params)
     local sneakIsApplicable = false
     local trickAttackTarget = nil
 
-    if spell:isAoE() == 0 and params.attackType ~= xi.attackType.RANGED then
+    if
+        spell:getAoE() == xi.aoeType.NONE and
+        params.attackType ~= xi.attackType.RANGED
+    then
         if
             caster:hasStatusEffect(xi.effect.SNEAK_ATTACK) and
             (caster:isBehind(target) or caster:hasStatusEffect(xi.effect.HIDE))

--- a/scripts/specs/core/CSpell.lua
+++ b/scripts/specs/core/CSpell.lua
@@ -56,7 +56,17 @@ end
 
 ---@nodiscard
 ---@return xi.magic.aoe
+function CSpell:getAoE()
+end
+
+---@nodiscard
+---@return boolean
 function CSpell:isAoE()
+end
+
+---@nodiscard
+---@return boolean
+function CSpell:isConal()
 end
 
 ---@nodiscard

--- a/src/map/lua/lua_spell.cpp
+++ b/src/map/lua/lua_spell.cpp
@@ -137,7 +137,17 @@ uint16 CLuaSpell::getElement()
     return m_PLuaSpell->getElement();
 }
 
-uint8 CLuaSpell::isAoE()
+bool CLuaSpell::isAoE() const
+{
+    return m_PLuaSpell->getAOE() == SPELLAOE_RADIAL;
+}
+
+bool CLuaSpell::isConal() const
+{
+    return m_PLuaSpell->getAOE() == SPELLAOE_CONAL;
+}
+
+uint8 CLuaSpell::getAoE() const
 {
     return m_PLuaSpell->getAOE();
 }
@@ -202,6 +212,8 @@ void CLuaSpell::Register()
     SOL_REGISTER("setCastTime", CLuaSpell::setCastTime);
     SOL_REGISTER("setMPCost", CLuaSpell::setMPCost);
     SOL_REGISTER("isAoE", CLuaSpell::isAoE);
+    SOL_REGISTER("getAoE", CLuaSpell::getAoE);
+    SOL_REGISTER("isConal", CLuaSpell::isConal);
     SOL_REGISTER("getRadius", CLuaSpell::getRadius);
     SOL_REGISTER("tookEffect", CLuaSpell::tookEffect);
     SOL_REGISTER("getMagicBurstMessage", CLuaSpell::getMagicBurstMessage);

--- a/src/map/lua/lua_spell.h
+++ b/src/map/lua/lua_spell.h
@@ -52,7 +52,9 @@ public:
     void   setCastTime(uint32 casttime);
     void   setMPCost(uint16 mpcost);
     bool   canTargetEnemy();
-    uint8  isAoE();
+    auto   getAoE() const -> uint8;
+    auto   isAoE() const -> bool;
+    auto   isConal() const -> bool;
     float  getRadius();
     bool   tookEffect();
     uint16 getTotalTargets();


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

"isAoE" doesnt make sense for "getAoE" and didn't match mobskill behavior.
So I added getAoE and isAoE and isConal.

There's some problems here since technically Manifestation can make some non-aoe spells aoe in a _meaningful_ way but that's still a problem before this PR.

## Steps to test these changes

CI passes, blue magic non-ranged spells remove SA
