### PR TITLE
Remove enemy HP clamp restriction for drain

### DIFF
--- a/scripts/globals/spells/absorb_spell.lua
+++ b/scripts/globals/spells/absorb_spell.lua
@@ -170,7 +170,6 @@ xi.spells.absorb.doDrainingSpell = function(caster, target, spell)
         finalDamage = utils.clamp(utils.handlePhalanx(target, finalDamage), 0, 99999)
         finalDamage = utils.clamp(utils.handleOneForAll(target, finalDamage), 0, 99999)
         finalDamage = utils.handleStoneskin(target, finalDamage, xi.attackType.MAGICAL)
-        finalDamage = utils.clamp(finalDamage, 0, targetPoints)
         finalDamage = target:checkDamageCap(finalDamage)
 
         -- Handle Bind break and TP?


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

This PR removes the clamp for Drain which couldn't drain anymore than the mob has HP.

<img width="199" height="75" alt="image" src="https://github.com/user-attachments/assets/10715b0c-03ff-4a87-ad10-83f00656cd69" />
<img width="1520" height="300" alt="image" src="https://github.com/user-attachments/assets/54662066-09bb-474c-a529-dca8561c04b4" />

It's not real.  It's never been real.

## Steps to test these changes

Drain a low level bunny with lots of missing HP.
