### PR TITLE
Fix Conquest Region Bonus mod

### DIFF
--- a/src/map/conquest_system.cpp
+++ b/src/map/conquest_system.cpp
@@ -134,7 +134,8 @@ void AddPlayerHomepoints(int32 count, REGION_TYPE region)
 
 void GainInfluencePoints(CCharEntity* PChar, uint32 points)
 {
-    points += (uint32)(PChar->getMod(xi::Mod::CONQUEST_REGION_BONUS) / 100.0);
+    const double percentage = 1.0 + static_cast<double>(PChar->getMod(xi::Mod::CONQUEST_REGION_BONUS)) / 100.0;
+    points                  = static_cast<uint32>(static_cast<double>(points) * percentage);
     conquest::AddInfluencePoints(points, PChar->profile.nation, PChar->loc.zone->GetRegionID());
 }
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

The Conquest Region Bonus (Influence) mod does nothing; it floors( 10 / 100 ) = 0.
This change makes the mod mimic the Conquest Bonus (CP) mod in the same file where the mod is supposed to increase the amount by a percentage.

## Steps to test these changes

Can give yourself the mod with !setmod CONQUEST_REGION_BONUS 10
Then kill stuff with and without the mod.