### PR TITLE
Roam: Retail captured values

### DIFF
--- a/data/ecosystems.yaml
+++ b/data/ecosystems.yaml
@@ -73,6 +73,10 @@ ecosystems:
             chr: e
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           acuex:
             id: 1
@@ -142,6 +146,11 @@ ecosystems:
                 mdef:          20
       botuli:
         id: 2
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           botulus:
             id: 3
@@ -201,6 +210,10 @@ ecosystems:
             - sight
             - ability
           speed: 32
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           blancmage:
             id: 4
@@ -268,8 +281,6 @@ ecosystems:
               mods:
                 udmgbreath: 2500
               mob_mods:
-                roam_turns:    2
-                roam_rate:    30
                 hp_standback: -1
                 no_link:       1
           gold_flan:
@@ -306,6 +317,11 @@ ecosystems:
                 udmgbreath: 2500
       hecteyes:
         id: 4
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           hecteye:
             id: 7
@@ -348,8 +364,6 @@ ecosystems:
               mods:
                 eva: 10
               mob_mods:
-                roam_cool:    55
-                roam_rate:    30
                 hp_standback: -1
       leech:
         id: 5
@@ -365,6 +379,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           leech:
             id: 8
@@ -393,8 +411,6 @@ ecosystems:
                   blind:        2
                   stun:         0
                   gravity:      0
-              mob_mods:
-                roam_distance: 15
           obdella:
             id: 9
             attributes:
@@ -525,6 +541,10 @@ ecosystems:
             chr: d
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           gigaworm:
             id: 13
@@ -595,6 +615,10 @@ ecosystems:
             - hearing
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           boil:
             id: 15
@@ -717,6 +741,11 @@ ecosystems:
                   gravity:     -2
       slug:
         id: 9
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           slug:
             id: 19
@@ -772,6 +801,10 @@ ecosystems:
             - hearing
           speed:     0
           charmable: true
+          mob_mods:
+            roam_cool:  122
+            roam_rate:   20
+            roam_turns:   2
         species:
           entozoon:
             id: 20
@@ -871,9 +904,6 @@ ecosystems:
                   gravity:     -3
               mob_mods:
                 magic_cool: 25
-                roam_cool:  90
-                roam_rate:  30
-
   aquan:
     id: 2
     families:
@@ -891,6 +921,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           carrier_crab:
             id: 24
@@ -940,8 +974,6 @@ ecosystems:
                   blind:       -2
                   stun:        -3
                   gravity:     -2
-              mob_mods:
-                roam_cool: 15
           krabkatoa:
             id: 26
             attributes:
@@ -1016,6 +1048,11 @@ ecosystems:
                   gravity:     -2
       craklaw:
         id: 12
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           craklaw:
             id: 29
@@ -1074,6 +1111,10 @@ ecosystems:
             eva: e
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           akagin:
             id: 30
@@ -1170,6 +1211,10 @@ ecosystems:
           detects:
             - hearing
           speed: 32
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           ogrebon:
             id: 33
@@ -1310,6 +1355,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           jagil:
             id: 37
@@ -1409,6 +1458,11 @@ ecosystems:
                   gravity:     4
       ruszor:
         id: 18
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           ruszor:
             id: 40
@@ -1458,6 +1512,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           azure_sea_monk:
             id: 41
@@ -1519,8 +1577,6 @@ ecosystems:
                   blind:       -1
                   stun:        -2
                   gravity:     -1
-              mob_mods:
-                roam_cool: 30
       uragnite:
         id: 20
         attributes:
@@ -1536,6 +1592,8 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_turns: 1
         species:
           limascabra:
             id: 43
@@ -1585,15 +1643,16 @@ ecosystems:
                   blind:       -1
                   stun:        -3
                   gravity:     -1
-              mob_mods:
-                roam_cool: 40
-                roam_rate: 30
-
   arcana:
     id: 3
     families:
       acrolith:
         id: 21
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           acrolith:
             id: 45
@@ -1643,6 +1702,10 @@ ecosystems:
           detects:
             - sight
             - magic
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           bomb:
             id: 46
@@ -1669,10 +1732,6 @@ ecosystems:
                   blind:       4
                   stun:        4
                   gravity:     4
-              mob_mods:
-                roam_cool:  30
-                roam_turns:  5
-                roam_rate:  20
           djinn:
             id: 47
             attributes:
@@ -1723,10 +1782,6 @@ ecosystems:
                   blind:       1
                   stun:        1
                   gravity:     1
-              mob_mods:
-                roam_cool:  40
-                roam_turns:  2
-                roam_rate:  20
       cardian:
         id: 23
         attributes:
@@ -1740,6 +1795,10 @@ ecosystems:
           detects:
             - hearing
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           batons:
             id: 49
@@ -1768,10 +1827,6 @@ ecosystems:
                   blind:       -2
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_cool:  40
-                roam_turns:  2
-                roam_rate:  20
           coins:
             id: 50
             attributes:
@@ -2020,6 +2075,11 @@ ecosystems:
                   gravity:      4
       cluster:
         id: 25
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           cluster:
             id: 59
@@ -2054,10 +2114,6 @@ ecosystems:
                   blind:       3
                   stun:        3
                   gravity:     3
-              mob_mods:
-                roam_cool:  40
-                roam_turns:  2
-                roam_rate:  20
       doll:
         id: 26
         attributes:
@@ -2069,6 +2125,10 @@ ecosystems:
             mnd: d
           detects:
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           doll:
             id: 60
@@ -2094,10 +2154,6 @@ ecosystems:
                   blind:        2
                   stun:        -3
                   gravity:      2
-              mob_mods:
-                roam_distance:  5
-                roam_cool:     55
-                roam_rate:     30
           gargoyles:
             id: 61
             attributes:
@@ -2124,6 +2180,11 @@ ecosystems:
                   gravity:      2
       evil_weapon:
         id: 27
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           evil_weapon:
             id: 62
@@ -2163,10 +2224,7 @@ ecosystems:
                   stun:        -2
                   gravity:     -2
               mob_mods:
-                mp_base:    50
-                roam_cool:  45
-                roam_turns:  3
-                roam_rate:  30
+                mp_base: 50
       golem:
         id: 28
         attributes:
@@ -2177,6 +2235,10 @@ ecosystems:
           detects:
             - sight
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           golem:
             id: 63
@@ -2203,10 +2265,7 @@ ecosystems:
                   stun:        2
                   gravity:     2
               mob_mods:
-                sight_range:    4
-                roam_distance:  5
-                roam_cool:     55
-                roam_rate:     30
+                sight_range: 4
           red_golems:
             id: 64
             attributes:
@@ -2378,6 +2437,10 @@ ecosystems:
             int: b
           detects:
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           magic_pot:
             id: 69
@@ -2409,10 +2472,6 @@ ecosystems:
                   gravity:     2
               mods:
                 mdef: 12
-              mob_mods:
-                roam_distance:  5
-                roam_cool:     55
-                roam_rate:     30
           millstones:
             id: 70
             attributes:
@@ -2453,6 +2512,10 @@ ecosystems:
           detects:
             - sight
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           marolith:
             id: 71
@@ -2549,6 +2612,10 @@ ecosystems:
           detects:
             - hearing
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           spheroid:
             id: 74
@@ -2642,6 +2709,10 @@ ecosystems:
           detects:
             - hearing
             - magic
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           chariot:
             id: 75
@@ -2753,6 +2824,11 @@ ecosystems:
             - sight
             - hearing
             - magic
+          mob_mods:
+            roam_cool:      15
+            roam_rate:      -1
+            roam_turns:      3
+            roam_turns_min:  3
         species:
           cog:
             id: 78
@@ -3006,8 +3082,6 @@ ecosystems:
                   blind:       2
                   stun:        2
                   gravity:     2
-              mob_mods:
-                roam_cool: 50
           elasmoth:
             id: 86
             attributes:
@@ -3062,6 +3136,11 @@ ecosystems:
                   gravity:      1
       buffalo:
         id: 40
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           buffalo:
             id: 88
@@ -3102,10 +3181,7 @@ ecosystems:
                 attp: 10
                 defp: 20
               mob_mods:
-                mp_base:    50
-                roam_cool:  50
-                roam_turns:  4
-                roam_rate:  30
+                mp_base: 50
       cehuetzi:
         id: 41
         species:
@@ -3185,8 +3261,6 @@ ecosystems:
                   blind:       0
                   stun:        0
                   gravity:     0
-              mob_mods:
-                roam_cool: 50
           orthrus:
             id: 91
             attributes:
@@ -3230,6 +3304,10 @@ ecosystems:
             - scent
           speed:     60
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           coeurl:
             id: 92
@@ -3255,10 +3333,6 @@ ecosystems:
                   blind:       -2
                   stun:         0
                   gravity:     -2
-              mob_mods:
-                roam_distance:  5
-                roam_cool:     55
-                roam_rate:     30
           collared_lynx:
             id: 93
             attributes:
@@ -3309,6 +3383,11 @@ ecosystems:
                   gravity:     -1
       dhalmel:
         id: 44
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           dhalmel:
             id: 95
@@ -3346,12 +3425,13 @@ ecosystems:
                   blind:       -2
                   stun:        -3
                   gravity:     -3
-              mob_mods:
-                roam_cool:  30
-                roam_turns:  2
-                roam_rate:  30
       gnole:
         id: 45
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           gnole:
             id: 96
@@ -3404,6 +3484,10 @@ ecosystems:
             - sight
             - scent
           speed: 50
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           legendary_manticore:
             id: 97
@@ -3456,13 +3540,13 @@ ecosystems:
               mods:
                 attp: 10
                 hpp:  50
-              mob_mods:
-                roam_distance: 30
-                roam_cool:     60
-                roam_turns:     4
-                roam_rate:     30
       marid:
         id: 47
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           marid:
             id: 99
@@ -3499,12 +3583,13 @@ ecosystems:
                   gravity:     -1
               mods:
                 defp: 20
-              mob_mods:
-                roam_cool:  30
-                roam_turns:  2
-                roam_rate:  30
       opo_opo:
         id: 48
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           opo_opo:
             id: 100
@@ -3543,10 +3628,6 @@ ecosystems:
                   blind:       -2
                   stun:         0
                   gravity:     -1
-              mob_mods:
-                roam_cool:  35
-                roam_turns:  3
-                roam_rate:  20
       raaz:
         id: 49
         attributes:
@@ -3560,6 +3641,10 @@ ecosystems:
           detects:
             - hearing
           speed: 60
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           fazz:
             id: 101
@@ -3632,6 +3717,10 @@ ecosystems:
             - sight
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           alabaster_rabbit:
             id: 103
@@ -3729,11 +3818,6 @@ ecosystems:
                   blind:       -3
                   stun:        -3
                   gravity:     -2
-              mob_mods:
-                roam_distance: 15
-                roam_cool:     35
-                roam_turns:     3
-                roam_rate:     30
       ram:
         id: 51
         attributes:
@@ -3747,6 +3831,10 @@ ecosystems:
           detects:
             - sight
             - scent
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           ovim:
             id: 107
@@ -3799,9 +3887,6 @@ ecosystems:
               mods:
                 attp: 10
                 defp: 20
-              mob_mods:
-                roam_cool: 60
-                roam_rate: 30
       sheep:
         id: 52
         attributes:
@@ -3814,6 +3899,10 @@ ecosystems:
             mnd: d
             chr: d
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           karakul:
             id: 109
@@ -3897,11 +3986,6 @@ ecosystems:
                   blind:       -2
                   stun:        -3
                   gravity:     -2
-              mob_mods:
-                roam_distance: 15
-                roam_cool:     60
-                roam_turns:     5
-                roam_rate:     30
       tiger:
         id: 53
         attributes:
@@ -3915,6 +3999,10 @@ ecosystems:
             chr: d
           speed:     60
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           legendary_tigers:
             id: 112
@@ -4004,10 +4092,6 @@ ecosystems:
                   gravity:      0
               mods:
                 attp: 10
