### PR TITLE
Minor changes in ToAU 12, 13, and 15

### DIFF
--- a/scripts/missions/toau/12_Royal_Puppeteer.lua
+++ b/scripts/missions/toau/12_Royal_Puppeteer.lua
@@ -51,7 +51,7 @@ mission.sections =
                     if missionStatus == 0 then
                         return mission:progressEvent(277)
                     elseif missionStatus == 1 then
-                        return mission:event(278)
+                        return mission:event(278):oncePerZone()
                     end
                 end,
             },

--- a/scripts/missions/toau/13_Lost_Kingdom.lua
+++ b/scripts/missions/toau/13_Lost_Kingdom.lua
@@ -45,7 +45,7 @@ mission.sections =
                         missionStatus == 0 and
                         player:hasKeyItem(xi.ki.VIAL_OF_SPECTRAL_SCENT)
                     then
-                        return mission:progressEvent(8)
+                        return mission:progressCutscene(8)
                     elseif
                         missionStatus == 1 and
                         not GetMobByID(caedarvaID.mob.JAZARAAT):isSpawned()
@@ -54,7 +54,7 @@ mission.sections =
                         -- There is no message returned here in captures
                         return mission:noAction()
                     elseif missionStatus == 2 then
-                        return mission:progressEvent(9)
+                        return mission:progressCutscene(9)
                     end
                 end,
             },
@@ -72,10 +72,10 @@ mission.sections =
             {
                 [8] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 1)
-                    player:delKeyItem(xi.ki.VIAL_OF_SPECTRAL_SCENT)
                 end,
 
                 [9] = function(player, csid, option, npc)
+                    player:delKeyItem(xi.ki.VIAL_OF_SPECTRAL_SCENT)
                     mission:complete(player)
                 end,
             },

--- a/scripts/missions/toau/15_The_Black_Coffin.lua
+++ b/scripts/missions/toau/15_The_Black_Coffin.lua
@@ -40,8 +40,13 @@ mission.sections =
                         player:getMissionStatus(mission.areaId) == 0
                     then
                         player:startEvent(8)
-                        player:startEvent(34, 1, 1, 1, 1, 1, 1, 1, 1)
-                        return mission:progressEvent(35)
+                        player:startEvent(34, { [7] = 1, isHidden = true })
+                        return mission:progressEvent(35, { isHidden = true })
+                    elseif
+                        not player:hasKeyItem(xi.ki.EPHRAMADIAN_GOLD_COIN) and
+                        player:getMissionStatus(mission.areaId) == 1
+                    then
+                        return mission:event(12):oncePerZone()
                     end
                 end,
             },
@@ -51,7 +56,7 @@ mission.sections =
                     prevZone == xi.zone.THE_ASHU_TALIF and
                     player:getMissionStatus(mission.areaId) == 2
                 then
-                    player:setPos(-456, -3, -405, 64)
+                    player:setPos(-444.059, -4.124, -413.934, 126)
                     return 9
                 end
             end,
@@ -60,7 +65,7 @@ mission.sections =
             {
                 [9] = function(player, csid, option, npc)
                     player:setMissionStatus(mission.areaId, 3)
-                    player:setPos(0, 0, 0, 0, 53)
+                    player:setPos(0, 0, 0, 0, xi.zone.NASHMAU)
                 end,
 
                 [35] = function(player, csid, option, npc)
@@ -79,7 +84,7 @@ mission.sections =
                     player:getYPos() == 0 and
                     player:getZPos() == 0
                 then
-                    player:setPos(-13, 2, -62, 194)
+                    player:setPos(0.016, 0, -23.753, 63)
                     return 281
                 end
             end,

--- a/scripts/zones/Arrapago_Reef/IDs.lua
+++ b/scripts/zones/Arrapago_Reef/IDs.lua
@@ -37,6 +37,7 @@ zones[xi.zone.ARRAPAGO_REEF] =
         SPINE_CHILL                   = 8404, -- You feel a chill run down your spine!
         PILE_OF_DISCARDED_MATERIALS   = 8435, -- There is a pile of discarded materials here.
         HAND_OVER_TO_IMMORTAL         = 8462, -- You hand over the % to the Immortal.
+        CUTTER_NOTHING_HAPPENS        = 8467, -- Nothing happens...
         CANNOT_ENTER                  = 8481, -- You cannot enter at this time. Please wait a while before trying again.
         AREA_FULL                     = 8482, -- This area is fully occupied. You were unable to enter.
         MEMBER_NO_REQS                = 8486, -- Not all of your party members meet the requirements for this objective. Unable to enter area.

--- a/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
+++ b/scripts/zones/Arrapago_Reef/npcs/Cutter.lua
@@ -11,7 +11,7 @@ local entity = {}
 
 entity.onTrigger = function(player, npc)
     if not xi.instance.onTrigger(player, npc, xi.zone.THE_ASHU_TALIF) then
-        player:messageSpecial(ID.text.YOU_NO_REQS)
+        player:messageSpecial(ID.text.CUTTER_NOTHING_HAPPENS)
     end
 end
 


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

- ToAU 12: Makes the line once per zone per capture.
- ToAU 13: Deletes the KI at the correct step and changes events to cutscenes. Video with both events (close together): https://youtu.be/tHi8gE5BlG0?t=2099
- ToAU 15: Sets the hidden status and fixes some event parameters per capture: https://drive.google.com/file/d/1MnQosdX99_0SMMcJMlRyAZAhtrqtrqKa/view?usp=drive_link
- ToAU 15: Adds extra event if you lose your coin and come back thanks to Siknoz: https://www.youtube.com/watch?v=m-0ctx7eC9o
- Uses the correct text if you do not have the pre-reqs to enter the Cutter thanks to Siknoz: https://www.youtube.com/watch?v=m-0ctx7eC9o

Note:
In ToAU 15 for event 8, I'm fairly confident that should be a cutscene, as the mobs do some weird things during the events if you do not drop aggro. I just forgot to get proof when running the mission so I did not set it.

## Steps to test these changes

Run the missions.
