### PR TITLE
Implement Valkeng for PUP AF Battlefield "Puppetmaster Blues"

### DIFF
--- a/data/zones/talacca_cove/mobs.yaml
+++ b/data/zones/talacca_cove/mobs.yaml
@@ -349,11 +349,12 @@ templates:
     id:            4123
     species:       automaton
     type:          [notorious, battlefield]
-    spell_list_id: 1
-    skill_list_id: 363
+    spell_list_id: 2
+    skill_list_id: 426
     attributes:
       combat:
         skill: axe
+        delay: 240
       jobs: [rdm, rdm]
       render:
         look:
@@ -368,6 +369,9 @@ templates:
         true_detection: true
       spawn:
         type: [scripted]
+      stats:
+        hp: 13200
+        mp: 13200
 
   Valkeng_Large:
     id:            7288
@@ -540,8 +544,7 @@ spawns:
     at:       [220.000, -40.500, 185.000, 65]
     level:    [80, 80]
   17010719:
-    template: Valkeng_Large
-    script:   Valkeng
+    template: Valkeng
     at:       [-180.000, 39.500, 185.000, 65]
     level:    [66, 66]
   17010720:

--- a/scripts/actions/mobskills/frame_change.lua
+++ b/scripts/actions/mobskills/frame_change.lua
@@ -1,0 +1,17 @@
+-----------------------------------
+-- Frame Change
+-- Description: Automaton spins around and turns invisible. Used for Ob and & Valkeng
+-----------------------------------
+---@type TMobSkill
+local mobskillObject = {}
+
+mobskillObject.onMobSkillCheck = function(target, mob, skill)
+    return 0
+end
+
+mobskillObject.onMobWeaponSkill = function(mob, target, skill, action)
+    skill:setMsg(xi.msg.basic.NONE)
+    return 0
+end
+
+return mobskillObject

--- a/scripts/enum/mob_skill.lua
+++ b/scripts/enum/mob_skill.lua
@@ -1211,6 +1211,7 @@ xi.mobSkill =
     WATER_SHOT                    = 2014,
     LIGHT_SHOT                    = 2015,
     DARK_SHOT                     = 2016,
+    FRAME_CHANGE_AUTOMATON        = 2018,
 
     -- HUNDRED_FISTS                 = 2020,
     ERASER_AUTOMATON              = 2021,

--- a/scripts/zones/Talacca_Cove/IDs.lua
+++ b/scripts/zones/Talacca_Cove/IDs.lua
@@ -51,6 +51,7 @@ zones[xi.zone.TALACCA_COVE] =
         QULTADA_CHIPS_ARE_DOWN        = 7877, -- Sometimes the chips are down...
         QULTADA_HEAT_UP               = 7878, -- Looks like things are beginning to heat up!
         YOUR_LEVEL_LIMIT_IS_NOW_75    = 7879, -- Your level limit is now 75.