-              mob_mods:
-                roam_distance: 15
-                roam_cool:     45
-                roam_turns:     3
       yztarg:
         id: 54
         attributes:
@@ -4018,6 +4102,10 @@ ecosystems:
             - sight
             - lowhp
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           red_yztarg:
             id: 115
@@ -4073,6 +4161,11 @@ ecosystems:
     families:
       antica:
         id: 55
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           antica:
             id: 117
@@ -4112,6 +4205,11 @@ ecosystems:
                   gravity:     -3
       bugbear:
         id: 56
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           bugbear:
             id: 118
@@ -4153,10 +4251,7 @@ ecosystems:
                 defp: 20
                 hpp:  10
               mob_mods:
-                sublink:     5
-                roam_cool:  50
-                roam_turns:  2
-                roam_rate:  30
+                sublink: 5
       gigas:
         id: 57
         attributes:
@@ -4170,6 +4265,10 @@ ecosystems:
             mnd: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  2
         species:
           berglisi:
             id: 119
@@ -4244,11 +4343,7 @@ ecosystems:
                   stun:         4
                   gravity:      0
               mob_mods:
-                roam_distance:   5
-                roam_cool:      25
-                roam_turns:      2
-                roam_rate:      30
-                gil_bonus:     180
+                gil_bonus: 180
           hecatoncheirs:
             id: 122
             attributes:
@@ -4311,6 +4406,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           armored_goblin:
             id: 124
@@ -4430,6 +4529,10 @@ ecosystems:
             chr: b
           detects:
             - sight
+          mob_mods:
+            roam_cool:  10
+            roam_rate:  20
+            roam_turns:  6
         species:
           experimental:
             id: 128
@@ -4561,6 +4664,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  10
+            roam_rate:  20
+            roam_turns:  6
         species:
           knight_ja:
             id: 132
@@ -4670,6 +4777,9 @@ ecosystems:
                   gravity:      2
       meeble:
         id: 61
+        attributes:
+          mob_mods:
+            roam_turns: 6
         species:
           meeble:
             id: 136
@@ -4780,6 +4890,10 @@ ecosystems:
           detects:
             - sight
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           orc:
             id: 139
@@ -4883,6 +4997,11 @@ ecosystems:
                   gravity:     -2
       orcish_warmachine:
         id: 64
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           orcish_warmachine:
             id: 143
@@ -4921,15 +5040,17 @@ ecosystems:
               mods:
                 hpp: 5
               mob_mods:
-                sublink:    2
-                roam_cool: 50
-                roam_rate: 30
+                sublink: 2
       poroggo:
         id: 65
         attributes:
           element: water
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           blue_poroggo:
             id: 144
@@ -5050,6 +5171,10 @@ ecosystems:
           detects:
             - sight
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           qiqirn:
             id: 147
@@ -5116,6 +5241,10 @@ ecosystems:
           detects:
             - hearing
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           golden_quadav:
             id: 149
@@ -5180,6 +5309,10 @@ ecosystems:
             mnd: d
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           blue_sahagin:
             id: 151
@@ -5381,6 +5514,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           cryptonberry:
             id: 157
@@ -5454,10 +5591,6 @@ ecosystems:
                   blind:        0
                   stun:        -2
                   gravity:     -1
-              mob_mods:
-                roam_cool:  25
-                roam_turns:  5
-                roam_rate:  30
           wantonberry:
             id: 160
             attributes:
@@ -5496,6 +5629,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           destroyer:
             id: 161
@@ -5586,6 +5723,10 @@ ecosystems:
           detects:
             - sight
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           blue_velkk:
             id: 164
@@ -5645,6 +5786,10 @@ ecosystems:
             mnd: e
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           armored_yagudo:
             id: 166
@@ -5734,6 +5879,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  30
+            roam_turns:  1
         species:
           amphiptere:
             id: 169
@@ -5810,6 +5959,10 @@ ecosystems:
           detects:
             - sight
             - hearing
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  4
         species:
           apkallu:
             id: 171
@@ -5868,6 +6021,10 @@ ecosystems:
                   blind:       -1
                   stun:        -2
                   gravity:     -1
+              mob_mods:
+                roam_cool:  15
+                roam_rate:  15
+                roam_turns:  1
       bat:
         id: 77
         attributes:
@@ -5882,6 +6039,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           bat:
             id: 173
@@ -5910,10 +6071,7 @@ ecosystems:
                   stun:        -2
                   gravity:     -3
               mob_mods:
-                sublink:     3
-                roam_cool:  35
-                roam_turns:  3
-                roam_rate:  30
+                sublink: 3
           vermilion_bat:
             id: 174
             attributes:
@@ -5954,6 +6112,10 @@ ecosystems:
           detects:
             - sight
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           bird:
             id: 175
@@ -6013,6 +6175,10 @@ ecosystems:
           element: earth
           detects:
             - sight
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           cockatrice:
             id: 177
@@ -6045,10 +6211,6 @@ ecosystems:
                   blind:       -2
                   stun:         2
                   gravity:     -3
-              mob_mods:
-                roam_cool:  30
-                roam_turns:  3
-                roam_rate:  30
           ziz:
             id: 178
             attributes:
@@ -6100,6 +6262,10 @@ ecosystems:
             - sight
           speed:     60
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           colibri:
             id: 179
@@ -6131,9 +6297,7 @@ ecosystems:
                 eva:  20
                 mdef: 14
               mob_mods:
-                mp_base:    50
-                roam_turns:  2
-                roam_rate:  30
+                mp_base: 50
           toucalibri:
             id: 180
             attributes:
@@ -6178,6 +6342,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           flock_bat:
             id: 181
@@ -6206,10 +6374,7 @@ ecosystems:
                   stun:        -2
                   gravity:     -3
               mob_mods:
-                sublink:     3
-                roam_cool:  35
-                roam_turns:  2
-                roam_rate:  30
+                sublink: 3
           flock_vermillion_bats:
             id: 182
             attributes:
@@ -6367,6 +6532,11 @@ ecosystems:
                 mdef:          40
       hippogryph:
         id: 83
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           hippogryph:
             id: 187
@@ -6408,9 +6578,7 @@ ecosystems:
               mods:
                 hpp: -20
               mob_mods:
-                mp_base:    50
-                roam_cool:  55
-                roam_turns:  2
+                mp_base: 50
       greater_bird:
         id: 84
         attributes:
@@ -6419,6 +6587,10 @@ ecosystems:
             def: b
           detects:
             - sight
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           gagana:
             id: 188
@@ -6450,10 +6622,6 @@ ecosystems:
                   gravity:      4
               mods:
                 mdef: 30
-              mob_mods:
-                roam_cool:  40
-                roam_turns:  2
-                roam_rate:  30
           legendary_roc:
             id: 189
             attributes:
@@ -6521,6 +6689,10 @@ ecosystems:
           detects:
             - sight
             - hearing
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           blue_tulfaire:
             id: 191
@@ -6668,6 +6840,10 @@ ecosystems:
           detects:
             - sight
             - hearing
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           ahriman:
             id: 195
@@ -6699,8 +6875,6 @@ ecosystems:
                 silenceres: 20
               mob_mods:
                 ga_chance:    60
-                roam_cool:    40
-                roam_turns:    5
                 hp_standback: -1
           akoman:
             id: 196
@@ -6764,6 +6938,10 @@ ecosystems:
             agi: d
             mnd: f
           speed: 50
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           crystal_demon:
             id: 198
@@ -6879,12 +7057,9 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mob_mods:
-                sublink:         1
-                link_radius:    15
-                roam_distance:  15
-                roam_cool:      50
-                roam_turns:      3
-                gil_bonus:     120
+                sublink:       1
+                link_radius:  15
+                gil_bonus:   120
           red_demon:
             id: 202
             attributes:
@@ -7108,6 +7283,10 @@ ecosystems:
             - sight
             - hearing
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           gargouille:
             id: 208
@@ -7180,6 +7359,10 @@ ecosystems:
             - sight
             - hearing
           speed: 50
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           devilet:
             id: 210
@@ -7263,8 +7446,6 @@ ecosystems:
                 hpp: -30
               mob_mods:
                 sublink:      13
-                roam_cool:    50
-                roam_turns:    3
                 hp_standback: -1
                 sight_range:  10
                 sound_range:   5
@@ -7311,6 +7492,10 @@ ecosystems:
             - magic
             - ability
             - scent
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           black_robe_flayer:
             id: 214
@@ -7369,9 +7554,7 @@ ecosystems:
               mods:
                 mdef: 20
               mob_mods:
-                sublink:    11
-                roam_cool:  50
-                roam_turns:  3
+                sublink: 11
       taurus:
         id: 94
         attributes:
@@ -7384,6 +7567,10 @@ ecosystems:
             eva: b
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           falxitaur:
             id: 216
@@ -7434,11 +7621,7 @@ ecosystems:
                   stun:        -1
                   gravity:     -1
               mob_mods:
-                sublink:     1
-                roam_cool:  40
-                roam_turns:  3
-                roam_rate:  30
-
+                sublink: 1
   dragon:
     id: 9
     families:
@@ -7451,6 +7634,10 @@ ecosystems:
             chr: d
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           dahak:
             id: 218
@@ -7506,7 +7693,6 @@ ecosystems:
                 mp_base:       10
                 sight_range:   18
                 sound_range:   10
-                roam_cool:     55
                 gil_bonus:   1000
           purple_dragon:
             id: 220
@@ -7611,9 +7797,6 @@ ecosystems:
               mods:
                 udmgbreath: -10000
                 mdef:           30
-              mob_mods:
-                roam_distance:  5
-                roam_cool:     55
       puk:
         id: 97
         attributes:
@@ -7629,6 +7812,10 @@ ecosystems:
             - sight
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           peapuk:
             id: 223
@@ -7692,6 +7879,10 @@ ecosystems:
             int: a
             mnd: f
             chr: b
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           black_feathered:
             id: 225
@@ -7720,8 +7911,6 @@ ecosystems:
                   blind:        0
                   stun:         0
                   gravity:      0
-              mob_mods:
-                roam_cool: 55
           black_wyrm:
             id: 226
             attributes:
@@ -7906,6 +8095,10 @@ ecosystems:
           detects:
             - sight
           speed: 70
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           ajattara:
             id: 232
@@ -8009,8 +8202,6 @@ ecosystems:
                   blind:       -3
                   stun:        -2
                   gravity:      0
-              mob_mods:
-                roam_cool: 55
       wyvern_pet:
         id: 100
         attributes:
@@ -8028,6 +8219,8 @@ ecosystems:
           detects:
             - sight
           speed: 70
+          mob_mods:
+            roam_turns: 6
         species:
           blue_wyvern:
             id: 236
@@ -8658,6 +8851,10 @@ ecosystems:
             acc: a
           detects:
             - magic
+          mob_mods:
+            roam_cool:  10
+            roam_rate:  -1
+            roam_turns:  4
         species:
           air_elemental:
             id: 256
@@ -8690,7 +8887,6 @@ ecosystems:
                   stun:         0
                   gravity:     11
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           baelfyr:
             id: 257
@@ -8720,8 +8916,6 @@ ecosystems:
                   blind:       -3
                   stun:         1
                   gravity:      1
-              mob_mods:
-                roam_turns: 3
           byrgen:
             id: 258
             attributes:
@@ -8750,8 +8944,6 @@ ecosystems:
                   blind:       11
                   stun:         1
                   gravity:     -3
-              mob_mods:
-                roam_turns: 3
           dark_elemental:
             id: 259
             attributes:
@@ -8783,7 +8975,6 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           earth_elemental:
             id: 260
@@ -8816,7 +9007,6 @@ ecosystems:
                   stun:        11
                   gravity:     -3
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           fire_elemental:
             id: 261
@@ -8849,7 +9039,6 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           gefyrst:
             id: 262
@@ -8879,8 +9068,6 @@ ecosystems:
                   blind:        1
                   stun:        -3
                   gravity:      1
-              mob_mods:
-                roam_turns: 3
           ice_elemental:
             id: 263
             attributes:
