### PR TITLE
Update instance to not zone players already in the instance

### DIFF
--- a/scripts/globals/instance.lua
+++ b/scripts/globals/instance.lua
@@ -511,8 +511,11 @@ xi.instance.onEventFinish = function(player, csid, option, npc, instanceInfo)
         local csidEntry, optionEntry = unpack(instanceInfo)
 
         if csid == csidEntry and option == optionEntry then
+            local playerZone = player:getZoneID()
             for _, v in ipairs(player:getParty()) do
-                v:setPos(0, 0, 0, 0, instance:getZone():getID())
+                if v:getZoneID() == playerZone then
+                    v:setPos(0, 0, 0, 0, instance:getZone():getID())
+                end
             end
 
             return true


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Fixes a double zone issue with instances.

For some instances like The Black Coffin, party members zone into the instance before the party leader. With the old code, a member would zone into the instance, then when the leader finishes their event, the member would re-zone.

## Steps to test these changes

Run The Black Coffin fight with 2 people.