### PR TITLE
fix umerited random deal to function

### DIFF
--- a/src/map/utils/battleutils.cpp
+++ b/src/map/utils/battleutils.cpp
@@ -5133,7 +5133,6 @@ void DoWildCardToEntity(CCharEntity* PCaster, CCharEntity* PTarget, const uint8 
  ************************************************************************/
 bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
 {
-    std::vector<uint16> resetCandidateList;
     std::vector<uint16> activeCooldownList;
 
     if (PChar == nullptr || PTarget == nullptr)
@@ -5152,7 +5151,6 @@ bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
         // Do not reset 1hrs or Random Deal
         if (recast->ID != Recast::Special && recast->ID != Recast::Special2 && recast->ID != Recast::RandomDeal)
         {
-            resetCandidateList.push_back(i);
             if (recast->RecastTime > 0s)
             {
                 activeCooldownList.push_back(i);
@@ -5160,7 +5158,7 @@ bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
         }
     }
 
-    if (resetCandidateList.size() == 0 || activeCooldownList.size() == 0)
+    if (activeCooldownList.size() == 0)
     {
         // Evade because we have no abilities that can be reset
         return false;
@@ -5204,19 +5202,19 @@ bool DoRandomDealToEntity(CCharEntity* PChar, CBattleEntity* PTarget)
     }
     else // Standard Version
     {
-        if (resetCandidateList.size() > 1)
+        if (activeCooldownList.size() > 1)
         {
             // Shuffle if more than 1 ability
-            xirand::ShuffleInPlace(resetCandidateList);
+            xirand::ShuffleInPlace(activeCooldownList);
         }
 
         // Reset first ability (shuffled or only)
-        PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, resetCandidateList.at(0));
+        PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, activeCooldownList.at(0));
 
-        // Reset 2 abilities by chance (could be 2 abilities that don't need resets)
-        if (resetCandidateList.size() > 1 && activeCooldownList.size() > 1 && resetTwoChance >= xirand::GetRandomNumber(1, 100))
+        // Reset 2 abilities by chance
+        if (activeCooldownList.size() > 1 && resetTwoChance >= xirand::GetRandomNumber(1, 100))
         {
-            PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, resetCandidateList.at(1));
+            PTarget->PRecastContainer->DeleteByIndex(RECAST_ABILITY, activeCooldownList.at(1));
         }
 
         if (PChar != PTarget)


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Currently, unmerited Random Deal and merited Random Deal have different behaviors, this PR addresses the unmerited version.

The flow before this change is this:

- Create a list of all abilities which have recast timers, and are not 2-hr abilities or random deal itself
- Shuffle the list of all abilities which have recast timers, pick one, and reset it
  - Note that this means it can pick an ability which does not NEED resetting, and reset it

After meriting random deal, this check changes and it begins only resetting abilities that are CURRENTLY on cooldown, and then additionally attempts to reset a second ability based on the reset odds based on the number of merits.

This change simply updates the non merited version of random deal to only look at abilities that are actively cooling down, instead of every ability. As it stands this ability cannot be functioning as intended. Some strange outcomes from it working this way are:

- using random deal, it not missing, and nothing happening except having your ability go on cooldown
- random deal getting WORSE as you get to higher levels and unlock more job abilities
   - If you have one ability on cooldown and 7 abilities with recast timers available to you (no matter how many of them are actually on cooldown), you only have a 1/7 chance of it actually having any effect whatsoever.

Based on some retail investigation, this might be functioning as intended but I think this is an extremely strong candidate for era+. It's a really limited case, it only applies to Corsairs above level 50 and below their first loaded deck merit (so not relevant in the subjob scenario), and it STILL only refreshes a single ability. If the feedback is that's too strong we can put an additional coin flip into whether or not random deal does anything or not, but then once it flips yes, it will actually reset something resettable.

Considering that at level 50 most jobs have their job abilities, I'd guess this has a 1/6-1/9 chance of doing anything at all once every 20 minutes as it currently stands.

## Steps to test these changes

The steps are very simple, put something on cooldown and use Random Deal. That thing should come off cooldown.