@@ -8912,7 +9099,6 @@ ecosystems:
                   stun:         0
                   gravity:     11
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           light_elemental:
             id: 264
@@ -8945,7 +9131,6 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           thunder_elemental:
             id: 265
@@ -8978,7 +9163,6 @@ ecosystems:
                   stun:        11
                   gravity:      0
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
           ungeweder:
             id: 266
@@ -9008,8 +9192,6 @@ ecosystems:
                   blind:        1
                   stun:        11
                   gravity:     11
-              mob_mods:
-                roam_turns: 3
           water_elemental:
             id: 267
             attributes:
@@ -9041,10 +9223,12 @@ ecosystems:
                   stun:        -3
                   gravity:      0
               mob_mods:
-                roam_turns:    3
                 hp_standback: -1
       heartwing:
         id: 104
+        attributes:
+          mob_mods:
+            roam_turns: 2
         species:
           heartwing:
             id: 268
@@ -9234,6 +9418,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           danaid:
             id: 273
@@ -9347,6 +9535,11 @@ ecosystems:
                 mdef: 30
       porxie:
         id: 108
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           porxie:
             id: 277
@@ -9403,6 +9596,11 @@ ecosystems:
           detects:
             - sight
             - magic
+          mob_mods:
+            roam_cool:      15
+            roam_rate:      -1
+            roam_turns:      3
+            roam_turns_min:  3
         species:
           lava_umbril:
             id: 278
@@ -9651,6 +9849,10 @@ ecosystems:
           detects:
             - hearing
           speed: 50
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           apex_seether:
             id: 285
@@ -9783,6 +9985,10 @@ ecosystems:
           detects:
             - hearing
           speed: 50
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           apex_wanderer:
             id: 289
@@ -9852,6 +10058,10 @@ ecosystems:
           detects:
             - hearing
           speed: 50
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           apex_weeper:
             id: 291
@@ -10111,6 +10321,10 @@ ecosystems:
             chr: a
             def: b
           speed: 30
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           adamantoise:
             id: 298
@@ -10140,9 +10354,6 @@ ecosystems:
                   gravity:      4
               mods:
                 defp: 20
-              mob_mods:
-                roam_cool: 50
-                roam_rate: 30
           ferromantoise:
             id: 299
             attributes:
@@ -10218,6 +10429,10 @@ ecosystems:
             chr: d
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           abyssobugard:
             id: 301
@@ -10270,10 +10485,6 @@ ecosystems:
               mods:
                 attp: 10
                 defp: 20
-              mob_mods:
-                roam_cool:  45
-                roam_turns:  3
-                roam_rate:  30
       eft:
         id: 124
         attributes:
@@ -10289,6 +10500,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           eft:
             id: 303
@@ -10314,10 +10529,6 @@ ecosystems:
                   blind:       -1
                   stun:        -1
                   gravity:      2
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  5
-                roam_rate:  30
           tarichuk:
             id: 304
             attributes:
@@ -10393,6 +10604,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           ash_lizard:
             id: 306
@@ -10419,10 +10634,6 @@ ecosystems:
                   blind:       -2
                   stun:         0
                   gravity:     -3
-              mob_mods:
-                roam_cool:  60
-                roam_turns:  4
-                roam_rate:  30
           hill_lizard:
             id: 307
             attributes:
@@ -10473,10 +10684,6 @@ ecosystems:
                   blind:       -1
                   stun:        -1
                   gravity:     -1
-              mob_mods:
-                roam_cool:  60
-                roam_turns:  4
-                roam_rate:  30
       matamata:
         id: 127
         attributes:
@@ -10492,6 +10699,10 @@ ecosystems:
             - sight
             - hearing
           speed: 30
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           matamata:
             id: 309
@@ -10570,6 +10781,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           far_east_peiste:
             id: 311
@@ -10654,6 +10869,10 @@ ecosystems:
             - scent
           speed:     50
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           lindwurm:
             id: 314
@@ -10718,10 +10937,6 @@ ecosystems:
                   blind:       -2
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_distance: 30
-                roam_cool:     40
-                roam_turns:     3
           ruby_raptors:
             id: 316
             attributes:
@@ -10770,6 +10985,10 @@ ecosystems:
             - sight
             - hearing
             - scent
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           mamool_ja_riden:
             id: 317
@@ -10855,15 +11074,16 @@ ecosystems:
                   gravity:     -2
               mods:
                 udmgbreath: -1250
-              mob_mods:
-                roam_cool: 50
-                roam_rate: 30
-
   luminian:
     id: 14
     families:
       aern:
         id: 131
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           aern:
             id: 320
@@ -10902,6 +11122,11 @@ ecosystems:
                 hpp: -10
       euvhi:
         id: 132
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           euvhi:
             id: 321
@@ -10943,6 +11168,11 @@ ecosystems:
                 mdef:  20
       hpemde:
         id: 133
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           hpemde:
             id: 322
@@ -10979,6 +11209,11 @@ ecosystems:
                   gravity:     -2
       phuabo:
         id: 134
+        attributes:
+          mob_mods:
+            roam_cool:  20
+            roam_rate:  13
+            roam_turns:  1
         species:
           phuabo:
             id: 323
@@ -11116,6 +11351,11 @@ ecosystems:
                   gravity:      0
       yovra:
         id: 137
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           yovra:
             id: 327
@@ -11166,6 +11406,8 @@ ecosystems:
             chr: d
           detects:
             - hearing
+          mob_mods:
+            roam_turns: 6
         species:
           bird_ghrah:
             id: 328
@@ -11379,6 +11621,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           sabotender:
             id: 334
@@ -11405,9 +11651,7 @@ ecosystems:
                   stun:        -2
                   gravity:      0
               mob_mods:
-                sublink:    7
-                roam_cool: 10
-                roam_rate: 20
+                sublink: 7
           sabotender_florido:
             id: 335
             attributes:
@@ -11438,6 +11682,11 @@ ecosystems:
                 sublink: 7
       flytrap:
         id: 142
+        attributes:
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           flytrap:
             id: 336
@@ -11489,6 +11738,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           coppercap:
             id: 337
@@ -11538,10 +11791,6 @@ ecosystems:
                   blind:        6
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_distance: 15
-                roam_cool:     60
-                roam_rate:     30
           mycelar:
             id: 339
             attributes:
@@ -11568,6 +11817,11 @@ ecosystems:
                   gravity:     -2
       goobbue:
         id: 144
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           goobbue:
             id: 340
@@ -11605,10 +11859,6 @@ ecosystems:
                   gravity:      0
               mods:
                 attp: 10
-              mob_mods:
-                roam_distance:  5
-                roam_cool:     60
-                roam_rate:     30
       leafkin:
         id: 145
         attributes:
@@ -11623,6 +11873,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           cirrus:
             id: 341
@@ -11741,6 +11995,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           adenium:
             id: 345
@@ -11940,6 +12198,10 @@ ecosystems:
             chr: d
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           ameretat:
             id: 352
@@ -11989,9 +12251,6 @@ ecosystems:
                   blind:        4
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_cool: 30
-                roam_rate: 30
           morbol_menace:
             id: 354
             attributes:
@@ -12070,6 +12329,11 @@ ecosystems:
                   gravity:      0
       panopt:
         id: 148
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           panopt:
             id: 357
@@ -12119,6 +12383,10 @@ ecosystems:
             chr: e
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           mitrastema:
             id: 358
@@ -12178,6 +12446,11 @@ ecosystems:
                 mp_base: 50
       sapling:
         id: 150
+        attributes:
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           sapling:
             id: 360
@@ -12215,8 +12488,7 @@ ecosystems:
                   stun:        -2
                   gravity:     -2
               mob_mods:
-                sublink:        4
-                roam_distance: 20
+                sublink: 4
       snapweed:
         id: 151
         attributes:
@@ -12232,6 +12504,10 @@ ecosystems:
           detects:
             - hearing
             - scent
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           jewelweed:
             id: 361
@@ -12304,6 +12580,10 @@ ecosystems:
             chr: e
           detects:
             - hearing
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           fall_treant:
             id: 363
@@ -12404,9 +12684,7 @@ ecosystems:
               mods:
                 defp: 20
               mob_mods:
-                sublink:    4
-                roam_cool: 65
-                roam_rate: 30
+                sublink: 4
           winter_treant:
             id: 367
             attributes:
@@ -12952,6 +13230,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           corpselight:
             id: 391
@@ -13051,6 +13333,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           corse:
             id: 394
@@ -13085,10 +13371,6 @@ ecosystems:
                   gravity:     -1
               mods:
                 udmgbreath: -5000
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  2
-                roam_rate:  30
           golden_hat_corse:
             id: 395
             attributes:
@@ -13195,6 +13477,11 @@ ecosystems:
                   gravity:      6
       doomed:
         id: 170
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           doomed:
             id: 398
@@ -13230,9 +13517,6 @@ ecosystems:
                   blind:        8
                   stun:         0
                   gravity:      0
-              mob_mods:
-                roam_cool: 55
-                roam_rate: 30
       dullahan:
         id: 171
         attributes:
@@ -13247,6 +13531,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           dullahan:
             id: 399
@@ -13318,6 +13606,10 @@ ecosystems:
             - hearing
             - lowhp
             - ability
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  2
         species:
           ephramadian:
             id: 401
@@ -13416,10 +13708,7 @@ ecosystems:
                   stun:         0
                   gravity:      0
               mob_mods:
-                roam_cool:   50
-                roam_turns:   2
-                roam_rate:   30
-                gil_bonus:  100
+                gil_bonus: 100
           hydra_fomor:
             id: 404
             attributes:
@@ -13528,6 +13817,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           bhoot:
             id: 407
@@ -13591,11 +13884,13 @@ ecosystems:
                   blind:        5
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_cool: 50
-                roam_rate: 30
       hound:
         id: 174
+        attributes:
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           hound:
             id: 409
@@ -13636,10 +13931,6 @@ ecosystems:
                   blind:        4
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  3
-                roam_rate:  30
       naraka:
         id: 175
         attributes:
@@ -13647,6 +13938,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           green_naraka:
             id: 410
@@ -13749,6 +14044,10 @@ ecosystems:
             - sight
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           adorned_qutrub:
             id: 413
@@ -13816,12 +14115,13 @@ ecosystems:
               mods:
                 hpp:          200
                 udmgbreath: 10000
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  3
-                roam_rate:  30
       shadow:
         id: 177
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  2
         species:
           shadow:
             id: 415
@@ -13856,10 +14156,6 @@ ecosystems:
                   blind:        2
                   stun:         0
                   gravity:      0
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  2
-                roam_rate:  30
       skeleton:
         id: 178
         attributes:
@@ -13867,6 +14163,10 @@ ecosystems:
           detects:
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           draugar:
             id: 416
@@ -14013,10 +14313,6 @@ ecosystems:
                   blind:        4
                   stun:        -2
                   gravity:     -2
-              mob_mods:
-                roam_cool:  65
-                roam_turns:  5
-                roam_rate:  30
       vampyr:
         id: 179
         attributes:
@@ -14033,6 +14329,10 @@ ecosystems:
             - sight
             - hearing
             - lowhp
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           strigoi:
             id: 420
@@ -14092,11 +14392,7 @@ ecosystems:
               mods:
                 udmgbreath: -1250
               mob_mods:
-                sublink:     3
-                roam_cool:  50
-                roam_turns:  2
-                roam_rate:  30
-
+                sublink: 3
   vermin:
     id: 19
     families:
@@ -14115,6 +14411,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           antlion:
             id: 422
@@ -14142,10 +14442,6 @@ ecosystems:
                   gravity:     -2
               mods:
                 defp: 20
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  2
-                roam_rate:  30
           formiceros:
             id: 423
             attributes:
@@ -14211,6 +14507,10 @@ ecosystems:
             - sight
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           blue_bee:
             id: 425
@@ -14238,9 +14538,6 @@ ecosystems:
                   blind:       -2
                   stun:        -2
                   gravity:      2
-              mob_mods:
-                roam_cool:  15
-                roam_turns:  2
           pephredo:
             id: 426
             attributes:
