### PR TITLE
Fix Res Ranks for Human/Taru mobs

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -9999,25 +9999,25 @@ ecosystems:
                 - sight
               resists:
                 rank_element:
-                  fire:     4
-                  ice:      5
-                  wind:     4
-                  earth:    5
-                  thunder:  4
-                  water:    5
-                  light:    8
-                  dark:    11 # absorbs on retail
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
+                  light:   0
+                  dark:    0
                 rank_status:
-                  paralyze:     5
-                  bind:         5
-                  silence:      4
-                  slow:         5
-                  poison:       5
-                  light_sleep:  8
-                  dark_sleep:  11 # absorbs on retail
-                  blind:       11 # absorbs on retail
-                  stun:         4
-                  gravity:      4
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
+                  light_sleep: 0
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
               mob_mods:
                 sight_range: 30
       mithra:
@@ -10074,25 +10074,25 @@ ecosystems:
                 - sight
               resists:
                 rank_element:
-                  fire:    1
-                  ice:     2
-                  wind:    1
-                  earth:   1
-                  thunder: 1
-                  water:   2
+                  fire:    0
+                  ice:     0
+                  wind:    0
+                  earth:   0
+                  thunder: 0
+                  water:   0
                   light:   0
-                  dark:    2
+                  dark:    0
                 rank_status:
-                  paralyze:    2
-                  bind:        2
-                  silence:     1
-                  slow:        1
-                  poison:      2
+                  paralyze:    0
+                  bind:        0
+                  silence:     0
+                  slow:        0
+                  poison:      0
                   light_sleep: 0
-                  dark_sleep:  2
-                  blind:       2
-                  stun:        1
-                  gravity:     1
+                  dark_sleep:  0
+                  blind:       0
+                  stun:        0
+                  gravity:     0
 
   lizard:
     id: 13


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This fixes the res ranks in the ecosystem for Human and Taru mobs.

Frank flubbed some copy pasta.

## Steps to test these changes

Fight Maat and behold that you're not being griefed anymore. 