+        VALKENG_STATUS                = 7880, -- Confirming status... Damage from [melee attacks/ranged attacks/magic]...<number>%. [Changing frame/Executing maneuver]...
     },
     mob =
     {

--- a/scripts/zones/Talacca_Cove/mobs/Valkeng.lua
+++ b/scripts/zones/Talacca_Cove/mobs/Valkeng.lua
@@ -1,0 +1,245 @@
+-----------------------------------
+-- Area: Talacca Cove
+--  Mob: Valkeng
+-----------------------------------
+local ID = zones[xi.zone.TALACCA_COVE]
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+local harlequinModel  = 1977
+local valoredgeModel  = 1983
+local sharpshotModel  = 1990
+local stormwakerModel = 1994
+
+local frames =
+{
+    [harlequinModel] =
+    {
+        skillList =
+        {
+            xi.mobSkill.SLAPSTICK_AUTOMATON,
+        },
+    },
+    [valoredgeModel] =
+    {
+        skillList    =
+        {
+            xi.mobSkill.CHIMERA_RIPPER_AUTOMATON,
+            xi.mobSkill.STRING_CLIPPER_AUTOMATON,
+            xi.mobSkill.SHIELD_BASH_AUTOMATON,
+        },
+        textOffset   = 0,
+        delay        = 240,
+        casting      = false,
+        specialSkill = 0,
+        specialCool  = 0,
+        regain       = 20,
+        fastCast     = 0,
+        onManeuver   = function(mob, maneuvers)
+            mob:setMod(xi.mod.REGAIN, math.max(mob:getMod(xi.mod.REGAIN), 20 + maneuvers * 20))
+            if maneuvers == 4 then
+                mob:setDelay(120)
+            end
+        end,
+    },
+    [sharpshotModel] =
+    {
+        skillList    =
+        {
+            xi.mobSkill.ARCUBALLISTA_AUTOMATON,
+            xi.mobSkill.SLAPSTICK_AUTOMATON,
+        },
+        textOffset   = 1,
+        delay        = 240,
+        casting      = false,
+        specialSkill = xi.mobSkill.RANGED_ATTACK_1,
+        specialCool  = 12,
+        regain       = 0,
+        fastCast     = 0,
+        onManeuver   = function(mob, maneuvers)
+            mob:setMobMod(xi.mobMod.SPECIAL_COOL, 12 - maneuvers * 2)
+        end,
+    },
+    [stormwakerModel] =
+    {
+        skillList    =
+        {
+            xi.mobSkill.SLAPSTICK_AUTOMATON,
+        },
+        textOffset   = 2,
+        delay        = 240,
+        casting      = true,
+        specialSkill = 0,
+        specialCool  = 0,
+        regain       = 0,
+        fastCast     = 20,
+        onManeuver   = function(mob, maneuvers)
+            mob:setMod(xi.mod.UFASTCAST, 20 + maneuvers * 20)
+        end,
+    },
+}
+
+local function handleAutomatonManeuver(mob, model, share)
+    local frame = frames[model]
+
+    if mob:getModelId() ~= model then
+        mob:showText(mob, ID.text.VALKENG_STATUS + frame.textOffset, share, 0, 0, 0, true)
+        mob:setMagicCastingEnabled(false)
+        mob:setMod(xi.mod.REGAIN, math.max(mob:getMod(xi.mod.REGAIN), frame.regain)) -- Regain accrued while in Valoredge never resets.
+        mob:setMod(xi.mod.UFASTCAST, frame.fastCast)
+        mob:setDelay(frame.delay)
+        mob:setMobMod(xi.mobMod.SPECIAL_SKILL, frame.specialSkill)
+        mob:setMobMod(xi.mobMod.SPECIAL_COOL, frame.specialCool)
+        mob:setLocalVar('maneuvers', 0)
+        mob:setLocalVar('nextManeuverTime', GetSystemTime() + 50)
+        mob:useMobAbility(xi.mobSkill.FRAME_CHANGE_AUTOMATON)
+        mob:timer(3300, function(mobArg)
+            if mobArg:isAlive() then
+                mobArg:setModelId(model)
+                mobArg:setMagicCastingEnabled(frame.casting)
+                mobArg:setMobAbilityEnabled(true)
+            end
+        end)
+
+        return
+    end
+
+    if mob:getLocalVar('maneuvers') < 4 then
+        mob:showText(mob, ID.text.VALKENG_STATUS + 3 + frame.textOffset, share, 0, 0, 0, true)
+        local maneuvers = mob:getLocalVar('maneuvers') + 1
+        mob:setLocalVar('maneuvers', maneuvers)
+        mob:setLocalVar('nextManeuverTime', GetSystemTime() + 25)
+        frame.onManeuver(mob, maneuvers)
+    end
+end
+
+entity.onMobInitialize = function(mob)
+    mob:addImmunity(xi.immunity.PETRIFY)
+    mob:addImmunity(xi.immunity.SILENCE)
+    mob:addImmunity(xi.immunity.DARK_SLEEP)
+
+    mob:addListener('TAKE_DAMAGE', 'VALKENG_TAKE_DAMAGE', function(mobArg, damage, attacker, attackType, damageType)
+        if attackType == xi.attackType.PHYSICAL then
+            mobArg:setLocalVar('meleeDamage', mobArg:getLocalVar('meleeDamage') + damage)
+        elseif attackType == xi.attackType.RANGED then
+            mobArg:setLocalVar('rangedDamage', mobArg:getLocalVar('rangedDamage') + damage)
+        else
+            mobArg:setLocalVar('magicDamage', mobArg:getLocalVar('magicDamage') + damage)
+        end
+    end)
+
+    mob:addListener('DISENGAGE', 'VALKENG_DISENGAGE', function(mobArg)
+        mobArg:setLocalVar('meleeDamage', 0)
+        mobArg:setLocalVar('rangedDamage', 0)
+        mobArg:setLocalVar('magicDamage', 0)
+        mobArg:setLocalVar('maneuvers', 0)
+        mobArg:setLocalVar('nextManeuverTime', 0)
+    end)
+end
+
+entity.onMobSpawn = function(mob)
+    mob:setModelId(harlequinModel)
+    mob:setMobAbilityEnabled(false)
+    mob:setMagicCastingEnabled(true)
+    mob:setMobMod(xi.mobMod.MAGIC_COOL, 23)
+    mob:setMobMod(xi.mobMod.SPECIAL_SKILL, 0)
+    mob:setMod(xi.mod.UDMGPHYS, 0)
+    mob:setMod(xi.mod.UDMGRANGE, 0)
+    mob:setMod(xi.mod.UDMGMAGIC, 0)
+    mob:setMod(xi.mod.REGAIN, 0)
+    mob:setMod(xi.mod.UFASTCAST, 0)
+    mob:setDelay(240)
+    mob:setLocalVar('maneuvers', 0)
+    mob:setLocalVar('meleeDamage', 0)
+    mob:setLocalVar('rangedDamage', 0)
+    mob:setLocalVar('magicDamage', 0)
+
+    mob:setMobMod(xi.mobMod.BASE_DAMAGE_MULTIPLIER, 150)
+end
+
+entity.onMobEngage = function(mob)
+    mob:setLocalVar('nextManeuverTime', GetSystemTime() + 25)
+end
+
+entity.onMobFight = function(mob, target)
+    if xi.combat.behavior.isEntityBusy(mob) then
+        return
+    end
+
+    -- Check if it's time for a manuever, if not, return.
+    if mob:getLocalVar('nextManeuverTime') > GetSystemTime() then
+        return
+    end
+
+    local meleeDamageTaken   = mob:getLocalVar('meleeDamage')
+    local rangedDamageTaken  = mob:getLocalVar('rangedDamage')
+    local magicDamageTaken   = mob:getLocalVar('magicDamage')
+    local totalDamageTaken   = meleeDamageTaken + rangedDamageTaken + magicDamageTaken
+    local highestDamageTaken = math.max(meleeDamageTaken, rangedDamageTaken, magicDamageTaken)
+    local damageShare        = math.floor(100 * highestDamageTaken / totalDamageTaken)
+
+    -- Update damage taken modifiers, only changes on status updates. Tested to confirm that one damage type will raise DT to 90%, even if its only a few damage.
+    mob:setMod(xi.mod.UDMGPHYS, -math.floor(9000 * meleeDamageTaken / totalDamageTaken))
+    mob:setMod(xi.mod.UDMGRANGE, -math.floor(9000 * rangedDamageTaken / totalDamageTaken))
+    mob:setMod(xi.mod.UDMGMAGIC, -math.floor(9000 * magicDamageTaken / totalDamageTaken))
+
+    -- Switch forms or execute maneuvers. Form/maneuver used based off of dominant damage type.
+    if highestDamageTaken == meleeDamageTaken then
+        handleAutomatonManeuver(mob, valoredgeModel, damageShare)
+    elseif highestDamageTaken == rangedDamageTaken then
+        handleAutomatonManeuver(mob, sharpshotModel, damageShare)
+    else
+        handleAutomatonManeuver(mob, stormwakerModel, damageShare)
+    end
+end
+
+entity.onMobSpellChoose = function(mob, target, spellId)
+    if
+        mob:getModelId() == harlequinModel and
+        mob:isEngaged()
+    then
+        return xi.magic.spell.DIA
+    end
+
+    local spellList =
+    {
+        [ 1] = { xi.magic.spell.BLAZE_SPIKES, mob,    false, xi.action.type.ENHANCING_FORCE_SELF, xi.effect.BLAZE_SPIKES, 0, 100 },
+        [ 2] = { xi.magic.spell.SLEEPGA_II,   target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,      2, 100 },
+        [ 3] = { xi.magic.spell.SLEEPGA,      target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,      1, 100 },
+        [ 4] = { xi.magic.spell.SLEEP,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.SLEEP_I,      1, 100 },
+        [ 5] = { xi.magic.spell.STUN,         target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.STUN,         1, 100 },
+        [ 6] = { xi.magic.spell.BLIND,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BLINDNESS,    1, 100 },
+        [ 7] = { xi.magic.spell.BIND,         target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BIND,         1, 100 },
+        [ 8] = { xi.magic.spell.POISONGA_II,  target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.POISON,       1, 100 },
+        [ 9] = { xi.magic.spell.BIO_II,       target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BIO,          4, 100 },
+        [10] = { xi.magic.spell.BURN,         target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.BURN,         1, 100 },
+        [11] = { xi.magic.spell.FROST,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.FROST,        1, 100 },
+        [12] = { xi.magic.spell.CHOKE,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.CHOKE,        1, 100 },
+        [13] = { xi.magic.spell.RASP,         target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.RASP,         1, 100 },
+        [14] = { xi.magic.spell.DROWN,        target, false, xi.action.type.ENFEEBLING_TARGET,    xi.effect.DROWN,        1, 100 },
+        [15] = { xi.magic.spell.DRAIN,        target, false, xi.action.type.DRAIN_HP,             nil,                    0, 100 },
+        [16] = { xi.magic.spell.ASPIR,        target, false, xi.action.type.DRAIN_MP,             nil,                    0, 100 },
+        [17] = { xi.magic.spell.FIRE_III,     target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [18] = { xi.magic.spell.BLIZZARD_III, target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [19] = { xi.magic.spell.FIRAGA_II,    target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [20] = { xi.magic.spell.BLIZZAGA_II,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [21] = { xi.magic.spell.STONEGA_III,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [22] = { xi.magic.spell.THUNDAGA_II,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [23] = { xi.magic.spell.WATERGA_III,  target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [24] = { xi.magic.spell.FLARE,        target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [25] = { xi.magic.spell.QUAKE,        target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [26] = { xi.magic.spell.BURST,        target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+        [27] = { xi.magic.spell.FLOOD,        target, false, xi.action.type.DAMAGE_TARGET,        nil,                    0, 100 },
+    }
+
+    return xi.combat.behavior.chooseAction(mob, target, nil, spellList)
+end
+
+entity.onMobMobskillChoose = function(mob, target, skillId)
+    local skillList = frames[mob:getModelId()].skillList
+
+    return skillList[math.randomInt(1, #skillList)]
+end
+
+return entity

--- a/sql/mob_skill_lists.sql
+++ b/sql/mob_skill_lists.sql
@@ -1918,6 +1918,11 @@ INSERT INTO `mob_skill_lists` VALUES ('Geush_Urvan',424,495); -- Snort
 INSERT INTO `mob_skill_lists` VALUES ('Geush_Urvan',424,496); -- Rabid Dance
 INSERT INTO `mob_skill_lists` VALUES ('Geush_Urvan',424,497); -- Lowing
 INSERT INTO `mob_skill_lists` VALUES ('OuryuCometh',425,1405); -- Ouryu Flying Attack
+INSERT INTO `mob_skill_lists` VALUES ('Valkeng_AF',426,1940);
+INSERT INTO `mob_skill_lists` VALUES ('Valkeng_AF',426,1941);
+INSERT INTO `mob_skill_lists` VALUES ('Valkeng_AF',426,1942);
+INSERT INTO `mob_skill_lists` VALUES ('Valkeng_AF',426,1943);
+INSERT INTO `mob_skill_lists` VALUES ('Valkeng_AF',426,1944);
 INSERT INTO `mob_skill_lists` VALUES ('Bloodlapper',436,2162);
 INSERT INTO `mob_skill_lists` VALUES ('Ghillie_Dhu',437,685);
 INSERT INTO `mob_skill_lists` VALUES ('Highlander_Lizard',438,371);

--- a/sql/mob_skills.sql
+++ b/sql/mob_skills.sql
@@ -1968,11 +1968,11 @@ INSERT INTO `mob_skills` VALUES (1936,1299,'shibaraku',0,0.0,7.0,2000,1500,4,0,0
 -- INSERT INTO `mob_skills` VALUES (1937,1681,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1938,1301,'warp_out_gessho',0,0.0,7.0,500,0,1,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1939,1302,'warp_in_gessho',0,0.0,7.0,500,0,1,0,0,0,0,0,0);
-INSERT INTO `mob_skills` VALUES (1940,1304,'chimera_ripper',0,0.0,7.0,2000,1,4,0,0,0,6,7,0);
-INSERT INTO `mob_skills` VALUES (1941,1305,'string_clipper',0,0.0,7.0,2000,1,4,0,0,0,4,0,0);
-INSERT INTO `mob_skills` VALUES (1942,1303,'arcuballista',0,0.0,15.0,2000,1,4,0,0,0,3,1,0);
+INSERT INTO `mob_skills` VALUES (1940,1304,'chimera_ripper',0,0.0,7.0,3466,1,4,0,0,0,6,7,0);
+INSERT INTO `mob_skills` VALUES (1941,1305,'string_clipper',0,0.0,7.0,3366,1,4,0,0,0,4,0,0);
+INSERT INTO `mob_skills` VALUES (1942,1303,'arcuballista',0,0.0,15.0,3133,1,4,0,0,0,3,1,0);
 INSERT INTO `mob_skills` VALUES (1943,1306,'slapstick',0,0.0,7.0,3116,1,4,0,0,0,5,8,0);
-INSERT INTO `mob_skills` VALUES (1944,1307,'shield_bash',0,0.0,7.0,2000,0,4,4,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (1944,1307,'shield_bash',0,0.0,7.0,1483,0,4,0,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1945,1219,'provoke',0,0.0,7.0,2000,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1946,435,'shock_absorber',0,0.0,7.0,2000,0,16,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (1947,438,'flashbulb',0,0.0,7.0,2000,0,4,4,0,0,0,0,0);
@@ -2046,7 +2046,7 @@ INSERT INTO `mob_skills` VALUES (2014,130,'water_shot',0,0.0,22.0,2000,0,4,4,0,0
 INSERT INTO `mob_skills` VALUES (2015,123,'light_shot',0,0.0,22.0,2000,0,4,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2016,124,'dark_shot',0,0.0,22.0,2000,0,4,4,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2017,1761,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
--- INSERT INTO `mob_skills` VALUES (2018,1762,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
+INSERT INTO `mob_skills` VALUES (2018,1365,'frame_change',0,0.0,7.0,3200,0,1,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2019,1763,'.',0,0.0,7.0,2000,1500,4,0,0,0,0,0,0);
 -- INSERT INTO `mob_skills` VALUES (2020,436,'hundred_fists',0,0.0,7.0,2000,0,1,4,0,0,0,0,0);
 INSERT INTO `mob_skills` VALUES (2021,438,'eraser',0,0.0,7.0,2000,0,16,4,0,0,0,0,0);


### PR DESCRIPTION
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

Implements the PUP AF Fight against "Valkeng"

Every 50s (or 25s if in the same form) Valkeng will do a "status update" which will change them into one of 3 forms based off of the dominant damage type taken. If the same damage type is dominant for a status update, will perform a maneuver instead and gain some sort of buff, outlined below. 

Physical damage being dominant switches Valkeng into Valoredge form, subsequent Maneuvers increase Regain. The regain increase from this form doesn't seem to go away and carries over between the other forms.
At 4 maneuvers, Valoredge gains a huge delay reduction.

Magic damage being dominant switches Valkeng into Stormwaker form, subsequent Maneuvers give 20% Fast Cast
At 4 maneuvers, Stormwakers spells are all instant cast.

Ranged damage being dominant switches Valkeng into Sharpshot form, subsequent Maneuvers give reduced ranged attack time, At 4 maneuvers, Sharpshot ranged attacks become nearly non-stop.

Valkeng also has a DT mechanic based off the ratio of damage it has taken, if only one damage type has been taken (for instance, all physical) it will have 90% physical DT, if its 50% magic and 50% physical, will have 45% of each, etc.

When it changes form, it uses a skill with a cool animation that spins them around and makes them go invisible before re-appearing as the new frame, it's pretty neat.

## Captures
https://youtu.be/yEXWHJL0XP4
https://youtu.be/q3QiFxc7uuE
https://www.dropbox.com/scl/fo/peyvhelxt42rf1qvymlky/AMuMC55oZkmVai-OPhQ78to?rlkey=o6ir5et5ijtgr68kpr3rp1p68&st=9k28td2k&dl=0

Ty @ThrisStraizo for all your captures.

## Steps to test these changes
!zone Talacca Cove and try out the "Puppetmaster Blues"