@@ -14333,6 +14630,10 @@ ecosystems:
             - sight
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  2
         species:
           beetle:
             id: 429
@@ -14358,10 +14659,6 @@ ecosystems:
                   blind:        0
                   stun:         0
                   gravity:      0
-              mob_mods:
-                roam_distance: 15
-                roam_cool:     60
-                roam_rate:     30
           black_beetles:
             id: 430
             attributes:
@@ -14463,6 +14760,10 @@ ecosystems:
           detects:
             - sight
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           caeferli:
             id: 433
@@ -14529,6 +14830,10 @@ ecosystems:
           detects:
             - sight
             - hearing
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  6
         species:
           chigoe:
             id: 435
@@ -14592,6 +14897,10 @@ ecosystems:
             chr: d
             def: e
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           crawler:
             id: 437
@@ -14620,9 +14929,6 @@ ecosystems:
                   blind:       -3
                   stun:        -3
                   gravity:     -2
-              mob_mods:
-                roam_cool: 55
-                roam_rate: 30
           defoliator:
             id: 438
             attributes:
@@ -14720,6 +15026,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           arundimite:
             id: 441
@@ -14771,9 +15081,6 @@ ecosystems:
                   blind:        3
                   stun:        -1
                   gravity:     -1
-              mob_mods:
-                roam_cool:  50
-                roam_turns:  2
       fly:
         id: 188
         attributes:
@@ -14788,6 +15095,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           apex_flys:
             id: 443
@@ -14880,6 +15191,10 @@ ecosystems:
             chr: e
           detects:
             - sight
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           croc:
             id: 446
@@ -14972,6 +15287,10 @@ ecosystems:
             - sight
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           ladybug:
             id: 449
@@ -15027,6 +15346,11 @@ ecosystems:
                   gravity:      6
       lucani:
         id: 191
+        attributes:
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           lucani:
             id: 451
@@ -15077,6 +15401,10 @@ ecosystems:
             chr: d
           detects:
             - sight
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           golden_mantid:
             id: 452
@@ -15190,6 +15518,11 @@ ecosystems:
                   gravity:      4
       mosquito:
         id: 193
+        attributes:
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           mosquito:
             id: 456
@@ -15242,6 +15575,10 @@ ecosystems:
             - hearing
             - scent
           charmable: true
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  1
         species:
           clawed_scolopendrid:
             id: 457
@@ -15344,9 +15681,7 @@ ecosystems:
               mods:
                 attp: 20
               mob_mods:
-                immunity:  256
-                roam_cool:  55
-                roam_rate:  30
+                immunity: 256
       spider:
         id: 195
         attributes:
@@ -15360,6 +15695,10 @@ ecosystems:
           detects:
             - hearing
           charmable: true
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           anansi:
             id: 461
@@ -15473,6 +15812,10 @@ ecosystems:
           detects:
             - sight
           charmable: true
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  2
         species:
           brown_fluturini:
             id: 465
@@ -15613,6 +15956,10 @@ ecosystems:
           detects:
             - hearing
             - magic
+          mob_mods:
+            roam_cool:  60
+            roam_rate:  40
+            roam_turns:  6
         species:
           coral_wamoura:
             id: 469
@@ -15673,6 +16020,11 @@ ecosystems:
                 sublink:  6
       wamouracampa:
         id: 198
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           wamouracampa:
             id: 471
@@ -15723,6 +16075,11 @@ ecosystems:
     families:
       amoeban:
         id: 199
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           amoeban:
             id: 472
@@ -15756,6 +16113,11 @@ ecosystems:
                 mdef: 12
       clionidae:
         id: 200
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           clionid:
             id: 473
@@ -15789,6 +16151,11 @@ ecosystems:
                 mdef: 12
       limule:
         id: 201
+        attributes:
+          mob_mods:
+            roam_cool:  15
+            roam_rate:  15
+            roam_turns:  1
         species:
           limule:
             id: 474
@@ -15820,6 +16187,11 @@ ecosystems:
                 mdef: 16
       murex:
         id: 202
+        attributes:
+          mob_mods:
+            roam_cool:  35
+            roam_rate:  35
+            roam_turns:  3
         species:
           murex:
             id: 475
@@ -16165,6 +16537,11 @@ ecosystems:
     families:
       animated_weapons:
         id: 203
+        attributes:
+          mob_mods:
+            roam_cool:  45
+            roam_rate:  15
+            roam_turns:  4
         species:
           animated_weapons:
             id: 476

--- a/data/enums/mob_mod.yaml
+++ b/data/enums/mob_mod.yaml
@@ -59,7 +59,7 @@ values:
   check_as_nm:            49 # If set , mob will check as a NM
   roam_reset_facing:      50 # Resume facing the default spawn rotation after roaming home.
   roam_turns:             51 # Maximum amount of turns during a roam
-  roam_rate:              52 # Roaming frequency. roam_cool - rand(roam_cool / (roam_rate / 10))
+  roam_rate:              52 # Rest is roam_cool minus rand(0..min(roam_cool * 10 / roam_rate, roam_cool)) whole seconds; -1 rests exactly roam_cool
   behavior:               53 # Add behaviors to mob
   gil_bonus:              54 # Allow mob to drop gil. Multiplier to gil dropped by mob (bonus / 100) * total
   idle_despawn:           55 # Time (in seconds) to despawn after being idle
@@ -106,3 +106,4 @@ values:
   trust_shield_size:      96 # TRUSTS ONLY: Set the size of the mob's shield. 3 = Default size, only used for trusts that use shields.
   bodyguard:              97 # Charmed mob defends its master similar to an avatar. (Maiden's Virelai)
   no_stuck_teleport:      98 # Disable the stuck-repath teleport fallback for this mob (terrain avoidance is intentional for this encounter).
+  roam_turns_min:         99 # Minimum amount of turns during a roam; 0 or unset means 1

--- a/data/zones/altaieu/mobs.yaml
+++ b/data/zones/altaieu/mobs.yaml
@@ -70,7 +70,7 @@ templates:
 
   Aerns_Wynav:
     id:            56
-    species:       blue_wyvern
+    species:       wynav
     type:          [called]
     skill_list_id: 714
     attributes:

--- a/data/zones/bibiki_bay/mobs.yaml
+++ b/data/zones/bibiki_bay/mobs.yaml
@@ -226,7 +226,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  643
-        animation_sub:  12
+        animation_sub:   4
         model_size:      1
         hitbox:         12
       spawn:
@@ -1322,7 +1322,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  131
-        animation_sub:  12
+        animation_sub:   4
         model_size:      1
         hitbox:         12
       behaviors:

--- a/data/zones/bostaunieux_oubliette/mobs.yaml
+++ b/data/zones/bostaunieux_oubliette/mobs.yaml
@@ -830,7 +830,6 @@ templates:
   Wurdalak:
     id:            6582
     species:       vampyr
-    type:          [notorious]
     spell_list_id: 293
     skill_list_id: 309
     attributes:

--- a/data/zones/ceizak_battlegrounds/mobs.yaml
+++ b/data/zones/ceizak_battlegrounds/mobs.yaml
@@ -93,7 +93,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  641
-        animation_sub:  12
+        animation_sub:   4
         hitbox:         10
       behaviors:
         aggressive: true

--- a/data/zones/escha_ruaun/mobs.yaml
+++ b/data/zones/escha_ruaun/mobs.yaml
@@ -776,7 +776,7 @@ templates:
 
   Eschan_Porxie:
     id:      5632
-    species: unclassified
+    species: porxie
     attributes:
       combat:
         skill: scythe

--- a/data/zones/escha_zitah/mobs.yaml
+++ b/data/zones/escha_zitah/mobs.yaml
@@ -402,7 +402,7 @@ templates:
 
   Eschan_Mosquito:
     id:            5543
-    species:       yellow_bee
+    species:       mosquito
     skill_list_id: 48
     attributes:
       combat:

--- a/data/zones/grand_palace_of_huxzoi/mobs.yaml
+++ b/data/zones/grand_palace_of_huxzoi/mobs.yaml
@@ -47,7 +47,7 @@ templates:
 
   Aerns_Wynav:
     id:            56
-    species:       blue_wyvern
+    species:       wynav
     type:          [called]
     skill_list_id: 714
     attributes:

--- a/data/zones/manaclipper/mobs.yaml
+++ b/data/zones/manaclipper/mobs.yaml
@@ -275,7 +275,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  1667
-        animation_sub:   12
+        animation_sub:    4
         model_size:       1
         hitbox:          12
       spawn:
@@ -306,7 +306,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  647
-        animation_sub:  12
+        animation_sub:   4
         model_size:      3
         hitbox:         16
       behaviors:

--- a/data/zones/marjami_ravine/mobs.yaml
+++ b/data/zones/marjami_ravine/mobs.yaml
@@ -23,7 +23,7 @@ templates:
 
   Canyon_Apkallu:
     id:            4987
-    species:       apkallu
+    species:       inguza
     skill_list_id: 27
     attributes:
       combat:
@@ -137,7 +137,7 @@ templates:
 
   Foraging_Apkallu:
     id:            4912
-    species:       apkallu
+    species:       inguza
     skill_list_id: 27
     attributes:
       combat:
@@ -162,7 +162,7 @@ templates:
 
   Gerent_Apkallu:
     id:            4797
-    species:       apkallu
+    species:       inguza
     skill_list_id: 27
     attributes:
       combat:

--- a/data/zones/outer_rakaznar_u1/mobs.yaml
+++ b/data/zones/outer_rakaznar_u1/mobs.yaml
@@ -232,7 +232,7 @@ templates:
 
   Biune_Porxie:
     id:      8118
-    species: unclassified
+    species: porxie
     type:    [battlefield]
     attributes:
       combat:
@@ -859,7 +859,7 @@ templates:
 
   Fetid_Veela:
     id:      8145
-    species: unclassified
+    species: veela
     type:    [battlefield]
     attributes:
       combat:

--- a/data/zones/reisenjima/mobs.yaml
+++ b/data/zones/reisenjima/mobs.yaml
@@ -308,7 +308,7 @@ templates:
 
   Ascended_Lucani:
     id:            5566
-    species:       ladybug
+    species:       lucani
     type:          [notorious]
     skill_list_id: 170
     attributes:
@@ -397,7 +397,7 @@ templates:
 
   Ascended_Mosquito:
     id:            5562
-    species:       yellow_bee
+    species:       mosquito
     type:          [notorious]
     skill_list_id: 48
     attributes:
@@ -490,7 +490,7 @@ templates:
 
   Ascended_Porxie:
     id:            5567
-    species:       pixie
+    species:       porxie
     type:          [notorious]
     skill_list_id: 195
     attributes:
@@ -766,7 +766,7 @@ templates:
 
   Devouring_Mosquito:
     id:            5369
-    species:       yellow_bee
+    species:       mosquito
     skill_list_id: 48
     attributes:
       combat:
@@ -882,7 +882,7 @@ templates:
 
   Heavenly_Veela:
     id:            5578
-    species:       pixie
+    species:       veela
     type:          [notorious]
     skill_list_id: 195
     attributes:
@@ -1052,7 +1052,7 @@ templates:
 
   Lucani:
     id:            5386
-    species:       ladybug
+    species:       lucani
     skill_list_id: 170
     attributes:
       combat:
@@ -1337,7 +1337,7 @@ templates:
 
   Porxie:
     id:            5379
-    species:       pixie
+    species:       porxie
     skill_list_id: 195
     attributes:
       combat:
@@ -1911,7 +1911,7 @@ templates:
 
   Wanton_Danaid:
     id:            5388
-    species:       pixie
+    species:       danaid
     spell_list_id: 20
     skill_list_id: 195
     attributes:

--- a/data/zones/the_garden_of_ruhmet/mobs.yaml
+++ b/data/zones/the_garden_of_ruhmet/mobs.yaml
@@ -47,7 +47,7 @@ templates:
 
   Aerns_Wynav:
     id:            56
-    species:       blue_wyvern
+    species:       wynav
     type:          [called]
     skill_list_id: 714
     attributes:

--- a/data/zones/yahse_hunting_grounds/mobs.yaml
+++ b/data/zones/yahse_hunting_grounds/mobs.yaml
@@ -39,7 +39,7 @@ templates:
           type:  standard
           model: 1361
         entity_flags:  641
-        animation_sub:  12
+        animation_sub:   4
         hitbox:         10
       behaviors:
         aggressive: true

--- a/scripts/mixins/families/gargouille.lua
+++ b/scripts/mixins/families/gargouille.lua
@@ -41,7 +41,10 @@ g_mixins.families.gargouille = function(gargouilleMob)
 
     -- Handle regular changes on roam.
     gargouilleMob:addListener('ROAM_TICK', 'GARGOUILLE_ROAM', function(mob)
-        if GetSystemTime() - mob:getLocalVar('formTimer') >= 0 then
+        if
+            GetSystemTime() - mob:getLocalVar('formTimer') >= 0 and
+            not mob:isFollowingPath()
+        then
             changeStance(mob)
         end
     end)

--- a/scripts/mixins/families/ghrah.lua
+++ b/scripts/mixins/families/ghrah.lua
@@ -143,6 +143,23 @@ local skinConfig = {
     }
 }
 
+-- two rest bands, {20..26} 44% of the time and {27..40} otherwise
+local roamBands =
+{
+    short = { cool = 26, rate = 40, chance = 44 },
+    long  = { cool = 40, rate = 30 },
+}
+
+local function rollRoamBand(mob)
+    if not mob:isFollowingPath() then
+        return
+    end
+
+    local band = math.randomInt(1, 100) <= roamBands.short.chance and roamBands.short or roamBands.long
+    mob:setMobMod(xi.mobMod.ROAM_COOL, band.cool)
+    mob:setMobMod(xi.mobMod.ROAM_RATE, band.rate)
+end
+
 -- Ghrah form determination using lookup table
 -- Ball form (0) is default, Human (1), Spider (2), Bird (3)
 local function getTargetForm(mob)
@@ -236,6 +253,7 @@ g_mixins.families.ghrah = function(ghrahMob)
 
     ghrahMob:addListener('ROAM_TICK', 'GHRAH_TICK', function(mob)
         handleFormChange(mob)
+        rollRoamBand(mob)
     end)
 
     ghrahMob:addListener('ENGAGE', 'GHRAH_ENGAGE', function(mob)

--- a/scripts/mixins/families/heartwing.lua
+++ b/scripts/mixins/families/heartwing.lua
@@ -1,0 +1,27 @@
+-----------------------------------
+require('scripts/globals/mixins')
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+-----------------------------------
+
+-- two rest bands, {19..37} 65% of the time and {34..67} otherwise
+local roamBands =
+{
+    short = { cool = 37, rate = 20, chance = 65 },
+    long  = { cool = 67, rate = 20 },
+}
+
+g_mixins.families.heartwing = function(heartwingMob)
+    heartwingMob:addListener('ROAM_TICK', 'HEARTWING_ROAM_TICK', function(mob)
+        if not mob:isFollowingPath() then
+            return
+        end
+
+        local band = math.randomInt(1, 100) <= roamBands.short.chance and roamBands.short or roamBands.long
+        mob:setMobMod(xi.mobMod.ROAM_COOL, band.cool)
+        mob:setMobMod(xi.mobMod.ROAM_RATE, band.rate)
+    end)
+end
+
+return g_mixins.families.heartwing

--- a/scripts/mixins/families/meeble.lua
+++ b/scripts/mixins/families/meeble.lua
@@ -1,0 +1,49 @@
+-----------------------------------
+require('scripts/globals/mixins')
+-----------------------------------
+g_mixins = g_mixins or {}
+g_mixins.families = g_mixins.families or {}
+-----------------------------------
+
+-- three rests in four are {45..60}; the fourth is a nap of 57 to 149 s asleep plus 9 s standing before the walk
+local restBands =
+{
+    awake = { cool = 60, rate = 40, chance = 76 },
+    nap   = { min = 57, max = 149, wake = 9, rate = -1 },
+}
+
+local subAwake  = 4
+local subAsleep = 5
+
+g_mixins.families.meeble = function(meebleMob)
+    meebleMob:addListener('SPAWN', 'MEEBLE_SPAWN', function(mob)
+        mob:setAnimationSub(subAwake)
+    end)
+
+    meebleMob:addListener('ROAM_TICK', 'MEEBLE_ROAM_TICK', function(mob)
+        if mob:isFollowingPath() then
+            if math.randomInt(1, 100) <= restBands.awake.chance then
+                mob:setMobMod(xi.mobMod.ROAM_COOL, restBands.awake.cool)
+                mob:setMobMod(xi.mobMod.ROAM_RATE, restBands.awake.rate)
+            else
+                mob:setMobMod(xi.mobMod.ROAM_COOL, math.randomInt(restBands.nap.min, restBands.nap.max) + restBands.nap.wake)
+                mob:setMobMod(xi.mobMod.ROAM_RATE, restBands.nap.rate)
+            end
+        elseif
+            mob:getMobMod(xi.mobMod.ROAM_RATE) == restBands.nap.rate and
+            mob:getAnimationSub() == subAwake
+        then
+            mob:setAnimationSub(subAsleep)
+            mob:timer((mob:getMobMod(xi.mobMod.ROAM_COOL) - restBands.nap.wake) * 1000, function(mobArg)
+                mobArg:setAnimationSub(subAwake)
+                mobArg:setMobMod(xi.mobMod.ROAM_RATE, restBands.awake.rate)
+            end)
+        end
+    end)
+
+    meebleMob:addListener('ENGAGE', 'MEEBLE_ENGAGE', function(mob)
+        mob:setAnimationSub(subAwake)
+    end)
+end
+
+return g_mixins.families.meeble

--- a/scripts/mixins/families/uragnite.lua
+++ b/scripts/mixins/families/uragnite.lua
@@ -30,8 +30,20 @@ xi.mix.uragnite = xi.mix.uragnite or {}
 g_mixins = g_mixins or {}
 g_mixins.families = g_mixins.families or {}
 
+-- animationSub 4 is out of the shell, 5 is closed
+local open   = 4
+local closed = 5
+
+-- an idle rest lasts 45 to 70 s; four rests in five close the shell for 18 to 32 s and open it 2 s before the walk
+local idleRestMin     = 45
+local idleRestMax     = 70
+local idleClosedMin   = 18
+local idleClosedMax   = 32
+local idleCloseChance = 80
+local idleOpenBefore  = 2
+
 local function enterShell(mob)
-    mob:setAnimationSub(mob:getAnimationSub() + 1)
+    mob:setAnimationSub(closed)
     mob:setAutoAttackEnabled(false)
     mob:addMod(xi.mod.UDMGPHYS, -7500)
     mob:addMod(xi.mod.UDMGRANGE, -7500)
@@ -39,11 +51,10 @@ local function enterShell(mob)
     mob:addMod(xi.mod.UDMGBREATH, -7500)
     mob:addMod(xi.mod.REGEN, mob:getLocalVar('[uragnite]inShellRegen'))
     mob:setMobMod(xi.mobMod.SKILL_LIST, mob:getLocalVar('[uragnite]inShellSkillList'))
-    mob:setMobMod(xi.mobMod.NO_MOVE, 1)
 end
 
 local function exitShell(mob)
-    mob:setAnimationSub(mob:getAnimationSub() - 1)
+    mob:setAnimationSub(open)
     mob:setAutoAttackEnabled(true)
     mob:delMod(xi.mod.UDMGPHYS, -7500)
     mob:delMod(xi.mod.UDMGRANGE, -7500)
@@ -91,21 +102,53 @@ g_mixins.families.uragnite = function(uragniteMob)
         mob:setLocalVar('[uragnite]timeInShellMin', 30)
         mob:setLocalVar('[uragnite]timeInShellMax', 45)
         mob:setLocalVar('[uragnite]inShellRegen', 50)
+        mob:setAnimationSub(open)
     end)
 
     uragniteMob:addListener('TAKE_DAMAGE', 'URAGNITE_TAKE_DAMAGE', function(mob, amount, attacker, attackType, damageType)
         if attackType == xi.attackType.PHYSICAL then
             if
                 math.randomInt(1, 100) <= mob:getLocalVar('[uragnite]chanceToShell') and
-                bit.band(mob:getAnimationSub(), 1) == 0
+                mob:getAnimationSub() == open
             then
                 enterShell(mob)
+                mob:setMobMod(xi.mobMod.NO_MOVE, 1)
                 local timeInShell = math.randomInt(mob:getLocalVar('[uragnite]timeInShellMin'), mob:getLocalVar('[uragnite]timeInShellMax'))
                 mob:timer(timeInShell * 1000, function(mobArg)
                     exitShell(mobArg)
                 end)
             end
         end
+    end)
+
+    uragniteMob:addListener('ROAM_TICK', 'URAGNITE_ROAM_TICK', function(mob)
+        if
+            mob:isFollowingPath() or
+            mob:getCurrentAction() == xi.action.category.SLEEP or
+            mob:getAnimationSub() ~= open
+        then
+            return
+        end
+
+        local rest = math.randomInt(idleRestMin, idleRestMax)
+        mob:wait(rest * 1000)
+        if math.randomInt(1, 100) > idleCloseChance then
+            return
+        end
+
+        local openAt  = rest - idleOpenBefore
+        local closeAt = math.max(0, openAt - math.randomInt(idleClosedMin, idleClosedMax))
+        mob:timer(closeAt * 1000, function(mobArg)
+            if mobArg:getAnimationSub() == open and not mobArg:isEngaged() then
+                enterShell(mobArg)
+            end
+        end)
+
+        mob:timer(openAt * 1000, function(mobArg)
+            if mobArg:getAnimationSub() == closed then
+                exitShell(mobArg)
+            end
+        end)
     end)
 end
 

--- a/scripts/tests/systems/roam/meeble_nap.lua
+++ b/scripts/tests/systems/roam/meeble_nap.lua
@@ -1,0 +1,32 @@
+describe('Meeble nap', function()
+    local player
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.TEMENOS })
+        mob    = player.entities:get('Temenos_Meeble')
+        mob:respawn()
+        mob:clearPath()
+    end)
+
+    it('spawns awake', function()
+        assert(mob:getAnimationSub() == 4, 'expected animationSub 4, got ' .. mob:getAnimationSub())
+    end)
+
+    it('sleeps and wakes before the rest ends', function()
+        mob:setMobMod(xi.mobMod.ROAM_COOL, 60)
+        mob:setMobMod(xi.mobMod.ROAM_RATE, -1)
+
+        xi.test.world:skipTime(3)
+        xi.test.world:tickEntity(mob)
+        assert(mob:getAnimationSub() == 5, 'expected asleep (5), got ' .. mob:getAnimationSub())
+
+        xi.test.world:skipTime(45)
+        xi.test.world:tickEntity(mob)
+        assert(mob:getAnimationSub() == 5, 'woke too early')
+
+        xi.test.world:skipTime(8)
+        xi.test.world:tickEntity(mob)
+        assert(mob:getAnimationSub() == 4, 'still asleep 9 s before the rest ends')
+    end)
+end)

--- a/scripts/tests/systems/roam/uragnite_shell.lua
+++ b/scripts/tests/systems/roam/uragnite_shell.lua
@@ -1,0 +1,36 @@
+describe('Uragnite shell', function()
+    local player
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.CEIZAK_BATTLEGROUNDS })
+        mob    = player.entities:get('Bight_Uragnite')
+        mob:respawn()
+        mob:clearPath()
+    end)
+
+    it('spawns open', function()
+        assert(mob:getAnimationSub() == 4, 'expected animationSub 4, got ' .. mob:getAnimationSub())
+    end)
+
+    it('closes during a rest and reopens', function()
+        local closedAt = nil
+        local openedAt = nil
+        for second = 1, 300 do
+            xi.test.world:skipTime(1)
+            xi.test.world:tickEntity(mob)
+            local sub = mob:getAnimationSub()
+            if sub == 5 and not closedAt then
+                closedAt = second
+            elseif sub == 4 and closedAt and not openedAt then
+                openedAt = second
+                break
+            end
+        end
+
+        assert(closedAt, 'the shell never closed')
+        assert(openedAt, 'the shell never opened again')
+        local closed = openedAt - closedAt
+        assert(closed >= 15 and closed <= 35, 'shell was closed for ' .. closed .. ' s')
+    end)
+end)

--- a/scripts/tests/systems/roam/wait.lua
+++ b/scripts/tests/systems/roam/wait.lua
@@ -1,0 +1,25 @@
+describe('wait', function()
+    local player
+    local mob
+
+    before_each(function()
+        player = xi.test.world:spawnPlayer({ zone = xi.zone.BATALLIA_DOWNS })
+        mob    = player.entities:get('Goblin_Pathfinder')
+        mob:respawn()
+        mob:clearPath()
+    end)
+
+    it('holds the path until it ends', function()
+        local x = mob:getXPos()
+        mob:pathThrough({ x + 10, mob:getYPos(), mob:getZPos() })
+        mob:wait(5000)
+        xi.test.world:skipTime(1)
+        xi.test.world:tickEntity(mob)
+        assert(math.abs(mob:getXPos() - x) < 0.1, 'mob moved during its wait')
+
+        xi.test.world:skipTime(5)
+        xi.test.world:tickEntity(mob)
+        xi.test.world:tickEntity(mob)
+        assert(math.abs(mob:getXPos() - x) > 0.1, 'mob never moved once the wait ended')
+    end)
+end)

--- a/scripts/zones/Castle_Zvahl_Baileys_[S]/mobs/Dire_Gargouille.lua
+++ b/scripts/zones/Castle_Zvahl_Baileys_[S]/mobs/Dire_Gargouille.lua
@@ -1,17 +1,10 @@
 -----------------------------------
--- Area: Xarcabard [S]
+-- Area: Castle Zvahl Baileys [S]
 --  Mob: Dire Gargouille
--- Note: PH for Graoully
 -----------------------------------
 mixins = { require('scripts/mixins/families/gargouille') }
 -----------------------------------
-local ID = zones[xi.zone.XARCABARD_S]
------------------------------------
 ---@type TMobEntity
 local entity = {}
-
-entity.onMobDespawn = function(mob)
-    xi.mob.phOnDespawn(mob, ID.mob.GRAOULLY, 10, 3600) -- 1 hour
-end
 
 return entity

--- a/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Gnarled_Gargouille.lua
+++ b/scripts/zones/Castle_Zvahl_Keep_[S]/mobs/Gnarled_Gargouille.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Castle Zvahl Keep [S]
+--  Mob: Gnarled Gargouille
+-----------------------------------
+mixins = { require('scripts/mixins/families/gargouille') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Ceizak_Battlegrounds/mobs/Bight_Uragnite.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/mobs/Bight_Uragnite.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Ceizak Battlegrounds
+--  Mob: Bight Uragnite
+-----------------------------------
+mixins = { require('scripts/mixins/families/uragnite') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Ceizak_Battlegrounds/mobs/Cornered_Heartwing.lua
+++ b/scripts/zones/Ceizak_Battlegrounds/mobs/Cornered_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Ceizak Battlegrounds
+--  Mob: Cornered Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Foret_de_Hennetiel/mobs/Bashful_Heartwing.lua
+++ b/scripts/zones/Foret_de_Hennetiel/mobs/Bashful_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Foret de Hennetiel
+--  Mob: Bashful Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Kamihr_Drifts/mobs/Shivering_Heartwing.lua
+++ b/scripts/zones/Kamihr_Drifts/mobs/Shivering_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Kamihr Drifts
+--  Mob: Shivering Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Manaclipper/mobs/Uragnite.lua
+++ b/scripts/zones/Manaclipper/mobs/Uragnite.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Manaclipper
+--  Mob: Uragnite
+-----------------------------------
+mixins = { require('scripts/mixins/families/uragnite') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Marjami_Ravine/mobs/Diffident_Heartwing.lua
+++ b/scripts/zones/Marjami_Ravine/mobs/Diffident_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Marjami Ravine
+--  Mob: Diffident Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Morimar_Basalt_Fields/mobs/Twirling_Heartwing.lua
+++ b/scripts/zones/Morimar_Basalt_Fields/mobs/Twirling_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Morimar Basalt Fields
+--  Mob: Twirling Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Temenos/mobs/Temenos_Meeble.lua
+++ b/scripts/zones/Temenos/mobs/Temenos_Meeble.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Temenos
+--  Mob: Temenos Meeble
+-----------------------------------
+mixins = { require('scripts/mixins/families/meeble') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Yahse_Hunting_Grounds/mobs/Bight_Uragnite.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/mobs/Bight_Uragnite.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Yahse Hunting Grounds
+--  Mob: Bight Uragnite
+-----------------------------------
+mixins = { require('scripts/mixins/families/uragnite') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Yahse_Hunting_Grounds/mobs/Shy_Heartwing.lua
+++ b/scripts/zones/Yahse_Hunting_Grounds/mobs/Shy_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Yahse Hunting Grounds
+--  Mob: Shy Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/scripts/zones/Yorcia_Weald/mobs/Abashed_Heartwing.lua
+++ b/scripts/zones/Yorcia_Weald/mobs/Abashed_Heartwing.lua
@@ -1,0 +1,10 @@
+-----------------------------------
+-- Area: Yorcia Weald
+--  Mob: Abashed Heartwing
+-----------------------------------
+mixins = { require('scripts/mixins/families/heartwing') }
+-----------------------------------
+---@type TMobEntity
+local entity = {}
+
+return entity

--- a/src/map/ai/ai_container.cpp
+++ b/src/map/ai/ai_container.cpp
@@ -430,7 +430,7 @@ auto CAIContainer::CanChangeState() const -> bool
 
 auto CAIContainer::CanFollowPath() const -> bool
 {
-    return PathFind && (!GetCurrentState() || GetCurrentState()->CanChangeState());
+    return PathFind && (!GetCurrentState() || (GetCurrentState()->CanChangeState() && GetCurrentState()->CanFollowPath()));
 }
 
 void CAIContainer::SetController(std::unique_ptr<CController> controller)

--- a/src/map/ai/controllers/mob_controller.cpp
+++ b/src/map/ai/controllers/mob_controller.cpp
@@ -1609,6 +1609,23 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
         co_return;
     }
 
+    // xi::RoamFlag::Ignore mobs never accept claim.
+    if (ignoreAggro)
+    {
+        PMob->m_OwnerID.clean();
+    }
+
+    // A resting mob has nothing to decide before its next timed event.
+    const bool standingStill = !PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->IsPatrolling() && PFollowTarget == nullptr;
+    const bool unmoved       = PMob->loc.p.x == m_IdleCheckedPosition.x && PMob->loc.p.y == m_IdleCheckedPosition.y && PMob->loc.p.z == m_IdleCheckedPosition.z;
+    const bool nothingDue    = m_Tick < NextIdleEventTime();
+    if (standingStill && unmoved && nothingDue)
+    {
+        co_return;
+    }
+
+    m_IdleCheckedPosition = PMob->loc.p;
+
     // An idle mob with no walkable ground anywhere near it is despawned after ~2 ticks.
     // Pathing mobs are exempt (a waypoint can read off-mesh on a poly seam), as are NO_DESPAWN mobs.
     if (!PMob->PAI->PathFind->IsFollowingPath() && !PMob->PAI->PathFind->ValidPosition(PMob->loc.p))
@@ -1619,12 +1636,6 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
             PMob->SetDespawnTime(200ms);
         }
         co_return;
-    }
-
-    // xi::RoamFlag::Ignore mobs never accept claim.
-    if (ignoreAggro)
-    {
-        PMob->m_OwnerID.clean();
     }
 
     if (PFollowTarget != nullptr && m_followType == FollowType::Roam)
@@ -1806,6 +1817,9 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
             }
             else if (PMob->CanRoam())
             {
+                const auto minTurns = static_cast<uint8>(PMob->getMobMod(xi::MobMod::RoamTurnsMin));
+                const auto maxTurns = static_cast<uint8>(PMob->getMobMod(xi::MobMod::RoamTurns));
+
                 // Worm dives underground; leave m_LastActionTime alone so it re-emerges promptly.
                 const bool isWormSurfacing = ((PMob->m_roamFlags & xi::RoamFlag::Worm) != xi::RoamFlag::None) && !PMob->IsNameHidden();
                 if (isWormSurfacing && !PMob->PAI->IsCurrentState<CMagicState>())
@@ -1832,7 +1846,7 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
                     luautils::OnMobRoamAction(PMob);
                     m_LastActionTime = m_Tick;
                 }
-                else if (!isWormSurfacing && PMob->PAI->PathFind->RoamAround(PMob->GetRoamAnchor(), PMob->GetRoamDistance(), static_cast<uint8>(PMob->getMobMod(xi::MobMod::RoamTurns)), PMob->m_roamFlags, PMob->roamRegion()))
+                else if (!isWormSurfacing && PMob->PAI->PathFind->RoamAround(PMob->GetRoamAnchor(), PMob->GetRoamDistance(), minTurns, maxTurns, PMob->m_roamFlags, PMob->roamRegion()))
                 {
                     if ((PMob->m_roamFlags & xi::RoamFlag::Stealth) != xi::RoamFlag::None)
                     {
@@ -1865,6 +1879,23 @@ auto CMobController::DoRoamTick(timer::time_point tick) -> Task<void>
     }
 
     co_return;
+}
+
+auto CMobController::NextIdleEventTime() const -> timer::time_point
+{
+    auto next = std::min({ m_LastActionTime + std::chrono::seconds(PMob->getMobMod(xi::MobMod::RoamCool)), m_mobHealTime + 10s, m_LastRoamScript + 3s });
+
+    if (m_WaitTime > m_Tick)
+    {
+        next = std::min(next, m_WaitTime);
+    }
+
+    if (PMob->m_neutral)
+    {
+        next = std::min(next, m_NeutralTime + kNeutralDuration);
+    }
+
+    return next;
 }
 
 void CMobController::Wait(timer::duration duration)
@@ -1901,8 +1932,11 @@ void CMobController::FollowRoamPath()
     // Path just finished this tick: schedule the next wander and handle worm/spawn-rotation cases.
     if (!PMob->PAI->PathFind->IsFollowingPath())
     {
-        const uint32 roamRandomness = std::clamp<uint32>(static_cast<uint16>(PMob->getMobMod(xi::MobMod::RoamCool) * 1000 / PMob->GetRoamRate()), 0, 120 * 1000);
-        m_LastActionTime            = m_Tick - std::chrono::milliseconds(xirand::GetRandomNumber(roamRandomness));
+        // rest a whole number of seconds drawn uniformly from [RoamCool - RoamCool * 10 / RoamRate, RoamCool]; a negative RoamRate rests exactly RoamCool
+        const uint32 roamCool  = static_cast<uint32>(std::max<int16>(PMob->getMobMod(xi::MobMod::RoamCool), 0));
+        const int16  roamRate  = PMob->getMobMod(xi::MobMod::RoamRate);
+        const uint32 roamRange = roamRate > 0 ? std::min<uint32>(roamCool * 10 / static_cast<uint32>(roamRate), roamCool) : 0;
+        m_LastActionTime       = m_Tick - std::chrono::seconds(xirand::GetRandomNumber(roamRange + 1));
 
         // Worm finished its underground roam - pop back up.
         if (((PMob->m_roamFlags & xi::RoamFlag::Worm) != xi::RoamFlag::None) && PMob->PAI->IsUntargetable())

--- a/src/map/ai/controllers/mob_controller.h
+++ b/src/map/ai/controllers/mob_controller.h
@@ -79,6 +79,7 @@ protected:
     virtual void HandleEnmity();
     virtual auto DoRoamTick(timer::time_point tick) -> Task<void>;
     void         Wait(timer::duration duration);
+    auto         NextIdleEventTime() const -> timer::time_point;
     void         FollowRoamPath();
     auto         ShouldCloseToTarget(float currentDistance) -> bool;
 
@@ -109,6 +110,7 @@ private:
     EntityId followTarget_{};
 
     timer::time_point m_LastActionTime;
+    position_t        m_IdleCheckedPosition{};
     timer::time_point m_nextMagicTime;
     timer::time_point m_LastMobSkillTime;
     timer::time_point m_LastSpecialTime;

--- a/src/map/ai/helpers/pathfind/path_builder.cpp
+++ b/src/map/ai/helpers/pathfind/path_builder.cpp
@@ -89,9 +89,11 @@ auto NavPathBuilder::findPath(const position_t& start, const position_t& end) co
     return result;
 }
 
-auto NavPathBuilder::findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>
+auto NavPathBuilder::findRoamTurnPoints(const position_t& start, float maxRadius, uint8 minTurns, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>
 {
-    const auto desiredTurnCount = static_cast<uint8_t>(xirand::GetRandomNumber<uint32>(maxTurns) + 1);
+    const auto lowTurns         = std::max<uint8>(minTurns, 1);
+    const auto highTurns        = std::max<uint8>(maxTurns, lowTurns);
+    const auto desiredTurnCount = xirand::GetRandomNumber<uint8>(lowTurns, static_cast<uint8>(highTurns + 1));
 
     std::vector<position_t> turnPoints;
 

--- a/src/map/ai/helpers/pathfind/path_builder.h
+++ b/src/map/ai/helpers/pathfind/path_builder.h
@@ -43,9 +43,9 @@ public:
     // Path from `start` to `end`, falling back to the nearest on-mesh point at either end, or nullopt when no path exists.
     auto findPath(const position_t& start, const position_t& end) const -> Maybe<PathResult>;
 
-    // Pick 1..maxTurns roam destinations within `maxRadius`, or nullopt on hard navmesh failure.
+    // Pick minTurns..maxTurns roam destinations within `maxRadius`, or nullopt on hard navmesh failure.
     // With a region, destinations are sampled from it instead of the disc around `start`.
-    auto findRoamTurnPoints(const position_t& start, float maxRadius, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>;
+    auto findRoamTurnPoints(const position_t& start, float maxRadius, uint8 minTurns, uint8 maxTurns, const RoamRegion* region) const -> Maybe<std::vector<position_t>>;
 
 private:
     NavMesh& navMesh_;

--- a/src/map/ai/helpers/pathfind/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind/pathfind.cpp
@@ -90,7 +90,7 @@ auto CPathFind::PathToImpl(const position_t& point, uint8 pathFlags) -> bool
     return found;
 }
 
-auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
+auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 minTurns, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
 {
     TracyZoneScoped;
     TracyZoneString(owner_->name());
@@ -99,7 +99,7 @@ auto CPathFind::RoamAround(const position_t& point, float maxRadius, uint8 maxTu
 
     roamFlags_  = roamFlags;
     roamRegion_ = region;
-    if (FindRandomPath(point, maxRadius, maxTurns, roamFlags, region))
+    if (FindRandomPath(point, maxRadius, minTurns, maxTurns, roamFlags, region))
     {
         return true;
     }
@@ -437,14 +437,14 @@ auto CPathFind::BuildDirectPath(const position_t& end) -> bool
     return true;
 }
 
-auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
+auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 minTurns, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool
 {
     TracyZoneScoped;
     TracyZoneString(owner_->name());
 
     const pathfind::NavPathBuilder builder{ navMesh() };
 
-    auto turnPoints = builder.findRoamTurnPoints(start, maxRadius, maxTurns, region);
+    auto turnPoints = builder.findRoamTurnPoints(start, maxRadius, minTurns, maxTurns, region);
     if (!turnPoints)
     {
         // Hard navmesh failure - bail rather than partially populate the turn list.

--- a/src/map/ai/helpers/pathfind/pathfind.cpp
+++ b/src/map/ai/helpers/pathfind/pathfind.cpp
@@ -43,6 +43,9 @@ namespace
 // Cap for AddPoints; patrol paths may exceed it, other callers are truncated with a warning.
 constexpr size_t kMaxPathPoints = 50;
 
+// region points tried for a recovery walk before settling for a far one
+constexpr int kRecoveryPointAttempts = 8;
+
 } // namespace
 
 CPathFind::CPathFind(CBaseEntity* PTarget)
@@ -396,8 +399,8 @@ auto CPathFind::FindPathInternal(const position_t& start, const position_t& end)
         return false;
     }
 
-    // cut the path where it first leaves the region
-    if (roamRegion_)
+    // cut the path where it first leaves the region, unless this walk brings the mob back onto it
+    if (roamRegion_ && !recoveringToRegion_)
     {
         auto from = start;
         for (std::size_t i = 0; i < built->points.size(); ++i)
@@ -451,6 +454,32 @@ auto CPathFind::FindRandomPath(const position_t& start, float maxRadius, uint8 m
         return false;
     }
     turnPoints_ = std::move(*turnPoints);
+
+    // nothing to walk to from here: path to a nearby point of the region with the full navmesh
+    if (turnPoints_.empty() && region)
+    {
+        Maybe<position_t> target;
+        for (int attempt = 0; attempt < kRecoveryPointAttempts; ++attempt)
+        {
+            const auto candidate = region->randomPoint(&navMesh());
+            if (!candidate)
+            {
+                break;
+            }
+
+            target = candidate;
+            if (isWithinDistance(owner_->position(), *candidate, maxRadius * 2.0f, true))
+            {
+                break;
+            }
+        }
+
+        if (target)
+        {
+            turnPoints_.push_back(*target);
+            recoveringToRegion_ = true;
+        }
+    }
 
     // Path to the first turn only; later turns chain in FinishedPath().
     // Turns are sampled around the anchor, but the walk starts from wherever the owner is.
@@ -551,6 +580,7 @@ auto CPathFind::Clear() -> void
 
     currentTurn_ = 0;
     turnPoints_.clear();
+    recoveringToRegion_ = false;
 
     // Drop any in-flight chunked sequence; the next PathTo / PathInRange starts fresh.
     chunked_.clear();
@@ -627,6 +657,8 @@ auto CPathFind::FinishedPath() -> void
         }
         return;
     }
+
+    recoveringToRegion_ = false;
 
     // Patrol paths loop forever while still roaming.
     if (IsPatrolling() && owner_->isRoaming())

--- a/src/map/ai/helpers/pathfind/pathfind.h
+++ b/src/map/ai/helpers/pathfind/pathfind.h
@@ -58,7 +58,7 @@ public:
     ~CPathFind();
 
     // Walk to a random point around the given point, or inside the region when the owner has one.
-    auto RoamAround(const position_t& point, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags = xi::RoamFlag::None, const RoamRegion* region = nullptr) -> bool;
+    auto RoamAround(const position_t& point, float maxRadius, uint8 minTurns, uint8 maxTurns, xi::RoamFlag roamFlags = xi::RoamFlag::None, const RoamRegion* region = nullptr) -> bool;
 
     // Find and walk to the given point.
     auto PathTo(const position_t& point, uint8 pathFlags = 0) -> bool;
@@ -134,7 +134,7 @@ private:
     auto BuildDirectPath(const position_t& end) -> bool;
 
     // Find a random path around the given point.
-    auto FindRandomPath(const position_t& start, float maxRadius, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool;
+    auto FindRandomPath(const position_t& start, float maxRadius, uint8 minTurns, uint8 maxTurns, xi::RoamFlag roamFlags, const RoamRegion* region) -> bool;
 
     // Core of StepTo, settling `stopShort` yalms short of `pos`.
     auto StepToInternal(const position_t& pos, bool run, float stopShort) -> void;

--- a/src/map/ai/helpers/pathfind/pathfind.h
+++ b/src/map/ai/helpers/pathfind/pathfind.h
@@ -170,6 +170,9 @@ private:
     // region to clip random-roam legs to, null for all other pathing; owned by the zone
     const RoamRegion* roamRegion_{ nullptr };
 
+    // this path may cross the region outline to get back inside
+    bool recoveringToRegion_{ false };
+
     timer::time_point timeAtPoint_;
 
     // Path is held while tick < unpauseTime_; time_point::min() means not paused.

--- a/src/map/entities/mob_entity.cpp
+++ b/src/map/entities/mob_entity.cpp
@@ -681,11 +681,6 @@ float CMobEntity::GetRoamDistance()
     return (float)getMobMod(xi::MobMod::RoamDistance);
 }
 
-float CMobEntity::GetRoamRate()
-{
-    return (float)getMobMod(xi::MobMod::RoamRate) / 10.0f;
-}
-
 float CMobEntity::GetRangedAttackRange()
 {
     // Defaulted range is 14 as observed on all retail fomor.
@@ -833,7 +828,9 @@ void CMobEntity::Spawn()
     }
 
     // Roam immediately on spawn
-    if (CanRoam() && PAI->PathFind->RoamAround(GetRoamAnchor(), GetRoamDistance(), static_cast<uint8>(getMobMod(xi::MobMod::RoamTurns)), m_roamFlags, roamRegion_))
+    const auto minTurns = static_cast<uint8>(getMobMod(xi::MobMod::RoamTurnsMin));
+    const auto maxTurns = static_cast<uint8>(getMobMod(xi::MobMod::RoamTurns));
+    if (CanRoam() && PAI->PathFind->RoamAround(GetRoamAnchor(), GetRoamDistance(), minTurns, maxTurns, m_roamFlags, roamRegion_))
     {
         PAI->PathFind->FollowPath(timer::now());
     }

--- a/src/map/entities/mob_entity.h
+++ b/src/map/entities/mob_entity.h
@@ -125,7 +125,6 @@ public:
 
     void         PostTick() override;
     float        GetRoamDistance();
-    float        GetRoamRate();
     virtual bool ValidTarget(CBattleEntity* PInitiator, uint16 targetFlags) override;
 
     virtual void HandleErrorMessage(std::unique_ptr<CBasicPacket>&) override

--- a/src/map/navmesh/detour_navmesh.cpp
+++ b/src/map/navmesh/detour_navmesh.cpp
@@ -62,7 +62,8 @@ constexpr size_t kMaxNavPolys = 2048;
 constexpr size_t kPathPolyLimit = 512;
 
 // From docs: The maximum number of polygons the visited array can hold.
-constexpr size_t kMaxQueryPolys = 16;
+// moveAlongSurface stops when this fills and still reports success
+constexpr size_t kMaxQueryPolys = 256;
 
 // Detour search extents, used to snap a query point onto the nearest poly.
 constexpr float smallPolyPickExt[3] = { 0.5f, 1.0f, 0.5f };
@@ -523,6 +524,12 @@ auto DetourNavMesh::moveAlongSurface(const position_t& start, const position_t& 
     if (dtStatusFailed(status))
     {
         return false;
+    }
+
+    // detour hands back the start height; take the height of the poly the walk ended on
+    if (visitedCount > 0)
+    {
+        navMeshQuery_.getPolyHeight(visited[visitedCount - 1], out, &out[1]);
     }
 
     result = fromDetour(out);

--- a/src/map/roam_region.cpp
+++ b/src/map/roam_region.cpp
@@ -76,19 +76,17 @@ constexpr float kSnapTolerance = 2.5f;
 // retail's 10th percentile leg
 constexpr float kMinStep = 2.0f;
 
-// 8 halvings land within 0.4% of the drawn step
-constexpr int kBoundaryBisections = 8;
+// rest a little inside the edge so the next leg still sees it; from the edge itself an outward leg crosses at t = 0 and is missed
+constexpr float kEdgeMargin = 0.05f;
 
-// how often a leg is checked on the way; a notch narrower than this can be stepped over
-constexpr float kEdgeSampleStep = 1.0f;
+// retail legs are log-normal about RoamDistance and end near twice it; the same spread and cap fit every captured family
+constexpr double kStepSigma = 0.40;
+constexpr float  kStepCap   = 2.0f;
 
-// retail legs run from 2 to 44 yalms around a mean of 10, which an exponential with RoamDistance as its mean fits
-auto sampleStepDistance(const float mean) -> float
+auto sampleStepDistance(const float median) -> float
 {
-    // truncated at the floor; an exponential is memoryless, so that is the floor plus a fresh draw
-    const auto floor = std::min(kMinStep, mean);
-
-    return floor - mean * std::log(xirand::GetRandomNumber(std::numeric_limits<float>::epsilon(), 1.0f));
+    const auto drawn = static_cast<float>(median * std::exp(xirand::GetNormalNumber(0.0, kStepSigma)));
+    return std::min(drawn, median * kStepCap);
 }
 
 // the only place the triangulator is named. it returns a flat triangle list indexing the rings concatenated in order
@@ -133,6 +131,14 @@ RoamRegion::RoamRegion(const Ring& outer, const std::vector<Ring>& holes)
 
         areaSum += std::abs(signedArea(a, b, c)) * 0.5f;
         triangles_.push_back({ .a = a, .b = b, .c = c, .areaSum = areaSum });
+    }
+
+    for (const auto& ring : rings)
+    {
+        for (size_t i = 0; i < ring.size(); ++i)
+        {
+            edges_.push_back({ .a = ring[i], .b = ring[(i + 1) % ring.size()] });
+        }
     }
 
     // the box every query checks before touching the triangles
@@ -216,47 +222,40 @@ auto RoamRegion::clampToRegion(const position_t& from, const Vector3& direction,
 {
     TracyZoneScoped;
 
-    const auto at = [&](const float along)
+    // a start outside the region gets no leg
+    if (!contains(from.x, from.z))
     {
-        return contains(from.x + direction.x * along, from.z + direction.z * along);
-    };
-
-    const auto edgeBetween = [&](float inside, float outside)
-    {
-        for (int i = 0; i < kBoundaryBisections; ++i)
-        {
-            const auto midpoint = (inside + outside) * 0.5f;
-            if (at(midpoint))
-            {
-                inside = midpoint;
-            }
-            else
-            {
-                outside = midpoint;
-            }
-        }
-
-        return inside;
-    };
-
-    // stop at the first exit, not the end; the ray may leave and come back
-    float inside = 0.0f;
-    for (float along = kEdgeSampleStep; along < distance; along += kEdgeSampleStep)
-    {
-        if (!at(along))
-        {
-            return edgeBetween(inside, along);
-        }
-
-        inside = along;
+        return 0.0f;
     }
 
-    if (at(distance))
+    // first crossing of a ring edge; the ray may leave and come back
+    float nearest = distance;
+    for (const auto& edge : edges_)
+    {
+        const float ex    = edge.b.x - edge.a.x;
+        const float ez    = edge.b.z - edge.a.z;
+        const float denom = direction.x * ez - direction.z * ex;
+        if (std::abs(denom) < 1e-6f)
+        {
+            continue;
+        }
+
+        const float dx = edge.a.x - from.x;
+        const float dz = edge.a.z - from.z;
+        const float t  = (dx * ez - dz * ex) / denom;
+        const float u  = (dx * direction.z - dz * direction.x) / denom;
+        if (t > 1e-4f && t < nearest && u >= 0.0f && u <= 1.0f)
+        {
+            nearest = t;
+        }
+    }
+
+    if (nearest >= distance)
     {
         return distance;
     }
 
-    return edgeBetween(inside, distance);
+    return std::max(nearest - kEdgeMargin, 0.0f);
 }
 
 auto RoamRegion::samplePoint() const -> position_t

--- a/src/map/roam_region.h
+++ b/src/map/roam_region.h
@@ -73,7 +73,16 @@ private:
     auto samplePoint() const -> position_t;
     auto acceptPoint(const position_t& point, const NavMesh* navMesh) const -> Maybe<position_t>;
 
+    struct Edge
+    {
+        Vector3 a;
+        Vector3 b;
+    };
+
     std::vector<Triangle> triangles_;
+
+    // ring edges, outer and holes
+    std::vector<Edge> edges_;
 
     // rejects a position before it walks the triangles
     std::ranges::minmax_result<float> boundsX_{};

--- a/src/map/utils/mobutils.cpp
+++ b/src/map/utils/mobutils.cpp
@@ -1309,23 +1309,11 @@ void SetupJob(CMobEntity* PMob)
 
 void SetupRoaming(CMobEntity* PMob)
 {
-    uint16 distance = 10;
-    uint16 turns    = 1;
-    uint16 cool     = 20;
-    uint16 rate     = 15;
-
-    if (PMob->m_EcoSystem == xi::Ecosystem::Beastmen)
-    {
-        distance = 20;
-        turns    = 5;
-        cool     = 45;
-    }
-
-    // default mob roaming mods
-    PMob->defaultMobMod(xi::MobMod::RoamDistance, distance);
-    PMob->defaultMobMod(xi::MobMod::RoamTurns, turns);
-    PMob->defaultMobMod(xi::MobMod::RoamCool, cool);
-    PMob->defaultMobMod(xi::MobMod::RoamRate, rate);
+    // default mob roaming mods; 6 is the median retail leg
+    PMob->defaultMobMod(xi::MobMod::RoamDistance, 6);
+    PMob->defaultMobMod(xi::MobMod::RoamTurns, 1);
+    PMob->defaultMobMod(xi::MobMod::RoamCool, 20);
+    PMob->defaultMobMod(xi::MobMod::RoamRate, 15);
 
     if ((PMob->m_roamFlags & xi::RoamFlag::Ambush) != xi::RoamFlag::None)
     {

--- a/src/test/tests/pathfind_region_tests.cpp
+++ b/src/test/tests/pathfind_region_tests.cpp
@@ -205,3 +205,21 @@ TEST_CASE("pathfind: a roam leg never crosses out of its region", "[pathfind][re
         }
     }
 }
+
+TEST_CASE("pathfind: a region mob that cannot sample a leg walks back onto its region", "[pathfind][region]")
+{
+    const auto  region = squareWithHole();
+    FlatNavMesh navMesh;
+
+    // outside the outline every sample fails
+    const position_t stranded{ -10.0f, -10.0f, 50.0f, 0, 0 };
+    auto             owner    = std::make_unique<StubOwner>(stranded, navMesh);
+    auto*            ownerPtr = owner.get();
+    CPathFind        pathFind(std::move(owner));
+
+    // the failed sample turns into a walk to a point inside, not cut at the outline
+    REQUIRE(pathFind.RoamAround(stranded, 10.0f, 1, 1, xi::RoamFlag::None, &region));
+    const auto destination = pathFind.GetDestination();
+    CHECK(region.contains(destination.x, destination.z));
+    CHECK_FALSE(region.contains(ownerPtr->position().x, ownerPtr->position().z));
+}

--- a/src/test/tests/pathfind_region_tests.cpp
+++ b/src/test/tests/pathfind_region_tests.cpp
@@ -196,7 +196,7 @@ TEST_CASE("pathfind: a roam leg never crosses out of its region", "[pathfind][re
             auto*     ownerPtr = owner.get();
             CPathFind pathFind(std::move(owner));
 
-            if (!pathFind.RoamAround(start, 30.0f, 1, xi::RoamFlag::None, &region))
+            if (!pathFind.RoamAround(start, 30.0f, 1, 1, xi::RoamFlag::None, &region))
             {
                 continue;
             }

--- a/src/test/tests/roam_region_tests.cpp
+++ b/src/test/tests/roam_region_tests.cpp
@@ -172,7 +172,7 @@ TEST_CASE("RoamRegion samples land inside the region", "[roam_region]")
 
 TEST_CASE("RoamRegion roam steps vary in length", "[roam_region]")
 {
-    // the requested distance is a mean, not a radius
+    // the requested distance is the median of a log-normal draw, not a radius
     const auto       region = squareWithHole();
     const position_t from{ 50.0f, -10.0f, 10.0f, 0, 0 };
 
@@ -240,4 +240,25 @@ TEST_CASE("RoamRegion with no geometry hands out nothing", "[roam_region]")
 
     CHECK_FALSE(region.randomPoint().has_value());
     CHECK_FALSE(region.randomPointAt({}, 10.0f).has_value());
+}
+
+TEST_CASE("RoamRegion clamps a leg at the first boundary it would cross", "[roam_region]")
+{
+    const auto    region = squareWithHole();
+    const Vector3 east{ .x = 1.0f, .y = 0.0f, .z = 0.0f };
+
+    // clear row: stops just short of the outer edge at x = 100
+    const position_t clearRow{ 10.0f, -10.0f, 20.0f, 0, 0 };
+    CHECK(std::abs(region.clampToRegion(clearRow, east, 200.0f) - 89.95f) < 0.01f);
+
+    // row through the hole: stops at the hole's near edge at x = 40
+    const position_t holeRow{ 10.0f, -10.0f, 50.0f, 0, 0 };
+    CHECK(std::abs(region.clampToRegion(holeRow, east, 200.0f) - 29.95f) < 0.01f);
+
+    // short leg comes back whole
+    CHECK(region.clampToRegion(holeRow, east, 20.0f) == 20.0f);
+
+    // outside start gets nothing
+    const position_t outside{ -5.0f, -10.0f, 50.0f, 0, 0 };
+    CHECK(region.clampToRegion(outside, east, 20.0f) == 0.0f);
 }


### PR DESCRIPTION
<!-- Remove space and place 'x' mark between square [] brackets or click the checkbox after saving to affirm the following points: -->
<!-- (it should look like this: - [x] I have ...) -->
**_I affirm:_**
- [x] I understand that if I do not agree to the following points by completing the checkboxes my PR will be ignored.
- [x] I understand I should leave resolving conversations to the LandSandBoat team so that reviewers won't miss what was said.
- [x] I have read and understood the [Contributing Guide](https://github.com/LandSandBoat/server/blob/base/CONTRIBUTING.md) and the [Code of Conduct](https://github.com/LandSandBoat/server/blob/base/CODE_OF_CONDUCT.md).
- [x] I have _**tested my code and the things my code has changed**_ since the last commit in the PR and will test after any later commits.

## What does this pull request do?

<img width="1494" height="1230" alt="roam_bands" src="https://github.com/user-attachments/assets/76ccd366-8770-428c-865e-459b42b2205e" />

Mixed bag of goodies:
- Assigns the correct species to a few mobs I noticed were off while capturing. Drops notorious flag from the Vampyrs in Bostonieux
- Snap mobs back to the proper height when spawning - this should fix the bug where Bees spawned on structures in Gustaberg
- Increases the number of visited polys when generating a walk - this was truncating long walks
- Reduces the median of roam legs from 10y to 6y and changes the distribution to more closely mirror retail
- Gets rid of Beastmen custom roam values from the C++
- Assign captured roam parameters to nearly all families
- Introduces a mobmod to assign a minimum number of turns per roam. Several species work this way such as Gears and Umbrils.
- Return earlier when mobs are not planning to walk, shaving a few milliseconds every tick.
- Fix a bug where wait() was not always being honored
- Adds or tweaks mixins for mobs with special roam properties:
  - Ghrahs and Heartwings bounce randomly between two roam profiles
  - Uragnites go in their shell 80% of the time while roaming
  - Meebles fall asleep 20% of the time while roaming
- Force mobs to path to a close region position if their current position isnt managing to generate roam legs
  - This fixes an issue where a region sometimes doesn't line up with the mesh and mobs end up stuck on top of small hills for which no escape exists. The longer term fix is to refine the regions.

I have a hundreds of captures I could share if desired but they're not very interesting - I literally just sat idle 30-1 hour next to mobs of each family

For future readers:
- ROAM_COOL: Maximum rest between two walks
- ROAM_RATE: How much of said rest is random. -1 disables randomization
- ROAM_TURNS: Maximum number of turns per walk
- ROAM_TURNS_MIN: Minimum number of turns per walk

## Steps to test these changes

<!-- Clear and detailed steps to test your changes here -->
